### PR TITLE
refactor(read-state): split compareOrder into isAfterBoundary and mayAdvanceTo

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -37,7 +37,13 @@ import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { roomStore } from '../stores/roomStore'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
-import { compareOrder, makeCacheOrderKey, type OrderPosition } from '../stores/shared/readState'
+import {
+  compareExact,
+  isAfterBoundary,
+  makeCacheOrderKey,
+  type ExactPosition,
+  type OrderPosition,
+} from '../stores/shared/readState'
 import type { ReadPointer } from '../stores/shared/readPointer'
 import { getBareJid } from './jid'
 import { logInfo } from './logger'
@@ -244,8 +250,8 @@ export function setupMdsSideEffects(
    *   result forward. A keyless (#1081-migrated) pointer orders by `lastReadAt`,
    *   which is documented as at or behind the message it names, so it
    *   under-advances further rather than past. Under-advancing is the direction
-   *   this module already prefers (`compareOrder`: "unresolved sorts first →
-   *   under-advance → over-count (safe)").
+   *   this module already prefers (`isAfterBoundary`: a keyless boundary reads
+   *   as at-or-after its millisecond → under-advance → over-count (safe)).
    * - It cannot regress the node: `publishDecision` is unchanged, and the one
    *   value we must never publish over — a remote marker we could not order — is
    *   still refused there. XEP-0490's receiver-side "MUST ignore older" rule is
@@ -267,15 +273,19 @@ export function setupMdsSideEffects(
       timestamp: pointer.timestamp.getTime(),
       tiebreak: pointer.tiebreak,
     }
-    let best: { pos: OrderPosition; stanzaId: string } | undefined
+    let best: { pos: ExactPosition; stanzaId: string } | undefined
     for (const m of messages) {
       if (!m.stanzaId) continue
-      const pos: OrderPosition = {
+      const pos: ExactPosition = {
         timestamp: m.timestamp.getTime(),
         tiebreak: makeCacheOrderKey(m, 'chat'),
       }
-      if (compareOrder(pos, pointerPos) > 0) continue // ahead of the pointer — never publish
-      if (!best || compareOrder(pos, best.pos) > 0) best = { pos, stanzaId: m.stanzaId }
+      // A BOUNDARY test against the pointer: a keyless pointer reads as
+      // at-or-after its millisecond, so we withhold that millisecond rather
+      // than publish past it — the under-advance this module prefers (#1173).
+      if (isAfterBoundary(pos, pointerPos)) continue // ahead of the pointer — never publish
+      // Picking the newest candidate: both sides are exact by construction.
+      if (!best || compareExact(pos, best.pos) > 0) best = { pos, stanzaId: m.stanzaId }
     }
     return best?.stanzaId
   }

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -29,6 +29,19 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
   }
 })
 import * as messageCache from '../utils/messageCache'
+import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
+
+/**
+ * A transient entry's position.
+ *
+ * These tests exercise identity, aliasing, coalescing and counting — never
+ * tie-breaks — so every fixture shares ONE key. Same-millisecond fixtures then
+ * compare equal, exactly as they did when they carried no key at all, while
+ * `ExactPosition` still holds: a transient entry is always noted from a real
+ * message, so in production its tie-break always resolves (#1173).
+ */
+const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'chat')
+const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -1071,7 +1084,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     seedCoverage('anchor-stanza')
     // One never-archived (noLocalStore) message, after the pointer.
     const key = scopeKey()
-    noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'ephemeral-1' }, 'chat'), transientAliases({ id: 'ephemeral-1' }, 'chat'))
+    noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'ephemeral-1' }, 'chat'), transientAliases({ id: 'ephemeral-1' }, 'chat'))
 
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
@@ -1097,13 +1110,13 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     it('re-noting the same logical message through a new alias does not increment the visible count twice', async () => {
       const key = scopeKey()
-      const r1 = noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+      const r1 = noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
       expect(r1.added).toBe(true)
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1)
 
       // Same logical message re-noted (plain alias registration, nothing new).
-      const r2 = noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+      const r2 = noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
       expect(r2.added).toBe(false)
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1) // NOT 2
@@ -1111,7 +1124,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     it('retracting the only transient unread moves the visible count 1 -> 0', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1)
 
@@ -1123,8 +1136,8 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     it('removing one of two transient unread messages moves the visible count 2 -> 1', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
-      noteTransient(key, { position: { timestamp: 1600 } }, transientIdentity({ id: 'm2' }, 'chat'), transientAliases({ id: 'm2' }, 'chat'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+      noteTransient(key, { position: posAt(1600) }, transientIdentity({ id: 'm2' }, 'chat'), transientAliases({ id: 'm2' }, 'chat'))
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
 
@@ -1135,13 +1148,13 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     it('a bridging alias that coalesces two separately-counted transient entries moves the visible count 2 -> 1', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, 'origin-key-O', ['origin-key-O'])
-      noteTransient(key, { position: { timestamp: 1500 } }, 'stanza-key-S', ['stanza-key-S'])
+      noteTransient(key, { position: posAt(1500) }, 'origin-key-O', ['origin-key-O'])
+      noteTransient(key, { position: posAt(1500) }, 'stanza-key-S', ['stanza-key-S'])
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
 
       // A copy carrying BOTH tiers bridges them: added:false, requiresRecount:true.
-      const r = noteTransient(key, { position: { timestamp: 1500 } }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O'])
+      const r = noteTransient(key, { position: posAt(1500) }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O'])
       expect(r).toEqual({ added: false, requiresRecount: true })
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1)
@@ -1149,7 +1162,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     it('an overlay change while not caught up stays conservative and does not clear the trusted count', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
       await chatStore.getState().recomputeUnreadForConversation(CID)
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1)
 
@@ -1160,7 +1173,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
         mamQueryStates.set(CID, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: true, isCaughtUpToLive: false })
         return { mamQueryStates }
       })
-      noteTransient(key, { position: { timestamp: 1600 } }, transientIdentity({ id: 'm2' }, 'chat'), transientAliases({ id: 'm2' }, 'chat'))
+      noteTransient(key, { position: posAt(1600) }, transientIdentity({ id: 'm2' }, 'chat'), transientAliases({ id: 'm2' }, 'chat'))
 
       await chatStore.getState().recomputeUnreadForConversation(CID)
 

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -62,9 +62,9 @@ function timeFor(id: string): Date {
  * The read pointer naming `id`, carrying that message's own timestamp.
  *
  * KEYED, exactly as `makeReadPointer` writes every pointer: the divider and the
- * unread count are derived by archive POSITION, and a keyless pointer cannot
- * certify its own (a missing key sorts first, so the message it NAMES would
- * sort after the boundary and take the divider itself).
+ * unread count are derived by archive POSITION. Under `isAfterBoundary`, a
+ * keyless pointer treats every row at its millisecond as after the boundary, so
+ * the message it NAMES would take the divider itself.
  */
 function pointerAt(id: string): ReadPointer {
   return makeReadPointer({ id, timestamp: timeFor(id) }, 'chat')

--- a/packages/fluux-sdk/src/stores/chatStore.resyncDivider.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.resyncDivider.test.ts
@@ -25,9 +25,9 @@ function seed(opts: { lastSeen: string | undefined; marker: string | undefined; 
   meta.set(CID, {
     unreadCount: 0,
     // KEYED, exactly as `makeReadPointer` writes every pointer: the divider is
-    // derived by archive POSITION, and a keyless pointer cannot certify its own
-    // (a missing key sorts first, so the message it NAMES would sort after the
-    // boundary and take the divider itself).
+    // derived by archive POSITION. Under `isAfterBoundary`, a keyless pointer
+    // treats every row at its millisecond as after the boundary, so the message
+    // it NAMES would take the divider itself.
     readPointer: seenMsg ? makeReadPointer(seenMsg, 'chat') : undefined,
   })
   const messages = new Map()

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1023,8 +1023,8 @@ describe('chatStore', () => {
       // generation and never runs the notification transition.
       chatStore.getState().setActiveConversation(CID)
 
-      // m2 shares the floor's exact millisecond and still counts as after it
-      // (a keyless floor sorts first) — the same rule the count uses.
+      // m2 shares the floor's exact millisecond and still counts as after it —
+      // `isAfterBoundary` applies the same keyless-boundary rule as the count.
       expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).toBeUndefined()
       expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m2')
     })
@@ -1057,8 +1057,8 @@ describe('chatStore', () => {
 
       chatStore.getState().resyncDividerToReadPointer(CID)
 
-      // m2 shares the floor's exact millisecond and must still count as after it
-      // (a keyless floor sorts first) — the same rule the count uses.
+      // m2 shares the floor's exact millisecond and must still count as after it —
+      // `isAfterBoundary` applies the same keyless-boundary rule as the count.
       expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m2')
     })
   })
@@ -1169,11 +1169,10 @@ describe('chatStore', () => {
       // names ('msg-150') — the reader left off deep in history. Seeding
       // conversationMeta.readPointer directly mimics a persisted read pointer
       // from a prior session (no live activation has run yet here). KEYED, as
-      // every persisted pointer is: `makeReadPointer` always writes the archive
-      // order key and `deserializeReadPointer` reads it back. Without it the
-      // pointer cannot certify its own position, and the message it NAMES sorts
-      // after the boundary (a keyless boundary means at-or-after its own
-      // millisecond — see `isAfterBoundary`), so
+      // every newly written pointer is: `makeReadPointer` always writes the
+      // cache order key and `deserializeReadPointer` reads it back. Without it,
+      // `isAfterBoundary` treats every row at the keyless pointer's millisecond
+      // as after the boundary, so
       // the divider would correctly-but-conservatively land on msg-150 itself.
       const A = 'alice@example.com'
       chatStore.getState().addConversation(createConversation(A))

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1172,7 +1172,8 @@ describe('chatStore', () => {
       // every persisted pointer is: `makeReadPointer` always writes the archive
       // order key and `deserializeReadPointer` reads it back. Without it the
       // pointer cannot certify its own position, and the message it NAMES sorts
-      // after the boundary (a missing key sorts first — see `compareOrder`), so
+      // after the boundary (a keyless boundary means at-or-after its own
+      // millisecond — see `isAfterBoundary`), so
       // the divider would correctly-but-conservatively land on msg-150 itself.
       const A = 'alice@example.com'
       chatStore.getState().addConversation(createConversation(A))

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -21,7 +21,7 @@ import {
   computeFloor,
   pointerlessDefers,
   worthReconcilingOnDeactivate,
-  compareOrder,
+  isAfterBoundary,
   makeCacheOrderKey,
   isRenderableStoredMessage,
   type OrderPosition,
@@ -2617,7 +2617,9 @@ export const chatStore = createStore<ChatState>()(
         // here too, since not every trigger path calls pruneTransient directly.
         pruneTransient(chatTransientScopeKey(conversationId), floorPos)
 
-        if (compareOrder(bottom, floorPos) > 0) return // coverage doesn't reach the floor
+        // A BOUNDARY test: a keyless (migrated) floor reads as at-or-after its
+        // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
+        if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
 
         const res = await messageCache.countUnreadInArchive(conversationId, {
           floor,

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -32,6 +32,19 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
   }
 })
 import * as messageCache from '../utils/messageCache'
+import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
+
+/**
+ * A transient entry's position.
+ *
+ * These tests exercise identity, aliasing, coalescing and counting — never
+ * tie-breaks — so every fixture shares ONE key. Same-millisecond fixtures then
+ * compare equal, exactly as they did when they carried no key at all, while
+ * `ExactPosition` still holds: a transient entry is always noted from a real
+ * message, so in production its tie-break always resolves (#1173).
+ */
+const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'room')
+const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -924,7 +937,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     const key = scopeKey()
     noteTransient(
       key,
-      { position: { timestamp: 1500 } },
+      { position: posAt(1500) },
       transientIdentity({ roomJid: ROOM, from: `${ROOM}/dave`, id: 'ephemeral-1' }, 'room'),
       transientAliases({ roomJid: ROOM, from: `${ROOM}/dave`, id: 'ephemeral-1' }, 'room')
     )
@@ -956,13 +969,13 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     it('re-noting the same logical message through a new alias does not increment the visible count twice', async () => {
       const key = scopeKey()
-      const r1 = noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
+      const r1 = noteTransient(key, { position: posAt(1500) }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
       expect(r1.added).toBe(true)
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
 
       // Same logical message re-noted (plain alias registration, nothing new).
-      const r2 = noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
+      const r2 = noteTransient(key, { position: posAt(1500) }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
       expect(r2.added).toBe(false)
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1) // NOT 2
@@ -970,7 +983,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     it('retracting the only transient unread moves the visible count 1 -> 0', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
 
@@ -982,8 +995,8 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     it('removing one of two transient unread messages moves the visible count 2 -> 1', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
-      noteTransient(key, { position: { timestamp: 1600 } }, transientIdentity(m2, 'room'), transientAliases(m2, 'room'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
+      noteTransient(key, { position: posAt(1600) }, transientIdentity(m2, 'room'), transientAliases(m2, 'room'))
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
 
@@ -994,13 +1007,13 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     it('a bridging alias that coalesces two separately-counted transient entries moves the visible count 2 -> 1', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, 'origin-key-O', ['origin-key-O'])
-      noteTransient(key, { position: { timestamp: 1500 } }, 'stanza-key-S', ['stanza-key-S'])
+      noteTransient(key, { position: posAt(1500) }, 'origin-key-O', ['origin-key-O'])
+      noteTransient(key, { position: posAt(1500) }, 'stanza-key-S', ['stanza-key-S'])
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
 
       // A copy carrying BOTH tiers bridges them: added:false, requiresRecount:true.
-      const r = noteTransient(key, { position: { timestamp: 1500 } }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O'])
+      const r = noteTransient(key, { position: posAt(1500) }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O'])
       expect(r).toEqual({ added: false, requiresRecount: true })
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
@@ -1008,7 +1021,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     it('an overlay change while not caught up stays conservative and does not clear the trusted count', async () => {
       const key = scopeKey()
-      noteTransient(key, { position: { timestamp: 1500 } }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
+      noteTransient(key, { position: posAt(1500) }, transientIdentity(m1, 'room'), transientAliases(m1, 'room'))
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
 
@@ -1019,7 +1032,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
         mamQueryStates.set(ROOM, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: true, isCaughtUpToLive: false })
         return { mamQueryStates }
       })
-      noteTransient(key, { position: { timestamp: 1600 } }, transientIdentity(m2, 'room'), transientAliases(m2, 'room'))
+      noteTransient(key, { position: posAt(1600) }, transientIdentity(m2, 'room'), transientAliases(m2, 'room'))
 
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
 

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -71,9 +71,9 @@ function rmsg(id: string, stanzaId: string, t: number): RoomMessage {
  * The read pointer naming `id`, carrying that message's own timestamp (#1081).
  *
  * KEYED, exactly as `makeReadPointer` writes every pointer: the divider and the
- * unread count are derived by archive POSITION, and a keyless pointer cannot
- * certify its own (a missing key sorts first, so the message it NAMES would
- * sort after the boundary and take the divider itself).
+ * unread count are derived by archive POSITION. Under `isAfterBoundary`, a
+ * keyless pointer treats every row at its millisecond as after the boundary, so
+ * the message it NAMES would take the divider itself.
  */
 function pointerIn(messages: RoomMessage[], id: string): ReadPointer {
   const found = messages.find((m) => m.id === id)

--- a/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
@@ -22,9 +22,9 @@ function msg(id: string, opts: { outgoing?: boolean; delayed?: boolean } = {}): 
 function seed(opts: { lastSeen: string | undefined; marker: string | undefined; messages: RoomMessage[] }) {
   const seenMsg = opts.messages.find((m) => m.id === opts.lastSeen)
   // KEYED, exactly as `makeReadPointer` writes every pointer: the divider is
-  // derived by archive POSITION, and a keyless pointer cannot certify its own
-  // (a missing key sorts first, so the message it NAMES would sort after the
-  // boundary and take the divider itself).
+  // derived by archive POSITION. Under `isAfterBoundary`, a keyless pointer
+  // treats every row at its millisecond as after the boundary, so the message
+  // it NAMES would take the divider itself.
   const readPointer = seenMsg ? makeReadPointer(seenMsg, 'room') : undefined
   const rooms = new Map()
   rooms.set(JID, {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2509,7 +2509,7 @@ describe('roomStore', () => {
       // the cache order key and `deserializeReadPointer` reads it back.
       // Without it the pointer cannot certify its own position, and the message
       // it NAMES sorts after the boundary (a missing key sorts first — see
-      // `compareOrder`), so the divider would correctly-but-conservatively land
+      // `isAfterBoundary`), so the divider would correctly-but-conservatively land
       // on msg-150 itself.
       const roomJid = 'test@conference.example.com'
       roomStore.getState().addRoom(createRoom(roomJid, { joined: true }))
@@ -6374,7 +6374,7 @@ describe('setActiveRoom new-message marker — delayed history unified with chat
    * `createMessage`'s default `new Date()` would make the "already read" message
    * the NEWEST in the fixture while sitting first in the array — an ordering the
    * resident array never has in production (PR B gave `messageArrayUtils` the
-   * same `compareOrder` tie-break, so index order and cache order agree).
+   * same `compareExact` tie-break, so index order and cache order agree).
    */
   const seenMsg = (): RoomMessage =>
     createMessage('seen', ROOM, 'alice', 'seen message', false, new Date('2025-01-15T09:00:00Z'))

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2367,8 +2367,8 @@ describe('roomStore', () => {
       // generation and never runs the notification transition.
       roomStore.getState().setActiveRoom(RJID)
 
-      // m2 shares the floor's exact millisecond and still counts as after it
-      // (a keyless floor sorts first) — the same rule the count uses.
+      // m2 shares the floor's exact millisecond and still counts as after it —
+      // `isAfterBoundary` applies the same keyless-boundary rule as the count.
       expect(roomStore.getState().roomMeta.get(RJID)?.readPointer).toBeUndefined()
       expect(roomStore.getState().firstNewMessageMarkers.get(RJID)).toBe('m2')
     })
@@ -2505,12 +2505,11 @@ describe('roomStore', () => {
       // ('msg-150') — the reader left off deep in history. Seeding
       // roomMeta.readPointer directly mimics a persisted read pointer
       // from a prior session (no live activation has run yet in this test).
-      // KEYED, as every persisted pointer is: `makeReadPointer` always writes
-      // the cache order key and `deserializeReadPointer` reads it back.
-      // Without it the pointer cannot certify its own position, and the message
-      // it NAMES sorts after the boundary (a missing key sorts first — see
-      // `isAfterBoundary`), so the divider would correctly-but-conservatively land
-      // on msg-150 itself.
+      // KEYED, as every newly written pointer is: `makeReadPointer` always
+      // writes the cache order key and `deserializeReadPointer` reads it back.
+      // Without it, `isAfterBoundary` treats every row at the keyless pointer's
+      // millisecond as after the boundary, so the divider would
+      // correctly-but-conservatively land on msg-150 itself.
       const roomJid = 'test@conference.example.com'
       roomStore.getState().addRoom(createRoom(roomJid, { joined: true }))
       roomStore.setState((state) => {

--- a/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
@@ -46,7 +46,7 @@ export function createRoom(jid: string, options: Partial<Room> = {}): Room {
  * (task 1) changed exactly that. Two KEYED positions sharing a millisecond now
  * break the tie on the cache order key: `isAhead`
  * (shared/readPointer.ts, ~line 99) does it, and `advanceReadPointer` routes
- * through `onMessageSeen`'s keyed `compareOrder`, which does it too. The bare
+ * through `onMessageSeen`'s keyed `mayAdvanceTo`, which does it too. The bare
  * "equal timestamps are NOT an advance" rule now applies ONLY when either side
  * is KEYLESS — i.e. a pointer migrated from the pre-#1081 `lastSeenMessageId` +
  * `lastReadAt` pair, whose timestamp cannot certify its own position.

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -38,7 +38,7 @@ import {
   computeFloor,
   pointerlessDefers,
   worthReconcilingOnDeactivate,
-  compareOrder,
+  isAfterBoundary,
   makeCacheOrderKey,
   isRenderableStoredMessage,
   type OrderPosition,
@@ -2434,7 +2434,9 @@ export const roomStore = createStore<RoomState>()(
     // too, since not every trigger path calls pruneTransient directly.
     pruneTransient(roomTransientScopeKey(roomJid), floorPos)
 
-    if (compareOrder(bottom, floorPos) > 0) return // coverage doesn't reach the floor
+    // A BOUNDARY test: a keyless (migrated) floor reads as at-or-after its
+    // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
+    if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
 
     const res = await messageCache.countRoomUnreadInArchive(roomJid, {
       floor,

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -1,5 +1,5 @@
 import { resolveArchivePosition } from '../../utils/messageCache'
-import type { OrderPosition } from './readState'
+import type { ExactPosition } from './readState'
 
 /**
  * Persisted contiguous-with-live coverage (Codex r3 #3/#4).
@@ -258,7 +258,7 @@ export function isCaughtUpForCounting(mam: {
  * react to them differently (e.g. only the latter warrants dropping the
  * record).
  */
-export type CoverageBottom = OrderPosition | 'missing' | 'unresolvable'
+export type CoverageBottom = ExactPosition | 'missing' | 'unresolvable'
 
 /**
  * Resolve a coverage record's `bottomId` to its archive position, scoped to

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -5,7 +5,7 @@
  * to reduce code duplication for common message array operations.
  */
 
-import { compareOrder, makeCacheOrderKey } from './readState'
+import { compareExact, makeCacheOrderKey } from './readState'
 
 /**
  * Generic interface for messages with a timestamp.
@@ -13,7 +13,7 @@ import { compareOrder, makeCacheOrderKey } from './readState'
  *
  * `id` and `from` are required for the timestamp-tiebreak sort below — the
  * resident array must break same-millisecond ties with the SAME total order
- * as the archive (`readState.ts`'s `compareOrder`), or the two can disagree
+ * as the archive (`readState.ts`'s `compareExact`), or the two can disagree
  * about which message came second.
  */
 export interface TimestampedMessage {
@@ -187,7 +187,7 @@ export function backfillArchiveIds<T extends ArchiveIdentifiableMessage>(
  * Sort messages by timestamp in ascending order (oldest first).
  *
  * Same-millisecond ties break by the message cache's own tie-break key
- * (`readState.ts`'s `compareOrder`), kind-discriminated: chat by `id` only,
+ * (`readState.ts`'s `compareExact`), kind-discriminated: chat by `id` only,
  * room by `from` then `id`. This is deliberately NOT a generic `from`-then-`id`
  * comparator — chat messages carry `from` too, so inferring the tiebreak from
  * field presence would silently apply the room rule to chat. The resident
@@ -204,7 +204,7 @@ export function sortMessagesByTimestamp<T extends TimestampedMessage>(
   kind: 'chat' | 'room'
 ): T[] {
   return [...messages].sort((a, b) =>
-    compareOrder(
+    compareExact(
       { timestamp: a.timestamp.getTime(), tiebreak: makeCacheOrderKey(a, kind) },
       { timestamp: b.timestamp.getTime(), tiebreak: makeCacheOrderKey(b, kind) }
     )

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -92,7 +92,7 @@ export function appendLive<T extends TimelineMessage>(
   // FIX 5 (read-state PR B, final whole-branch review): sort before trimming.
   // Live arrivals land in ARRIVAL order, but the cache orders same-millisecond
   // rows by the shared comparator (id for chat, (from, id) for room — see
-  // `compareOrder`/`makeCacheOrderKey`). The viewport observer advances the
+  // `compareExact`/`makeCacheOrderKey`). The viewport observer advances the
   // read pointer by RESIDENT INDEX, so an unsorted resident array can place a
   // same-ms sibling later than the cache would — the pointer then advances
   // past it while the cache walk still counts it as unread: a silent

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -577,8 +577,8 @@ describe('onActivate', () => {
   // count derives from exactly the same fallback (`computeFloor`).
   describe('no read pointer: the boundary is the historyFloor, never unreadCount', () => {
     it('places the divider at the first message after the floor', () => {
-      // The floor shares msg-2's millisecond and msg-2 still counts as after it
-      // (a keyless floor sorts first) — the same rule the count uses.
+      // The floor shares msg-2's millisecond and msg-2 still counts as after it —
+      // `isAfterBoundary` applies the same keyless-boundary rule as the count.
       const state = makeState({ historyFloor: new Date('2025-01-15T09:30:00Z'), unreadCount: 2 })
       const result = onActivate(state, messages, 'chat')
       expect(result.firstNewMessageId).toBe('msg-2')
@@ -708,8 +708,8 @@ describe('onActivate — floor-derived divider (PR C, D5)', () => {
     expect(r.firstNewMessageId).toBe('m3')
   })
 
-  // Pointerless: the floor is historyFloor, and a same-ms message counts as
-  // strictly after it (keyless sorts first) — matching the count exactly.
+  // Pointerless: the floor is historyFloor, and `isAfterBoundary` counts a
+  // same-ms message as after that keyless boundary — matching the count exactly.
   it('uses historyFloor when there is no pointer, counting a same-millisecond message as after', () => {
     const state = { unreadCount: 1, mentionsCount: 0, readPointer: undefined,
       historyFloor: new Date(2000), firstNewMessageId: undefined }

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -61,7 +61,8 @@ function seen(id: string, timestamp: Date): ReadPointer {
  * KEYED, via `makeReadPointer` — exactly how production builds a pointer for a
  * message it holds. The key is what says "this timestamp is that message's own",
  * and without it the message the pointer NAMES sorts after the floor (a missing
- * key sorts first, see `compareOrder`) and would itself become the divider.
+ * boundary means at-or-after its millisecond, see `isAfterBoundary`) and
+ * would itself become the divider.
  * `seen()` above is the keyless population — a pointer migrated from the
  * pre-#1081 `lastSeenMessageId` + `lastReadAt` pair, which genuinely cannot
  * certify its own position.
@@ -698,7 +699,7 @@ describe('onActivate — floor-derived divider (PR C, D5)', () => {
   //
   // Pointer m2@2000 (keyed, absent from the slice); m3@2000 is resident.
   //   before -> ladder finds the first message strictly after 2000 => 'm4'
-  //   PR C   -> compareOrder ranks m3 after m2 at the same ms  => 'm3'
+  //   PR C   -> mayAdvanceTo ranks m3 after m2 at the same ms  => 'm3'
   it('places the divider on a same-millisecond sibling of a NON-RESIDENT pointer', () => {
     const state = { unreadCount: 2, mentionsCount: 0,
       readPointer: makeReadPointer({ id: 'm2', timestamp: new Date(2000) }, 'chat'),
@@ -1111,11 +1112,11 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
   // NEGATIVE POLARITY — this is the forward-only guard itself. The keyed branch
   // does NOT go through `advance()`: it builds the pointer directly, and both
   // stores commit whatever comes back after only a reference check. So this
-  // `compareOrder(...) > 0` is the SOLE thing standing between a
-  // same-millisecond sibling that sorts BEFORE the pointer and a BACKWARDS
-  // pointer move — which, on a forward-only position, is unrecoverable.
-  // Relaxing the comparison to `>= 0` (or to a key-blind `>=` on timestamps
-  // alone) is caught here and nowhere else.
+  // `mayAdvanceTo(...)` is the SOLE thing standing between a same-millisecond
+  // sibling that sorts BEFORE the pointer and a BACKWARDS pointer move —
+  // which, on a forward-only position, is unrecoverable. Relaxing it to accept
+  // equality (or to a key-blind `>=` on timestamps alone) is caught here and
+  // nowhere else.
   it('does NOT move a KEYED, OFF-SLICE pointer back onto a same-millisecond sibling that sorts before it', () => {
     const state = { unreadCount: 1, mentionsCount: 0,
       readPointer: makeReadPointer({ id: 'm2', timestamp: new Date(1000) }, 'chat'),

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -22,10 +22,12 @@
 
 import { advance, makeReadPointer, type PointerSource, type ReadPointer } from './readPointer'
 import {
-  compareOrder,
+  isAfterBoundary,
+  mayAdvanceTo,
   computeFloor,
   isRenderableStoredMessage,
   makeCacheOrderKey,
+  type ExactPosition,
   type OrderPosition,
   type RenderabilityCheckFields,
 } from './readState'
@@ -303,11 +305,13 @@ export function onActivate(
     for (const m of messages) {
       if (m.isOutgoing) continue
       if (!isRenderableStoredMessage(m)) continue
-      const pos: OrderPosition = {
+      const pos: ExactPosition = {
         timestamp: m.timestamp.getTime(),
         tiebreak: makeCacheOrderKey(m, kind),
       }
-      if (compareOrder(pos, floorPos) > 0) {
+      // The DIVIDER question: a keyless floor means at-or-after its
+      // millisecond, placing the divider conservatively early (#1173).
+      if (isAfterBoundary(pos, floorPos)) {
         firstNewMessageId = m.id
         break
       }
@@ -436,7 +440,7 @@ export function onWindowBecameVisible(
  * messages for good.
  *
  * A KEYED current pointer (carries `tiebreak`) is ordered by cache
- * POSITION via `compareOrder`, not by array index — its position is provable
+ * POSITION via `mayAdvanceTo`, not by array index — its position is provable
  * without being resident in `messages` (PR C, D4). The off-slice guard and the
  * `atLiveEdge` escape hatch below apply only to a KEYLESS (migrated) pointer,
  * whose bare timestamp cannot certify a position.
@@ -469,14 +473,15 @@ export function onMessageSeen(
   // Keyed pointer: compare cache POSITIONS. The pointer no longer has to be
   // resident, and a same-millisecond sibling that sorts after it is a genuine
   // advance. Safe against the resident array because PR B gave
-  // `messageArrayUtils` the same `compareOrder` tie-break, so array index and
-  // cache order agree.
+  // `messageArrayUtils` the same tie-break, so array index and cache order
+  // agree.
   if (state.readPointer.tiebreak) {
     const target = messages[newIdx]
-    return compareOrder(
+    // The ADVANCE question: never overtake at a shared millisecond (#1173).
+    return mayAdvanceTo(
       { timestamp: target.timestamp.getTime(), tiebreak: makeCacheOrderKey(target, kind) },
       { timestamp: state.readPointer.timestamp.getTime(), tiebreak: state.readPointer.tiebreak }
-    ) > 0
+    )
       ? advanced()
       : state
   }

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -9,7 +9,7 @@
 
 import type { NotificationMessage } from './notificationState'
 import * as notifState from './notificationState'
-import { compareOrder, makeCacheOrderKey } from './readState'
+import { mayAdvanceTo, makeCacheOrderKey } from './readState'
 import { makeReadPointer, type ReadPointer } from './readPointer'
 
 /** The notification-relevant slice of a conversation/room metadata entry. */
@@ -82,11 +82,11 @@ function resolveAdvance<T extends NotificationMessage & { stanzaId?: string }>(
   if (!current) return makeReadPointer(match, kind)
 
   if (current.tiebreak) {
-    const ahead =
-      compareOrder(
-        { timestamp: match.timestamp.getTime(), tiebreak: makeCacheOrderKey(match, kind) },
-        { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
-      ) > 0
+    // The ADVANCE question — never overtake at a shared millisecond (#1173).
+    const ahead = mayAdvanceTo(
+      { timestamp: match.timestamp.getTime(), tiebreak: makeCacheOrderKey(match, kind) },
+      { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
+    )
     return ahead ? makeReadPointer(match, kind) : 'no-advance'
   }
 

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -62,11 +62,18 @@ describe('isAhead', () => {
     expect(isAhead(candidate, current)).toBe(true)
   })
 
-  // CONTROL for the polarity inversion. compareOrder sorts a MISSING key FIRST,
-  // which is safe for a floor (under-advance -> over-count) and UNSAFE for a
-  // pointer: it would let any keyed candidate overtake a migrated keyless
-  // pointer at the same millisecond. A naive `compareOrder(candidate, current) > 0`
-  // implementation passes every test above and fails these two.
+  // CONTROL for the polarity inversion (#1173). The COUNTING comparator,
+  // `isAfterBoundary`, reads a MISSING key on the boundary as at-or-after its
+  // millisecond — safe for a floor (under-advance -> over-count) and UNSAFE for
+  // a pointer, where it would let any keyed candidate overtake a migrated
+  // keyless pointer at the same millisecond. Substituting it here passes every
+  // test above and fails these two.
+  //
+  // That substitution no longer compiles — `isAfterBoundary` takes an
+  // `ExactPosition` row, which a possibly-keyless pointer is not — so these two
+  // are now a second line of defence rather than the only one. Keep both: the
+  // type guard pins the SHAPE, these pin the BEHAVIOUR. See
+  // `readState.enforcement.test.ts`.
   it('is NOT ahead at an equal ms when the CURRENT pointer is keyless (migrated)', () => {
     const current: ReadPointer = { messageId: 'legacy', timestamp: at(1000) }
     const candidate = makeReadPointer({ id: 'm2', timestamp: at(1000) }, 'chat')

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -69,9 +69,10 @@ export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: s
  * The persisted property is `archiveOrderKey`, NOT `tiebreak`. The in-memory
  * field was renamed because the key never held an archive id — it is the
  * IndexedDB cursor tie-break built from the CLIENT message id — but the ON-DISK
- * name is deliberately left alone: every pointer already stored carries
- * `archiveOrderKey`, and renaming it here would silently orphan all of them,
- * degrading each to the keyless at-or-after-timestamp fallback. Do not "finish
+ * name is deliberately left alone: every stored pointer that has this key
+ * carries it as `archiveOrderKey`, and renaming it here would silently orphan
+ * those keys, degrading those pointers to the keyless at-or-after-timestamp
+ * fallback. Do not "finish
  * the rename" on this side without a migration and its own compatibility
  * argument.
  */

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -15,7 +15,7 @@
  * All functions here are pure.
  */
 
-import { compareOrder, makeCacheOrderKey, type CacheOrderKey } from './readState'
+import { mayAdvanceTo, makeCacheOrderKey, type CacheOrderKey } from './readState'
 
 /**
  * Where the user has read to. Written atomically or not at all.
@@ -107,37 +107,27 @@ export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): 
 /**
  * Is `candidate` strictly further along than `current`?
  *
- * Timestamp first. A same-millisecond tie is broken by the cache order key —
- * but ONLY when both sides carry one (read-state PR C, D2). A key is what
- * certifies that a pointer's timestamp is its named message's own: pointers
- * built by `makeReadPointer` always have one, while a pointer migrated from the
- * pre-#1081 `lastSeenMessageId` + `lastReadAt` pair carries `lastReadAt` and no
- * key at all.
+ * This is the ADVANCE question, so it is answered by {@link mayAdvanceTo}: a
+ * same-millisecond tie is broken by the cache order key ONLY when both sides
+ * carry one (read-state PR C, D2), and otherwise it refuses to move. A key is
+ * what certifies that a pointer's timestamp is its named message's own —
+ * pointers built by `makeReadPointer` always have one, while a pointer migrated
+ * from the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair carries
+ * `lastReadAt` and no key at all.
  *
- * Do NOT simplify this to `compareOrder(candidate, current) > 0`. `compareOrder`
- * sorts a MISSING key FIRST, which is the safe direction for a FLOOR
- * (under-advance -> over-count) and the UNSAFE direction for a POINTER: it would
- * let any keyed candidate overtake a migrated keyless pointer sharing its
- * millisecond, advancing a forward-only position past messages nothing has
- * proven were read. Same comparator, inverted safety. When either side is
- * keyless we fall back to strict millisecond comparison — today's behaviour,
- * preserved exactly where the position is not provable.
+ * The counting question's comparator (`isAfterBoundary`) has the OPPOSITE
+ * missing-key rule and must never be substituted here — it would let any keyed
+ * candidate overtake a migrated keyless pointer sharing its millisecond,
+ * advancing a forward-only position past messages nothing has proven were read.
+ * That used to be guarded by this comment alone (#1173); it is now guarded by
+ * the type — `isAfterBoundary` takes an `ExactPosition` row, which a pointer,
+ * being possibly keyless, is not. See `readState.enforcement.test.ts`.
  */
 export function isAhead(candidate: ReadPointer, current: ReadPointer | undefined): boolean {
   if (!current) return true
-  const candidateMs = candidate.timestamp.getTime()
-  const currentMs = current.timestamp.getTime()
-  if (candidateMs !== currentMs) return candidateMs > currentMs
-
-  const candidateKey = candidate.tiebreak
-  const currentKey = current.tiebreak
-  if (!candidateKey || !currentKey) return false
-
-  return (
-    compareOrder(
-      { timestamp: candidateMs, tiebreak: candidateKey },
-      { timestamp: currentMs, tiebreak: currentKey }
-    ) > 0
+  return mayAdvanceTo(
+    { timestamp: candidate.timestamp.getTime(), tiebreak: candidate.tiebreak },
+    { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
   )
 }
 

--- a/packages/fluux-sdk/src/stores/shared/readState.enforcement.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.enforcement.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Type-level enforcement of the two ordering questions (#1173).
+ *
+ * The `@ts-expect-error` directives below are consumed by `npm run typecheck`,
+ * not by vitest: an UNUSED `@ts-expect-error` is itself error TS2578, so each
+ * directive fails the build the moment the call it guards starts compiling.
+ * That is the whole point of this file. The rule it pins used to live only in a
+ * doc comment on `isAhead`, and mutation testing during #1170 twice reduced a
+ * positional comparison on this same code path to a key-blind `>=` with the
+ * entire suite green. A comment does not survive a refactor that also deletes
+ * its controls; a compile error does.
+ *
+ * Do not "fix" a failure here by widening a signature or deleting a directive.
+ * A directive reported as unused means the guard it stands for is gone.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  compareExact,
+  isAfterBoundary,
+  mayAdvanceTo,
+  makeCacheOrderKey,
+  type ExactPosition,
+  type OrderPosition,
+} from './readState'
+
+/** An archive row: its tie-break is always resolvable, so it orders exactly. */
+const row: ExactPosition = { timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm1' }, 'chat') }
+const laterRow: ExactPosition = { timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm2' }, 'chat') }
+
+/**
+ * What a #1081-migrated pointer's position actually is: a bare millisecond with
+ * no provable position inside it. This is the value the whole issue is about.
+ */
+const keyless: OrderPosition = { timestamp: 1000 }
+
+/**
+ * NEVER CALLED. These calls exist only to be typechecked — running them would
+ * dereference a tie-break that is absent by construction, which is precisely
+ * what the compiler now refuses to let production code do.
+ */
+function _rejectedAtCompileTime(): void {
+  // @ts-expect-error #1173: a keyless position has no tie-break to compare with.
+  compareExact(keyless, row)
+  // @ts-expect-error #1173: ...and the same holds on the right-hand side.
+  compareExact(row, keyless)
+
+  // THE unsafe call the issue is about. `isAfterBoundary` reads a missing
+  // tie-break on the BOUNDARY as at-or-after (over-count — safe for counting);
+  // reusing it to ask "may the pointer advance?" is exactly what would let a
+  // keyed candidate overtake a keyless pointer at the same millisecond. Its
+  // `row` parameter is exact, so a pointer position — which may be keyless —
+  // cannot be passed as one, and the reduction does not compile.
+  // @ts-expect-error #1173: `isAfterBoundary` orders an archive ROW; a pointer is not one.
+  isAfterBoundary(keyless, row)
+}
+
+describe('the two ordering questions', () => {
+  it('keeps the compile-time guard referenced (see _rejectedAtCompileTime)', () => {
+    // The guard above is enforced by `npm run typecheck`, not by this runner:
+    // each of its three directives fails the build with TS2578 (an unused
+    // suppression) the moment the call it guards starts compiling.
+    expect(typeof _rejectedAtCompileTime).toBe('function')
+  })
+
+  it('still orders two exact positions', () => {
+    expect(compareExact(row, laterRow)).toBeLessThan(0)
+  })
+
+  it('answers the advance question conservatively for a keyless candidate', () => {
+    // `mayAdvanceTo` accepts the keyless side precisely because it must answer
+    // for it — and its answer is "no".
+    expect(mayAdvanceTo(keyless, row)).toBe(false)
+  })
+
+  it('gives the two questions OPPOSITE answers at an equal millisecond', () => {
+    // The single fact this whole split exists to keep visible. Same row, same
+    // keyless counterpart, same millisecond, deliberately opposite results.
+    expect(isAfterBoundary(row, keyless)).toBe(true) // over-count — safe for counting
+    expect(mayAdvanceTo(row, keyless)).toBe(false) // never overtake — safe for advancing
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/readState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.test.ts
@@ -1,24 +1,75 @@
 import { describe, it, expect } from 'vitest'
-import { compareOrder, computeFloor, makeCacheOrderKey, pointerlessDefers, isValidCacheOrderKey } from './readState'
+import {
+  compareExact,
+  computeFloor,
+  isAfterBoundary,
+  makeCacheOrderKey,
+  mayAdvanceTo,
+  pointerlessDefers,
+  isValidCacheOrderKey,
+} from './readState'
 import { makeReadPointer } from './readPointer'
 
-describe('compareOrder', () => {
+describe('compareExact', () => {
   it('orders by timestamp first', () => {
-    expect(compareOrder({ timestamp: 1 }, { timestamp: 2 })).toBeLessThan(0)
+    const a = { timestamp: 1, tiebreak: makeCacheOrderKey({ id: 'z' }, 'chat') }
+    const b = { timestamp: 2, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+    expect(compareExact(a, b)).toBeLessThan(0) // timestamp wins over the tie-break
   })
   it('room ties break by (from, id)', () => {
     const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/al', id: 'z' }, 'room') }
     const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/bo', id: 'a' }, 'room') }
-    expect(compareOrder(a, b)).toBeLessThan(0) // 'al' < 'bo' wins over id
+    expect(compareExact(a, b)).toBeLessThan(0) // 'al' < 'bo' wins over id
   })
   it('chat ties break by id ONLY, ignoring from', () => {
     const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'zed@x', id: 'a' }, 'chat') }
     const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'amy@x', id: 'b' }, 'chat') }
-    expect(compareOrder(a, b)).toBeLessThan(0) // id 'a' < 'b'; `from` must not participate
+    expect(compareExact(a, b)).toBeLessThan(0) // id 'a' < 'b'; `from` must not participate
   })
-  it('a missing key sorts before a present one at equal timestamp (conservative)', () => {
-    const k = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
-    expect(compareOrder({ timestamp: 5 }, k)).toBeLessThan(0)
+})
+
+/**
+ * The one fact these two describe-blocks exist to keep apart (#1173): at an
+ * equal millisecond a MISSING tie-break means the OPPOSITE thing depending on
+ * which question is asked. Both rules predate this split; only one of them was
+ * ever written down as code.
+ */
+describe('isAfterBoundary — the counting/divider question', () => {
+  const row = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+
+  it("counts a row at a KEYLESS boundary's own millisecond as after it (over-count, safe)", () => {
+    // The old `compareOrder` phrasing of this same fact was "a missing key
+    // sorts BEFORE a present one at an equal timestamp". Read from the row's
+    // side, that is exactly "the row is after the boundary".
+    expect(isAfterBoundary(row, { timestamp: 5 })).toBe(true)
+  })
+  it('still orders by timestamp against a keyless boundary', () => {
+    expect(isAfterBoundary(row, { timestamp: 6 })).toBe(false)
+    expect(isAfterBoundary(row, { timestamp: 4 })).toBe(true)
+  })
+  it('uses the tie-break when the boundary has one', () => {
+    expect(isAfterBoundary(row, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
+    expect(isAfterBoundary(row, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
+  })
+})
+
+describe('mayAdvanceTo — the advance/seen question', () => {
+  const candidate = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+
+  it('refuses to overtake a KEYLESS current position at an equal millisecond', () => {
+    // The inverse of the boundary rule above, on identical inputs.
+    expect(mayAdvanceTo(candidate, { timestamp: 5 })).toBe(false)
+  })
+  it('refuses to advance from a KEYLESS candidate at an equal millisecond', () => {
+    expect(mayAdvanceTo({ timestamp: 5 }, candidate)).toBe(false)
+  })
+  it('still advances by strict millisecond when the timestamps differ', () => {
+    expect(mayAdvanceTo({ timestamp: 6 }, { timestamp: 5 })).toBe(true)
+    expect(mayAdvanceTo({ timestamp: 4 }, { timestamp: 5 })).toBe(false)
+  })
+  it('uses the tie-break when both sides have one', () => {
+    expect(mayAdvanceTo(candidate, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
+    expect(mayAdvanceTo(candidate, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -43,30 +43,108 @@ export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'cha
   return kind === 'room' ? { kind: 'room', from: msg.from ?? '', id: msg.id } : { kind: 'chat', id: msg.id }
 }
 
-/** A position in message-cache order: a timestamp, optionally refined by a key. */
+/**
+ * A position in message-cache order: a timestamp, optionally refined by a key.
+ *
+ * The tie-break is optional because a pointer migrated from the pre-#1081
+ * `lastSeenMessageId` + `lastReadAt` pair carries only a millisecond, with no
+ * provable position inside it. Such a value is a FLOOR — it means "at least
+ * here", not "exactly here".
+ *
+ * {@link ExactPosition} is the refinement that does mean "exactly here". Prefer
+ * it wherever a position is genuinely resolvable — every message resolves to
+ * one, because {@link makeCacheOrderKey} always produces a key — so that the
+ * compiler, rather than a comment, is what keeps a floor out of a comparison
+ * that assumes exactness.
+ */
 export interface OrderPosition {
   timestamp: number
   tiebreak?: CacheOrderKey
 }
 
 /**
- * Total order over cached message positions: timestamp first, then the kind-aware
- * tie-break key. A missing key sorts BEFORE a present one at an equal
- * timestamp — unresolved sorts first, which under-advances rather than
- * over-advances (over-counting unread is the recoverable direction).
+ * A position whose tie-break is known, so it can be ordered exactly against
+ * another such position.
+ *
+ * An `OrderPosition` is deliberately NOT assignable to this (#1173): the only
+ * way to obtain one is to actually have a tie-break, which in practice means
+ * the position came from a message rather than from a bare `lastReadAt`.
  */
-export function compareOrder(a: OrderPosition, b: OrderPosition): number {
-  if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
-  const ak = a.tiebreak,
-    bk = b.tiebreak
-  if (!ak && !bk) return 0
-  if (!ak) return -1 // unresolved sorts first → under-advance → over-count (safe)
-  if (!bk) return 1
-  if (ak.kind === 'room' && bk.kind === 'room') {
-    if (ak.from !== bk.from) return ak.from < bk.from ? -1 : 1
-    return ak.id < bk.id ? -1 : ak.id > bk.id ? 1 : 0
+export interface ExactPosition extends OrderPosition {
+  tiebreak: CacheOrderKey
+}
+
+/**
+ * Break a same-millisecond tie between two known tie-breaks. Kind-aware: chat
+ * compares `id` only, room compares `from` then `id` — see {@link CacheOrderKey}
+ * for why one generic shape would be wrong.
+ *
+ * Private, and takes the KEYS rather than the positions, so it cannot be
+ * mistaken for a general comparator over positions and cannot be reached with a
+ * keyless one. The three functions below are the only entry points.
+ */
+function compareTiebreak(a: CacheOrderKey, b: CacheOrderKey): number {
+  if (a.kind === 'room' && b.kind === 'room') {
+    if (a.from !== b.from) return a.from < b.from ? -1 : 1
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
   }
-  return ak.id < bk.id ? -1 : ak.id > bk.id ? 1 : 0 // chat: id only
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0 // chat: id only
+}
+
+/**
+ * Total order over two positions that are BOTH exact — timestamp first, then
+ * the tie-break. This is the comparator for ordering messages against each
+ * other: sorting a resident array, picking the newest of a candidate set.
+ *
+ * It deliberately has no answer for a keyless position, because there is no
+ * single right one. The two questions the codebase actually asks —
+ * {@link isAfterBoundary} and {@link mayAdvanceTo} — have OPPOSITE
+ * missing-tie-break rules, so a comparator that picked one of them would be
+ * silently wrong at every call site that meant the other. That was #1173.
+ * Passing a possibly-keyless `OrderPosition` here does not compile.
+ */
+export function compareExact(a: ExactPosition, b: ExactPosition): number {
+  if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
+  return compareTiebreak(a.tiebreak, b.tiebreak)
+}
+
+/**
+ * "Is this row after the read boundary?" — the COUNTING and DIVIDER question.
+ *
+ * A missing tie-break on the BOUNDARY means AT-OR-AFTER its timestamp: every
+ * row sharing the boundary's millisecond, including the boundary's own message,
+ * counts as after it. That over-counts by up to the same-millisecond sibling
+ * set, which is the recoverable direction — an over-count clears the moment the
+ * user reads, while an under-count hides a message permanently.
+ *
+ * `row` is an {@link ExactPosition} because an archive row always resolves to
+ * one. That is not a formality: it is what stops this function from being used
+ * to answer the advance question, where this same rule is unsafe (#1173).
+ */
+export function isAfterBoundary(row: ExactPosition, boundary: OrderPosition): boolean {
+  if (row.timestamp !== boundary.timestamp) return row.timestamp > boundary.timestamp
+  if (!boundary.tiebreak) return true // at-or-after timestamp → over-count (safe)
+  return compareTiebreak(row.tiebreak, boundary.tiebreak) > 0
+}
+
+/**
+ * "May the read pointer advance to this?" — the ADVANCE and SEEN question.
+ *
+ * A missing tie-break on EITHER side means STRICT MILLISECOND: never overtake.
+ * The key is what certifies that a pointer's timestamp is its named message's
+ * own, so when either side lacks one, nothing about their relative order within
+ * a shared millisecond is provable. The read pointer is forward-only, so a
+ * position given away here is unrecoverable; refusing to move merely
+ * over-counts, which the user clears by reading.
+ *
+ * This is the exact inverse of {@link isAfterBoundary}'s rule, on purpose. The
+ * two questions are not interchangeable — that is why they are two functions
+ * (#1173) rather than one comparator with a warning attached to it.
+ */
+export function mayAdvanceTo(candidate: OrderPosition, current: OrderPosition): boolean {
+  if (candidate.timestamp !== current.timestamp) return candidate.timestamp > current.timestamp
+  if (!candidate.tiebreak || !current.tiebreak) return false // strict ms → never overtake (safe)
+  return compareTiebreak(candidate.tiebreak, current.tiebreak) > 0
 }
 
 /**

--- a/packages/fluux-sdk/src/stores/shared/transientUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/transientUnread.test.ts
@@ -10,6 +10,19 @@ import {
   type ScopeKey,
 } from './transientUnread'
 import { roomStanzaKey } from '../../utils/roomMessageIdentity'
+import { makeCacheOrderKey, type ExactPosition } from './readState'
+
+/**
+ * A transient entry's position.
+ *
+ * These tests exercise identity, aliasing, coalescing and counting — never
+ * tie-breaks — so every fixture shares ONE key. Same-millisecond fixtures then
+ * compare equal, exactly as they did when they carried no key at all, while
+ * `ExactPosition` still holds: a transient entry is always noted from a real
+ * message, so in production its tie-break always resolves (#1173).
+ */
+const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'room')
+const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 // Fresh scope per test: entityIds are unique so no state leaks between tests
 // (the module holds module-level state, matching the always-on lifetime the
@@ -25,7 +38,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note(msg, 10)
     // simulate deactivate + reactivate: nothing is called; the entry must remain
@@ -36,7 +49,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note(msg, 10)
     note({ ...msg, stanzaId: 'S1' }, 10) // same logical message, higher identity tier
@@ -47,7 +60,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note({ ...msg, stanzaId: 'S1' }, 10)
     removeTransient(K, roomStanzaKey(K.entityId, 'S1'))
@@ -57,7 +70,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
   it('two room messages with the SAME id but different senders count as two', () => {
     const K = freshScopeKey()
     const note = (m: { roomJid: string; from: string; id: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'dup' }, 10)
     note({ roomJid: K.entityId, from: `${K.entityId}/bo`, id: 'dup' }, 11)
@@ -67,7 +80,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
   it('a partial pointer advance drops only the passed entries', () => {
     const K = freshScopeKey()
     const note = (m: { roomJid: string; from: string; id: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'a' }, 10)
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'b' }, 20)
@@ -78,7 +91,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     expect(note(msg, 10).added).toBe(true)
     expect(note({ ...msg, stanzaId: 'S1' }, 10).added).toBe(false) // merged, not new
@@ -87,11 +100,11 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
   it('coalesces two entries when a later alias bridges them', () => {
     const K = freshScopeKey()
     // Two copies land separately (no shared tier yet), then a copy carrying BOTH tiers arrives.
-    noteTransient(K, { position: { timestamp: 10 } }, 'origin-key-O', ['origin-key-O'])
-    noteTransient(K, { position: { timestamp: 10 } }, 'stanza-key-S', ['stanza-key-S'])
+    noteTransient(K, { position: posAt(10) }, 'origin-key-O', ['origin-key-O'])
+    noteTransient(K, { position: posAt(10) }, 'stanza-key-S', ['stanza-key-S'])
     expect(transientCounts(K, { timestamp: 5 }).unread).toBe(2)
 
-    const r = noteTransient(K, { position: { timestamp: 10 } }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O']) // bridges both
+    const r = noteTransient(K, { position: posAt(10) }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O']) // bridges both
     expect(r).toEqual({ added: false, requiresRecount: true }) // nothing added, but 2 -> 1
     expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1) // coalesced, not 2
   })
@@ -100,10 +113,10 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note(msg, 10)
-    const r = noteTransient(K, { position: { timestamp: 10 } }, transientIdentity(msg, 'room'), transientAliases(msg, 'room'))
+    const r = noteTransient(K, { position: posAt(10) }, transientIdentity(msg, 'room'), transientAliases(msg, 'room'))
     expect(r).toEqual({ added: false, requiresRecount: false })
   })
 
@@ -111,7 +124,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     const K = freshScopeKey()
     const msg = { roomJid: K.entityId, from: `${K.entityId}/al`, id: 'm1' }
     const note = (m: typeof msg & { stanzaId?: string }, at: number) =>
-      noteTransient(K, { position: { timestamp: at } }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
+      noteTransient(K, { position: posAt(at) }, transientIdentity(m, 'room'), transientAliases(m, 'room'))
 
     note(msg, 10)
     expect(removeTransient(K, transientIdentity(msg, 'room')).removed).toBe(true)
@@ -124,9 +137,9 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     // stored position, rather than computing the minimum across every
     // coalesced entry (5) and the incoming note itself (30).
     const K = freshScopeKey()
-    noteTransient(K, { position: { timestamp: 20 } }, 'tier-a', ['tier-a']) // first-matched under a naive impl
-    noteTransient(K, { position: { timestamp: 5 } }, 'tier-b', ['tier-b']) // earliest of all three
-    const r = noteTransient(K, { position: { timestamp: 30 } }, 'tier-a', ['tier-a', 'tier-b'])
+    noteTransient(K, { position: posAt(20) }, 'tier-a', ['tier-a']) // first-matched under a naive impl
+    noteTransient(K, { position: posAt(5) }, 'tier-b', ['tier-b']) // earliest of all three
+    const r = noteTransient(K, { position: posAt(30) }, 'tier-a', ['tier-a', 'tier-b'])
     expect(r).toEqual({ added: false, requiresRecount: true })
     // A boundary of 10 sits strictly between the earliest (5) and tier-a's own
     // original position (20): correct behaviour reads 0 (5 <= 10, already
@@ -142,7 +155,7 @@ describe('transientUnread — scope isolation', () => {
     const accountA: ScopeKey = { accountScope: 'alice@x', kind: 'room', entityId: roomJid }
     const accountB: ScopeKey = { accountScope: 'bob@x', kind: 'room', entityId: roomJid }
 
-    noteTransient(accountA, { position: { timestamp: 10 } }, transientIdentity({ roomJid, from: `${roomJid}/al`, id: 'm1' }, 'room'), [
+    noteTransient(accountA, { position: posAt(10) }, transientIdentity({ roomJid, from: `${roomJid}/al`, id: 'm1' }, 'room'), [
       'k-a',
     ])
 
@@ -155,7 +168,7 @@ describe('transientUnread — scope isolation', () => {
     const chatKey: ScopeKey = { accountScope: 'me@x', kind: 'chat', entityId }
     const roomKey: ScopeKey = { accountScope: 'me@x', kind: 'room', entityId }
 
-    noteTransient(chatKey, { position: { timestamp: 10 } }, transientIdentity({ id: 'c1' }, 'chat'), transientAliases({ id: 'c1' }, 'chat'))
+    noteTransient(chatKey, { position: posAt(10) }, transientIdentity({ id: 'c1' }, 'chat'), transientAliases({ id: 'c1' }, 'chat'))
 
     expect(transientCounts(chatKey, { timestamp: 5 }).unread).toBe(1)
     expect(transientCounts(roomKey, { timestamp: 5 }).unread).toBe(0)
@@ -170,7 +183,7 @@ describe('transientUnread — chat identity (bare id, no tiers)', () => {
 
   it('counts a noted chat message as unread until the boundary passes it', () => {
     const K = freshScopeKey('chat')
-    noteTransient(K, { position: { timestamp: 10 } }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
+    noteTransient(K, { position: posAt(10) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
     expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1)
     expect(transientCounts(K, { timestamp: 15 }).unread).toBe(0)
   })
@@ -179,25 +192,43 @@ describe('transientUnread — chat identity (bare id, no tiers)', () => {
 describe('transientUnread — pruneTransient', () => {
   it('drops entries at or behind the boundary and leaves later ones', () => {
     const K = freshScopeKey()
-    noteTransient(K, { position: { timestamp: 10 } }, 'a', ['a'])
-    noteTransient(K, { position: { timestamp: 20 } }, 'b', ['b'])
+    noteTransient(K, { position: posAt(10) }, 'a', ['a'])
+    noteTransient(K, { position: posAt(20) }, 'b', ['b'])
 
-    const result = pruneTransient(K, { timestamp: 10 })
+    // The boundary names the SAME position as entry 'a' — the read pointer
+    // sitting exactly on it. A bare `{ timestamp: 10 }` boundary would be a
+    // keyless (migrated) pointer, which deliberately does NOT prune an entry
+    // sharing its millisecond: that is the over-count-safe rule (#1173),
+    // pinned by its own test below.
+    const result = pruneTransient(K, posAt(10))
     expect(result).toEqual({ removed: 1 })
     expect(transientCounts(K, undefined).unread).toBe(1)
   })
 
+  it('a KEYLESS boundary does not prune an entry sharing its millisecond', () => {
+    // The migrated-pointer case (#1173). A keyless boundary means at-or-after
+    // its timestamp, so an entry at that exact millisecond stays counted rather
+    // than being dropped — an over-count the user clears by reading, instead of
+    // an under-count that would hide the message for good. This is the rule the
+    // prune test above deliberately does NOT exercise.
+    const K = freshScopeKey()
+    noteTransient(K, { position: posAt(10) }, 'a', ['a'])
+
+    expect(pruneTransient(K, { timestamp: 10 })).toEqual({ removed: 0 })
+    expect(transientCounts(K, { timestamp: 10 }).unread).toBe(1)
+  })
+
   it('removed aliases can no longer resolve for removeTransient', () => {
     const K = freshScopeKey()
-    noteTransient(K, { position: { timestamp: 10 } }, 'canon', ['canon', 'alias1'])
-    pruneTransient(K, { timestamp: 10 })
+    noteTransient(K, { position: posAt(10) }, 'canon', ['canon', 'alias1'])
+    pruneTransient(K, posAt(10))
     expect(removeTransient(K, 'alias1').removed).toBe(false)
   })
 
   it('an undefined boundary counts everything (no floor yet)', () => {
     const K = freshScopeKey()
-    noteTransient(K, { position: { timestamp: 10 } }, 'a', ['a'])
-    noteTransient(K, { position: { timestamp: 999999 } }, 'b', ['b'])
+    noteTransient(K, { position: posAt(10) }, 'a', ['a'])
+    noteTransient(K, { position: posAt(999999) }, 'b', ['b'])
     expect(transientCounts(K, undefined).unread).toBe(2)
   })
 })
@@ -210,9 +241,9 @@ describe('transientUnread — clearTransientScope', () => {
     const chatKey: ScopeKey = { accountScope, kind: 'chat', entityId: 'c@x' }
     const otherAccount: ScopeKey = { accountScope: 'untouched@x', kind: 'room', entityId: 'r@c' }
 
-    noteTransient(roomKey, { position: { timestamp: 10 } }, 'a', ['a'])
-    noteTransient(chatKey, { position: { timestamp: 10 } }, 'b', ['b'])
-    noteTransient(otherAccount, { position: { timestamp: 10 } }, 'c', ['c'])
+    noteTransient(roomKey, { position: posAt(10) }, 'a', ['a'])
+    noteTransient(chatKey, { position: posAt(10) }, 'b', ['b'])
+    noteTransient(otherAccount, { position: posAt(10) }, 'c', ['c'])
 
     clearTransientScope(accountScope)
 

--- a/packages/fluux-sdk/src/stores/shared/transientUnread.ts
+++ b/packages/fluux-sdk/src/stores/shared/transientUnread.ts
@@ -1,4 +1,4 @@
-import { compareOrder, type OrderPosition } from './readState'
+import { compareExact, isAfterBoundary, type ExactPosition, type OrderPosition } from './readState'
 import { roomCanonicalKey, roomIdentityKeys, type RoomIdentityFields } from '../../utils/roomMessageIdentity'
 
 /**
@@ -39,9 +39,12 @@ export interface ScopeKey {
   entityId: string
 }
 
-/** A transient entry's only payload: the position it counts at. */
+/**
+ * A transient entry's only payload: the position it counts at. Exact, because
+ * every entry is noted from a real message, so its tie-break always resolves.
+ */
 export interface TransientEntry {
-  position: OrderPosition
+  position: ExactPosition
 }
 
 export interface NoteTransientResult {
@@ -165,7 +168,7 @@ export function noteTransient(key: ScopeKey, entry: TransientEntry, identity: st
         scope.canonicalByAlias.set(alias, canonicalId)
       }
     }
-    const movedEarlier = compareOrder(entry.position, stored.entry.position) < 0
+    const movedEarlier = compareExact(entry.position, stored.entry.position) < 0
     if (movedEarlier) stored.entry = { position: entry.position }
     return { added: false, requiresRecount: movedEarlier }
   }
@@ -178,7 +181,7 @@ export function noteTransient(key: ScopeKey, entry: TransientEntry, identity: st
   for (const id of ids) {
     const stored = scope.entries.get(id)!
     for (const alias of stored.aliases) unionAliases.add(alias)
-    if (compareOrder(stored.entry.position, earliestPosition) < 0) earliestPosition = stored.entry.position
+    if (compareExact(stored.entry.position, earliestPosition) < 0) earliestPosition = stored.entry.position
   }
 
   const survivorId = ids[0]
@@ -200,7 +203,7 @@ export function transientCounts(key: ScopeKey, boundary: OrderPosition | undefin
   if (!scope) return { unread: 0 }
   let unread = 0
   for (const { entry } of scope.entries.values()) {
-    if (boundary === undefined || compareOrder(entry.position, boundary) > 0) unread++
+    if (boundary === undefined || isAfterBoundary(entry.position, boundary)) unread++
   }
   return { unread }
 }
@@ -215,7 +218,7 @@ export function pruneTransient(key: ScopeKey, boundary: OrderPosition): { remove
   if (!scope) return { removed: 0 }
   let removed = 0
   for (const [canonicalId, stored] of scope.entries) {
-    if (compareOrder(stored.entry.position, boundary) <= 0) {
+    if (!isAfterBoundary(stored.entry.position, boundary)) {
       scope.entries.delete(canonicalId)
       for (const alias of stored.aliases) scope.canonicalByAlias.delete(alias)
       removed++

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1494,7 +1494,7 @@ describe('countUnreadInArchive (chat)', () => {
     expect(res!.unread).toBe(3)
   })
 
-  it('missing tiebreak falls back to strict-after-timestamp (over-counts, safe)', async () => {
+  it('missing tiebreak falls back to at-or-after-timestamp (over-counts, safe)', async () => {
     const t = new Date(5000)
     await messageCache.saveMessages([
       createMockMessage(CONV, { id: 'm1', timestamp: t, isOutgoing: false }),
@@ -1583,7 +1583,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     expect(res).toEqual({ unread: 1 })
   })
 
-  it('missing tiebreak falls back to strict-after-timestamp (over-counts, safe)', async () => {
+  it('missing tiebreak falls back to at-or-after-timestamp (over-counts, safe)', async () => {
     const t = new Date(5000)
     await messageCache.saveRoomMessages([
       createMockRoomMessage(ROOM, { id: 'm1', from: `${ROOM}/alice`, timestamp: t, isOutgoing: false }),

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1501,8 +1501,8 @@ describe('countUnreadInArchive (chat)', () => {
       createMockMessage(CONV, { id: 'm2', timestamp: t, isOutgoing: false }),
       createMockMessage(CONV, { id: 'm3', timestamp: new Date(6000), isOutgoing: false }),
     ])
-    // No tiebreak on the pointer (migrated legacy pointer): per compareOrder,
-    // an unresolved key sorts BEFORE any resolved one at an equal timestamp, so BOTH
+    // No tiebreak on the pointer (migrated legacy pointer): per isAfterBoundary,
+    // a keyless boundary means at-or-after its own millisecond, so BOTH
     // m1 (the pointer's own message) and m2 (its same-ms sibling) resolve as "after"
     // the pointer — the read boundary itself gets re-counted rather than a genuinely
     // unread sibling being silently dropped. m3 (a later timestamp) counts regardless.

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -13,9 +13,10 @@ import { getStorageScopeJid } from './storageScope'
 import { roomCanonicalKey, roomIdentityKeys, roomStanzaKey, roomOriginKey } from './roomMessageIdentity'
 import {
   makeCacheOrderKey,
-  compareOrder,
+  isAfterBoundary,
   isRenderableStoredMessage,
   type CacheOrderKey,
+  type ExactPosition,
   type OrderPosition,
 } from '../stores/shared/readState'
 
@@ -850,10 +851,10 @@ export interface UnreadCountArgs {
    * The read pointer's position, for a strict-after-POSITION test rather than a
    * timestamp-only test — two messages can share a millisecond. When
    * `tiebreak` is omitted (a pointer migrated from the pre-#1081 legacy
-   * fields), `compareOrder` treats the pointer's key as unresolved, and an
-   * unresolved key sorts BEFORE any resolved one at an equal timestamp — so
-   * every row at the pointer's exact millisecond, including the pointer's own
-   * message, resolves as "after" the pointer and gets counted. That is
+   * fields), {@link isAfterBoundary} reads the boundary as at-or-after its
+   * timestamp — so every row at the pointer's exact millisecond, including the
+   * pointer's own message, resolves as "after" the pointer and gets counted.
+   * That is
    * at-or-after-TIMESTAMP semantics, not strict-after-timestamp: it over-counts
    * by up to the same-ms sibling set, which is the safe direction (an
    * over-count clears the moment the user reads; an under-count would hide a
@@ -877,12 +878,16 @@ function toPointerPosition(pointer: UnreadCountArgs['pointer']): OrderPosition |
 }
 
 /**
- * Whether an archive row's position sorts strictly after the read pointer. No
- * pointer means everything from `floor` counts. Uses {@link compareOrder} —
- * never hand-roll this comparison, it is the one place total order is defined.
+ * Whether an archive row sorts strictly after the read boundary. No pointer
+ * means everything from `floor` counts.
+ *
+ * This is the COUNTING question, so it uses {@link isAfterBoundary} — a keyless
+ * pointer means at-or-after its millisecond, which over-counts (safe). Never
+ * hand-roll this comparison, and never substitute the advance comparator: its
+ * missing-key rule is the opposite one (#1173).
  */
-function isStrictlyAfterPointer(position: OrderPosition, pointerPosition: OrderPosition | undefined): boolean {
-  return pointerPosition ? compareOrder(position, pointerPosition) > 0 : true
+function isStrictlyAfterPointer(position: ExactPosition, pointerPosition: OrderPosition | undefined): boolean {
+  return pointerPosition ? isAfterBoundary(position, pointerPosition) : true
 }
 
 /**
@@ -925,7 +930,7 @@ export async function countUnreadInArchive(
       if (stored.conversationId === conversationId) {
         const message = deserializeMessage(stored)
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
-          const position: OrderPosition = {
+          const position: ExactPosition = {
             timestamp: stored.timestamp,
             tiebreak: makeCacheOrderKey(message, 'chat'),
           }
@@ -1304,7 +1309,7 @@ export async function getRoomMessageCount(roomJid: string): Promise<number> {
  * Cursors `room_ts_from_id` — `[roomJid, timestamp, from, id]` — forward from
  * `floor`. This is that index's first consumer. The upper bound is
  * `[roomJid, Infinity, '￿', '￿']`; every row in range is visited and
- * adjudicated independently by {@link compareOrder}, so it is the `Infinity`
+ * adjudicated independently by {@link isAfterBoundary}, so it is the `Infinity`
  * in the timestamp slot — not the `'￿'` string sentinels — that makes the
  * bound safe: any finite timestamp compares less than `Infinity`, so the
  * trailing `from`/`id` components are never actually reached. Swapping
@@ -1343,7 +1348,7 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
       if (stored.roomJid === roomJid) {
         const message = deserializeRoomMessage(stored)
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
-          const position: OrderPosition = {
+          const position: ExactPosition = {
             timestamp: stored.timestamp,
             tiebreak: makeCacheOrderKey(message, 'room'),
           }
@@ -1385,7 +1390,7 @@ export async function resolveArchivePosition(
   entityId: string,
   archiveId: string,
   isRoom: boolean
-): Promise<OrderPosition | null> {
+): Promise<ExactPosition | null> {
   const message = isRoom
     ? await getRoomMessageByStanzaId(entityId, archiveId)
     : await getMessageByStanzaId(archiveId)


### PR DESCRIPTION
`compareOrder` answered two questions with one missing-tie-break rule. That rule is correct in one direction and unsafe in the other, and which one you get depends on which side is keyless:

| Question | A missing tie-break must mean | Direction |
|---|---|---|
| "Is this row after the read boundary?" (counting, divider) | at-or-after timestamp | over-count — safe |
| "May the pointer advance to this?" (advance, seen) | strict millisecond, never overtake | under-advance — safe |

Until now the only thing keeping the boundary rule out of the advance path was prose — the doc comment on `isAhead` saying *"Do NOT simplify this to `compareOrder(candidate, current) > 0`"* — plus two keyless control tests. That is not enough: mutation testing during #1170 found two merge blockers where a positional comparison reduced to a key-blind `>=` with the entire suite green, both on this same code path. A comment does not survive a refactor that also deletes its controls.

## What changed

`compareOrder` is deleted, not deprecated. Three functions replace it in `readState.ts`:

| Function | Question | Missing tie-break |
|---|---|---|
| `compareExact(a, b)` | ordering two messages against each other — sorting, picking a newest | **unrepresentable**: both sides must be exact |
| `isAfterBoundary(row, boundary)` | counting / divider | on the boundary → at-or-after timestamp |
| `mayAdvanceTo(candidate, current)` | advance / seen | on either side → strict millisecond |

Enforcement is a new `ExactPosition` (tie-break **required**) refining `OrderPosition` (tie-break optional, because a #1081-migrated pointer genuinely is a floor). `OrderPosition` is not assignable to `ExactPosition`.

Every caller moved to the one matching its question — read at the call site, not guessed:

- **counting / divider** → `isAfterBoundary`: `messageCache.isStrictlyAfterPointer` (both cursor walks), `notificationState.onActivate`, the coverage-reaches-the-floor test in both stores, `transientCounts` / `pruneTransient`, and the MDS publisher's never-publish-ahead-of-the-pointer filter.
- **advance / seen** → `mayAdvanceTo`: `readPointer.isAhead`, `notificationState.onMessageSeen`, `readMarkerSync.resolveAdvance`.
- **message-vs-message** → `compareExact`: `sortMessagesByTimestamp`, the MDS publisher's newest-candidate selection, transient coalescing.