### PR TITLE
fix(muc): submit the hat destroy completion when the server renames the field

### DIFF
--- a/packages/fluux-sdk/src/core/modules/MUC.hats.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.hats.test.ts
@@ -419,6 +419,27 @@ describe('MUC Hat Management (XEP-0317)', () => {
       return mockEl('field', { var: varName, type: 'jid-single', label }, [required])
     }
 
+    /** Build a required text-single field carrying no options and no default value */
+    function textField(varName: string, label: string): MockChild {
+      const required = mockEl('required', {})
+      return mockEl('field', { var: varName, type: 'text-single', label }, [required])
+    }
+
+    /** Read the submitted `<x/>` of an IQ recorded by the mock transport */
+    function submittedFields(callIndex: number): Map<string, unknown> | null {
+      const iq = mockXmppClientInstance.iqCaller.request.mock.calls[callIndex][0]
+      const command = iq.children[0]
+      const dataForm = command.children.find((c: { name: string }) => c.name === 'x')
+      if (!dataForm) return null
+      const fields = dataForm.children.filter((c: { name: string }) => c.name === 'field')
+      return new Map(
+        fields.map((f: { attrs: { var: string }; children: Array<{ children: unknown[] }> }) => {
+          const value = f.children[0]?.children?.[0]
+          return [f.attrs.var, value]
+        })
+      )
+    }
+
     it('should map original field values to server form fields when names differ', async () => {
       await connectClient()
 
@@ -473,6 +494,90 @@ describe('MUC Hat Management (XEP-0317)', () => {
 
       // `hats#uri` should NOT be present (server didn't use this field name)
       expect(fieldMap.has('hats#uri')).toBe(false)
+    })
+
+    /**
+     * ejabberd 26.01–26.04 answer the destroy command with a single `text-single`
+     * field named `hat`, carrying no options and no default value. None of the
+     * name, option or jid strategies can fill it, so the completion used to go out
+     * with no `<x/>` at all — which the room process could not parse (#1198).
+     */
+    it('should map the only original value onto the only unmatched server field', async () => {
+      await connectClient()
+
+      const serverForm = executingResponse('session-destroy', [
+        textField('hat', 'Hat URI'),
+      ])
+
+      mockXmppClientInstance.iqCaller.request
+        .mockResolvedValueOnce(serverForm)
+        .mockResolvedValueOnce(emptyResultResponse())
+
+      await xmppClient.muc.destroyHat('room@conference.example.com', 'urn:hat:mod')
+
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(2)
+
+      const completeIq = mockXmppClientInstance.iqCaller.request.mock.calls[1][0]
+      const command = completeIq.children[0]
+      expect(command.attrs.action).toBe('complete')
+      expect(command.attrs.sessionid).toBe('session-destroy')
+
+      // The completion must carry a submit form, not an empty <command/>
+      const fieldMap = submittedFields(1)
+      expect(fieldMap).not.toBeNull()
+      expect(fieldMap!.get('hat')).toBe('urn:hat:mod')
+      // The client's own field name is not what the server asked for
+      expect(fieldMap!.has('hats#uri')).toBe(false)
+    })
+
+    it('should still fill server fields by exact name (create)', async () => {
+      await connectClient()
+
+      // ejabberd's create form reuses the client's own var names
+      const serverForm = executingResponse('session-create', [
+        textField('hats#uri', 'Hat URI'),
+        textField('hats#title', 'Hat title'),
+        textField('hats#hue', 'Hat hue'),
+      ])
+
+      mockXmppClientInstance.iqCaller.request
+        .mockResolvedValueOnce(serverForm)
+        .mockResolvedValueOnce(emptyResultResponse())
+
+      await xmppClient.muc.createHat('room@conference.example.com', 'Moderator', 'urn:hat:mod', 210)
+
+      const fieldMap = submittedFields(1)
+      expect(fieldMap).not.toBeNull()
+      expect(fieldMap!.get('hats#uri')).toBe('urn:hat:mod')
+      expect(fieldMap!.get('hats#title')).toBe('Moderator')
+      expect(fieldMap!.get('hats#hue')).toBe('210')
+    })
+
+    it('should not guess when several server fields and several values are unmatched', async () => {
+      await connectClient()
+
+      // Neither field matches by name, neither carries options, neither is jid-single,
+      // and two original values are unused — the mapping is ambiguous, so the
+      // positional rule must stay out of it rather than pair them arbitrarily.
+      const serverForm = executingResponse('session-ambiguous', [
+        textField('alpha', 'Alpha'),
+        textField('beta', 'Beta'),
+      ])
+
+      mockXmppClientInstance.iqCaller.request
+        .mockResolvedValueOnce(serverForm)
+        .mockResolvedValueOnce(emptyResultResponse())
+
+      await xmppClient.muc.assignHat(
+        'room@conference.example.com',
+        'user@example.com',
+        'urn:hat:mod',
+      )
+
+      const fieldMap = submittedFields(1)
+      const submitted = fieldMap ? [...fieldMap.values()] : []
+      expect(submitted).not.toContain('user@example.com')
+      expect(submitted).not.toContain('urn:hat:mod')
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -2447,6 +2447,10 @@ export class MUC extends BaseModule {
    * 2. For list-single/list-multi fields: find an original value among the
    *    field's options
    * 3. For jid-single fields: use a jid value from the original fields
+   *
+   * A renamed plain `text-single` matches none of those, which is how the
+   * destroy command used to submit an empty form (see the positional rule
+   * below).
    */
   private buildCompletionFields(
     command: Element,
@@ -2499,6 +2503,20 @@ export class MUC extends BaseModule {
       if (field.value && !Array.isArray(field.value)) {
         result[field.var] = field.value
       }
+    }
+
+    // 5. Last resort: a renamed field carrying neither options nor a default
+    // (ejabberd 26.01-26.04 answer the destroy command with a bare
+    // `text-single` named `hat`). Pair it up only when the mapping is
+    // unambiguous — exactly one field left to fill and exactly one value left
+    // to place. Anything else stays unfilled rather than guessed.
+    const unmatched = serverForm.fields.filter(
+      field => field.var && field.var !== 'FORM_TYPE' && result[field.var] === undefined
+    )
+    const usedValues = Object.values(result)
+    const unusedValues = originalValues.filter(value => !usedValues.includes(value))
+    if (unmatched.length === 1 && unusedValues.length === 1) {
+      result[unmatched[0].var] = unusedValues[0]
     }
 
     return result


### PR DESCRIPTION
Deleting a hat appeared to work and then reverted: the row spun the "deleting" spinner, the hat came back, and nothing explained why.

`buildCompletionFields` fills the XEP-0050 completion form by exact var name, by matching an original value against a list field's options, or through a `jid-single` special case. ejabberd 26.01-26.04 answer the destroy command with a single `text-single` field named `hat` carrying no options and no default value, which matches none of those. The client therefore sent the completion with no data form at all.

This adds a final positional rule: when exactly one server field is still unfilled and exactly one original value is still unused, pair them. Ambiguous forms are left unfilled rather than guessed, so the rule cannot invent a mapping.

Three things worth knowing about the defect:

**It is server-version-bound.** ejabberd 26.01-26.04 present the bare `text-single` form. 26.07 fixed its half in ejabberd commit 7131a86 by making the field a `list-single` with options, which the existing option-matching strategy already handles. The client fix is still needed for anyone on the affected releases, and for any future server that presents a form we cannot otherwise map.

**The command was not rejected.** The empty completion crashed the ejabberd room process with `function_clause`, so no IQ reply was ever sent and the client hung for the full 30s timeout before failing. That is why it looked like "deleting, then reverting" rather than an error. That crash path is a separate server-side gap from commit 7131a86 - the missing `XData /= undefined` guard at `mod_muc_room.erl:5038-5042` covers only the create alternative - and it has been reported upstream and confirmed for a future release.

**The word "previously" in the issue is refuted.** Hat age, server restart, assignment state and exotic URIs were all tested against an affected server and fail identically. Every hat deletion fails there; there is nothing special about older hats.

Creation was never affected because ejabberd's create form reuses the client's own var names, and assignment was never affected because its `hat` field carries options. Destroy was the only hat command with no viable strategy.

The `destroyHat` test previously mocked a `completed` response, so the two-step branch was never entered, and the multi-step test only covered assignment. The added tests close both gaps and pin the ambiguous case.

The 30s ad-hoc command timeout and the generic error wording are left alone and tracked separately.

Closes #1198
