### PR TITLE
refactor(read-state): rename the persisted tie-break to `tiebreak`, reading the old name

### DIFF
--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
@@ -226,14 +226,13 @@ describe('StateSnapshot', () => {
       await snapshot.flush()
 
       const [persisted] = adapterData.store.get('user@example.com')!.rooms as Array<{
-        readPointer?: { messageId: string; timestamp: number; archiveOrderKey?: unknown }
+        readPointer?: { messageId: string; timestamp: number; tiebreak?: unknown }
       }>
       // The tie-break's `id` is NOT persisted: it is `messageId`, and storing a
       // second copy made a disagreement representable on disk. Only `from`,
       // which the pointer cannot reconstruct, rides through. The persisted
-      // property keeps its historical name `archiveOrderKey`; only the
-      // in-memory field is `tiebreak`.
-      expect(persisted?.readPointer?.archiveOrderKey).toEqual({
+      // property name matches the in-memory field.
+      expect(persisted?.readPointer?.tiebreak).toEqual({
         kind: 'room',
         from: 'room@conf.example.com/alice',
       })

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -195,15 +195,15 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     expect(spy).toHaveBeenCalledWith(CID)
     // Assert the KEY, not just that a recount was scheduled. The fixture above
-    // is a real on-disk blob, so it has to carry the PERSISTED property name
-    // `archiveOrderKey` — the in-memory field is `tiebreak`, and
-    // `deserializeReadPointer` deliberately ignores that never-written name. A
-    // fixture written under the wrong name still restores a pointer, just a
-    // KEYLESS one, so a test that only checks the recount stays green while the
-    // hydrated position silently degrades to the at-or-after-timestamp
-    // fallback. This assertion is what makes that failure loud: the `id` is
-    // reconstructed from `messageId`, so a keyed hydration is only possible
-    // when the fixture used the on-disk name.
+    // is a real on-disk blob written by a build BEFORE the tie-break's on-disk
+    // rename, so it carries the historical name `archiveOrderKey` — which
+    // `deserializeReadPointer` still reads through its documented fallback. A
+    // fixture whose key name no reader recognises still restores a pointer,
+    // just a KEYLESS one, so a test that only checks the recount stays green
+    // while the hydrated position silently degrades to the
+    // at-or-after-timestamp fallback. This assertion is what makes that failure
+    // loud: the `id` is reconstructed from `messageId`, so a keyed hydration is
+    // only possible when the stored name was actually recognised.
     expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.tiebreak).toEqual({
       kind: 'chat',
       id: 'p0',

--- a/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
@@ -97,7 +97,7 @@ const STORAGE_KEY = buildScopedStorageKey('xmpp-chat-storage', JID)
 interface LegacyMeta {
   lastSeenMessageId?: string
   lastReadAt?: string
-  readPointer?: { messageId: string; timestamp: number; archiveOrderKey?: unknown }
+  readPointer?: { messageId: string; timestamp: number; tiebreak?: unknown; archiveOrderKey?: unknown }
   unreadCount?: number
 }
 
@@ -240,7 +240,7 @@ describe('post-rehydrate readPointer backfill', () => {
   // directly rather than assumed from the plain messageId/timestamp case above.
   it('round-trips a persisted tiebreak through the new-format deserialize branch', async () => {
     persistConversations([
-      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'chat', id: 'm2' } } }],
+      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
@@ -282,26 +282,30 @@ describe('post-rehydrate readPointer backfill', () => {
   // A malformed persisted key must be DROPPED at this real persistence surface
   // too, not just at the deserializeReadPointer unit level — the pointer itself
   // (messageId/timestamp) survives.
-  // The chat blob is a verbatim JSON.stringify of the live objects, so renaming
-  // the in-memory field would leak the new name to disk and orphan every stored
-  // pointer. The persisted property stays `archiveOrderKey`.
-  it('persists the tie-break under its on-disk name, not the in-memory one', async () => {
+  // The on-disk rename, at the real persistence surface: a blob written under
+  // the historical name hydrates through the fallback, and the very next
+  // persist re-emits it under `tiebreak` alone. This is also what makes the
+  // fallback's removal condition true in practice — the whole blob is rewritten,
+  // so one persist sheds the old name for the entire account.
+  it('rewrites a pointer stored under the historical name under `tiebreak`', async () => {
     persistConversations([
       [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'chat', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
+    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+
     chatStore.setState((state) => ({ conversationMeta: new Map(state.conversationMeta) }))
     flushThrottledStorage()
 
     const onDisk = diskEntry('conversationMeta', CONV).readPointer as Record<string, unknown>
-    expect(onDisk.archiveOrderKey).toEqual({ kind: 'chat', id: 'm2' })
-    expect('tiebreak' in onDisk).toBe(false)
+    expect(onDisk.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+    expect('archiveOrderKey' in onDisk).toBe(false)
   })
 
   it('drops a malformed persisted tiebreak but keeps the rest of the pointer', async () => {
     persistConversations([
-      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'room', id: 'm2' } } }],
+      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, tiebreak: { kind: 'room', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -54,8 +54,6 @@ import {
   advance,
   deserializeReadPointer,
   makeReadPointer,
-  toPersistedReadPointer,
-  type PersistedReadPointer,
   type ReadPointer,
 } from './shared/readPointer'
 import * as notifState from './shared/notificationState'
@@ -627,15 +625,14 @@ interface LegacyReadState {
 }
 
 /**
- * On disk the pointer's tie-break keeps its historical property name
- * `archiveOrderKey`; only the in-memory field is `tiebreak`. This blob is a
- * verbatim `JSON.stringify` of the live objects, so the boundary has to be in
- * the persisted TYPE as well as in the value (see {@link PersistedReadPointer}).
+ * This blob is a verbatim `JSON.stringify` of the live objects, so the pointer
+ * goes to disk in its in-memory shape: `tiebreak` under its own name, keeping
+ * its `id`, and `timestamp` as an ISO string. That differs from
+ * `serializeReadPointer`'s epoch-ms, id-less form used by room read state and
+ * the state snapshot; `deserializeReadPointer` reads both.
  */
-type PersistedConversationMetadata = Omit<ConversationMetadata, 'readPointer'> &
-  PersistedReadState & { readPointer?: PersistedReadPointer }
-type PersistedConversation = Omit<Conversation, 'readPointer'> &
-  PersistedReadState & { readPointer?: PersistedReadPointer }
+type PersistedConversationMetadata = ConversationMetadata & PersistedReadState
+type PersistedConversation = Conversation & PersistedReadState
 
 /**
  * Legacy read state still waiting to become a `readPointer`, keyed by the
@@ -716,16 +713,12 @@ interface PersistedState {
 function withUnmigratedReadState<T extends { readPointer?: ReadPointer }>(
   entries: Map<string, T>,
   legacy: Map<string, LegacyReadState> | undefined
-): [string, Omit<T, 'readPointer'> & PersistedReadState & { readPointer?: PersistedReadPointer }][] {
-  // Every entry passes through `onDisk` so the pointer is written under its
-  // on-disk property name (see {@link PersistedReadPointer}).
-  const onDisk = (value: T): Omit<T, 'readPointer'> & { readPointer?: PersistedReadPointer } =>
-    value.readPointer ? { ...value, readPointer: toPersistedReadPointer(value.readPointer) } : value
-  if (!legacy || legacy.size === 0) return Array.from(entries.entries(), ([id, value]) => [id, onDisk(value)])
-  const out: [string, Omit<T, 'readPointer'> & PersistedReadState & { readPointer?: PersistedReadPointer }][] = []
+): [string, T & PersistedReadState][] {
+  if (!legacy || legacy.size === 0) return Array.from(entries.entries())
+  const out: [string, T & PersistedReadState][] = []
   for (const [id, value] of entries) {
     const carry = value.readPointer ? undefined : legacy.get(id)
-    out.push(carry ? [id, { ...onDisk(value), ...carry }] : [id, onDisk(value)])
+    out.push(carry ? [id, { ...value, ...carry }] : [id, value])
   }
   return out
 }

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -420,11 +420,15 @@ describe('an old build reading the renamed on-disk form', () => {
     expect(isAhead(sameMsCandidate, seenByOldBuild)).toBe(false)
     expect(advance(seenByOldBuild, sameMsCandidate)).toBe(seenByOldBuild)
 
-    // Same-position comparison over the two: the keyless (old-build) view sorts
-    // FIRST, i.e. at or behind the position actually stored — never ahead of it.
+    // And the counting side of the same degradation: against the KEYLESS
+    // boundary an old build restored, the very message the pointer names still
+    // reads as after the boundary — so it is counted unread again. That is the
+    // at-or-after-timestamp over-count, which a read clears. `stored` comes from
+    // `makeReadPointer`, which always resolves a tie-break, so it is an
+    // ExactPosition; only the boundary may be keyless.
     expect(
       isAfterBoundary(
-        { timestamp: stored.timestamp.getTime(), tiebreak: stored.tiebreak },
+        { timestamp: stored.timestamp.getTime(), tiebreak: stored.tiebreak! },
         { timestamp: seenByOldBuild.timestamp.getTime(), tiebreak: seenByOldBuild.tiebreak }
       )
     ).toBe(true)

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -7,7 +7,7 @@ import {
   deserializeReadPointer,
 } from './readPointer'
 import type { ReadPointer } from './readPointer'
-import { isValidCacheOrderKey } from './readState'
+import { isAfterBoundary, isValidCacheOrderKey } from './readState'
 
 const at = (ms: number) => new Date(ms)
 
@@ -152,7 +152,7 @@ describe('serialization', () => {
   // through into ordering comparisons. Dropping only the key (not the whole
   // pointer) keeps the id/timestamp that are otherwise fine.
   it('drops a malformed persisted tiebreak instead of trusting it', () => {
-    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, archiveOrderKey: { kind: 'room', id: 'x' } })
+    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, tiebreak: { kind: 'room', id: 'x' } })
     expect(back!.tiebreak).toBeUndefined() // missing `from` → invalid → dropped
     expect(back!.messageId).toBe('m') // the pointer itself survives
   })
@@ -174,12 +174,12 @@ describe('serialization', () => {
 describe('serialization: the tie-break id is not persisted', () => {
   it('omits `id` from a persisted chat key', () => {
     const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    expect(serializeReadPointer(p).archiveOrderKey).toEqual({ kind: 'chat' })
+    expect(serializeReadPointer(p).tiebreak).toEqual({ kind: 'chat' })
   })
 
   it('omits `id` from a persisted room key but keeps `from` (the room tie-break needs it)', () => {
     const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    expect(serializeReadPointer(p).archiveOrderKey).toEqual({ kind: 'room', from: 'room@x/nick' })
+    expect(serializeReadPointer(p).tiebreak).toEqual({ kind: 'room', from: 'room@x/nick' })
   })
 
   it('no persisted pointer carries an id beside the messageId', () => {
@@ -187,7 +187,7 @@ describe('serialization: the tie-break id is not persisted', () => {
     const room = makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room')
     for (const p of [chat, room]) {
       const onDisk = JSON.parse(JSON.stringify(serializeReadPointer(p)))
-      expect(onDisk.archiveOrderKey).not.toHaveProperty('id')
+      expect(onDisk.tiebreak).not.toHaveProperty('id')
     }
   })
 
@@ -267,12 +267,14 @@ describe('serialization: the tie-break id is not persisted', () => {
   // build DROPS the key and degrades to the documented at-or-after-timestamp
   // fallback, which over-counts — the safe, recoverable direction. Asserted
   // here rather than assumed, because shipping a format an older build
-  // mis-read in the unsafe direction would be unrecoverable.
+  // mis-read in the unsafe direction would be unrecoverable. Since the on-disk
+  // rename, an old build does not even find this value; the guard is asserted
+  // anyway so the id-less form stays independently unreadable by it.
   it('an old build drops the new id-less key rather than mis-reading it', () => {
     const chat = serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))
     const room = serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room'))
-    expect(isValidCacheOrderKey(chat.archiveOrderKey)).toBe(false)
-    expect(isValidCacheOrderKey(room.archiveOrderKey)).toBe(false)
+    expect(isValidCacheOrderKey(chat.tiebreak)).toBe(false)
+    expect(isValidCacheOrderKey(room.tiebreak)).toBe(false)
   })
 
   // The pointer itself must still load on an old build: only the key degrades.
@@ -291,45 +293,148 @@ describe('serialization: the tie-break id is not persisted', () => {
     ['a room key with no from', { kind: 'room' }],
     ['a room key with a non-string from', { kind: 'room', from: 7 }],
     ['a non-object key', 'chat'],
-  ])('drops %s', (_label, archiveOrderKey) => {
-    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, archiveOrderKey })
+  ])('drops %s', (_label, tiebreak) => {
+    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, tiebreak })
     expect(back!.tiebreak).toBeUndefined()
     expect(back!.messageId).toBe('m')
   })
 })
 
-// The in-memory field is `tiebreak`; the PERSISTED property is still
-// `archiveOrderKey`. Renaming the on-disk name would orphan every stored
-// pointer, so it is deliberately unchanged — asserted against literal JSON so
-// the format cannot drift with the next rename.
-describe('the on-disk property name is not renamed with the field', () => {
-  it('writes the exact bytes the previous build wrote', () => {
+// The on-disk property is now `tiebreak`, matching the in-memory field. The
+// historical name `archiveOrderKey` is still READ, never written — see the
+// removal condition documented at the fallback in `deserializeReadPointer`.
+describe('the on-disk tie-break property', () => {
+  it('writes only `tiebreak`, never the historical name', () => {
     expect(JSON.stringify(serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))))
-      .toBe('{"messageId":"m1","timestamp":1000,"archiveOrderKey":{"kind":"chat"}}')
+      .toBe('{"messageId":"m1","timestamp":1000,"tiebreak":{"kind":"chat"}}')
 
     expect(
       JSON.stringify(
         serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'))
       )
-    ).toBe('{"messageId":"m2","timestamp":2000,"archiveOrderKey":{"kind":"room","from":"room@x/nick"}}')
+    ).toBe('{"messageId":"m2","timestamp":2000,"tiebreak":{"kind":"room","from":"room@x/nick"}}')
   })
 
-  it('never writes the in-memory name to disk', () => {
+  it('never writes the historical name to disk', () => {
     const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    expect(JSON.stringify(serializeReadPointer(p))).not.toContain('tiebreak')
+    expect(JSON.stringify(serializeReadPointer(p))).not.toContain('archiveOrderKey')
   })
 
-  it('hydrates a pointer stored by the previous build', () => {
-    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat' } })).toEqual({
+  // Rename compatibility 1 — NEW build, OLD data. A pointer written under the
+  // historical name is found by the fallback and hydrates identically to one
+  // written under the new name. Lossless: nothing degrades, nothing is rewritten.
+  it.each([
+    ['chat', { kind: 'chat' }, { kind: 'chat', id: 'm1' }],
+    ['room', { kind: 'room', from: 'room@x/nick' }, { kind: 'room', from: 'room@x/nick', id: 'm1' }],
+  ])('reads a %s pointer stored under the historical name (lossless)', (_label, onDiskKey, expected) => {
+    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: onDiskKey })).toEqual({
       messageId: 'm1',
       timestamp: at(1000),
-      tiebreak: { kind: 'chat', id: 'm1' },
+      tiebreak: expected,
     })
+    // ...and identically to the same key stored under the new name.
+    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: onDiskKey })).toEqual(
+      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, tiebreak: onDiskKey })
+    )
   })
 
-  it('ignores a pointer stored under the in-memory name (never a written format)', () => {
+  it('prefers `tiebreak` when a blob somehow carries both names', () => {
     expect(
-      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, tiebreak: { kind: 'chat' } })!.tiebreak
-    ).toBeUndefined()
+      deserializeReadPointer({
+        messageId: 'm1',
+        timestamp: 1000,
+        tiebreak: { kind: 'chat' },
+        archiveOrderKey: { kind: 'room', from: 'stale@x/nick' },
+      })!.tiebreak
+    ).toEqual({ kind: 'chat', id: 'm1' })
+  })
+
+  // Rename compatibility 3 — new build writes, new build reads. Unchanged.
+  it('round-trips a pointer written and read by this build', () => {
+    for (const p of [
+      makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'),
+      makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'),
+    ]) {
+      expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
+    }
+  })
+})
+
+// Rename compatibility 2 — OLD build, NEW data. This is the direction that
+// matters: an older build looks for `archiveOrderKey` and only for that, so it
+// finds nothing. Asserted against a replica of that build's read rather than
+// assumed, because a format an old build mis-read in the UNSAFE direction (an
+// over-advanced forward-only pointer) would be unrecoverable.
+describe('an old build reading the renamed on-disk form', () => {
+  /**
+   * How every build before the rename read the tie-break: `raw.archiveOrderKey`
+   * through the hydration step. Both halves are reproduced here — a test that
+   * only asserted "the property is absent" would not show what the absence
+   * COSTS, which is the whole compatibility claim.
+   */
+  const oldBuildRead = (raw: Record<string, unknown>): ReadPointer | undefined => {
+    const { messageId, timestamp, archiveOrderKey } = raw as {
+      messageId?: string
+      timestamp?: number
+      archiveOrderKey?: unknown
+    }
+    if (typeof messageId !== 'string' || typeof timestamp !== 'number') return undefined
+    // The old hydration reconstructed the id from `messageId` exactly as today's
+    // does; what it could not do is look under any other property name.
+    const k = archiveOrderKey && typeof archiveOrderKey === 'object' ? (archiveOrderKey as Record<string, unknown>) : undefined
+    const tiebreak =
+      k?.kind === 'chat'
+        ? ({ kind: 'chat', id: messageId } as const)
+        : k?.kind === 'room' && typeof k.from === 'string'
+          ? ({ kind: 'room', from: k.from, id: messageId } as const)
+          : undefined
+    return { messageId, timestamp: new Date(timestamp), ...(tiebreak ? { tiebreak } : {}) }
+  }
+
+  const onDisk = (p: ReadPointer) => JSON.parse(JSON.stringify(serializeReadPointer(p)))
+
+  it('still loads the read position itself — only the tie-break is lost', () => {
+    for (const p of [
+      makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'),
+      makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'),
+    ]) {
+      const seen = oldBuildRead(onDisk(p))!
+      expect(seen.messageId).toBe(p.messageId)
+      expect(seen.timestamp).toEqual(p.timestamp)
+      expect(seen.tiebreak).toBeUndefined()
+    }
+  })
+
+  // The consequence, stated as behaviour rather than as a missing property: a
+  // keyless pointer cannot be overtaken by a same-millisecond candidate, so the
+  // forward-only position UNDER-advances. That is the at-or-after-timestamp
+  // fallback — it over-counts unread, which a read clears. The unsafe direction
+  // would be an over-advanced pointer, which nothing can recover.
+  it('degrades in the over-count direction, never the over-advance direction', () => {
+    const stored = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const seenByOldBuild = oldBuildRead(onDisk(stored))!
+    const sameMsCandidate = makeReadPointer({ id: 'm2-later-id', timestamp: at(1000) }, 'chat')
+
+    // A keyed candidate sharing the millisecond does NOT overtake the keyless
+    // pointer the old build restored.
+    expect(isAhead(sameMsCandidate, seenByOldBuild)).toBe(false)
+    expect(advance(seenByOldBuild, sameMsCandidate)).toBe(seenByOldBuild)
+
+    // Same-position comparison over the two: the keyless (old-build) view sorts
+    // FIRST, i.e. at or behind the position actually stored — never ahead of it.
+    expect(
+      isAfterBoundary(
+        { timestamp: stored.timestamp.getTime(), tiebreak: stored.tiebreak },
+        { timestamp: seenByOldBuild.timestamp.getTime(), tiebreak: seenByOldBuild.tiebreak }
+      )
+    ).toBe(true)
+  })
+
+  // The old build's own key guard would have rejected the value anyway (the
+  // id-less form shipped in the previous step), so nothing about the rename
+  // makes it MORE likely to mis-read the key: it has no key to read at all.
+  it('has no key to validate at all', () => {
+    expect(isValidCacheOrderKey(onDisk(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')).archiveOrderKey))
+      .toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -66,20 +66,17 @@ export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: s
 /**
  * JSON-safe form for localStorage.
  *
- * The persisted property is `archiveOrderKey`, NOT `tiebreak`. The in-memory
- * field was renamed because the key never held an archive id — it is the
- * IndexedDB cursor tie-break built from the CLIENT message id — but the ON-DISK
- * name is deliberately left alone: every stored pointer that has this key
- * carries it as `archiveOrderKey`, and renaming it here would silently orphan
- * those keys, degrading those pointers to the keyless at-or-after-timestamp
- * fallback. Do not "finish
- * the rename" on this side without a migration and its own compatibility
- * argument.
+ * The persisted property is `tiebreak`, matching the in-memory field. Builds
+ * before this one wrote it as `archiveOrderKey` — a name that was always wrong
+ * (the key never held an archive id; it is the IndexedDB cursor tie-break built
+ * from the CLIENT message id). Those blobs are still READ, by the fallback in
+ * {@link deserializeReadPointer}, which is where the condition for eventually
+ * deleting that tolerance is recorded.
  */
 export interface SerializedReadPointer {
   messageId: string
   timestamp: number
-  archiveOrderKey?: SerializedCacheOrderKey
+  tiebreak?: SerializedCacheOrderKey
 }
 
 /** The minimal message shape a pointer can be built from. */
@@ -146,46 +143,23 @@ export function advance(current: ReadPointer | undefined, candidate: ReadPointer
  * {@link SerializedCacheOrderKey}). The in-memory key keeps its full shape;
  * only the on-disk form omits the redundant `id`.
  *
- * An OLDER build reading this format validates the key with the equivalent
- * guard (now called `isValidCacheOrderKey`), which requires
- * `typeof k.id === 'string'` — so it drops the key and degrades to the
- * at-or-after-timestamp fallback, which over-counts rather than under-counts
- * (the safe, recoverable direction). The `messageId` and `timestamp` it needs
- * are untouched.
+ * An OLDER build reading this format finds no tie-break at all: it looks only
+ * under `archiveOrderKey` (and would reject this id-less key anyway, via
+ * `isValidCacheOrderKey`'s `typeof k.id === 'string'` requirement). It
+ * therefore degrades to the at-or-after-timestamp fallback, which over-counts
+ * rather than under-counts — the safe, recoverable direction, since a keyless
+ * pointer can only UNDER-advance. The `messageId` and `timestamp` it needs are
+ * untouched. Asserted in `readPointer.test.ts` against a replica of that
+ * build's read, not assumed.
  */
 export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointer {
   const key = pointer.tiebreak
   return {
     messageId: pointer.messageId,
     timestamp: pointer.timestamp.getTime(),
-    // On-disk name kept as `archiveOrderKey` on purpose — see {@link SerializedReadPointer}.
-    ...(key ? { archiveOrderKey: key.kind === 'room' ? { kind: 'room', from: key.from } : { kind: 'chat' } } : {}),
-  }
-}
-
-/**
- * The pointer as the CHAT storage blob carries it: the live object handed to a
- * plain `JSON.stringify` (so `timestamp` becomes an ISO string on disk, and the
- * tie-break keeps its `id`) — unlike {@link serializeReadPointer}, which is the
- * epoch-ms, id-less form used by room read state and the state snapshot.
- *
- * It exists only to hold the on-disk property name `archiveOrderKey` while the
- * in-memory field is `tiebreak`: the chat store persists its metadata verbatim,
- * so without this the rename would leak to disk and orphan every stored pointer
- * (see {@link SerializedReadPointer}). Nothing else about the shape changes.
- */
-export interface PersistedReadPointer {
-  messageId: string
-  timestamp: Date
-  archiveOrderKey?: CacheOrderKey
-}
-
-/** Rename boundary for the verbatim-persisted chat blob. See {@link PersistedReadPointer}. */
-export function toPersistedReadPointer(pointer: ReadPointer): PersistedReadPointer {
-  return {
-    messageId: pointer.messageId,
-    timestamp: pointer.timestamp,
-    ...(pointer.tiebreak ? { archiveOrderKey: pointer.tiebreak } : {}),
+    // The on-disk name is `tiebreak`, the same as in memory. `archiveOrderKey`
+    // is read back but never written — see {@link deserializeReadPointer}.
+    ...(key ? { tiebreak: key.kind === 'room' ? { kind: 'room', from: key.from } : { kind: 'chat' } } : {}),
   }
 }
 
@@ -220,6 +194,10 @@ function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | 
  * {@link serializeReadPointer} writes epoch ms; the chat storage blob writes an
  * ISO string through its plain `JSON.stringify`.
  *
+ * The tie-break is likewise accepted under either name — `tiebreak` (what we
+ * write) or the historical `archiveOrderKey` — and the condition for eventually
+ * dropping that second name is recorded at the fallback itself.
+ *
  * `tiebreak` is rebuilt by {@link hydrateCacheOrderKey} — never taken
  * verbatim — and DROPPED when what it carries is unusable. Storage is untrusted
  * input, so a corrupt key must not ride through into ordering comparisons.
@@ -230,15 +208,32 @@ function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | 
  */
 export function deserializeReadPointer(raw: unknown): ReadPointer | undefined {
   if (!raw || typeof raw !== 'object') return undefined
-  // `archiveOrderKey` is the on-disk property name, deliberately unchanged by the
-  // in-memory `tiebreak` rename — see {@link SerializedReadPointer}.
-  const { messageId, timestamp, archiveOrderKey } = raw as {
+  const { messageId, timestamp, tiebreak, archiveOrderKey } = raw as {
     messageId?: unknown
     timestamp?: unknown
+    tiebreak?: unknown
     archiveOrderKey?: unknown
   }
   if (typeof messageId !== 'string' || messageId.length === 0) return undefined
-  const validKey = hydrateCacheOrderKey(archiveOrderKey, messageId)
+  // Same shape as the `timestamp` tolerance above: this is the one place that
+  // reads either name back. We still only ever WRITE `tiebreak`; the
+  // `archiveOrderKey` branch is read-only tolerance for blobs written before the
+  // on-disk rename.
+  //
+  // REMOVABLE WHEN storage still holding the old name no longer matters, which
+  // is a bounded condition rather than "forever": every writer re-serializes the
+  // WHOLE blob, not the row that changed — `saveRoomReadState` stringifies the
+  // entire room map, the chat persist adapter re-emits every `conversationMeta`
+  // entry, and the state snapshot re-serializes every room. So the FIRST persist
+  // any build from this one onwards performs sheds `archiveOrderKey` for the
+  // entire account, not merely for the conversation that was read; an account
+  // opened once after upgrading is fully converted, dormant ones are not.
+  // Deleting this branch then costs those dormant pointers their tie-break and
+  // nothing else — `messageId` and `timestamp` still load, so they degrade to
+  // the at-or-after-timestamp fallback (over-count, the recoverable direction),
+  // never to a lost read position. Remove it once that trade is acceptable for
+  // the oldest storage still in the field.
+  const validKey = hydrateCacheOrderKey(tiebreak ?? archiveOrderKey, messageId)
 
   if (typeof timestamp === 'number') {
     return Number.isFinite(timestamp)

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -194,11 +194,13 @@ export function worthReconcilingOnDeactivate(
  *
  * No longer on the hydration path: `deserializeReadPointer` rebuilds the key
  * and takes its `id` from `messageId` instead of validating a persisted one.
- * It is kept because it still describes how an OLDER build reads today's
- * on-disk form — the `typeof k.id === 'string'` requirement is what makes an
- * old build drop the new id-less key and degrade to the at-or-after-timestamp
- * fallback (over-count, the safe direction) instead of mis-reading it. That
- * compatibility claim is asserted against this function in `readPointer.test.ts`.
+ * It is kept because it describes an OLDER build's second line of defence
+ * against today's on-disk form: since the tie-break's rename that build no
+ * longer even finds the property (it reads `archiveOrderKey` only), and the
+ * `typeof k.id === 'string'` requirement here would reject the id-less key had
+ * it found one. Either way it degrades to the at-or-after-timestamp fallback
+ * (over-count, the safe direction) rather than mis-reading the key. Both halves
+ * of that compatibility claim are asserted in `readPointer.test.ts`.
  */
 export function isValidCacheOrderKey(v: unknown): v is CacheOrderKey {
   if (!v || typeof v !== 'object') return false

--- a/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
@@ -144,4 +144,55 @@ describe('room read-state persistence', () => {
     )
     expect(loadRoomReadState(JID).has('r@c')).toBe(false)
   })
+
+  // The tie-break's on-disk rename at the room persistence surface. Rows written
+  // by a build before the rename carry `archiveOrderKey` and must still load
+  // with their key intact — losing it here would silently downgrade a real read
+  // position to the at-or-after-timestamp fallback for every room of every
+  // account that upgraded.
+  it('loads a room row written under the historical tie-break name', () => {
+    localStorage.setItem(
+      getRoomReadStateStorageKey(JID),
+      JSON.stringify([
+        ['r@c', { readPointer: { messageId: 'm7', timestamp: 7000, archiveOrderKey: { kind: 'room', from: 'r@c/alice' } } }],
+      ])
+    )
+
+    expect(loadRoomReadState(JID).get('r@c')?.readPointer).toEqual({
+      messageId: 'm7',
+      timestamp: at(7000),
+      tiebreak: { kind: 'room', from: 'r@c/alice', id: 'm7' },
+    })
+  })
+
+  // ...and the evidence behind the fallback's removal condition: a save
+  // re-serializes the WHOLE map, so one write sheds the historical name for
+  // every room of the account, not only the room whose pointer moved.
+  it('a single save rewrites every room under the new name', () => {
+    localStorage.setItem(
+      getRoomReadStateStorageKey(JID),
+      JSON.stringify([
+        ['moved@c', { readPointer: { messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'room', from: 'moved@c/alice' } } }],
+        ['untouched@c', { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'room', from: 'untouched@c/bob' } } }],
+      ])
+    )
+
+    const state = loadRoomReadState(JID)
+    // Only one room advances — the other is never touched this session.
+    state.set('moved@c', {
+      readPointer: makeReadPointer({ id: 'm9', from: 'moved@c/alice', timestamp: at(9000) }, 'room'),
+    })
+    saveRoomReadState(state, JID)
+    flush()
+
+    const written = localStorage.getItem(getRoomReadStateStorageKey(JID))!
+    expect(written).not.toContain('archiveOrderKey')
+    expect(written).toContain('tiebreak')
+    // The untouched room kept its position; only the property name changed.
+    expect(loadRoomReadState(JID).get('untouched@c')?.readPointer).toEqual({
+      messageId: 'm2',
+      timestamp: at(2000),
+      tiebreak: { kind: 'room', from: 'untouched@c/bob', id: 'm2' },
+    })
+  })
 })


### PR DESCRIPTION
The read pointer's tie-break was written to disk as `archiveOrderKey` while the in-memory field was `tiebreak`. That mismatch was deliberate: renaming it in #1200 would have orphaned every stored pointer, so it was left for a change that could carry its own compatibility argument. This is that change.

`serializeReadPointer` and the chat storage blob now write `tiebreak` and nothing else. `deserializeReadPointer` reads either name, preferring the new one, following the same shape as its existing epoch-ms/ISO-string tolerance for `timestamp`.

The fallback carries its removal condition in a comment at the call site rather than only here. Every writer re-serializes the whole blob rather than the row that changed — `saveRoomReadState` stringifies the entire room map, the chat persist adapter re-emits every `conversationMeta` entry, and the state snapshot re-serializes every room — so the first persist after upgrading sheds the old name for an entire account, not just the conversation that was read. Only accounts never opened since the upgrade retain it, and deleting the branch later costs those pointers their tie-break and nothing else.

`toPersistedReadPointer` and `PersistedReadPointer` existed only to hold the divergent on-disk name and are gone; the chat blob persists the live shape. No stored read position is moved — only the property name changes.

### Compatibility

- **New build, old data** — the fallback finds `archiveOrderKey` and hydrates identically to the new name. Lossless.
- **Old build, new data** — an older build looks only under `archiveOrderKey`, finds nothing, and degrades to the at-or-after-timestamp fallback: it over-counts unread, which a read clears. It never over-advances the forward-only pointer, the direction that would be unrecoverable. Asserted against a replica of the pre-rename read rather than assumed, including the behavioural consequence on both sides (`mayAdvanceTo` refuses to overtake; `isAfterBoundary` counts the named message again).
- **New build, new data** — round-trips unchanged.

### Provenance

Validated through the local gate, which passed clean with 0 findings across review, test, document and lint. #1205 merged mid-run and deleted `compareOrder`, which one of the new tests imported, so the run's rebase step resolved that conflict and re-expressed the assertion in terms of `isAfterBoundary`. Custody of that validated commit was then stuck — it survived only as an unreferenced object in the gate — so it was recovered from there by hand rather than re-derived. A reviewer seeing that unusual provenance should not have to guess at it.

The follow-up commit fixes a type error in the recovered commit: `isAfterBoundary` requires an `ExactPosition` row, which the gate's test step did not catch because vitest does not typecheck. `npm run typecheck`, `npm test` and `npm run lint` are clean locally.
