### PR TITLE
feat: tell a lagging unread badge apart from one that stayed wrong

### DIFF
--- a/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
@@ -181,6 +181,20 @@ describe('every fan-out record survives the privacy gate', () => {
       unreadCount: 3,
       heldMs: 2000,
     },
+    {
+      name: 'read-state/unread-persists',
+      kind: 'conversation',
+      id: 'bob@x.tld',
+      heldMs: 30_000,
+      peakUnread: 21,
+    },
+    {
+      name: 'read-state/unread-focus-cleared',
+      kind: 'conversation',
+      id: 'bob@x.tld',
+      heldMs: 10_000,
+      peakUnread: 21,
+    },
     { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
     { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'msg-1' },
   ]
@@ -345,6 +359,52 @@ describe('stage-3 detector mappings', () => {
     }
   })
 
+  it('maps persistence to a bug, unlike the suspect that opened the episode', () => {
+    // The severity step is the point: 2s is a plausible propagation delay, 30s of the
+    // user looking straight at the message is not.
+    const record = recordForSignal({
+      name: 'read-state/unread-persists',
+      kind: 'conversation',
+      id: 'bob@x.tld',
+      heldMs: 30_000,
+      peakUnread: 21,
+    })
+    expect(record?.id.s).toBe('read-state/unread-persists')
+    expect(record?.sev).toBe('bug')
+    expect(record?.observed).toBe(30_000)
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['conv', 'peak'])
+  })
+
+  it('maps an episode close to the duration, with the peak as context', () => {
+    const record = recordForSignal({
+      name: 'read-state/unread-focus-cleared',
+      kind: 'conversation',
+      id: 'bob@x.tld',
+      heldMs: 10_000,
+      peakUnread: 21,
+    })
+
+    expect(record?.id.s).toBe('read-state/unread-focus-cleared')
+    // `drift`: it measures an episode, it does not complain about one.
+    expect(record?.sev).toBe('drift')
+    expect(record?.observed).toBe(10_000)
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['conv', 'peak'])
+    expect(record?.ctx?.find(([k]) => k.s === 'peak')?.[1]).toBe(21)
+  })
+
+  it('closes a room episode in the room namespace', async () => {
+    await warmRoom('muc@conf.x.tld')
+    const record = recordForSignal({
+      name: 'read-state/unread-focus-cleared',
+      kind: 'room',
+      id: 'muc@conf.x.tld',
+      heldMs: 5000,
+      peakUnread: 3,
+    })
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['room', 'peak'])
+    expect((record!.ctx![0][1] as { s: string }).s).not.toBe('c:unresolved')
+  })
+
   it('maps a FAB-at-live-edge to the measured distance', () => {
     const record = recordForSignal({
       name: 'scroll/fab-at-live-edge',
@@ -409,6 +469,20 @@ describe('FANOUT_IDS', () => {
             id: 'bob@x.tld',
             unreadCount: 3,
             heldMs: 2000,
+          },
+          {
+            name: 'read-state/unread-persists',
+            kind: 'conversation',
+            id: 'bob@x.tld',
+            heldMs: 30_000,
+            peakUnread: 21,
+          },
+          {
+            name: 'read-state/unread-focus-cleared',
+            kind: 'conversation',
+            id: 'bob@x.tld',
+            heldMs: 10_000,
+            peakUnread: 21,
           },
           { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
           { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'm' },

--- a/apps/fluux/src/anomaly/detectors/signalRecords.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.ts
@@ -153,6 +153,42 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
         ],
       }
 
+    case 'read-state/unread-persists':
+      // `bug`, where the 2s record is only `suspect`. After this long with the user
+      // looking straight at the message, a mark-read that has not landed is not a
+      // propagation delay — it did not happen.
+      return {
+        id: ID.unreadPersists,
+        sev: 'bug',
+        expected: 0,
+        observed: signal.heldMs,
+        ctx: [
+          signal.kind === 'room'
+            ? [CTX.room, roomToken(signal.id)]
+            : [CTX.conv, convToken(signal.id)],
+          [CTX.peak, signal.peakUnread],
+        ],
+      }
+
+    case 'read-state/unread-focus-cleared':
+      // `drift`, not `suspect`: this is the MEASUREMENT that closes an episode the
+      // `suspect` record already opened, not a second complaint about it. Pairing the
+      // two by conversation gives the observed recovery time; `unread-persists` is the
+      // separate proof that the count stayed wrong. No close record means only that
+      // recovery was not observed.
+      return {
+        id: ID.unreadFocusCleared,
+        sev: 'drift',
+        expected: 0,
+        observed: signal.heldMs,
+        ctx: [
+          signal.kind === 'room'
+            ? [CTX.room, roomToken(signal.id)]
+            : [CTX.conv, convToken(signal.id)],
+          [CTX.peak, signal.peakUnread],
+        ],
+      }
+
     case 'scroll/fab-at-live-edge':
       // `expected: 0` reads as "no FAB while at the live edge". The observed value
       // is the independently measured distance, which is what makes the record
@@ -204,6 +240,8 @@ export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
   ID.slowCorrection,
   ID.mainThreadStall,
   ID.unreadSurvivesFocus,
+  ID.unreadPersists,
+  ID.unreadFocusCleared,
   ID.fabAtLiveEdge,
   ID.jumpTargetMiss,
 ])

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -243,6 +243,7 @@ describe('detector tick', () => {
     for (let i = 0; i < 5; i++) tick.sample()
     tick.stop()
     expect(seen.some((s) => s.name === 'scroll/fab-at-live-edge')).toBe(false)
+    expect(seen.some((s) => s.name === 'read-state/unread-survives-focus')).toBe(false)
   })
 
   it('goes quiet when an unmeasurable viewport makes the FAB check blind', () => {

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -28,6 +28,7 @@ import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
 
 /** How often the world is sampled. */
 const TICK_MS = 1000
+const MAX_SAMPLE_GAP_TICKS = 5
 
 /** The FAB's marker attribute, shared with the scroll e2e suite. */
 const FAB_SELECTOR = '[data-fab="scroll-to-bottom"]'
@@ -104,7 +105,9 @@ export interface DetectorTick {
 }
 
 export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): DetectorTick {
-  const unread = createUnreadSurvivesFocusDetector()
+  const unread = createUnreadSurvivesFocusDetector({
+    maxSampleGapMs: intervalMs * MAX_SAMPLE_GAP_TICKS,
+  })
   const fab = createFabAtLiveEdgeDetector()
 
   /**
@@ -162,18 +165,35 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
         active,
         focused: world.focused(),
         viewportAtBottom: active ? isViewportAtBottom(active.kind, active.id) : false,
+        windowAtLiveEdge: active ? world.windowAtLiveEdge(active.kind, active.id) : false,
         unreadCount: active ? world.unreadCount(active.kind, active.id) : 0,
         scopeKey: world.scopeKey(),
       },
       now,
     )
-    if (unreadVerdict) {
+    if (unreadVerdict?.kind === 'held') {
       signalAnomaly({
         name: 'read-state/unread-survives-focus',
         kind: unreadVerdict.active.kind,
         id: unreadVerdict.active.id,
         unreadCount: unreadVerdict.unreadCount,
         heldMs: unreadVerdict.heldMs,
+      })
+    } else if (unreadVerdict?.kind === 'persisted') {
+      signalAnomaly({
+        name: 'read-state/unread-persists',
+        kind: unreadVerdict.active.kind,
+        id: unreadVerdict.active.id,
+        heldMs: unreadVerdict.heldMs,
+        peakUnread: unreadVerdict.peakUnread,
+      })
+    } else if (unreadVerdict?.kind === 'cleared') {
+      signalAnomaly({
+        name: 'read-state/unread-focus-cleared',
+        kind: unreadVerdict.active.kind,
+        id: unreadVerdict.active.id,
+        heldMs: unreadVerdict.heldMs,
+        peakUnread: unreadVerdict.peakUnread,
       })
     }
 

--- a/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.test.ts
+++ b/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   createUnreadSurvivesFocusDetector,
   type UnreadFocusSample,
+  type UnreadFocusVerdict,
 } from './unreadSurvivesFocus'
 
 const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
@@ -12,6 +13,7 @@ function bad(overrides: Partial<UnreadFocusSample> = {}): UnreadFocusSample {
     active: ACTIVE,
     focused: true,
     viewportAtBottom: true,
+    windowAtLiveEdge: true,
     unreadCount: 3,
     scopeKey: 'acct-1',
     ...overrides,
@@ -26,7 +28,8 @@ describe('unreadSurvivesFocus — fires', () => {
     const v = d.observe(bad(), 2000)
 
     expect(v).not.toBeNull()
-    expect(v!.unreadCount).toBe(3)
+    expect(v!.kind).toBe('held')
+    expect(v!.kind === 'held' && v!.unreadCount).toBe(3)
     expect(v!.heldMs).toBe(2000)
     expect(v!.active).toEqual(ACTIVE)
   })
@@ -39,6 +42,7 @@ describe('unreadSurvivesFocus — fires', () => {
     const verdicts = [3000, 4000, 5000, 6000].map((t) => d.observe(bad(), t))
 
     expect(verdicts.filter(Boolean)).toHaveLength(1)
+    expect(verdicts.find(Boolean)!.kind).toBe('held')
   })
 
   it('reports again after the condition breaks and recurs', () => {
@@ -71,6 +75,12 @@ describe('unreadSurvivesFocus — stays silent', () => {
     const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
     d.observe(bad({ viewportAtBottom: false }), 0)
     expect(d.observe(bad({ viewportAtBottom: false }), 5000)).toBeNull()
+  })
+
+  it('while the loaded message window has slid away from the live edge', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ windowAtLiveEdge: false }), 0)
+    expect(d.observe(bad({ windowAtLiveEdge: false }), 5000)).toBeNull()
   })
 
   it('when there is nothing unread', () => {
@@ -130,5 +140,200 @@ describe('unreadSurvivesFocus — resets', () => {
     d.observe(bad({ scopeKey: 'acct-2' }), 0)
     d.observe(bad({ scopeKey: 'acct-2' }), 100)
     expect(d.observe(bad({ scopeKey: 'acct-2' }), 2200)).not.toBeNull()
+  })
+})
+
+
+describe('unreadSurvivesFocus — episode duration', () => {
+  // The threshold record is emitted the moment 2s is crossed, so its heldMs is always
+  // ~2000 and says nothing about how long the badge actually stayed wrong. Real logs
+  // showed exactly that: seven records, every one of them heldMs 2007-2009. Pairing a
+  // closing measurement with each episode is what makes the duration knowable.
+
+  it('reports the true duration when the condition finally clears', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    expect(d.observe(bad(), 2000)!.kind).toBe('held')
+
+    // ...still wrong for another eight seconds, then read.
+    d.observe(bad(), 6000)
+    const cleared = d.observe(bad({ unreadCount: 0 }), 10_000)
+
+    expect(cleared).not.toBeNull()
+    expect(cleared!.kind).toBe('cleared')
+    expect(cleared!.heldMs, 'the full episode, not the threshold').toBe(10_000)
+    expect(cleared!.active).toEqual(ACTIVE)
+  })
+
+  it('carries the worst count seen, not the count at the end', () => {
+    // A badge that climbed to 21 while being watched is a different story from one
+    // that sat at 1, and by the time it clears the count is 0 either way.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ unreadCount: 3 }), 0)
+    d.observe(bad({ unreadCount: 21 }), 2000)
+    d.observe(bad({ unreadCount: 5 }), 3000)
+    const cleared = d.observe(bad({ unreadCount: 0 }), 4000)
+
+    expect(cleared!.kind === 'cleared' && cleared!.peakUnread).toBe(21)
+  })
+
+  it('says nothing about an episode that never crossed the threshold', () => {
+    // Nothing was claimed, so there is nothing to close. A closing record here would
+    // invent an episode the log never reported.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 500)
+    expect(d.observe(bad({ unreadCount: 0 }), 1000)).toBeNull()
+  })
+
+  it('says NOTHING when the conversation is switched away from', () => {
+    // The badge was still wrong when we stopped watching. Reporting a duration here
+    // would measure how long the detector could look, and name a recovery that may
+    // never have happened.
+    const other = { kind: 'conversation' as const, id: 'carol@x.tld' }
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ active: other }), 5000)).toBeNull()
+  })
+
+  it('says NOTHING when the window loses focus with the count still up', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ focused: false }), 7000)).toBeNull()
+  })
+
+  it('says NOTHING when the viewport leaves the live edge', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ viewportAtBottom: false }), 7000)).toBeNull()
+  })
+
+  it('says NOTHING when the store scope changes under it', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ scopeKey: 'acct-2' }), 7000)).toBeNull()
+  })
+
+  it('does not call it a clear when focus and the count drop on the same tick', () => {
+    // Ambiguous: the count may have cleared BECAUSE the user left. Conservative.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ unreadCount: 0, focused: false }), 5000)).toBeNull()
+  })
+
+  it('emits nothing further once an episode has been closed', () => {
+    // The pair is one held + one cleared. A second closing record would double-count
+    // the episode in any review that folds them together.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    expect(d.observe(bad({ unreadCount: 0 }), 5000)!.kind).toBe('cleared')
+    expect(d.observe(bad({ unreadCount: 0 }), 6000)).toBeNull()
+    expect(d.observe(bad({ unreadCount: 0 }), 7000)).toBeNull()
+  })
+
+  it('reports a fresh pair when the condition recurs', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    d.observe(bad({ unreadCount: 0 }), 3000)
+
+    d.observe(bad(), 4000)
+    expect(d.observe(bad(), 6000)!.kind).toBe('held')
+    expect(d.observe(bad({ unreadCount: 0 }), 9000)!.kind).toBe('cleared')
+  })
+})
+
+
+describe('unreadSurvivesFocus — persistence', () => {
+  // Answers "brief lag or actually stuck" WITHOUT needing to witness the recovery.
+  // The app marks read on focus change and tab switch, so a badge may routinely clear
+  // only once the user has navigated away — precisely when nothing is watching.
+
+  it('reports again once the condition has held far past the threshold', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000, persistMs: 30_000 })
+    d.observe(bad(), 0)
+    expect(d.observe(bad(), 2000)!.kind).toBe('held')
+    for (let now = 3000; now <= 20_000; now += 1000) {
+      expect(d.observe(bad(), now)).toBeNull()
+    }
+
+    let persisted: UnreadFocusVerdict | null = null
+    for (let now = 21_000; now <= 30_000; now += 1000) {
+      persisted = d.observe(bad(), now)
+    }
+    expect(persisted!.kind).toBe('persisted')
+    expect(persisted!.heldMs).toBe(30_000)
+    expect(persisted!.kind === 'persisted' && persisted!.peakUnread).toBe(3)
+  })
+
+  it('reports persistence once, not on every later tick', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000, persistMs: 30_000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    const after: (UnreadFocusVerdict | null)[] = []
+    for (let now = 3000; now <= 90_000; now += 1000) {
+      after.push(d.observe(bad(), now))
+    }
+    expect(after.filter(Boolean)).toHaveLength(1)
+  })
+
+  it('restarts after an unobserved sampling gap', () => {
+    const d = createUnreadSurvivesFocusDetector({
+      holdMs: 2000,
+      persistMs: 30_000,
+      maxSampleGapMs: 5000,
+    })
+    d.observe(bad(), 0)
+    expect(d.observe(bad(), 2000)!.kind).toBe('held')
+
+    expect(d.observe(bad(), 40_000)).toBeNull()
+    expect(d.observe(bad(), 42_000)!.kind).toBe('held')
+  })
+
+  it('stays silent for an episode that ends before the persistence window', () => {
+    // The control: a badge that lagged two seconds and recovered must not be filed
+    // as one that stayed wrong.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000, persistMs: 30_000 })
+    d.observe(bad(), 0)
+    expect(d.observe(bad(), 2000)!.kind).toBe('held')
+    const cleared = d.observe(bad({ unreadCount: 0 }), 5000)
+    expect(cleared!.kind).toBe('cleared')
+    expect(cleared!.heldMs).toBe(5000)
+  })
+
+  it('still reports the true duration when a persistent episode finally clears', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000, persistMs: 30_000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    let persisted: UnreadFocusVerdict | null = null
+    for (let now = 3000; now <= 30_000; now += 1000) {
+      persisted = d.observe(bad(), now)
+    }
+    expect(persisted!.kind).toBe('persisted')
+
+    for (let now = 31_000; now < 100_000; now += 1000) {
+      d.observe(bad(), now)
+    }
+    const cleared = d.observe(bad({ unreadCount: 0 }), 100_000)
+    expect(cleared!.kind).toBe('cleared')
+    expect(cleared!.heldMs).toBe(100_000)
+  })
+
+  it('starts a fresh persistence clock for a new episode', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000, persistMs: 30_000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 2000)
+    for (let now = 3000; now <= 30_000; now += 1000) d.observe(bad(), now)
+    d.observe(bad({ unreadCount: 0 }), 31_000) // cleared
+
+    d.observe(bad(), 32_000)
+    expect(d.observe(bad(), 34_000)!.kind).toBe('held')
+    expect(d.observe(bad(), 40_000), 'only 8s into the new episode').toBeNull()
   })
 })

--- a/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.ts
+++ b/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.ts
@@ -1,18 +1,18 @@
 /**
  * `read-state/unread-survives-focus` — an unread count that outlives being read.
  *
- * When a conversation is active, the window is focused, and the newest message is
- * actually on screen, the user is reading it. `useWindowVisibility` marks it read on
- * focus regain, so an unread count that persists in that state means the clearing
- * path did not run or did not stick.
+ * When a conversation is active, the window is focused, the loaded message window is
+ * at the archive tail, and the viewport is at its bottom, the user is reading the
+ * newest message. `useWindowVisibility` marks it read on focus regain, so an unread
+ * count that persists in that state means the clearing path did not run or did not
+ * stick.
  *
- * The "actually on screen" part is why this uses the VIEWPORT, not the SDK's
- * `windowAtLiveEdge`: the latter is true for any backgrounded conversation parked at
- * the tail, so it is not evidence anyone saw anything. See
- * `utils/viewportAtBottom.ts`.
+ * Both position signals are required. `windowAtLiveEdge` alone is true for any
+ * backgrounded conversation parked at the tail, while `viewportAtBottom` alone can be
+ * true at the bottom of a resident slice that has newer messages beyond it.
  *
- * PURE: every input is passed in, including the clock. The detector holds only the
- * timestamp the condition began and which conversation it is watching.
+ * PURE: every input is passed in, including the clock. The detector retains only the
+ * current episode's timing, identity, scope, peak count and reporting state.
  *
  * @module Anomaly/Detectors/UnreadSurvivesFocus
  */
@@ -25,6 +25,8 @@ export interface UnreadFocusSample {
   focused: boolean
   /** Is the newest message actually on screen — viewport truth, not window truth. */
   viewportAtBottom: boolean
+  /** Is the loaded message window at the tail of the archive. */
+  windowAtLiveEdge: boolean
   /** The canonical unread count for the active conversation. */
   unreadCount: number
   /**
@@ -36,29 +38,86 @@ export interface UnreadFocusSample {
   scopeKey: string
 }
 
-export interface UnreadFocusVerdict {
-  /** How long the condition had held when it was reported. */
-  heldMs: number
-  unreadCount: number
-  active: { kind: 'conversation' | 'room'; id: string }
-}
+/**
+ * One episode produces up to three verdicts, and the distinction between them is the
+ * whole point.
+ *
+ * `held` fires the moment the threshold is crossed — "this is going wrong now".
+ *
+ * `persisted` fires if the condition is STILL true much later. This is what separates
+ * a badge that lagged a moment from one that stayed wrong, and it does so WITHOUT
+ * needing to witness the recovery — which matters, because this app marks read on a
+ * focus change or a tab switch, so the badge may routinely clear only once the user
+ * has navigated away, exactly when nothing is watching.
+ *
+ * `cleared` fires only when the count genuinely reaches zero while the conversation is
+ * still active, focused and at the live edge. It is the sole case where a real duration
+ * is knowable.
+ *
+ * Losing sight of the episode any other way — focus lost, viewport moved, conversation
+ * switched, store rebuilt — ends it SILENTLY. An earlier revision reported those as
+ * `cleared`, which measured how long the detector could watch rather than how long the
+ * badge was wrong, and named a recovery that had not happened.
+ */
+export type UnreadFocusVerdict =
+  | {
+      kind: 'held'
+      /** Time since the condition began — barely past the threshold, by construction. */
+      heldMs: number
+      unreadCount: number
+      active: { kind: 'conversation' | 'room'; id: string }
+    }
+  | {
+      kind: 'persisted'
+      /** How long it had held when it proved persistent. */
+      heldMs: number
+      /** The highest unread count seen so far this episode. */
+      peakUnread: number
+      active: { kind: 'conversation' | 'room'; id: string }
+    }
+  | {
+      kind: 'cleared'
+      /** How long the condition ACTUALLY lasted, end to end. */
+      heldMs: number
+      /** The highest unread count seen during the episode. */
+      peakUnread: number
+      active: { kind: 'conversation' | 'room'; id: string }
+    }
 
 export interface UnreadSurvivesFocusDetector {
-  /** Evaluate one sample. Returns a verdict at most once per episode. */
+  /**
+   * Evaluate one sample.
+   *
+   * At most one verdict per call. A genuine observed recovery can return `cleared`;
+   * losing sight of an episode resets it silently.
+   */
   observe(sample: UnreadFocusSample, now: number): UnreadFocusVerdict | null
 }
 
 /** How long the condition must hold continuously before it is reportable. */
 const DEFAULT_HOLD_MS = 2000
+/**
+ * How long before "still wrong" stops being a plausible propagation delay.
+ *
+ * Well past any settle: a mark-read that has not landed after half a minute of the
+ * user looking straight at the message is not lagging, it did not happen.
+ */
+const DEFAULT_PERSIST_MS = 30_000
+/** Largest observed interval that still counts as continuous sampling. */
+const DEFAULT_MAX_SAMPLE_GAP_MS = 5_000
 
 export interface UnreadSurvivesFocusOptions {
   holdMs?: number
+  persistMs?: number
+  maxSampleGapMs?: number
 }
 
 export function createUnreadSurvivesFocusDetector(
   opts: UnreadSurvivesFocusOptions = {},
 ): UnreadSurvivesFocusDetector {
   const holdMs = opts.holdMs ?? DEFAULT_HOLD_MS
+  const persistMs = opts.persistMs ?? DEFAULT_PERSIST_MS
+  const maxSampleGapMs = opts.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS
 
   /** The conversation currently under observation, as `kind:id`. */
   let watching: string | null = null
@@ -71,15 +130,46 @@ export function createUnreadSurvivesFocusDetector(
    * bounds frequency, and suppressing forever would hide a regression.
    */
   let reported: string | null = null
+  /** The conversation `reported` refers to, preserved for a genuine observed recovery. */
+  let reportedActive: { kind: 'conversation' | 'room'; id: string } | null = null
+  /** Worst count seen this episode — a badge that grew while watched says more. */
+  let peakUnread = 0
+  /** Whether this episode has already been reported as persistent. */
+  let escalated = false
+  let lastSampleAt: number | null = null
 
-  function reset(): void {
+  /**
+   * End the current episode, reporting its true duration only for an observed recovery.
+   *
+   * Returns the verdict rather than emitting, so every reset path clears the same
+   * state. Anything other than a genuine recovery closes silently because its outcome
+   * is unknown.
+   */
+  function endEpisode(now: number, recovered: boolean): UnreadFocusVerdict | null {
+    const verdict: UnreadFocusVerdict | null =
+      recovered && reported !== null && reportedActive !== null && since !== null
+        ? { kind: 'cleared', heldMs: now - since, peakUnread, active: reportedActive }
+        : null
     watching = null
     since = null
     reported = null
+    reportedActive = null
+    peakUnread = 0
+    escalated = false
+    return verdict
   }
 
   return {
     observe(sample: UnreadFocusSample, now: number): UnreadFocusVerdict | null {
+      const sampleGap = lastSampleAt === null ? null : now - lastSampleAt
+      lastSampleAt = now
+      if (
+        sampleGap !== null &&
+        (!Number.isFinite(sampleGap) || sampleGap < 0 || sampleGap > maxSampleGapMs)
+      ) {
+        endEpisode(now, false)
+      }
+
       // A scope CHANGE means the store was rebuilt. Drop everything: an observation
       // spanning the rebuild describes two different worlds.
       //
@@ -90,30 +180,47 @@ export function createUnreadSurvivesFocusDetector(
         scope = sample.scopeKey
       } else if (scope !== sample.scopeKey) {
         scope = sample.scopeKey
-        reset()
-        return null
+        // The store was rebuilt. Whatever became of the badge is now unknowable, so
+        // the episode ends without claiming a recovery.
+        return endEpisode(now, false)
       }
 
       const holds =
         sample.active !== null &&
         sample.focused &&
         sample.viewportAtBottom &&
+        sample.windowAtLiveEdge &&
         sample.unreadCount > 0
 
       if (!holds || sample.active === null) {
-        reset()
-        return null
+        // A GENUINE recovery is the one case worth a duration: the count reached zero
+        // while the user was still looking at the conversation. Everything else —
+        // focus lost, scrolled away, switched conversation — merely ends the
+        // observation, and reporting it as a clear would name a recovery that may
+        // never have happened.
+        const recovered =
+          sample.active !== null &&
+          sample.focused &&
+          sample.viewportAtBottom &&
+          sample.windowAtLiveEdge &&
+          sample.unreadCount === 0 &&
+          watching === `${sample.active.kind}:${sample.active.id}`
+        return endEpisode(now, recovered)
       }
 
       const target = `${sample.active.kind}:${sample.active.id}`
       if (watching !== target) {
         // Switching conversations restarts the clock; the previous conversation's
-        // elapsed time says nothing about this one.
+        // elapsed time says nothing about this one, and the switch reveals nothing
+        // about whether its badge recovered.
+        const closing = endEpisode(now, false)
         watching = target
         since = now
-        reported = null
-        return null
+        peakUnread = sample.unreadCount
+        return closing
       }
+
+      peakUnread = Math.max(peakUnread, sample.unreadCount)
 
       if (since === null) {
         since = now
@@ -122,10 +229,22 @@ export function createUnreadSurvivesFocusDetector(
 
       const heldMs = now - since
       if (heldMs < holdMs) return null
-      if (reported === target) return null
 
-      reported = target
-      return { heldMs, unreadCount: sample.unreadCount, active: sample.active }
+      if (reported !== target) {
+        reported = target
+        reportedActive = sample.active
+        return { kind: 'held', heldMs, unreadCount: sample.unreadCount, active: sample.active }
+      }
+
+      // Still true much later. Reported once, and independently of ever seeing the
+      // recovery — which is what makes the "lagged or stuck" question answerable at
+      // all when the badge only clears after the user has looked away.
+      if (!escalated && heldMs >= persistMs) {
+        escalated = true
+        return { kind: 'persisted', heldMs, peakUnread, active: sample.active }
+      }
+
+      return null
     },
   }
 }

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -116,6 +116,8 @@ export const ID = Object.freeze({
   slowCorrection: mint('scroll/slow-correction', 'id'),
   mainThreadStall: mint('perf/main-thread-stall', 'id'),
   unreadSurvivesFocus: mint('read-state/unread-survives-focus', 'id'),
+  unreadPersists: mint('read-state/unread-persists', 'id'),
+  unreadFocusCleared: mint('read-state/unread-focus-cleared', 'id'),
   fabAtLiveEdge: mint('scroll/fab-at-live-edge', 'id'),
   jumpTargetMiss: mint('scroll/jump-target-miss', 'id'),
 })
@@ -137,6 +139,8 @@ export const CTX = Object.freeze({
   distFromBottom: mint('distFromBottom', 'ctx'),
   /** How long a condition had held continuously when it was reported. */
   heldMs: mint('heldMs', 'ctx'),
+  /** The worst unread count reached during an episode. */
+  peak: mint('peak', 'ctx'),
   /** Signed px by which a jump target sat outside the viewport. */
   offBy: mint('offBy', 'ctx'),
 })

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -78,6 +78,23 @@ export type AnomalySignal =
       heldMs: number
     }
   | {
+      name: 'read-state/unread-persists'
+      kind: 'conversation' | 'room'
+      id: string
+      /** How long it had held when it proved persistent. */
+      heldMs: number
+      peakUnread: number
+    }
+  | {
+      name: 'read-state/unread-focus-cleared'
+      kind: 'conversation' | 'room'
+      id: string
+      /** How long the episode actually lasted, end to end. */
+      heldMs: number
+      /** The worst unread count reached while it ran. */
+      peakUnread: number
+    }
+  | {
       name: 'scroll/fab-at-live-edge'
       /** Independently measured — NOT the scroll hook's own at-bottom state. */
       distFromBottom: number

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -52,15 +52,37 @@ Each entry below is added by the stage that introduces it.
 
 | id | sev | Meaning | What to do |
 |---|---|---|---|
-| `read-state/unread-survives-focus` | suspect | A conversation was active, the window focused, and the newest message actually on screen, yet the unread count stayed above zero for `ctx.heldMs`. `observed` is the count | The mark-read path on focus regain did not run or did not stick. Check the read pointer for that conversation and whether a recount overwrote it |
+| `read-state/unread-survives-focus` | suspect | A conversation was active, the window focused, and the newest message actually on screen at the archive tail, yet the unread count stayed above zero for `ctx.heldMs`. `observed` is the count | The mark-read path on focus regain did not run or did not stick. Check the read pointer for that conversation and whether a recount overwrote it |
+| `read-state/unread-persists` | bug | The same condition was continuously observed 30s later. `observed` is how long it had held; `ctx.peak` is the worst count reached | The mark-read did not merely lag, it did not happen. This is the record that makes the finding actionable |
+| `read-state/unread-focus-cleared` | drift | The count genuinely reached zero while the conversation was still active, focused and at the live edge. `observed` is the real end-to-end duration | Not a complaint — the measurement that says how bad an episode was |
+
+**How to read the three.** Within one `sid`, match records by their conversation or room
+token. The `suspect` record fires the instant the threshold is crossed, so its `heldMs`
+is always ~2000 and says nothing about severity. A following `unread-persists` proves
+that the same badge stayed wrong for at least 30s; a following `unread-focus-cleared`
+gives the observed recovery time. If neither follows, the episode's outcome is unknown.
+
+`unread-focus-cleared` is deliberately narrow: it is emitted **only** on a genuine
+recovery under observation. Losing sight of an episode any other way — focus lost,
+viewport moved, conversation switched, store rebuilt — ends it **silently**. An earlier
+revision reported those as clears, which measured how long the detector could watch
+rather than how long the badge was wrong.
+
+So the absence of a close record means **the end was not observed**. It does NOT mean
+the badge never recovered — the app marks read on focus change and tab switch, so a
+badge may routinely clear just after the user looks away, and the per-id cooldown can
+also suppress a close when two episodes fall inside one minute. Judge severity from
+`unread-persists`, never from a missing `unread-focus-cleared`.
 
 `suspect` rather than `bug` on purpose: the app marks read on focus regain, so a count
 lingering briefly is more likely propagation delay than a broken invariant, and `bug`
 has to keep meaning "an invariant broke". Promote it if the log shows it is not noisy.
 
-This uses the **viewport**, not the SDK's `windowAtLiveEdge` — the latter is true for
-any backgrounded conversation parked at the tail, so it is not evidence anyone saw
-anything.
+This requires both the **viewport** and the SDK's `windowAtLiveEdge`. The latter alone
+is true for any backgrounded conversation parked at the tail, while the viewport alone
+can be at the bottom of a resident slice with newer unread messages beyond it. A missed
+sampling window ends the episode silently, so suspended timers cannot turn an
+unobserved interval into persistence evidence.
 
 _(stage 5 adds `badge-vs-pointer` and `pointer-regression`, both of which need SDK
 seams that do not exist yet.)_

--- a/docs/superpowers/plans/2026-07-30-anomaly-log-stage-3.md
+++ b/docs/superpowers/plans/2026-07-30-anomaly-log-stage-3.md
@@ -41,20 +41,10 @@ when the bug is present, which §5.1 calls the worst possible detector failure.
 
 → **Requires a new measurement seam.** See §1.2 and Decision D1.
 
-### 0.2 `unread-survives-focus` has a ready-made "at live edge" oracle
+### 0.2 `unread-survives-focus` live-edge contract
 
-`src/utils/viewportAtBottom.ts` already exists for precisely this distinction, and its module comment
-makes the argument the detector needs:
-
-> `windowAtLiveEdge` (SDK) says where the *loaded message window* sits; it is true for any
-> backgrounded conversation parked at the tail […] It is therefore NOT evidence that the user saw
-> anything. The only real evidence is the scroll viewport.
-
-`isViewportAtBottom(kind, id)` is the correct oracle, and unknown ids return `false` — it never
-invents a read position. `ChatView` and `RoomView` already register their refs.
-
-Using `windowAtLiveEdge` instead would fire on every backgrounded conversation. Named here because it
-is the obvious wrong choice.
+See `docs/ANOMALY_INVARIANTS.md` for the current sampling contract and named non-cases. It owns the
+runtime semantics; this implementation plan does not duplicate them.
 
 ### 0.3 `jump-target-miss` has an exact settle point already
 

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -479,13 +479,9 @@ seam exists:
 - **accepts an identical rewrite** — the same pointer written twice is idempotence, not regression.
   Only a strictly-behind pointer within one generation is an anomaly.
 
-`unread-survives-focus` stays in stage 3, and its reset condition is **only** the publicly
-observable account/storage-scope change — it cannot see a generation change before stage 5, so the
-spec must not claim it reacts to one. That is tolerable here in a way it was not for
-`pointer-regression`: this detector requires the condition to hold continuously for 2s while the
-conversation is active and focused, so a rehydration inside the window disturbs the state it is
-watching and the timer restarts on the next evaluation rather than producing a verdict from a
-half-rebuilt store.
+`unread-survives-focus` stays in stage 3 because it needs no private generation seam. The runtime
+invariant registry owns its current continuity and reset contract, including how the publicly
+observable account/storage scope bounds an episode.
 
 **Why `badge-vs-pointer` is deferred.** The original design proposed
 `recomputeCountsFromPointer` (`stores/shared/notificationState.ts:637`) as an oracle. That is not


### PR DESCRIPTION
A day of real Dev-build logs showed seven `read-state/unread-survives-focus` records with `heldMs` between 2007 and 2009 — every one of them. That is not a measurement, it is the threshold: the record fires the instant 2s is crossed and the episode then latches, so the log could not tell a badge that lagged a moment from one that stayed wrong for ten minutes. That distinction is what decides whether the finding matters at all.

Two records now answer it.

| id | sev | Meaning |
|---|---|---|
| `read-state/unread-persists` | bug | The condition was still true 30s later |
| `read-state/unread-focus-cleared` | drift | The count genuinely reached zero while still under observation; `observed` is the real duration |

`unread-persists` answers the question **without** needing to witness the recovery, which matters because the app marks read on a focus change or a tab switch — so a badge may routinely clear only once the user has navigated away, exactly when nothing is watching.

`unread-focus-cleared` is deliberately narrow. Losing sight of an episode any other way — focus lost, viewport moved, conversation switched, store rebuilt — ends it silently. An earlier revision of this change reported those as clears, which measured how long the detector could watch rather than how long the badge was wrong. A missing close record therefore means the end was not observed, not that the badge never recovered; the registry says so and points severity at `unread-persists` instead.

### Two false positives closed

Both were present in the detector as originally merged, so this also corrects records already being written.

**Slid-up windows.** The unread condition now requires the loaded message window to be at the archive tail as well as the viewport at its bottom. At the bottom of a slid-up window the viewport check passes while newer messages remain unloaded, so a non-zero count is correct there and was being reported as a fault. The scroll FAB detector already required both signals; this one did not.

**Unobserved gaps.** Episodes now reset when sampling is not continuous. Durations were wall-clock, so a suspended timer — a sleeping laptop — counted as observed time, and a resumed session could report an unbroken half hour of wrongness it never saw.

Consequently, `read-state/*` records produced by builds before this change should be treated as unconfirmed.
