### PR TITLE
test(read-state): make the pointerlessDefers defer guards falsifiable

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -456,18 +456,34 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     expect(vi.mocked(messageCache.countUnreadInArchive)).not.toHaveBeenCalled()
   })
 
-  it('a pointerless entity with a nonzero persisted count defers rather than trusting a zero derivation', async () => {
-    await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
-    setMeta({
-      unreadCount: 4,
-      readPointer: undefined,
-      historyFloor: new Date(0), // ensure a floor exists so !floor isn't what defers this
-    })
+  // #1174: this used to seed `historyFloor: new Date(0)` against a coverage
+  // anchor at t=500, which put the coverage bottom ABOVE the floor — so
+  // `isAfterBoundary` deferred the recount before `pointerlessDefers` could
+  // matter, and the surviving count proved the coverage gate had fired, not
+  // the guard. The coverage-gate branch it was really exercising already has
+  // its own unambiguous test ("a resolved coverage bottom sitting above the
+  // floor defers"), so this one is repaired to test what it names: the bottom
+  // (400) now sits BELOW the floor (500), leaving the guard as the ONLY thing
+  // that can stand this recount down. Distinct from the sibling above, which
+  // reaches the same guard through the stuck-legacy-migration path rather than
+  // a plain pointerless conversation.
+  it('a pointerless conversation with a nonzero persisted count defers at pointerlessDefers, not at the coverage gate', async () => {
+    await messageCache.saveMessages([
+      archiveMsg('anchor', 400, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('m1', 1000),
+      archiveMsg('m2', 1001),
+      archiveMsg('m3', 1002),
+    ])
     seedCoverage('anchor-stanza')
+    setMeta({ unreadCount: 6, readPointer: undefined, historyFloor: new Date(500) })
 
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
-    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(4)
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
+    // Assert the mechanism, not just the outcome: the guard must stop the
+    // derivation before it ever reads the archive, not merely produce a count
+    // that happens to match the seed.
+    expect(vi.mocked(messageCache.countUnreadInArchive)).not.toHaveBeenCalled()
   })
 
   // The reviewer's control (requirement 1), rewritten for PR C's D6 deletion.

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -360,18 +360,34 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // deferred
   // ---------------------------------------------------------------------
 
-  it('a pointerless entity with a nonzero persisted count defers rather than trusting a zero derivation', async () => {
-    await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
-    setMeta({
-      unreadCount: 4,
-      readPointer: undefined,
-      historyFloor: new Date(0), // ensure a floor exists so !floor isn't what defers this
-    })
+  // #1174: this used to seed `historyFloor: new Date(0)` against a coverage
+  // anchor at t=500, which put the coverage bottom ABOVE the floor — so
+  // `isAfterBoundary` deferred the recount before `pointerlessDefers` could
+  // matter, and the surviving count proved the coverage gate had fired, not
+  // the guard. Both room `pointerlessDefers` call sites could be deleted with
+  // this test still green. The coverage-gate branch it was really exercising
+  // already has its own unambiguous test ("a resolved coverage bottom sitting
+  // above the floor defers"), so this one is repaired to test what it names:
+  // the bottom (400) now sits BELOW the floor (500), leaving the guard as the
+  // ONLY thing that can stand this recount down. Counterpart to chatStore's
+  // "NONZERO persisted count still defers via pointerlessDefers".
+  it('a pointerless room with a nonzero persisted count defers at pointerlessDefers, not at the coverage gate', async () => {
+    await messageCache.saveRoomMessages([
+      archiveMsg('anchor', 400, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('m1', 1000),
+      archiveMsg('m2', 1001),
+      archiveMsg('m3', 1002),
+    ])
     seedCoverage('anchor-stanza')
+    setMeta({ unreadCount: 6, readPointer: undefined, historyFloor: new Date(500) })
 
     await roomStore.getState().recomputeUnreadForRoom(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
+    // Assert the mechanism, not just the outcome: the guard must stop the
+    // derivation before it ever reads the archive, not merely produce a count
+    // that happens to match the seed.
+    expect(vi.mocked(messageCache.countRoomUnreadInArchive)).not.toHaveBeenCalled()
   })
 
   // The reviewer's control (requirement 1, mirrored from Task 7), rewritten


### PR DESCRIPTION
Two tests, one in `chatStore.archiveUnread.test.ts` and one in `roomStore.archiveUnread.test.ts`, were titled *"a pointerless entity with a nonzero persisted count defers rather than trusting a zero derivation"* — they named the `pointerlessDefers` guard but never reached it. Each seeded a `historyFloor` of 0 against a coverage anchor at t=500, putting the coverage bottom **above** the floor, so the coverage gate deferred the recount before the guard could matter. The surviving count proved the gate had fired, not the guard.

The consequence was a genuine coverage hole: both `pointerlessDefers` call sites could be deleted from `roomStore.ts` with the entire SDK suite still green.

Both tests are repaired by putting the coverage bottom **below** the floor (anchor at 400, floor at 500), leaving the guard as the only thing that can stand the recount down. Each now also asserts the archive counting function was never called, so it checks the mechanism rather than only that a count happened to survive.

The false-confidence tests were repaired in place rather than left beside newly added ones: the branch they were really exercising — a resolved coverage bottom sitting above the floor — already has its own unambiguous test in each file, so renaming them would have left a third test of an already-covered branch and added no falsifiability.

Test-only; no production code is touched.

Each test was proven to bite by deleting the guard it covers. With both `pointerlessDefers` guards commented out, the room test fails (`expected 3 to be 6`) where the original version of that file stayed fully green, and the chat test fails alongside its sibling.

Refs #1174 — this closes only the coverage hole. Whether to consolidate the duplicated guard or pin its source shape remains open on that issue.