### PR TITLE
refactor(read-state): make the read pointer's wire name an explicit state

### DIFF
--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -254,8 +254,8 @@ export function createStoreBindings(
     // [MDS] line sits inline with the [Scroll]/[Nav] trace at the moment it mutates the marker.
     if (isMarkerDebugEnabled()) {
       const beforeSeen = isRoom
-        ? stores.room.roomMeta.get(conversationId)?.readPointer?.messageId
-        : stores.chat.conversationMeta.get(conversationId)?.readPointer?.messageId
+        ? stores.room.roomMeta.get(conversationId)?.readPointer?.identity.messageId
+        : stores.chat.conversationMeta.get(conversationId)?.readPointer?.identity.messageId
       const isActive = isRoom
         ? stores.room.activeRoomJid === conversationId
         : stores.chat.activeConversationId === conversationId
@@ -263,8 +263,8 @@ export function createStoreBindings(
       else stores.chat.applyRemoteDisplayed(conversationId, stanzaId)
       const after = getStores()
       const afterSeen = isRoom
-        ? after.room.roomMeta.get(conversationId)?.readPointer?.messageId
-        : after.chat.conversationMeta.get(conversationId)?.readPointer?.messageId
+        ? after.room.roomMeta.get(conversationId)?.readPointer?.identity.messageId
+        : after.chat.conversationMeta.get(conversationId)?.readPointer?.identity.messageId
       markerDebugLog('read:displayed-synced (remote device)', {
         conversationId, stanzaId, kind: isRoom ? 'room' : 'chat', isActive,
         lastSeenBefore: beforeSeen, lastSeenAfter: afterSeen, advanced: beforeSeen !== afterSeen,

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -64,6 +64,7 @@ import {
 import { DummyPlaintextPlugin } from './e2ee/DummyPlaintextPlugin'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 import * as messageCache from '../utils/messageCache'
+import type { ReadPointer } from '../stores/shared/readPointer'
 
 function stubXmppPrimitives(): XMPPPrimitives {
   return {
@@ -633,10 +634,13 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // this the derivation would correctly DEFER (see chatStore.test.ts's
       // "phantom-badge cleanup" describe for that control) and the badge
       // fix below would not apply — this test proves the fix survives PR B.
-      const readPointer = {
-        messageId: 'read-msg',
-        timestamp: new Date('2026-06-10T00:00:00Z'),
-        tiebreak: { kind: 'chat' as const, id: 'read-msg' },
+      const readPointer: ReadPointer = {
+        order: {
+          role: 'exact',
+          timestamp: new Date('2026-06-10T00:00:00Z').getTime(),
+          tiebreak: { kind: 'chat', id: 'read-msg' },
+        },
+        identity: { state: 'local', messageId: 'read-msg' },
       }
       chatStore.setState((s) => {
         const conversationMeta = new Map(s.conversationMeta)
@@ -666,6 +670,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // The coverage record's bottom resolves to a position strictly before
       // the floor (proving coverage reaches at least that far back).
       vi.mocked(messageCache.resolveArchivePosition).mockResolvedValueOnce({
+        role: 'exact',
         timestamp: new Date('2026-06-09T23:00:00Z').getTime(),
         tiebreak: { kind: 'chat', id: 'archive-anchor' },
       })
@@ -913,10 +918,13 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // Model catch-up already complete, with a resolvable coverage bottom —
       // the realistic state by the time a deferred decrypt runs — and a
       // badge that is currently stale/inflated relative to the truth.
-      const readPointer = {
-        messageId: 'read-msg',
-        timestamp: new Date('2026-06-10T00:00:00Z'),
-        tiebreak: { kind: 'room' as const, from: `${ROOM}/alice`, id: 'read-msg' },
+      const readPointer: ReadPointer = {
+        order: {
+          role: 'exact',
+          timestamp: new Date('2026-06-10T00:00:00Z').getTime(),
+          tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'read-msg' },
+        },
+        identity: { state: 'local', messageId: 'read-msg' },
       }
       roomStore.setState((s) => {
         const roomMeta = new Map(s.roomMeta)
@@ -934,6 +942,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // The coverage record's bottom resolves to a position strictly before
       // the floor (proving coverage reaches at least that far back).
       vi.mocked(messageCache.resolveArchivePosition).mockResolvedValueOnce({
+        role: 'exact',
         timestamp: new Date('2026-06-09T23:00:00Z').getTime(),
         tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'archive-anchor' },
       })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -176,19 +176,11 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
       const conversationMeta = new Map(state.conversationMeta)
       conversationMeta.set(EXACT_CHAT, {
         ...conversationMeta.get(EXACT_CHAT)!,
-        readPointer: {
-          messageId: 'exact-7',
-          timestamp: new Date(7_000),
-          tiebreak: { kind: 'chat', id: 'exact-7' },
-        },
+        readPointer: { order: { role: 'exact', timestamp: new Date(7_000).getTime(), tiebreak: { kind: 'chat', id: 'exact-7' } }, identity: { state: 'local', messageId: 'exact-7' } },
       })
       conversationMeta.set(FALLBACK_CHAT, {
         ...conversationMeta.get(FALLBACK_CHAT)!,
-        readPointer: {
-          messageId: 'own-4',
-          timestamp: new Date(4_000),
-          tiebreak: { kind: 'chat', id: 'own-4' },
-        },
+        readPointer: { order: { role: 'exact', timestamp: new Date(4_000).getTime(), tiebreak: { kind: 'chat', id: 'own-4' } }, identity: { state: 'local', messageId: 'own-4' } },
       })
       return { conversationMeta }
     })
@@ -196,11 +188,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
       const roomMeta = new Map(state.roomMeta)
       roomMeta.set(ROOM, {
         ...roomMeta.get(ROOM)!,
-        readPointer: {
-          messageId: 'shared-id',
-          timestamp: new Date(8_000),
-          tiebreak: { kind: 'room', from: alice, id: 'shared-id' },
-        },
+        readPointer: { order: { role: 'exact', timestamp: new Date(8_000).getTime(), tiebreak: { kind: 'room', from: alice, id: 'shared-id' } }, identity: { state: 'local', messageId: 'shared-id' } },
       })
       return { roomMeta }
     })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -50,6 +50,7 @@ import { setStorageScopeJid, _resetStorageScopeForTesting } from '../utils/stora
 import type { Message } from './types/chat'
 import type { Room, RoomMessage } from './types/room'
 import { getLocalPart } from './jid'
+import type { ReadPointer } from '../stores/shared/readPointer'
 
 const CID = 'juliet@capulet.example'
 const OWN_JID = 'romeo@montague.example/phone'
@@ -71,20 +72,36 @@ function timeFor(id: string): Date {
  * timestamp AND its cache order key. A pointer without a key is the
  * pre-#1081 migrated shape, covered separately in mdsSideEffects.test.ts.
  */
-function pointerAt(id: string): {
-  messageId: string
-  timestamp: Date
-  tiebreak: { kind: 'chat'; id: string }
-} {
-  return { messageId: id, timestamp: timeFor(id), tiebreak: { kind: 'chat', id } }
+function pointerAt(id: string): ReadPointer {
+  return {
+    order: { role: 'exact', timestamp: timeFor(id).getTime(), tiebreak: { kind: 'chat', id } },
+    identity: { state: 'local', messageId: id },
+  }
 }
 
-function roomPointerAt(id: string, from = `${ROOM}/alice`): {
-  messageId: string
-  timestamp: Date
-  tiebreak: { kind: 'room'; from: string; id: string }
-} {
-  return { messageId: id, timestamp: timeFor(id), tiebreak: { kind: 'room', from, id } }
+function roomPointerAt(id: string, from = `${ROOM}/alice`): ReadPointer {
+  return {
+    order: { role: 'exact', timestamp: timeFor(id).getTime(), tiebreak: { kind: 'room', from, id } },
+    identity: { state: 'local', messageId: id },
+  }
+}
+
+/**
+ * The same positions, ADDRESSABLE: minted from a message that already carried an
+ * archive id. This is what every peer message and every MUC reflection produces.
+ */
+function addressablePointerAt(id: string, archiveId: string): ReadPointer {
+  return {
+    order: { role: 'exact', timestamp: timeFor(id).getTime(), tiebreak: { kind: 'chat', id } },
+    identity: { state: 'addressable', messageId: id, archiveId },
+  }
+}
+
+function addressableRoomPointerAt(id: string, archiveId: string, from = `${ROOM}/alice`): ReadPointer {
+  return {
+    order: { role: 'exact', timestamp: timeFor(id).getTime(), tiebreak: { kind: 'room', from, id } },
+    identity: { state: 'addressable', messageId: id, archiveId },
+  }
 }
 
 /** A cached (IndexedDB) 1:1 row, incoming so it carries a server stanza-id. */
@@ -757,7 +774,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
       const roomMeta = new Map(state.roomMeta)
       roomMeta.set(ROOM, {
         ...roomMeta.get(ROOM)!,
-        readPointer: { messageId: 'shared-id', timestamp: timeFor('shared-id') },
+        readPointer: { order: { role: 'floor', timestamp: new Date(timeFor('shared-id')).getTime() }, identity: { state: 'local', messageId: 'shared-id' } },
       })
       return { roomMeta }
     })
@@ -784,6 +801,75 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     // The deliberate asymmetry (#1189): MUC reflection supplies the exact
     // stanza-id shortly, so an approximation would degrade a working path.
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+  // ==========================================================================
+  // What the IDENTITY VARIANT does — and does NOT — remove from the machinery
+  // above.
+  //
+  // The design note that produced this shape predicted #1175 would "dissolve":
+  // with the archive id on the pointer, the publisher would need no lookup, so
+  // the async / serial-drain / revalidate constraint list would disappear WITH
+  // the lookup. That is only half right, and the half it gets wrong is why every
+  // test above still exists.
+  //
+  //  - `addressable` pointers: correct. Resolution is a field read. No resident
+  //    slice, no `lastMessage`, no IndexedDB, no await that could span a session
+  //    boundary. Every peer message and every MUC reflection mints one.
+  //  - `local` pointers: WRONG. The archive id genuinely does not exist yet, so
+  //    the only way to find one is still to read the archive — and the `local`
+  //    population is precisely the case #1175 and #1189 were opened for (a 1:1
+  //    resting on the user's own send, whose row may never acquire an id at all).
+  //
+  // So the machinery is SCOPED, not deleted. These three cases pin that split so
+  // nobody deletes it on the strength of the prediction.
+  // ==========================================================================
+
+  it('an ADDRESSABLE pointer publishes with no lookup of any kind', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: addressablePointerAt('m7', 's7') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    // The whole #1175 apparatus is skipped: nothing touched the cache, and
+    // nothing needed the resident slice either.
+    expect(getMessages).not.toHaveBeenCalled()
+    expect(getMessage).not.toHaveBeenCalled()
+    expect(getRoomMessage).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('an addressable ROOM pointer likewise skips the room cache lookup', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedRoom()
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: addressableRoomPointerAt('r5', 'rs5') })
+      return { roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
+    expect(getRoomMessage).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('a LOCAL pointer still needs the cache — the machinery cannot be deleted', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    // The 1:1 resting state: the pointer names our own send, which carries no
+    // archive id, so the position is `local` and unresolvable from the pointer
+    // alone. Without the cache read there is nothing to publish at all.
+    getMessages.mockResolvedValue([cachedMsg('m1', 's1'), cachedMsg('m7', undefined)])
+    patchMeta({ readPointer: pointerAt('m7') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getMessages).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
     cleanup()
   })
 })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -24,6 +24,7 @@ import { roomStore } from '../stores/roomStore'
 import type { Message } from './types/chat'
 import type { Room, RoomMessage } from './types/room'
 import { getLocalPart } from './jid'
+import { makeReadPointer, type ReadPointer } from '../stores/shared/readPointer'
 
 // Deterministic per-id timestamp: 'm3' → base + 3s. A read pointer carries the
 // timestamp of the message it names (#1081), so `pointerAt` can build one from
@@ -33,9 +34,13 @@ function timeFor(id: string): Date {
   return new Date(BASE_TIME + (Number(id.replace(/\D/g, '')) || 0) * 1000)
 }
 
-/** The read pointer naming `id`, carrying that message's own timestamp. */
-function pointerAt(id: string): { messageId: string; timestamp: Date } {
-  return { messageId: id, timestamp: timeFor(id) }
+/**
+ * The read pointer naming `id`, carrying that message's own timestamp — but as a
+ * FLOOR, i.e. the pre-#1081 migrated shape with no tie-break. The exact variant
+ * is covered in mdsSideEffects.cache.test.ts.
+ */
+function pointerAt(id: string): ReadPointer {
+  return { order: { role: 'floor', timestamp: timeFor(id).getTime() }, identity: { state: 'local', messageId: id } }
 }
 
 function msg(id: string, stanzaId: string | undefined): Message {
@@ -97,7 +102,7 @@ function seedMeta(cid: string, seenMessageId?: string): void {
 /** Patch a conversationMeta entry in place (fires the conversationMeta subscription). */
 function patchMeta(
   cid: string,
-  patch: Partial<{ readPointer: { messageId: string; timestamp: Date }; unreadCount: number }>
+  patch: Partial<{ readPointer: ReadPointer; unreadCount: number }>
 ): void {
   chatStore.setState((state) => {
     const newMeta = new Map(state.conversationMeta)
@@ -165,11 +170,10 @@ function seedRoom(jid: string, messages: RoomMessage[], seenMessageId?: string):
       meta.set(jid, {
         ...existing,
         readPointer: {
-          messageId: seenMessageId,
-          timestamp: seen?.timestamp ?? new Date(0),
-          tiebreak: seen
-            ? { kind: 'room', from: seen.from, id: seenMessageId }
-            : undefined,
+          order: seen
+            ? { role: 'exact', timestamp: seen.timestamp.getTime(), tiebreak: { kind: 'room', from: seen.from, id: seenMessageId } }
+            : { role: 'floor', timestamp: 0 },
+          identity: { state: 'local', messageId: seenMessageId },
         },
       })
       return { roomMeta: meta }
@@ -342,7 +346,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m2')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m2')
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     cleanup()
   })
@@ -381,7 +385,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m2')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m2')
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
     cleanup()
@@ -408,8 +412,8 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(
-      chatStore.getState().conversationMeta.get(cid)?.readPointer?.tiebreak
-    ).toEqual({ kind: 'chat', id: 'm2' })
+      chatStore.getState().conversationMeta.get(cid)?.readPointer?.order
+    ).toEqual({ role: 'exact', timestamp: timeFor('m2').getTime(), tiebreak: { kind: 'chat', id: 'm2' } })
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
     cleanup()
@@ -429,7 +433,7 @@ describe('setupMdsSideEffects', () => {
     // has NO tiebreak, and its timestamp is lastReadAt — documented as at
     // or behind the message it names (readPointer.ts). Ordering by it therefore
     // under-advances: m3 sits past lastReadAt=2s and must not be selected.
-    patchMeta(cid, { readPointer: { messageId: 'm4', timestamp: timeFor('m2') } })
+    patchMeta(cid, { readPointer: { order: { role: 'floor', timestamp: new Date(timeFor('m2')).getTime() }, identity: { state: 'local', messageId: 'm4' } } })
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
@@ -450,7 +454,7 @@ describe('setupMdsSideEffects', () => {
     // the window (the shape issue #1175 describes).
     seedMessages(cid, [msg('m9', 's9'), msg('m10', 's10')])
     seedMeta(cid)
-    patchMeta(cid, { readPointer: { messageId: 'evicted-m2', timestamp: timeFor('m2') } })
+    patchMeta(cid, { readPointer: { order: { role: 'floor', timestamp: new Date(timeFor('m2')).getTime() }, identity: { state: 'local', messageId: 'evicted-m2' } } })
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
@@ -613,7 +617,7 @@ describe('setupMdsSideEffects', () => {
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m2')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m2')
     cleanup()
   })
 
@@ -642,7 +646,7 @@ describe('setupMdsSideEffects', () => {
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)])
 
     // The stashed marker was drained and applied to the room.
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m2')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m2')
 
     // And it must NOT cause an echo republish: lastKnownNodeStanzaId[ROOM] was
     // recorded during the seed, so consider() is echo-suppressed.
@@ -709,11 +713,7 @@ describe('setupMdsSideEffects', () => {
       const meta = new Map(s.roomMeta)
       meta.set(ROOM, {
         ...meta.get(ROOM)!,
-        readPointer: {
-          messageId: newest.id,
-          timestamp: newest.timestamp,
-          tiebreak: { kind: 'room', from: newest.from, id: newest.id },
-        },
+        readPointer: { order: { role: 'exact', timestamp: new Date(newest.timestamp).getTime(), tiebreak: { kind: 'room', from: newest.from, id: newest.id } }, identity: { state: 'local', messageId: newest.id } },
       })
       return { roomMeta: meta }
     })
@@ -822,11 +822,7 @@ describe('setupMdsSideEffects', () => {
       const meta = new Map(s.roomMeta)
       meta.set(ROOM, {
         ...meta.get(ROOM)!,
-        readPointer: {
-          messageId: 'm2',
-          timestamp: new Date(2),
-          tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' },
-        },
+        readPointer: { order: { role: 'exact', timestamp: new Date(2).getTime(), tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' } }, identity: { state: 'local', messageId: 'm2' } },
       })
       return { roomMeta: meta }
     })
@@ -1035,15 +1031,20 @@ describe('setupMdsSideEffects', () => {
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // Five conversations, each read to its newest message. No resident arrays —
-    // memory windowing is the realistic cold-start shape, so the pointers resolve
-    // through the lastMessage preview.
+    // memory windowing is the realistic cold-start shape. Each pointer was minted
+    // from a peer message, so it is ADDRESSABLE and resolves by a field read
+    // rather than by looking anything up; what this case pins is the SWEEP (one
+    // publish per position the node lacks), not the resolution mechanism. The
+    // degraded `local` resolution — resident slice, then lastMessage preview,
+    // then the cache — is covered by the cases above and in
+    // `mdsSideEffects.cache.test.ts`.
     const jids = Array.from({ length: 5 }, (_, i) => `contact${i}@example.com`)
     chatStore.setState((state) => {
       const meta = new Map(state.conversationMeta)
       const convs = new Map(state.conversations)
       for (const cid of jids) {
         const newest = { ...msg('m2', `${cid}-s2`), id: `${cid}-m2`, conversationId: cid }
-        const readPointer = { messageId: newest.id, timestamp: newest.timestamp }
+        const readPointer = makeReadPointer(newest, 'chat')
         meta.set(cid, { unreadCount: 0, readPointer, lastMessage: newest } as never)
         convs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer } as never)
       }
@@ -1322,7 +1323,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m2')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m2')
 
     // And no echo republish on top of the migration.
     await vi.advanceTimersByTimeAsync(2_000)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -21,11 +21,17 @@
  * session never managed to publish is retried without waiting for a further
  * local read advance (#1145).
  *
- * Read positions resolve from resident state first and from the IndexedDB
- * message cache second (#1175), so a BACKGROUNDED entity — which keeps no
- * resident message array — still resolves and publishes. That makes resolution
- * asynchronous, so `consider()` runs as a LATEST-WINS SERIAL DRAIN per JID and
- * revalidates every input after the await; see `consider`/`considerOnce`.
+ * An ADDRESSABLE read pointer already carries the archive id XEP-0490 publishes,
+ * so resolving it is a field read: no residency, no cache, nothing to order.
+ *
+ * A LOCAL one does not — the archive id genuinely does not exist yet, and for
+ * the user's own 1:1 sends it may never — so it still resolves from resident
+ * state first and from the IndexedDB message cache second (#1175), which is what
+ * lets a BACKGROUNDED entity (no resident message array) publish at all. That
+ * path is asynchronous, so `consider()` runs as a LATEST-WINS SERIAL DRAIN per
+ * JID and revalidates every input after the await; see `consider`/`considerOnce`.
+ * The identity variant SCOPES that machinery to the degraded population rather
+ * than removing it — see the split pinned in `mdsSideEffects.cache.test.ts`.
  *
  * @module Core/MdsSideEffects
  */
@@ -40,9 +46,9 @@ import { createKeyedCoalescer } from '../utils/keyedCoalescer'
 import {
   compareExact,
   isAfterBoundary,
-  makeCacheOrderKey,
+  exactPosition,
   type ExactPosition,
-  type OrderPosition,
+  type PointerOrder,
 } from '../stores/shared/readState'
 import type { ReadPointer } from '../stores/shared/readPointer'
 import { getBareJid } from './jid'
@@ -247,10 +253,10 @@ export function setupMdsSideEffects(
    *   pointer are filtered out. Ordering uses the pointer's own
    *   timestamp/`tiebreak` rather than its index, so the pointer's
    *   message need not be resident — a newer resident window cannot drag the
-   *   result forward. A keyless (#1081-migrated) pointer orders by `lastReadAt`,
+   *   result forward. A FLOOR (#1081-migrated) pointer orders by `lastReadAt`,
    *   which is documented as at or behind the message it names, so it
    *   under-advances further rather than past. Under-advancing is the direction
-   *   this module already prefers (`isAfterBoundary`: a keyless boundary reads
+   *   this module already prefers (`isAfterBoundary`: a floor boundary reads
    *   as at-or-after its millisecond → under-advance → over-count (safe)).
    * - It cannot regress the node: `publishDecision` is unchanged, and the one
    *   value we must never publish over — a remote marker we could not order — is
@@ -267,23 +273,16 @@ export function setupMdsSideEffects(
    */
   function newestResolvableAtOrBehind(
     messages: Array<{ stanzaId?: string; from?: string; id: string; timestamp: Date }>,
-    pointer: { timestamp: Date; tiebreak?: OrderPosition['tiebreak'] }
+    boundary: PointerOrder
   ): string | undefined {
-    const pointerPos: OrderPosition = {
-      timestamp: pointer.timestamp.getTime(),
-      tiebreak: pointer.tiebreak,
-    }
     let best: { pos: ExactPosition; stanzaId: string } | undefined
     for (const m of messages) {
       if (!m.stanzaId) continue
-      const pos: ExactPosition = {
-        timestamp: m.timestamp.getTime(),
-        tiebreak: makeCacheOrderKey(m, 'chat'),
-      }
-      // A BOUNDARY test against the pointer: a keyless pointer reads as
+      const pos = exactPosition(m, 'chat')
+      // A BOUNDARY test against the pointer: a `floor` pointer reads as
       // at-or-after its millisecond, so we withhold that millisecond rather
       // than publish past it — the under-advance this module prefers (#1173).
-      if (isAfterBoundary(pos, pointerPos)) continue // ahead of the pointer — never publish
+      if (isAfterBoundary(pos, boundary)) continue // ahead of the pointer — never publish
       // Picking the newest candidate: both sides are exact by construction.
       if (!best || compareExact(pos, best.pos) > 0) best = { pos, stanzaId: m.stanzaId }
     }
@@ -296,35 +295,54 @@ export function setupMdsSideEffects(
       : chatStore.getState().conversationMeta.get(jid)?.readPointer
   }
 
+  /**
+   * The de-dup key for "we have already handled THIS position".
+   *
+   * Covers the identity as well as the order, deliberately: a `local` pointer
+   * that converges to `addressable` is the SAME position with a better name, and
+   * that is exactly the change that makes it publishable. Keying on the order
+   * alone would short-circuit the pass that should finally send it.
+   */
   function pointerIdentity(pointer: ReadPointer | undefined): string | undefined {
     if (!pointer) return undefined
-    const key = pointer.tiebreak
+    const { order, identity } = pointer
     return JSON.stringify([
-      pointer.messageId,
-      pointer.timestamp.getTime(),
-      key?.kind ?? null,
-      key?.kind === 'room' ? key.from : null,
-      key?.id ?? null,
+      identity.messageId,
+      identity.state === 'addressable' ? identity.archiveId : null,
+      order.timestamp,
+      order.role,
+      order.role === 'exact' ? order.tiebreak.kind : null,
+      order.role === 'exact' && order.tiebreak.kind === 'room' ? order.tiebreak.from : null,
     ])
   }
 
   /**
-   * Resolve the exact `(sender, id)` target named by a room pointer.
+   * Resolve the exact `(sender, id)` target named by a `local` room pointer.
    *
    * Room client ids are unique only per sender. Without a room cache-order
    * key, choosing any matching row would risk publishing a WRONG forward-only
    * MDS position that no device can walk back. Refusing to resolve preserves the
    * exact-position contract and costs only a retryable delay.
+   *
+   * Takes the pointer rather than re-reading the store, so both resolution
+   * sources answer for the SAME position the caller already read and revalidated.
+   * Only reached for a `local` pointer: an `addressable` one already carries the
+   * archive id this lookup exists to find.
    */
-  function exactRoomPointerTarget(jid: string): { messageId: string; from: string } | undefined {
-    const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
-    const key = pointer?.tiebreak
-    if (!pointer?.messageId || key?.kind !== 'room' || key.from.length === 0) return undefined
-    return { messageId: pointer.messageId, from: key.from }
+  function exactRoomPointerTarget(pointer: ReadPointer): { messageId: string; from: string } | undefined {
+    const { order, identity } = pointer
+    if (order.role !== 'exact' || order.tiebreak.kind !== 'room' || order.tiebreak.from.length === 0) {
+      return undefined
+    }
+    return { messageId: identity.messageId, from: order.tiebreak.from }
   }
 
   /**
-   * Resolve the stanza-id of the message a conversation's/room's read pointer names.
+   * Resolve a LOCAL pointer's stanza-id from resident state.
+   *
+   * Only reached for `identity.state === 'local'`: an `addressable` pointer
+   * needs no resolution at all (see {@link resolveSeenStanzaId}), so everything
+   * below is the degraded path and nothing else.
    *
    * The two branches differ deliberately. A MUC reflects our own message back
    * with a room-assigned `stanza-id`, so a room pointer resolves exactly, and
@@ -335,9 +353,9 @@ export function setupMdsSideEffects(
    * stanza-ids at all would have nothing resolvable at or behind the pointer for
    * a fallback to find. So the asymmetry is the point, not an omission.
    */
-  function resolveFromStores(jid: string): string | undefined {
+  function resolveFromStores(jid: string, pointer: ReadPointer): string | undefined {
     if (isRoom(jid)) {
-      const target = exactRoomPointerTarget(jid)
+      const target = exactRoomPointerTarget(pointer)
       if (!target) return undefined
       const { messageId: seenId, from } = target
       const messages = roomStore.getState().roomRuntime.get(jid)?.messages ?? []
@@ -350,9 +368,7 @@ export function setupMdsSideEffects(
         ?? roomStore.getState().rooms.get(jid)?.lastMessage
       return last?.id === seenId && last.from === from ? last.stanzaId : undefined
     }
-    const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
-    const seenId = pointer?.messageId
-    if (!seenId) return undefined
+    const seenId = pointer.identity.messageId
     const messages = chatStore.getState().messages.get(jid) || []
     const fromSlice = messages.find((m) => m.id === seenId)?.stanzaId
     if (fromSlice) return fromSlice
@@ -363,11 +379,11 @@ export function setupMdsSideEffects(
     // The pointer names a message with no stanza-id — in 1:1 the normal resting
     // state once the user has replied. Publish the newest position we CAN
     // address at or behind it rather than staying silent for the session.
-    return newestResolvableAtOrBehind(messages, pointer)
+    return newestResolvableAtOrBehind(messages, pointer.order)
   }
 
   /**
-   * Resolve the pointer from the IndexedDB message cache (#1175).
+   * Resolve a LOCAL pointer from the IndexedDB message cache (#1175).
    *
    * The store-backed resolution above can only see what is RESIDENT, and a
    * backgrounded entity keeps no resident array at all — `setActiveConversation`
@@ -379,25 +395,24 @@ export function setupMdsSideEffects(
    * cached rows at or before the pointer's timestamp — and hands it to the same
    * {@link newestResolvableAtOrBehind} the resident fallback uses. That is
    * deliberately one code path for two jobs: the pointer's own row is the newest
-   * thing at or behind itself, so an exactly-resolvable pointer yields its own
-   * stanza-id, and only an unresolvable one degrades to the #1189 approximation.
-   * Ordering against the pointer is what makes it safe in the direction that
-   * matters — a row newer than the pointer can never be selected, so this cannot
-   * publish ahead of the true read position, exactly as for the resident scan.
+   * thing at or behind itself, so a pointer whose named row has since acquired
+   * an archive id yields that id, and only a still-unresolvable one degrades to
+   * the #1189 approximation. Ordering against the pointer is what makes it safe
+   * in the direction that matters — a row newer than the pointer can never be
+   * selected, so this cannot publish ahead of the true read position, exactly as
+   * for the resident scan.
    *
    * Rooms keep the exact-position contract and get NO at-or-behind fallback, in
    * the cache as in memory — see {@link resolveFromStores} for why.
    */
-  async function resolveFromCache(jid: string): Promise<string | undefined> {
+  async function resolveFromCache(jid: string, pointer: ReadPointer): Promise<string | undefined> {
     if (!messageCache.isMessageCacheAvailable()) return undefined
     if (isRoom(jid)) {
-      const target = exactRoomPointerTarget(jid)
+      const target = exactRoomPointerTarget(pointer)
       if (!target) return undefined
       const cached = await messageCache.getRoomMessage(jid, target.messageId, target.from)
       return cached?.stanzaId
     }
-    const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
-    if (!pointer?.messageId) return undefined
     // `before` is an exclusive upper bound, so probe one millisecond past the
     // pointer to include the message sitting exactly on it; it also forces the
     // backwards cursor, so `limit` yields the NEWEST rows rather than the
@@ -406,24 +421,52 @@ export function setupMdsSideEffects(
     // this one has nothing to return (see messageCache.entityTimestampRange).
     const rows = await messageCache.getMessages(jid, {
       after: new Date(0),
-      before: new Date(pointer.timestamp.getTime() + 1),
+      before: new Date(pointer.order.timestamp + 1),
       limit: CACHE_LOOKBACK,
     })
-    return newestResolvableAtOrBehind(rows, pointer)
+    return newestResolvableAtOrBehind(rows, pointer.order)
   }
 
   /**
-   * Resolve the pointer, resident state first and the cache second.
+   * Resolve the wire name of a conversation's/room's read position.
    *
-   * Ordering is a cost decision, not a correctness one: both sources answer with
-   * a position at or behind the pointer, so neither can over-advance. Preferring
-   * the resident answer keeps every case that resolves today free of an
-   * IndexedDB read — including the active-conversation #1189 fallback, where the
-   * cached copy of an own send has no stanza-id either, so the read could not
-   * have improved on it.
+   * The identity variant splits this into two genuinely different jobs, and the
+   * split is the point of the whole shape:
+   *
+   * - **`addressable`** — a FIELD READ. The archive id was captured from the very
+   *   message the pointer names, at mint, so there is no lookup, no residency
+   *   requirement, no IndexedDB read and nothing to order. Every peer message and
+   *   every MUC reflection mints one, so this is the common path.
+   * - **`local`** — the degraded path, and the only reason the machinery below
+   *   still exists. The pointer names a message that had no archive id when the
+   *   position was taken: in a 1:1 that is the normal resting state once the user
+   *   replies (the server never echoes our own sends back, so the row may NEVER
+   *   acquire one), and in a MUC it is the window before the reflection lands.
+   *   Resolving it needs the archive, resident state first and the cache second.
+   *
+   * Ordering resident-before-cache is a cost decision, not a correctness one:
+   * both sources answer with a position at or behind the pointer, so neither can
+   * over-advance. Preferring the resident answer keeps every case that resolves
+   * from memory free of an IndexedDB read — including the active-conversation
+   * #1189 fallback, where the cached copy of an own send has no stanza-id either,
+   * so the read could not have improved on it.
+   *
+   * NOTE ON #1195: the async / serial-drain / revalidate machinery in
+   * `consider()` is NOT removed by the identity variant, and the design note
+   * that predicted it would be was wrong about the `local` population. It is
+   * skipped for `addressable` pointers — no await ever reaches the cache for
+   * them — but the branch above still needs it, and the `local` population is
+   * exactly the 1:1-resting-on-an-own-send case that #1175 and #1189 were opened
+   * for. The function therefore stays `async` and every caller keeps
+   * revalidating after the await.
    */
   async function resolveSeenStanzaId(jid: string): Promise<string | undefined> {
-    return resolveFromStores(jid) ?? (await resolveFromCache(jid))
+    const pointer = readPointer(jid)
+    if (!pointer) return undefined
+    // The wire name we already hold. No lookup can improve on it: it came from
+    // the message this position names, bound by identity at mint time.
+    if (pointer.identity.state === 'addressable') return pointer.identity.archiveId
+    return resolveFromStores(jid, pointer) ?? (await resolveFromCache(jid, pointer))
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
@@ -151,7 +151,7 @@ describe('StateSnapshot', () => {
           mentionsCount: 1,
           isBookmarked: true,
           autojoin: true,
-          readPointer: { messageId: 'msg-42', timestamp: readAt.getTime() },
+          readPointer: { order: { role: 'floor', timestamp: new Date(readAt.getTime()).getTime() }, identity: { state: 'local', messageId: 'msg-42' } },
           messages: [],
         }],
       })
@@ -168,11 +168,14 @@ describe('StateSnapshot', () => {
       expect(room?.selfOccupant?.nick).toBe('me')
       expect(room?.unreadCount).toBe(3)
       expect(room?.autojoin).toBe(true)
-      // A Date, not the epoch number that sits on disk: a pointer carrying a
-      // number compares false against every message Date it meets, silently.
-      expect(room?.readPointer).toEqual({ messageId: 'msg-42', timestamp: readAt })
-      expect(roomStore.getState().roomMeta.get('room@conf.example.com')?.readPointer)
-        .toEqual({ messageId: 'msg-42', timestamp: readAt })
+      // Epoch ms, which is what `order.timestamp` is in memory as well as on
+      // disk — the ISO/Date ambiguity the old shape carried is gone.
+      const restored = {
+        order: { role: 'floor', timestamp: readAt.getTime() },
+        identity: { state: 'local', messageId: 'msg-42' },
+      }
+      expect(room?.readPointer).toEqual(restored)
+      expect(roomStore.getState().roomMeta.get('room@conf.example.com')?.readPointer).toEqual(restored)
     })
 
     // PR B (Task 8, cold-start rehydrate trigger): a room restored here may
@@ -204,15 +207,18 @@ describe('StateSnapshot', () => {
     it('persists the room read pointer so it can be hydrated back', async () => {
       const readAt = new Date('2026-04-21T09:15:00Z')
       roomStore.getState().addRoom(makeRoom('room@conf.example.com', {
-        readPointer: { messageId: 'msg-7', timestamp: readAt },
+        readPointer: { order: { role: 'floor', timestamp: new Date(readAt).getTime() }, identity: { state: 'local', messageId: 'msg-7' } },
       }))
 
       await snapshot.flush()
 
       const [persisted] = adapterData.store.get('user@example.com')!.rooms as Array<{
-        readPointer?: { messageId: string; timestamp: number }
+        readPointer?: unknown
       }>
-      expect(persisted?.readPointer).toEqual({ messageId: 'msg-7', timestamp: readAt.getTime() })
+      expect(persisted?.readPointer).toEqual({
+        order: { role: 'floor', timestamp: readAt.getTime() },
+        identity: { state: 'local', messageId: 'msg-7' },
+      })
     })
 
     // Task 2 (#1102): the structured tiebreak rides through this
@@ -226,25 +232,24 @@ describe('StateSnapshot', () => {
       await snapshot.flush()
 
       const [persisted] = adapterData.store.get('user@example.com')!.rooms as Array<{
-        readPointer?: { messageId: string; timestamp: number; tiebreak?: unknown }
+        readPointer?: { order?: { tiebreak?: unknown } }
       }>
       // The tie-break's `id` is NOT persisted: it is `messageId`, and storing a
       // second copy made a disagreement representable on disk. Only `from`,
       // which the pointer cannot reconstruct, rides through. The persisted
       // property name matches the in-memory field.
-      expect(persisted?.readPointer?.tiebreak).toEqual({
+      expect(persisted?.readPointer?.order?.tiebreak).toEqual({
         kind: 'room',
         from: 'room@conf.example.com/alice',
       })
 
       // Read back: a fresh hydrate into an empty room store must recover it,
-      // with `id` reconstructed from `messageId`.
+      // with `id` reconstructed from the identity's `messageId`.
       roomStore.getState().removeRoom('room@conf.example.com')
       await snapshot.hydrate('user@example.com')
-      expect(roomStore.getState().rooms.get('room@conf.example.com')?.readPointer?.tiebreak).toEqual({
-        kind: 'room',
-        from: 'room@conf.example.com/alice',
-        id: 'msg-8',
+      expect(roomStore.getState().rooms.get('room@conf.example.com')?.readPointer?.order).toMatchObject({
+        role: 'exact',
+        tiebreak: { kind: 'room', from: 'room@conf.example.com/alice', id: 'msg-8' },
       })
     })
 

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -95,7 +95,7 @@ export function useChatActive() {
   // count and the divider resync-on-scroll-up trigger in MessageList.
   const activeReadPointerId = useChatStore((s) => {
     if (!s.activeConversationId) return undefined
-    return s.conversationMeta.get(s.activeConversationId)?.readPointer?.messageId
+    return s.conversationMeta.get(s.activeConversationId)?.readPointer?.identity.messageId
   })
   // Provisional divider: derived from the local pointer while a synced XEP-0490
   // read position is still unresolved — rendered muted until confirmed.

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -725,7 +725,10 @@ describe('useNotificationEvents', () => {
           // the notification and this case could not tell a working read-pointer
           // check from a missing one.
           unreadCount: 1,
-          readPointer: { messageId: 'm1', timestamp: new Date() },
+          readPointer: {
+            order: { role: 'exact', timestamp: Date.now(), tiebreak: { kind: 'chat', id: 'm1' } },
+            identity: { state: 'local', messageId: 'm1' },
+          },
           lastMessage: {
             id: 'm1',
             // A body is required: without one `isPreviewableMessage` rejects the

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -84,7 +84,7 @@ export function useRoomActive() {
   // and the divider resync-on-scroll-up trigger in MessageList.
   const activeReadPointerId = useRoomStore((s) => {
     if (!s.activeRoomJid) return undefined
-    return s.roomMeta.get(s.activeRoomJid)?.readPointer?.messageId
+    return s.roomMeta.get(s.activeRoomJid)?.readPointer?.identity.messageId
   })
 
   // Provisional divider: derived from the local pointer while a synced XEP-0490

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -194,9 +194,23 @@ export { isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions 
 export { computeBadgeCount, shouldNotifyConversation, shouldNotifyRoom } from './stores/shared/notificationState'
 export type { EntityNotificationState, NotificationMessage, EntityContext, BadgeInput } from './stores/shared/notificationState'
 
-// Read pointer (canonical read position; supersedes lastSeenMessageId + lastReadAt, issue #1081)
-export type { ReadPointer } from './stores/shared/readPointer'
-export { makeReadPointer, isAhead, advance } from './stores/shared/readPointer'
+// Read pointer (canonical read position; supersedes lastSeenMessageId + lastReadAt, issue #1081).
+//
+// A pointer is `{ order, identity }`: one ORDER, and two NAMES that answer
+// different questions. `identity` is a DISCRIMINATED union — `addressable`
+// carries the XEP-0359 archive id that XEP-0490 publishes, `local` says the
+// position has no wire name yet — so a consumer that wants to publish a position
+// has to say what it does when there isn't one. `order` is likewise `exact` or
+// `floor`. See `stores/shared/readPointer.ts` for why neither name can replace
+// the other.
+export type { ReadPointer, PointerIdentity, PointerSource } from './stores/shared/readPointer'
+export { makeReadPointer, withArchiveId, isAhead, advance } from './stores/shared/readPointer'
+export type {
+  CacheOrderKey,
+  PointerOrder,
+  ExactPosition,
+  FloorPosition,
+} from './stores/shared/readState'
 
 // Viewport evidence (read-state PR B, Task 11): SDK-owned, generation-scoped
 // "is the viewport genuinely at the live edge" state. `beginViewportGeneration`

--- a/packages/fluux-sdk/src/stores/chatSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.test.ts
@@ -384,7 +384,7 @@ describe('chatSelectors', () => {
       const meta: ConversationMetadata = {
         unreadCount: 5,
         lastMessage: undefined,
-        readPointer: { messageId: 'm1', timestamp: new Date() },
+        readPointer: { order: { role: 'floor', timestamp: new Date().getTime() }, identity: { state: 'local', messageId: 'm1' } },
       }
       const conversationMeta = new Map([['user@example.com', meta]])
       const state = createMockState({ conversationMeta })

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -41,7 +41,7 @@ import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
  * message, so in production its tie-break always resolves (#1173).
  */
 const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'chat')
-const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
+const posAt = (timestamp: number): ExactPosition => ({ role: 'exact', timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -134,7 +134,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 99, // stale — must be overwritten by the exact derivation
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -155,7 +155,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     setMeta({
       unreadCount: 0,
       // Legacy/migrated shape: no tiebreak at all.
-      readPointer: { messageId: 'p0', timestamp: new Date(1000) },
+      readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -204,9 +204,10 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // at-or-after-timestamp fallback. This assertion is what makes that failure
     // loud: the `id` is reconstructed from `messageId`, so a keyed hydration is
     // only possible when the stored name was actually recognised.
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.tiebreak).toEqual({
-      kind: 'chat',
-      id: 'p0',
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.order).toEqual({
+      role: 'exact',
+      timestamp: 1000,
+      tiebreak: { kind: 'chat', id: 'p0' },
     })
     // Restore the un-wrapped action so later tests aren't left with a spy.
     chatStore.setState({ recomputeUnreadForConversation: original })
@@ -217,7 +218,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // ---------------------------------------------------------------------
 
   it('a forward MAM merge into a non-active conversation with new messages triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } } })
     chatStore.setState({ activeConversationId: 'someone-else@example.com' })
     const original = chatStore.getState().recomputeUnreadForConversation
     const spy = vi.fn(original)
@@ -257,7 +258,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // ---------------------------------------------------------------------
 
   it('a remote marker advancing a non-active conversation triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } } })
     chatStore.setState({ activeConversationId: 'someone-else@example.com' })
     const original = chatStore.getState().recomputeUnreadForConversation
     const spy = vi.fn(original)
@@ -294,7 +295,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // tell a real recompute from a no-op.
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'chat', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ activeConversationId: CID })
@@ -316,7 +317,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // the fire-and-forget recount below.
     expect(chatStore.getState().activeConversationId).toBe(CID)
     // The pointer advanced (resolveRemoteDisplayed's job, unaffected by this fix).
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('p0')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
     // The divider was positioned at the first message after the new pointer.
     expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('u1')
     // FIX 3: the count is re-derived from the archive (u1, u2, u3), not left
@@ -388,7 +389,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       archiveMsg('u2', 1002),
     ])
     seedCoverage('anchor-stanza')
-    setMeta({ unreadCount: 7, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 7, readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } } })
 
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
@@ -397,7 +398,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
     expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(2)
     // The recount still never touches the read position it counted against.
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('p0')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
   })
 
   // Task 6b, residual state (a): pointerless, migration outstanding, persisted
@@ -491,7 +492,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5, // the persisted/trusted value
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     // Coverage IS proven and resolvable — but mamQueryStates is left at its
     // default (NOT caught up to live), so the caught-up gate is the single
@@ -504,7 +505,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('p0')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(5)
   })
 
@@ -512,7 +513,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     chatStore.setState((state) => {
       const mamQueryStates = new Map(state.mamQueryStates)
@@ -530,7 +531,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 6,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     // bottomId names an archive stanza-id that was never saved — unresolvable.
     seedCoverage('nonexistent-stanza-id')
@@ -561,7 +562,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 8, // trusted — must survive untouched
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('gap-anchor-stanza')
 
@@ -596,7 +597,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     chatStore.getState().addMessage(archiveMsg('z-msg', T))
     // Viewport observer reports 'z-msg' seen while it is the only resident message.
     chatStore.getState().advanceReadPointer(CID, 'z-msg')
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('z-msg')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('z-msg')
 
     // A same-millisecond sibling arrives live, SECOND.
     chatStore.getState().addMessage(archiveMsg('a-msg', T))
@@ -610,7 +611,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // array, so the forward-only guard must NOT move the pointer backward
     // past the already-confirmed 'z-msg'.
     chatStore.getState().advanceReadPointer(CID, 'a-msg')
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('z-msg')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('z-msg')
 
     // Settle: the user navigates away, and the archive-derived recompute runs.
     chatStore.setState({ activeConversationId: null })
@@ -641,7 +642,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'chat', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     // Active + focused (default windowVisible), but viewportAtLiveEdge is
@@ -694,7 +695,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -724,7 +725,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -787,7 +788,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -830,7 +831,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5, // stale — the slow recompute below would derive 1 (u1) from THIS pointer
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ activeConversationId: CID })
@@ -854,7 +855,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       meta.set(CID, {
         ...meta.get(CID)!,
         unreadCount: 0,
-        readPointer: { messageId: 'u1', timestamp: new Date(1001), tiebreak: { kind: 'chat', id: 'u1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1001).getTime(), tiebreak: { kind: 'chat', id: 'u1' } }, identity: { state: 'local', messageId: 'u1' } },
       })
       return { conversationMeta: meta }
     })
@@ -869,7 +870,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // stale derivation (computed against a pointer that moved since) must not
     // clobber it.
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('u1')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('u1')
   })
 
   // ---------------------------------------------------------------------
@@ -890,7 +891,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // A stale marker left over from before the boundary moved, on the ACTIVE
@@ -924,7 +925,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({
@@ -939,7 +940,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     })
 
     chatStore.getState().advanceReadPointer(CID, 'u1')
-    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('u1')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('u1')
 
     // The count converges (the advance's whole purpose) — but the divider the
     // reader is looking at survives. Clearing it belongs to read-through
@@ -960,7 +961,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages(resident)
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ messages: new Map([[CID, resident]]) })
@@ -990,7 +991,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState((state) => {
@@ -1029,7 +1030,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       setMeta({
         unreadCount: 5,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1040,7 +1041,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     })
 
     it('deferred outcome', async () => {
-      setMeta({ unreadCount: 3, mentionsCount: SEEDED_MENTIONS, readPointer: { messageId: 'p0', timestamp: new Date(1000) } })
+      setMeta({ unreadCount: 3, mentionsCount: SEEDED_MENTIONS, readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'p0' } } })
       // Not caught up — defers.
 
       await chatStore.getState().recomputeUnreadForConversation(CID)
@@ -1053,7 +1054,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       setMeta({
         unreadCount: 3,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countUnreadInArchive).mockResolvedValueOnce(null)
@@ -1079,7 +1080,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // One never-archived (noLocalStore) message, after the pointer.
@@ -1103,7 +1104,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
       setMeta({
         unreadCount: 0,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
     })
@@ -1204,7 +1205,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0 derived below
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'chat', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       // Active + focused (default windowVisible), with the full history
@@ -1217,7 +1218,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // The viewport observer reports the NEWEST resident message seen —
       // reaching the live edge.
       chatStore.getState().advanceReadPointer(CID, 'm3')
-      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('m3')
+      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('m3')
 
       // Poll for the fire-and-forget archive recount (this fix's trigger) to
       // settle, rather than guessing a tick count.
@@ -1238,7 +1239,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 and the correct 2
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'chat', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({
@@ -1249,7 +1250,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // The viewport observer reports 'm1' seen — the user scrolled PARTWAY,
       // not to the bottom. 'm2' and 'm3' remain genuinely unread.
       chatStore.getState().advanceReadPointer(CID, 'm1')
-      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('m1')
+      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('m1')
 
       // Exactly 2 remaining (m2, m3) — neither the stale 5 (trigger missing)
       // nor a wrongly-zeroed 0 (a broken floor/pointer would over-clear).
@@ -1268,7 +1269,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // above) while unreadCount is stale.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'm1' } }, identity: { state: 'local', messageId: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.getState().addConversation(createConversation('someone-else@example.com'))
@@ -1308,7 +1309,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // here), same as the fully-read sibling test above.
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.getState().addConversation(createConversation('someone-else@example.com'))
@@ -1395,7 +1396,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 3,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1403,7 +1404,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
       // A surviving outgoing-boundary advance would put this at 'mine' and drop
       // the count to 1 by swallowing u1.
-      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('p0')
+      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
     })
 
@@ -1418,7 +1419,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1432,7 +1433,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await chatStore.getState().recomputeUnreadForConversation(CID)
 
       // The reply came from another device. Nothing here is evidence we read u1.
-      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.messageId).toBe('p0')
+      expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(3)
     })
 
@@ -1468,7 +1469,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 1,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1509,7 +1510,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // viewport observer has nothing left to advance.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'm1' } }, identity: { state: 'local', messageId: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({ messages: new Map([[CID, [anchor, m1]]]) })
@@ -1539,7 +1540,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, p0, u1, u2])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({ messages: new Map([[CID, [anchor, p0, u1, u2]]]) })

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -150,9 +150,9 @@ describe('chatStore.applyRemoteDisplayed', () => {
     chatStore.getState().applyRemoteDisplayed(cid, 's3')
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m3')
+    expect(meta?.readPointer?.identity.messageId).toBe('m3')
     // Also verify the combined conversations map is kept in sync.
-    expect(chatStore.getState().conversations.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversations.get(cid)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('never regresses the read pointer when the incoming marker is behind current', () => {
@@ -164,8 +164,8 @@ describe('chatStore.applyRemoteDisplayed', () => {
 
     chatStore.getState().applyRemoteDisplayed(cid, 's1') // behind → must be ignored
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
-    expect(chatStore.getState().conversations.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
+    expect(chatStore.getState().conversations.get(cid)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('stores a pending high-water mark when the stanza-id is not yet loaded', () => {
@@ -199,7 +199,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     chatStore.getState().applyRemoteDisplayed(cid, 's2')
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m3') // unchanged
+    expect(meta?.readPointer?.identity.messageId).toBe('m3') // unchanged
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined) // cleared
     // Combined conversations map kept in sync.
     expect(chatStore.getState().conversations.get(cid)?.pendingRemoteDisplayedStanzaId).toBe(undefined)
@@ -227,7 +227,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     chatStore.getState().applyRemoteDisplayed(cid, 's4', messages)
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m4')
+    expect(meta?.readPointer?.identity.messageId).toBe('m4')
 
     // Let the fire-and-forget archive recount run to completion.
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -259,7 +259,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     chatStore.getState().applyRemoteDisplayed(cid, 's3', mergedPage)
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m3')
+    expect(meta?.readPointer?.identity.messageId).toBe('m3')
     // Resolved, so the high-water mark is retired rather than left to re-fire.
     expect(meta?.pendingRemoteDisplayedStanzaId).toBeUndefined()
     // The count is NOT this page's own tally (which would be 1: m4 alone). It
@@ -310,7 +310,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
 
     // Pointer resolved at p0 (forward-only sync is unconditional and
     // unaffected by PR B).
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('p0')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('p0')
 
     // The archive-derived recount runs (fire-and-forget) but defers: no
     // mamQueryStates/conversationCoverage were seeded, so coverage down to
@@ -358,7 +358,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     // PR B: the pointer resolves synchronously, but the count is no longer
     // written synchronously from this page — the archive-derived recount is
     // still pending on the gated cache read below, so the count is untouched.
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('p0')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('p0')
     expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
 
     // User opens the conversation before the cache read lands. No coverage
@@ -412,7 +412,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     )
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m5')
+    expect(meta?.readPointer?.identity.messageId).toBe('m5')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
   })
 })
@@ -435,8 +435,8 @@ describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     chatStore.getState().markAsRead(cid)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
-    expect(chatStore.getState().conversations.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
+    expect(chatStore.getState().conversations.get(cid)?.readPointer?.identity.messageId).toBe('m3')
     expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
   })
 
@@ -457,7 +457,7 @@ describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     chatStore.getState().markAsRead(cid)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m1')
     expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
   })
 
@@ -470,7 +470,7 @@ describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     chatStore.getState().markAsRead(cid)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m1')
     expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
   })
 })
@@ -557,7 +557,7 @@ describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE div
     chatStore.getState().applyRemoteDisplayed(cid, 's4')
 
     // Read position advanced to m4 …
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m4')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
   })
 
@@ -577,7 +577,7 @@ describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE div
     chatStore.getState().applyRemoteDisplayed(cid, 's4')
 
     // Read position still advances (forward-only sync is unconditional) …
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m4')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
     // … but the session divider for the inactive conversation is left untouched;
     // it is recomputed the next time the conversation is activated.
     expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m3')
@@ -599,7 +599,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     await chatStore.getState().activateConversation(cid)
 
     // The pending marker is resolved at activation, advancing the read position.
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m4')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
     // So the divider reflects the synced read (m4 is the last message → nothing new),
     // NOT the stale 'm3' it would show if the marker resolved after onActivate.
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
@@ -618,7 +618,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
 
     await chatStore.getState().activateConversation(cid)
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
 
     // Leave (deactivation evicts the resident message array — memory windowing).
     await chatStore.getState().activateConversation(null)
@@ -633,7 +633,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
       return { conversationMeta: newMeta }
     })
     await chatStore.getState().activateConversation(cid)
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   // Regression (bug: "read on another device, still unread on return"): a NEWER remote read
@@ -652,7 +652,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
 
     await chatStore.getState().activateConversation(cid)
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
 
     await chatStore.getState().activateConversation(null)
 
@@ -666,7 +666,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
       return { conversationMeta: newMeta }
     })
     await chatStore.getState().activateConversation(cid)
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m4')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
   })
 
   // Regression (gate burn on stash): a fold that could not resolve (marker's message not
@@ -682,7 +682,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
 
     await chatStore.getState().activateConversation(cid)
     // Unresolvable → stash survives, pointer untouched.
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m1')
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
 
     await chatStore.getState().activateConversation(null)
@@ -692,7 +692,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
 
     await chatStore.getState().activateConversation(cid)
     // The gate must allow the retry (the marker was never actually folded).
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m9')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m9')
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
   })
 
@@ -718,7 +718,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     await chatStore.getState().activateConversation(cid)
 
     // The retried fold advances the pointer to the synced position…
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m5')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m5')
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
     // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m6')
@@ -803,7 +803,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const full = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4), timed('m5', 's5', 5)]
     chatStore.getState().applyRemoteDisplayed(cid, 's4', full)
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m4')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m5')
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
   })
@@ -863,7 +863,7 @@ describe('chatStore fresh-instance catch-up preserves the remote read position',
     chatStore.getState().mergeMAMMessages(cid, archive(), {}, true, 'forward')
 
     const meta = chatStore.getState().conversationMeta.get(cid)
-    expect(meta?.readPointer?.messageId).toBe('m3')
+    expect(meta?.readPointer?.identity.messageId).toBe('m3')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
   })
 
@@ -894,7 +894,7 @@ describe('chatStore fresh-instance catch-up preserves the remote read position',
 
     chatStore.getState().mergeMAMMessages(cid, archive(), {}, true, 'forward')
 
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(5)
   })
@@ -937,30 +937,30 @@ describe('chatStore.advanceReadPointer presence gate', () => {
     seedWithPointer('m1')
     connectionStore.getState().setWindowVisible(true)
     chatStore.getState().advanceReadPointer(cid, 'm3')
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('does not advance the read pointer while the window is unfocused', () => {
     seedWithPointer('m1')
     connectionStore.getState().setWindowVisible(false)
     chatStore.getState().advanceReadPointer(cid, 'm3')
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m1')
   })
 
   it('leaves the combined conversations map untouched while unfocused', () => {
     seedWithPointer('m1')
     connectionStore.getState().setWindowVisible(false)
     chatStore.getState().advanceReadPointer(cid, 'm3')
-    expect(chatStore.getState().conversations.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversations.get(cid)?.readPointer?.identity.messageId).toBe('m1')
   })
 
   it('resumes advancing once the window regains focus', () => {
     seedWithPointer('m1')
     connectionStore.getState().setWindowVisible(false)
     chatStore.getState().advanceReadPointer(cid, 'm2')
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m1')
     connectionStore.getState().setWindowVisible(true)
     chatStore.getState().advanceReadPointer(cid, 'm3')
-    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m3')
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
@@ -7,6 +7,7 @@ import { _resetStorageScopeForTesting, setStorageScopeJid, buildScopedStorageKey
 import { localStorageMock } from '../core/sideEffects.testHelpers'
 import { chatStore, migrateReadPointer } from './chatStore'
 import { _resetForTesting, flush as flushThrottledStorage } from './shared/throttledStorage'
+import type { ReadPointer } from './shared/readPointer'
 
 Object.defineProperty(globalThis, 'localStorage', {
   value: localStorageMock,
@@ -52,25 +53,33 @@ beforeEach(async () => {
 describe('read pointer migration', () => {
   it('pairs an id with its persisted timestamp when both exist', async () => {
     const p = await migrateReadPointer(CONV, { lastSeenMessageId: 'm2', lastReadAt: at(2000) })
-    expect(p).toEqual({ messageId: 'm2', timestamp: at(2000) })
+    expect(p).toMatchObject({ order: { timestamp: 2000 }, identity: { messageId: 'm2' } })
   })
 
-  it('resolves the timestamp from the cache when only the id survived', async () => {
+  it('keeps the archive identity when the cached row is resolved by id', async () => {
+    await messageCache.updateMessage('m2', { stanzaId: 'archive-m2' })
     const p = await migrateReadPointer(CONV, { lastSeenMessageId: 'm2' })
-    expect(p).toMatchObject({ messageId: 'm2', timestamp: at(2000) })
+    expect(p).toEqual({
+      order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } },
+      identity: { state: 'addressable', messageId: 'm2', archiveId: 'archive-m2' },
+    })
   })
 
   // Control: resolving to the OLDEST message AFTER lastReadAt would return m3
   // here. That is ahead of where the user was, and the pointer is forward-only,
   // so it would destroy the position unrecoverably.
-  it('resolves lastReadAt-only to the newest message AT OR BEFORE it', async () => {
+  it('keeps a timestamp-resolved cached row local without moving its order', async () => {
+    await messageCache.updateMessage('m2', { stanzaId: 'archive-m2' })
     const p = await migrateReadPointer(CONV, { lastReadAt: at(2500) })
-    expect(p).toMatchObject({ messageId: 'm2', timestamp: at(2000) })
+    expect(p).toEqual({
+      order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } },
+      identity: { state: 'local', messageId: 'm2' },
+    })
   })
 
   it('resolves exactly when lastReadAt lands on a message timestamp', async () => {
     const p = await migrateReadPointer(CONV, { lastReadAt: at(2000) })
-    expect(p).toMatchObject({ messageId: 'm2', timestamp: at(2000) })
+    expect(p).toMatchObject({ order: { timestamp: 2000 }, identity: { messageId: 'm2' } })
   })
 
   it('yields no pointer when lastReadAt predates every cached message', async () => {
@@ -97,7 +106,13 @@ const STORAGE_KEY = buildScopedStorageKey('xmpp-chat-storage', JID)
 interface LegacyMeta {
   lastSeenMessageId?: string
   lastReadAt?: string
-  readPointer?: { messageId: string; timestamp: number; tiebreak?: unknown; archiveOrderKey?: unknown }
+  /**
+   * Whatever a shipped build actually wrote: the CURRENT nested shape, or one of
+   * the pre-identity flat ones (`tiebreak` / `archiveOrderKey`, with or without
+   * the key's redundant id). Deliberately `unknown` — the point of these cases
+   * is to drive real on-disk blobs through the untrusted hydration boundary.
+   */
+  readPointer?: unknown
   unreadCount?: number
 }
 
@@ -137,8 +152,8 @@ describe('post-rehydrate readPointer backfill', () => {
     await chatStore.persist.rehydrate()
 
     await vi.waitFor(() => {
-      expect(pointerOf(CONV)).toMatchObject({ messageId: 'm2', timestamp: at(2000) })
-      expect(pointerOf(OTHER)).toMatchObject({ messageId: 'o1', timestamp: at(1500) })
+      expect(pointerOf(CONV)).toMatchObject({ order: { timestamp: 2000 }, identity: { messageId: 'm2' } })
+      expect(pointerOf(OTHER)).toMatchObject({ order: { timestamp: 1500 }, identity: { messageId: 'o1' } })
     }, { timeout: 2000 })
   })
 
@@ -151,7 +166,7 @@ describe('post-rehydrate readPointer backfill', () => {
 
     await chatStore.persist.rehydrate()
 
-    await vi.waitFor(() => expect(pointerOf(CONV)).toEqual({ messageId: 'm2', timestamp: at(2000) }), { timeout: 2000 })
+    await vi.waitFor(() => expect(pointerOf(CONV)).toMatchObject({ order: { timestamp: 2000 }, identity: { messageId: 'm2' } }), { timeout: 2000 })
   })
 
   // Both maps must move together: a pointer visible in conversationMeta but not
@@ -178,7 +193,10 @@ describe('post-rehydrate readPointer backfill', () => {
     await vi.waitFor(() => expect(release).toBeDefined(), { timeout: 2000 })
 
     // The user opens the conversation and reads to the live edge.
-    const live = { messageId: 'm3', timestamp: at(3000) }
+    const live: ReadPointer = {
+      order: { role: 'exact', timestamp: 3000, tiebreak: { kind: 'chat', id: 'm3' } },
+      identity: { state: 'local', messageId: 'm3' },
+    }
     chatStore.setState((state) => {
       const meta = new Map(state.conversationMeta)
       meta.set(CONV, { ...meta.get(CONV)!, readPointer: live })
@@ -215,14 +233,21 @@ describe('post-rehydrate readPointer backfill', () => {
       { type: 'chat', id: 'o1', conversationId: OTHER, from: OTHER, body: 'x', timestamp: at(1500), isOutgoing: false },
     ] as never)
     persistConversations([
-      [CONV, { lastSeenMessageId: 'm3', readPointer: { messageId: 'm1', timestamp: 1000 } }],
+      [CONV, { lastSeenMessageId: 'm3', readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'm1' } } }],
       [OTHER, { lastSeenMessageId: 'o1' }],
     ])
 
     await chatStore.persist.rehydrate()
-    await vi.waitFor(() => expect(pointerOf(OTHER)).toMatchObject({ messageId: 'o1', timestamp: at(1500) }), { timeout: 2000 })
+    await vi.waitFor(
+      () => expect(pointerOf(OTHER)?.identity.messageId).toBe('o1'),
+      { timeout: 2000 }
+    )
+    expect(pointerOf(OTHER)?.order.timestamp).toBe(1500)
 
-    expect(pointerOf(CONV)).toEqual({ messageId: 'm1', timestamp: at(1000) })
+    expect(pointerOf(CONV)).toEqual({
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'm1' },
+    })
   })
 
   // Cold start paints the persisted count instead of flashing an empty badge.
@@ -240,15 +265,16 @@ describe('post-rehydrate readPointer backfill', () => {
   // directly rather than assumed from the plain messageId/timestamp case above.
   it('round-trips a persisted tiebreak through the new-format deserialize branch', async () => {
     persistConversations([
-      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } } }],
+      [CONV, { readPointer: { order: { role: 'exact', timestamp: new Date(2000).getTime(), tiebreak: { kind: 'chat', id: 'm2' } }, identity: { state: 'local', messageId: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
-    expect(chatStore.getState().conversations.get(CONV)?.readPointer?.tiebreak).toEqual({
-      kind: 'chat',
-      id: 'm2',
+    expect(pointerOf(CONV)?.order).toEqual({ role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } })
+    expect(chatStore.getState().conversations.get(CONV)?.readPointer?.order).toEqual({
+      role: 'exact',
+      timestamp: 2000,
+      tiebreak: { kind: 'chat', id: 'm2' },
     })
   })
 
@@ -276,42 +302,51 @@ describe('post-rehydrate readPointer backfill', () => {
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+    expect(pointerOf(CONV)?.order).toMatchObject({ role: 'exact', tiebreak: { kind: 'chat', id: 'm2' } })
   })
 
-  // A malformed persisted key must be DROPPED at this real persistence surface
-  // too, not just at the deserializeReadPointer unit level — the pointer itself
-  // (messageId/timestamp) survives.
-  // The on-disk rename, at the real persistence surface: a blob written under
-  // the historical name hydrates through the fallback, and the very next
-  // persist re-emits it under `tiebreak` alone. This is also what makes the
-  // fallback's removal condition true in practice — the whole blob is rewritten,
-  // so one persist sheds the old name for the entire account.
-  it('rewrites a pointer stored under the historical name under `tiebreak`', async () => {
+  // The identity migration at the real persistence surface: a pre-identity flat
+  // blob hydrates through the migration branch, and the very next persist
+  // re-emits it in the nested `{ order, identity }` shape. This is what makes
+  // that branch's removal condition true in practice — the whole blob is
+  // rewritten, so ONE persist converts the entire account, not merely the
+  // conversation that was read.
+  it('rewrites a pre-identity flat pointer into the nested shape on the next persist', async () => {
     persistConversations([
       [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'chat', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
-    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+    // Migrated, and the position did not move: same name, same millisecond.
+    expect(pointerOf(CONV)).toEqual({
+      order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } },
+      identity: { state: 'local', messageId: 'm2' },
+    })
 
     chatStore.setState((state) => ({ conversationMeta: new Map(state.conversationMeta) }))
     flushThrottledStorage()
 
     const onDisk = diskEntry('conversationMeta', CONV).readPointer as Record<string, unknown>
-    expect(onDisk.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+    expect(onDisk.order).toEqual({ role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } })
+    expect(onDisk.identity).toEqual({ state: 'local', messageId: 'm2' })
+    // Every pre-identity name is gone from disk — including the one copy of the
+    // message id that used to sit beside the order.
     expect('archiveOrderKey' in onDisk).toBe(false)
+    expect('messageId' in onDisk).toBe(false)
   })
 
-  it('drops a malformed persisted tiebreak but keeps the rest of the pointer', async () => {
+  // A malformed persisted key must be DROPPED at this real persistence surface
+  // too, not just at the deserializeReadPointer unit level — the pointer itself
+  // (name and timestamp) survives, as a floor.
+  it('degrades a malformed persisted tiebreak to a floor but keeps the rest of the pointer', async () => {
     persistConversations([
-      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, tiebreak: { kind: 'room', id: 'm2' } } }],
+      [CONV, { readPointer: { order: { role: 'exact', timestamp: new Date(2000).getTime(), tiebreak: { kind: 'room', id: 'm2' } }, identity: { state: 'local', messageId: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.tiebreak).toBeUndefined() // missing `from` → invalid → dropped
-    expect(pointerOf(CONV)?.messageId).toBe('m2')
+    expect(pointerOf(CONV)?.order.role).toBe('floor') // missing `from` → invalid → exact degrades to floor
+    expect(pointerOf(CONV)?.identity.messageId).toBe('m2')
   })
 })
 
@@ -391,7 +426,7 @@ describe('unmigrated legacy read state survives the persist', () => {
     ] as never)
 
     relaunch()
-    await vi.waitFor(() => expect(pointerOf(LATE)).toMatchObject({ messageId: 'late1', timestamp: at(1500) }), { timeout: 2000 })
+    await vi.waitFor(() => expect(pointerOf(LATE)).toMatchObject({ order: { timestamp: 1500 }, identity: { messageId: 'late1' } }), { timeout: 2000 })
   })
 
   // The other half of the same guarantee, for the id-only shape.
@@ -417,14 +452,14 @@ describe('unmigrated legacy read state survives the persist', () => {
     // tiebreak onto the pointer (unlike the both-fields branch above,
     // which copies the legacy pair through verbatim) — the point of this
     // assertion is messageId/timestamp, not the tie-break's exact shape.
-    await vi.waitFor(() => expect(pointerOf(CONV)).toMatchObject({ messageId: 'm2', timestamp: at(2000) }), { timeout: 2000 })
+    await vi.waitFor(() => expect(pointerOf(CONV)).toMatchObject({ order: { timestamp: 2000 }, identity: { messageId: 'm2' } }), { timeout: 2000 })
     // This assertion means to observe the final persisted blob, not a
     // mid-pass write still sitting in the throttle's pending thunk.
     flushThrottledStorage()
 
     expect(diskEntry('conversationMeta', CONV).readPointer).toMatchObject({
-      messageId: 'm2',
-      timestamp: at(2000).toISOString(),
+      order: { role: 'exact', timestamp: 2000 },
+      identity: { state: 'local', messageId: 'm2' },
     })
     expect('lastSeenMessageId' in diskEntry('conversationMeta', CONV)).toBe(false)
     // The compat map is not on disk to check any more — nothing writes it.
@@ -440,7 +475,10 @@ describe('unmigrated legacy read state survives the persist', () => {
     await settle()
     expect(legacyOnDisk(LATE).lastReadAt).toBe(at(1800).toISOString())
 
-    const live = { messageId: 'live1', timestamp: at(9000) }
+    const live: ReadPointer = {
+      order: { role: 'exact', timestamp: 9000, tiebreak: { kind: 'chat', id: 'live1' } },
+      identity: { state: 'local', messageId: 'live1' },
+    }
     chatStore.setState((state) => {
       const meta = new Map(state.conversationMeta)
       meta.set(LATE, { ...meta.get(LATE)!, readPointer: live })
@@ -453,8 +491,8 @@ describe('unmigrated legacy read state survives the persist', () => {
     flushThrottledStorage()
 
     expect(diskEntry('conversationMeta', LATE).readPointer).toEqual({
-      messageId: 'live1',
-      timestamp: at(9000).toISOString(),
+      order: { role: 'exact', timestamp: 9000, tiebreak: { kind: 'chat', id: 'live1' } },
+      identity: { state: 'local', messageId: 'live1' },
     })
     expect('lastReadAt' in diskEntry('conversationMeta', LATE)).toBe(false)
   })
@@ -525,7 +563,7 @@ describe('catch-up hydration does not fabricate a pointer over un-migrated read 
     // Launch 2: the cache can answer now. The pointer lands where the user
     // actually was — BEHIND the two messages a snap would have marked read.
     relaunch()
-    await vi.waitFor(() => expect(pointerOf(LATE)).toMatchObject({ messageId: 'l1', timestamp: at(1500) }), { timeout: 2000 })
+    await vi.waitFor(() => expect(pointerOf(LATE)).toMatchObject({ order: { timestamp: 1500 }, identity: { messageId: 'l1' } }), { timeout: 2000 })
   })
 
   // Control, inverted by PR C, D6. It used to assert that a conversation with

--- a/packages/fluux-sdk/src/stores/chatStore.resyncDivider.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.resyncDivider.test.ts
@@ -81,7 +81,7 @@ describe('chatStore.resyncDividerToReadPointer', () => {
     seed({ lastSeen: 'm2', marker: 'm1', messages: [msg('m1'), msg('m2'), msg('m3')] })
     chatStore.getState().resyncDividerToReadPointer(CID)
     const meta = chatStore.getState().conversationMeta.get(CID)!
-    expect(meta.readPointer?.messageId).toBe('m2')
+    expect(meta.readPointer?.identity.messageId).toBe('m2')
     expect(meta.unreadCount).toBe(0)
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -229,13 +229,13 @@ describe('chatStore', () => {
         conversationMeta.set(cid, {
           ...conversationMeta.get(cid)!,
           unreadCount: 2,
-          readPointer: { messageId: read.id, timestamp: read.timestamp },
+          readPointer: { order: { role: 'floor', timestamp: new Date(read.timestamp).getTime() }, identity: { state: 'local', messageId: read.id } },
         })
         const conversations = new Map(s.conversations)
         conversations.set(cid, {
           ...conversations.get(cid)!,
           unreadCount: 2,
-          readPointer: { messageId: read.id, timestamp: read.timestamp },
+          readPointer: { order: { role: 'floor', timestamp: new Date(read.timestamp).getTime() }, identity: { state: 'local', messageId: read.id } },
         })
         const messages = new Map(s.messages)
         messages.set(cid, [read, realUnread])
@@ -263,13 +263,13 @@ describe('chatStore', () => {
         conversationMeta.set(cid, {
           ...conversationMeta.get(cid)!,
           unreadCount: 2,
-          readPointer: { messageId: read.id, timestamp: read.timestamp },
+          readPointer: { order: { role: 'floor', timestamp: new Date(read.timestamp).getTime() }, identity: { state: 'local', messageId: read.id } },
         })
         const conversations = new Map(s.conversations)
         conversations.set(cid, {
           ...conversations.get(cid)!,
           unreadCount: 2,
-          readPointer: { messageId: read.id, timestamp: read.timestamp },
+          readPointer: { order: { role: 'floor', timestamp: new Date(read.timestamp).getTime() }, identity: { state: 'local', messageId: read.id } },
         })
         // No resident messages array — the durable (never-opened) path.
         return { conversationMeta, conversations, activeConversationId: null }
@@ -1180,11 +1180,7 @@ describe('chatStore', () => {
         const meta = new Map(state.conversationMeta)
         meta.set(A, {
           ...meta.get(A)!,
-          readPointer: {
-            messageId: 'msg-150',
-            timestamp: new Date(150 * 60_000),
-            tiebreak: { kind: 'chat', id: 'msg-150' },
-          },
+          readPointer: { order: { role: 'exact', timestamp: new Date(150 * 60_000).getTime(), tiebreak: { kind: 'chat', id: 'msg-150' } }, identity: { state: 'local', messageId: 'msg-150' } },
         })
         return { conversationMeta: meta }
       })
@@ -1337,7 +1333,7 @@ describe('chatStore', () => {
       chatStore.getState().addConversation({
         ...createConversation(id),
         unreadCount: 4,
-        readPointer: { messageId: 'prior-seen', timestamp: new Date('2025-01-15T09:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-15T09:00:00Z').getTime() }, identity: { state: 'local', messageId: 'prior-seen' } },
       })
       // Backgrounded: never activated, so `isActive` is false. Deliberately NOT
       // a raw `setState({ activeConversationId })` — `setActiveConversation` is
@@ -1360,9 +1356,9 @@ describe('chatStore', () => {
       const conv = chatStore.getState().conversations.get(id)
       const meta = chatStore.getState().conversationMeta.get(id)
       // Both assertions are reversals: pre-D1 these were 'carbon-from-my-phone' and 0.
-      expect(meta?.readPointer?.messageId).toBe('prior-seen')
+      expect(meta?.readPointer?.identity.messageId).toBe('prior-seen')
       expect(meta?.unreadCount).toBe(4)
-      expect(conv?.readPointer?.messageId).toBe('prior-seen')
+      expect(conv?.readPointer?.identity.messageId).toBe('prior-seen')
       expect(conv?.unreadCount).toBe(4)
     })
 
@@ -1975,7 +1971,7 @@ describe('chatStore', () => {
       chatStore.getState().addConversation({
         ...createConversation('alice@example.com'),
         unreadCount: 2,
-        readPointer: { messageId: 'older', timestamp: new Date('2025-01-10T10:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } },
       })
       // Add a message so markAsRead can use its timestamp
       chatStore.getState().addMessage({
@@ -1999,7 +1995,7 @@ describe('chatStore', () => {
       const conv = chatStore.getState().conversations.get('alice@example.com')
       expect(conv?.unreadCount).toBe(0)
       // The whole position moved to msg1 — id and timestamp together.
-      expect(conv?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: messageTimestamp })
+      expect(conv?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: messageTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
     })
 
     // Replaces 'should set lastReadAt to current time when no messages exist'
@@ -2024,7 +2020,7 @@ describe('chatStore', () => {
       chatStore.getState().addConversation({
         ...createConversation('alice@example.com'),
         unreadCount: 0, // Already read
-        readPointer: { messageId: 'older', timestamp: new Date('2025-01-10T10:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } },
       })
 
       // Add a newer message
@@ -2047,7 +2043,7 @@ describe('chatStore', () => {
       chatStore.getState().markAsRead('alice@example.com')
 
       const conv = chatStore.getState().conversations.get('alice@example.com')
-      expect(conv?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: messageTimestamp })
+      expect(conv?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: messageTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
     })
 
     it('should not trigger state update when called twice at the same read position (regression test for infinite loop)', () => {
@@ -2077,7 +2073,7 @@ describe('chatStore', () => {
       chatStore.getState().markAsRead('alice@example.com')
       const convAfterFirst = chatStore.getState().conversations.get('alice@example.com')
       expect(convAfterFirst?.unreadCount).toBe(0)
-      expect(convAfterFirst?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: messageTimestamp })
+      expect(convAfterFirst?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: messageTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
 
       // Capture conversation reference after first markAsRead
       const conversationsMapAfterFirst = chatStore.getState().conversations
@@ -2117,8 +2113,8 @@ describe('chatStore', () => {
       await chatStore.persist.rehydrate()
 
       const pointer = chatStore.getState().conversationMeta.get('alice@example.com')?.readPointer
-      expect(pointer?.timestamp).toBeInstanceOf(Date)
-      expect(pointer).toEqual({ messageId: 'msg1', timestamp: new Date('2025-01-10T10:00:00.000Z') })
+      expect(typeof pointer?.order.timestamp).toBe('number')
+      expect(pointer).toEqual({ order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00.000Z').getTime() }, identity: { state: 'local', messageId: 'msg1' } })
     })
 
     it('places the new-messages divider from the read pointer timestamp in setActiveConversation', () => {
@@ -2135,7 +2131,7 @@ describe('chatStore', () => {
           type: 'chat',
           unreadCount: 1,
           // Position resolved elsewhere (deep in history, not in this slice)
-          readPointer: { messageId: 'msg-older', timestamp: new Date('2025-01-10T10:00:00.000Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00.000Z').getTime() }, identity: { state: 'local', messageId: 'msg-older' } },
         })
         const newMessages = new Map(state.messages)
         newMessages.set('alice@example.com', [{
@@ -2165,7 +2161,7 @@ describe('chatStore', () => {
       chatStore.getState().addConversation({
         ...createConversation(conversationId),
         unreadCount: 2,
-        readPointer: { messageId: 'm1', timestamp: new Date('2025-01-10T10:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
       })
       chatStore.getState().addMessage({
         type: 'chat', id: 'm1', conversationId, from: conversationId, body: 'first',
@@ -2188,7 +2184,7 @@ describe('chatStore', () => {
       chatStore.getState().markReadToNewest(conversationId)
 
       const meta = chatStore.getState().conversationMeta.get(conversationId)
-      expect(meta?.readPointer?.messageId).toBe('m3')
+      expect(meta?.readPointer?.identity.messageId).toBe('m3')
       expect(meta?.unreadCount).toBe(0)
       expect(chatStore.getState().firstNewMessageMarkers.has(conversationId)).toBe(false)
     })
@@ -2198,7 +2194,7 @@ describe('chatStore', () => {
       chatStore.getState().addConversation({
         ...createConversation(conversationId),
         unreadCount: 2,
-        readPointer: { messageId: 'm1', timestamp: new Date('2025-01-10T10:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
       })
       chatStore.getState().addMessage({
         type: 'chat', id: 'm1', conversationId, from: conversationId, body: 'first',
@@ -3909,7 +3905,7 @@ describe('chatStore', () => {
           // tally of 2 unread messages (m2, m3) — so a broken defer gate that
           // commits the derived count instead of returning early fails loudly.
           unreadCount: 5,
-          readPointer: { messageId: 'm1', timestamp: new Date('2025-01-10T10:00:00Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-10T10:00:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
         })
         const convs = new Map(state.conversations)
         convs.set(conversationId, { ...convs.get(conversationId)!, unreadCount: 5 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -22,9 +22,9 @@ import {
   pointerlessDefers,
   worthReconcilingOnDeactivate,
   isAfterBoundary,
-  makeCacheOrderKey,
+  exactPosition,
   isRenderableStoredMessage,
-  type OrderPosition,
+  type PointerOrder,
 } from './shared/readState'
 import {
   transientCounts,
@@ -763,10 +763,20 @@ export async function migrateReadPointer(
   const { lastSeenMessageId, lastReadAt } = legacy
 
   if (lastSeenMessageId && lastReadAt) {
-    return { messageId: lastSeenMessageId, timestamp: lastReadAt }
+    // A FLOOR, and the type now says so: `lastReadAt` is at or behind the
+    // message `lastSeenMessageId` names, so the position is known only to a
+    // millisecond. It also enters `local` — no archive id was ever stored here,
+    // and it must never acquire one: a floor's name and order already disagree,
+    // so giving it a wire name would widen that inconsistency (`withArchiveId`
+    // refuses this pointer for exactly that reason).
+    return { order: { role: 'floor', timestamp: lastReadAt.getTime() }, identity: { state: 'local', messageId: lastSeenMessageId } }
   }
 
   if (lastSeenMessageId) {
+    // Resolved BY ITS IDENTIFIER, so "I know exactly which archived message this
+    // is" is earned: the row's own archive id may ride along, and this pointer
+    // mints `addressable` when the cached row carries one. Contrast the
+    // timestamp-resolved branch below, which cannot make that claim.
     const cached = await messageCache.getMessage(lastSeenMessageId)
     if (cached) return makeReadPointer(cached, 'chat')
     return undefined
@@ -790,7 +800,28 @@ export async function migrateReadPointer(
       before: new Date(lastReadAt.getTime() + 1),
       limit: 1,
     })
-    return newest ? makeReadPointer(newest, 'chat') : undefined
+    if (!newest) return undefined
+
+    // Deliberately WITHOUT the row's archive id, so this pointer mints `local`.
+    //
+    // This row was located by TIMESTAMP, not by identity, and two messages can
+    // share a millisecond — so it can be the wrong message. The pointer is
+    // internally consistent either way (it takes this row's id, timestamp and
+    // tie-break together), and the ORDER is unchanged by dropping the archive
+    // id. What an `addressable` identity would add is a claim of exactness we
+    // never established, and the XEP-0490 publisher would then send that archive
+    // id to the user's other devices as an exact read position — forward-only,
+    // and unrecoverable if it names the wrong row.
+    //
+    // `local` is the honest encoding: claim exactness only where we have it.
+    // It costs nothing lasting — this pointer still converges through the normal
+    // paths, when the position next advances onto a message that carries an
+    // archive id, or when the publisher resolves it.
+    const timestampLocatedLocalSource = {
+      id: newest.id,
+      timestamp: newest.timestamp,
+    }
+    return makeReadPointer(timestampLocatedLocalSource, 'chat')
   }
 
   return undefined
@@ -1465,7 +1496,7 @@ export const chatStore = createStore<ChatState>()(
           // one is never re-folded (that would reposition the divider on every
           // return). Gate + retry policy live in shared/readMarkerSync.
           const foldOnce = (stage: string) => {
-            const lastSeenBefore = get().conversationMeta.get(id)?.readPointer?.messageId
+            const lastSeenBefore = get().conversationMeta.get(id)?.readPointer?.identity.messageId
             const fold = foldPendingRemoteDisplayed(
               mdsGate,
               id,
@@ -1477,7 +1508,7 @@ export const chatStore = createStore<ChatState>()(
                 conversationId: id,
                 pendingStanzaId: fold.pending,
                 lastSeenBefore,
-                lastSeenAfter: get().conversationMeta.get(id)?.readPointer?.messageId,
+                lastSeenAfter: get().conversationMeta.get(id)?.readPointer?.identity.messageId,
                 resolved: fold.resolved,
               })
             } else if (fold.pending) {
@@ -1503,7 +1534,7 @@ export const chatStore = createStore<ChatState>()(
           // degraded case is gone. What a cache miss costs is CONTEXT: the
           // latest slice is kept, the divider lands wherever the boundary falls
           // inside it, and MAM catch-up heals the cache for the next open.
-          const pointer = get().conversationMeta.get(id)?.readPointer?.messageId
+          const pointer = get().conversationMeta.get(id)?.readPointer?.identity.messageId
           if (pointer) {
             const loaded = get().messages.get(id) ?? []
             if (!loaded.some((m) => m.id === pointer)) {
@@ -1658,7 +1689,7 @@ export const chatStore = createStore<ChatState>()(
           const before = transientCounts(scopeKey, undefined).unread
           const result = noteTransient(
             scopeKey,
-            { position: { timestamp: msg.timestamp.getTime(), tiebreak: makeCacheOrderKey(msg, 'chat') } },
+            { position: exactPosition(msg, 'chat') },
             transientIdentity({ id: msg.id }, 'chat'),
             transientAliases({ id: msg.id }, 'chat')
           )
@@ -1871,10 +1902,7 @@ export const chatStore = createStore<ChatState>()(
           // later recompute trigger. Pruning is a memory bound only:
           // transientCounts already excludes entries at/behind the boundary.
           if (updated.readPointer && updated.readPointer !== notifInput.readPointer) {
-            pruneTransient(chatTransientScopeKey(conversationId), {
-              timestamp: updated.readPointer.timestamp.getTime(),
-              tiebreak: updated.readPointer.tiebreak,
-            })
+            pruneTransient(chatTransientScopeKey(conversationId), updated.readPointer.order)
           }
 
           const draft = draftConversationMaps(state)
@@ -1900,7 +1928,7 @@ export const chatStore = createStore<ChatState>()(
 
           // Skip update if already fully read: pointer at the computed newest id,
           // no unread count, and no "new messages" divider to clear.
-          const currentSeenMessageId = (meta?.readPointer ?? existing.readPointer)?.messageId
+          const currentSeenMessageId = (meta?.readPointer ?? existing.readPointer)?.identity.messageId
           const currentUnreadCount = meta?.unreadCount ?? existing.unreadCount ?? 0
           if (
             currentSeenMessageId === newest.id &&
@@ -1915,10 +1943,7 @@ export const chatStore = createStore<ChatState>()(
           // Task 9: mark-all-read jumps the pointer straight to the newest
           // message — prune the overlay now rather than leaving every noted
           // entry to a later recompute trigger.
-          pruneTransient(chatTransientScopeKey(conversationId), {
-            timestamp: readPointer.timestamp.getTime(),
-            tiebreak: readPointer.tiebreak,
-          })
+          pruneTransient(chatTransientScopeKey(conversationId), readPointer.order)
 
           const draft = draftConversationMaps(state)
           draft.setMeta(conversationId, {
@@ -2020,10 +2045,7 @@ export const chatStore = createStore<ChatState>()(
           // pruned-away entry was already excluded from transientCounts by
           // the boundary comparison, this just reclaims the memory.
           if (updated.readPointer) {
-            pruneTransient(chatTransientScopeKey(conversationId), {
-              timestamp: updated.readPointer.timestamp.getTime(),
-              tiebreak: updated.readPointer.tiebreak,
-            })
+            pruneTransient(chatTransientScopeKey(conversationId), updated.readPointer.order)
           }
 
           const draft = draftConversationMaps(state)
@@ -2576,7 +2598,7 @@ export const chatStore = createStore<ChatState>()(
         // count below is computed AGAINST. Re-checked at the final commit
         // (see that guard's comment) to close a race the new allowActive
         // trigger (advanceReadPointer) makes materially more likely.
-        const pointerIdAtCompute = metaNow.readPointer?.messageId
+        const pointerIdAtCompute = metaNow.readPointer?.identity.messageId
         const unreadInputVersionAtCompute = chatUnreadInputVersion.get(conversationId) ?? 0
 
         const floor = computeFloor(metaNow.readPointer, metaNow.historyFloor)
@@ -2597,26 +2619,24 @@ export const chatStore = createStore<ChatState>()(
           if (record) get().clearConversationCoverage(conversationId, record.bottomId)
           return
         }
-        // The floor as an OrderPosition: when the floor came from the pointer,
-        // reuse the pointer's own order key so the comparison isn't blind to a
-        // coverage bottom sharing its exact millisecond; a historyFloor-derived
-        // floor has no such key (unresolved sorts conservatively).
-        const floorPos: OrderPosition = metaNow.readPointer
-          ? { timestamp: metaNow.readPointer.timestamp.getTime(), tiebreak: metaNow.readPointer.tiebreak }
-          : { timestamp: floor.getTime() }
+        // The boundary: the pointer's own order when there is one, so the
+        // comparison is not blind to a coverage bottom sharing its exact
+        // millisecond; a historyFloor-derived boundary knows only a millisecond
+        // and says so (unresolved sorts conservatively).
+        const floorPos: PointerOrder = metaNow.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
 
         // Task 9 safety net: this recompute is one of the "pointer advance /
         // content settled" triggers — bound the transient overlay's memory
         // here too, since not every trigger path calls pruneTransient directly.
         pruneTransient(chatTransientScopeKey(conversationId), floorPos)
 
-        // A BOUNDARY test: a keyless (migrated) floor reads as at-or-after its
+        // A BOUNDARY test: a FLOOR (migrated) boundary reads as at-or-after its
         // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
         if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
 
         const res = await messageCache.countUnreadInArchive(conversationId, {
           floor,
-          pointer: metaNow.readPointer,
+          pointer: metaNow.readPointer?.order,
         })
         if (!recountContextIsCurrent()) return
         if (res === null) return // unavailable — IndexedDB error
@@ -2650,7 +2670,7 @@ export const chatStore = createStore<ChatState>()(
           // the newer, correct value — worst case this recompute under-acts
           // once; the next trigger (another arrival, deactivation, or
           // activation) re-derives it.
-          if (meta.readPointer?.messageId !== pointerIdAtCompute) return state
+          if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) return state
 
           // Rederive the divider (requirement 5): the boundary may have moved
           // since a marker was last parked here (a remote pointer advance).

--- a/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
@@ -21,6 +21,7 @@ import type { Message, Conversation } from '../core/types'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, getStorageScopeJid } from '../utils/storageScope'
 import { _clearAllTransientForTesting } from './shared/transientUnread'
+import type { ReadPointer } from './shared/readPointer'
 import {
   currentViewportGeneration,
   currentViewportEvidence,
@@ -105,7 +106,7 @@ function reportCurrent(conversationId: string, evidence: 'at-edge' | 'away'): vo
  * reset without touching the SDK's own activation code path under test.
  */
 function setPriorReadState(id: string, unreadCount: number, priorMessageId: string): void {
-  const priorPointer = { messageId: priorMessageId, timestamp: new Date('2025-01-15T08:00:00Z') }
+  const priorPointer: ReadPointer = { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: priorMessageId } }
   chatStore.setState((state) => {
     const meta = state.conversationMeta.get(id)
     const conv = state.conversations.get(id)
@@ -177,7 +178,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       // Break check (a): gating on `isActive && windowVisible` only would take the
       // "sees it" branch here and wrongly report unreadCount 4 (unchanged from the
       // seed, since force-zero was removed) / pointer advanced.
-      expect(conv?.readPointer?.messageId).toBe(PRIOR_MESSAGE_ID)
+      expect(conv?.readPointer?.identity.messageId).toBe(PRIOR_MESSAGE_ID)
       expect(conv?.unreadCount).toBe(5)
     })
 
@@ -189,7 +190,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       chatStore.getState().addMessage(msg)
 
       const conv = chatStore.getState().conversations.get('alice@example.com')
-      expect(conv?.readPointer?.messageId).toBe(msg.id)
+      expect(conv?.readPointer?.identity.messageId).toBe(msg.id)
       expect(conv?.unreadCount).toBe(0)
     })
 
@@ -200,7 +201,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       chatStore.getState().addMessage(createMessage('alice@example.com', 'incoming, no report yet'))
 
       const conv = chatStore.getState().conversations.get('alice@example.com')
-      expect(conv?.readPointer?.messageId).toBe(PRIOR_MESSAGE_ID)
+      expect(conv?.readPointer?.identity.messageId).toBe(PRIOR_MESSAGE_ID)
       expect(conv?.unreadCount).toBe(5)
     })
 
@@ -213,7 +214,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       chatStore.getState().addMessage(createMessage('alice@example.com', 'incoming while unfocused'))
 
       const conv = chatStore.getState().conversations.get('alice@example.com')
-      expect(conv?.readPointer?.messageId).toBe(PRIOR_MESSAGE_ID)
+      expect(conv?.readPointer?.identity.messageId).toBe(PRIOR_MESSAGE_ID)
       expect(conv?.unreadCount).toBe(5)
     })
   })
@@ -245,7 +246,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       const convB = chatStore.getState().conversations.get('convB@example.com')
       // Break check (b) territory: if B's evidence had inherited/started at-edge
       // (instead of 'unknown'), this would wrongly advance and zero the count.
-      expect(convB?.readPointer?.messageId).toBe(PRIOR_B)
+      expect(convB?.readPointer?.identity.messageId).toBe(PRIOR_B)
       expect(convB?.unreadCount).toBe(5)
     })
 
@@ -275,7 +276,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       chatStore.getState().addMessage(createMessage('convB@example.com', 'arrives after A (only) reports'))
 
       const convB = chatStore.getState().conversations.get('convB@example.com')
-      expect(convB?.readPointer?.messageId).toBe(PRIOR_B)
+      expect(convB?.readPointer?.identity.messageId).toBe(PRIOR_B)
       expect(convB?.unreadCount).toBe(5)
       // B's OWN evidence is unaffected by a report scoped to A's key.
       expect(currentViewportEvidence(evidenceKey('convB@example.com'))).toBe('unknown')
@@ -296,7 +297,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       chatStore.getState().addMessage(msg)
 
       const convB = chatStore.getState().conversations.get('convB@example.com')
-      expect(convB?.readPointer?.messageId).toBe(msg.id)
+      expect(convB?.readPointer?.identity.messageId).toBe(msg.id)
       expect(convB?.unreadCount).toBe(0)
     })
   })
@@ -324,7 +325,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       reportViewport(evidenceKey('alice@example.com'), firstGeneration, 'at-edge')
       chatStore.getState().addMessage(createMessage('alice@example.com', 'arrives after the stale re-activation report'))
       const convAfterStaleReport = chatStore.getState().conversations.get('alice@example.com')
-      expect(convAfterStaleReport?.readPointer?.messageId).toBe(PRIOR)
+      expect(convAfterStaleReport?.readPointer?.identity.messageId).toBe(PRIOR)
       expect(convAfterStaleReport?.unreadCount).toBe(5)
 
       // A report on the NEW (current) generation is accepted.
@@ -332,7 +333,7 @@ describe('chatStore viewport-evidence gate (Task 11)', () => {
       const msg = createMessage('alice@example.com', 'arrives once the new generation reports at-edge')
       chatStore.getState().addMessage(msg)
       const convAfterFreshReport = chatStore.getState().conversations.get('alice@example.com')
-      expect(convAfterFreshReport?.readPointer?.messageId).toBe(msg.id)
+      expect(convAfterFreshReport?.readPointer?.identity.messageId).toBe(msg.id)
       expect(convAfterFreshReport?.unreadCount).toBe(0)
     })
   })

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -44,7 +44,7 @@ import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
  * message, so in production its tie-break always resolves (#1173).
  */
 const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'room')
-const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
+const posAt = (timestamp: number): ExactPosition => ({ role: 'exact', timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
@@ -152,7 +152,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 99, // stale — must be overwritten by the exact derivation
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -174,7 +174,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -195,7 +195,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     setMeta({
       unreadCount: 0,
       // Legacy/migrated shape: no tiebreak at all.
-      readPointer: { messageId: 'p0', timestamp: new Date(1000) },
+      readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -220,7 +220,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // ---------------------------------------------------------------------
 
   it('a forward MAM merge into a non-active room with new messages triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } } })
     roomStore.setState({ activeRoomJid: 'someone-else@conference.example.com' })
     const original = roomStore.getState().recomputeUnreadForRoom
     const spy = vi.fn(original)
@@ -260,7 +260,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // ---------------------------------------------------------------------
 
   it('a remote marker advancing a non-active room triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } } })
     roomStore.setState({ activeRoomJid: 'someone-else@conference.example.com' })
     const original = roomStore.getState().recomputeUnreadForRoom
     const spy = vi.fn(original)
@@ -287,7 +287,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -319,7 +319,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // tell a real recompute from a no-op.
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -341,7 +341,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // the fire-and-forget recount below.
     expect(roomStore.getState().activeRoomJid).toBe(ROOM)
     // The pointer advanced (resolveRemoteDisplayed's job, unaffected by this fix).
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
     // The divider was positioned at the first message after the new pointer.
     expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('u1')
     // FIX 3: the count is re-derived from the archive (u1, u2, u3), not left
@@ -396,7 +396,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5, // the persisted/trusted value
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     // Coverage IS proven and resolvable — but mamQueryStates is left at its
     // default (NOT caught up to live), so the caught-up gate is the single
@@ -409,7 +409,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     await roomStore.getState().recomputeUnreadForRoom(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(5)
   })
 
@@ -417,7 +417,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     roomStore.setState((state) => {
       const mamQueryStates = new Map(state.mamQueryStates)
@@ -435,7 +435,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 6,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     // bottomId names an archive stanza-id that was never saved — unresolvable.
     seedCoverage('nonexistent-stanza-id')
@@ -466,7 +466,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 8, // trusted — must survive untouched
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('gap-anchor-stanza')
 
@@ -506,8 +506,8 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     roomStore.getState().addMessage(ROOM, archiveMsg('m1', T, { from: `${ROOM}/zulu`, nick: 'zulu' }))
     // Viewport observer reports zulu's message seen while it is the only resident message.
     roomStore.getState().advanceReadPointer(ROOM, 'm1')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.tiebreak).toMatchObject({ from: `${ROOM}/zulu` })
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.order).toMatchObject({ tiebreak: { from: `${ROOM}/zulu` } })
 
     // A same-millisecond message from a DIFFERENT occupant arrives live, SECOND.
     roomStore.getState().addMessage(ROOM, archiveMsg('m2', T, { from: `${ROOM}/alice`, nick: 'alice' }))
@@ -525,7 +525,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // resident array, so the forward-only guard must NOT move the pointer
     // backward past the already-confirmed zulu message.
     roomStore.getState().advanceReadPointer(ROOM, 'm2')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
 
     // Settle: the user navigates away, and the archive-derived recompute runs.
     roomStore.setState({ activeRoomJid: null })
@@ -556,7 +556,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     // Active + focused (default windowVisible), but viewportAtLiveEdge is
@@ -605,7 +605,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -635,7 +635,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -679,7 +679,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -718,7 +718,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5, // stale — the slow recompute below would derive 1 (u1) from THIS pointer
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -742,7 +742,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       meta.set(ROOM, {
         ...meta.get(ROOM)!,
         unreadCount: 0,
-        readPointer: { messageId: 'u1', timestamp: new Date(1001), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'u1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1001).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'u1' } }, identity: { state: 'local', messageId: 'u1' } },
       })
       return { roomMeta: meta }
     })
@@ -754,7 +754,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     // The direct write's fresher, correct state survives untouched.
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('u1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('u1')
   })
 
   // ---------------------------------------------------------------------
@@ -786,7 +786,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     seedActiveWithStaleMarker([anchor, p0, u1])
@@ -810,7 +810,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState((state) => {
@@ -823,7 +823,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     })
 
     roomStore.getState().advanceReadPointer(ROOM, 'u1')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('u1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('u1')
 
     // The count converges (the advance's whole purpose) — but the divider the
     // reader is looking at survives. Clearing it belongs to read-through
@@ -844,7 +844,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState((state) => {
@@ -880,7 +880,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 5,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -891,7 +891,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     })
 
     it('deferred outcome', async () => {
-      setMeta({ unreadCount: 3, mentionsCount: SEEDED_MENTIONS, readPointer: { messageId: 'p0', timestamp: new Date(1000) } })
+      setMeta({ unreadCount: 3, mentionsCount: SEEDED_MENTIONS, readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'p0' } } })
       // Not caught up — defers.
 
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
@@ -904,7 +904,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 3,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countRoomUnreadInArchive).mockResolvedValueOnce(null)
@@ -930,7 +930,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // One never-archived (noLocalStore) message, after the pointer.
@@ -959,7 +959,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
       setMeta({
         unreadCount: 0,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
     })
@@ -1070,7 +1070,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0 derived below
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       // Active + focused (default windowVisible), with the full history
@@ -1081,7 +1081,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // The viewport observer reports the NEWEST resident message seen —
       // reaching the live edge.
       roomStore.getState().advanceReadPointer(ROOM, 'm3')
-      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
 
       // Poll for the fire-and-forget archive recount (this fix's trigger) to
       // settle, rather than guessing a tick count.
@@ -1101,7 +1101,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 and the correct 2
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(500).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } }, identity: { state: 'local', messageId: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.setState({ activeRoomJid: ROOM })
@@ -1110,7 +1110,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // The viewport observer reports 'm1' seen — the user scrolled PARTWAY,
       // not to the bottom. 'm2' and 'm3' remain genuinely unread.
       roomStore.getState().advanceReadPointer(ROOM, 'm1')
-      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
 
       // Exactly 2 remaining (m2, m3) — neither the stale 5 (trigger missing)
       // nor a wrongly-zeroed 0 (a broken floor/pointer would over-clear).
@@ -1129,7 +1129,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // above) while unreadCount is stale.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } }, identity: { state: 'local', messageId: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.getState().addRoom(createRoom('other-room@conference.example.com'))
@@ -1169,7 +1169,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // here), same as the fully-read sibling test above.
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.getState().addRoom(createRoom('other-room@conference.example.com'))
@@ -1262,7 +1262,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 3,
         mentionsCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1270,7 +1270,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
       // A surviving outgoing-boundary advance would put this at 'mine' and drop
       // the count to 1 by swallowing u1.
-      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
       expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(4)
     })
@@ -1287,7 +1287,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 4,
         mentionsCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1301,7 +1301,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await roomStore.getState().recomputeUnreadForRoom(ROOM)
 
       // The reply came from another device. Nothing here is evidence we read u1.
-      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(3)
       expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(4)
     })
@@ -1339,7 +1339,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       ])
       setMeta({
         unreadCount: 1,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1392,7 +1392,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // can never schedule a recount. This is the reported defect.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } }, identity: { state: 'local', messageId: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       seedResident([anchor, m1])
@@ -1426,7 +1426,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, p0, u1, u2])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       seedResident([anchor, p0, u1, u2])
@@ -1451,7 +1451,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       ])
       setMeta({
         unreadCount: 0, // nothing to correct downward
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } }, identity: { state: 'local', messageId: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countRoomUnreadInArchive).mockClear()

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -119,7 +119,7 @@ function seedRoom(
     // construction — a position we cannot locate in this slice, i.e. the
     // migrated shape — so it stays keyless.
     const readPointer: ReadPointer = pointerTimestamp
-      ? { messageId: seenMessageId, timestamp: pointerTimestamp }
+      ? { order: { role: 'floor', timestamp: pointerTimestamp.getTime() }, identity: { state: 'local', messageId: seenMessageId } }
       : pointerIn(messages, seenMessageId)
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
@@ -163,13 +163,13 @@ describe('roomStore.applyRemoteDisplayed', () => {
   it('advances the read pointer forward to the local id of the matching stanza-id', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
     roomStore.getState().applyRemoteDisplayed(ROOM, 's3')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('never regresses the read pointer (incoming marker behind current)', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm3')
     roomStore.getState().applyRemoteDisplayed(ROOM, 's1')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('stores a pending high-water mark when the stanza-id is not yet loaded', () => {
@@ -177,7 +177,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().applyRemoteDisplayed(ROOM, 's-future')
     const meta = roomStore.getState().roomMeta.get(ROOM)
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe('s-future')
-    expect(meta?.readPointer?.messageId).toBe('m1')
+    expect(meta?.readPointer?.identity.messageId).toBe('m1')
   })
 
   it('clears a stale pending marker when the message is loaded but position already past it', () => {
@@ -192,7 +192,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().applyRemoteDisplayed(ROOM, 's1')
     const after = roomStore.getState().roomMeta.get(ROOM)
     expect(after?.pendingRemoteDisplayedStanzaId).toBe(undefined)
-    expect(after?.readPointer?.messageId).toBe('m2')
+    expect(after?.readPointer?.identity.messageId).toBe('m2')
   })
 
   // PR C, D3 widening — at the store layer, where it actually bites. The store
@@ -223,7 +223,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().applyRemoteDisplayed(ROOM, 's3', mergedPage)
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m3')
+    expect(meta?.readPointer?.identity.messageId).toBe('m3')
     // Resolved, so the high-water mark is retired rather than left to re-fire.
     expect(meta?.pendingRemoteDisplayedStanzaId).toBeUndefined()
     // The count is NOT this page's own tally (which would be 1: m4 alone). It
@@ -246,7 +246,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
 
     roomStore.getState().applyRemoteDisplayed(ROOM, 's4')
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m4')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m4')
     expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBe('m3')
   })
 
@@ -260,7 +260,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
 
     roomStore.getState().applyRemoteDisplayed(ROOM, 's4')
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m4')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m4')
     expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m3')
   })
 
@@ -296,7 +296,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().applyRemoteDisplayed(ROOM, 's4', messages)
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m4')
+    expect(meta?.readPointer?.identity.messageId).toBe('m4')
 
     // Let the fire-and-forget archive recount run to completion.
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -332,7 +332,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().applyRemoteDisplayed(ROOM, 's2', messages)
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m2')
+    expect(meta?.readPointer?.identity.messageId).toBe('m2')
 
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(3)
@@ -352,7 +352,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     )
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m5')
+    expect(meta?.readPointer?.identity.messageId).toBe('m5')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
   })
 
@@ -399,7 +399,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
 
     // Pointer resolved at p0 (forward-only sync is unconditional and
     // unaffected by PR B).
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
 
     // The archive-derived recount runs (fire-and-forget) but defers: no
     // mamQueryStates/roomCoverage were seeded, so coverage down to the new
@@ -439,7 +439,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     // PR B: the pointer resolves synchronously, but the count is no longer
     // written synchronously from this page — the archive-derived recount is
     // still pending on the gated cache read below, so the count is untouched.
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('p0')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
 
     // User opens the room before the cache read lands. No coverage record or
@@ -493,7 +493,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
 
     await roomStore.getState().activateRoom(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m4')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m4')
     expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
   })
 
@@ -511,7 +511,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       return { roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
-    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m3')
 
     // Leave (deactivation evicts the resident message array).
     await roomStore.getState().activateRoom(null)
@@ -528,7 +528,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       return { roomRuntime: rt, roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
-    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   // Regression (bug: "read on another device, still unread on return"): a NEWER remote read
@@ -547,7 +547,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       return { roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
-    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m3')
 
     // Leave (deactivation evicts the resident message array).
     await roomStore.getState().activateRoom(null)
@@ -563,7 +563,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       return { roomRuntime: rt, roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
-    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.messageId).toBe('m4')
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m4')
   })
 
   // Regression (gate burn on stash): the first activation fold may find the marker's
@@ -584,7 +584,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
 
     await roomStore.getState().activateRoom(RETRY_ROOM)
     // Unresolvable → stash survives, pointer untouched.
-    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.readPointer?.identity.messageId).toBe('m1')
     expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.pendingRemoteDisplayedStanzaId).toBe('s9')
 
     await roomStore.getState().activateRoom(null)
@@ -600,7 +600,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
 
     await roomStore.getState().activateRoom(RETRY_ROOM)
     // The gate must allow the retry (the marker was never actually folded).
-    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.readPointer?.messageId).toBe('m9')
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.readPointer?.identity.messageId).toBe('m9')
     expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
   })
 
@@ -632,7 +632,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     await roomStore.getState().activateRoom(DEEP_ROOM)
 
     // The retried fold advances the pointer to the synced position…
-    expect(roomStore.getState().roomMeta.get(DEEP_ROOM)?.readPointer?.messageId).toBe('m5')
+    expect(roomStore.getState().roomMeta.get(DEEP_ROOM)?.readPointer?.identity.messageId).toBe('m5')
     expect(roomStore.getState().roomMeta.get(DEEP_ROOM)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
     // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
     expect(roomSelectors.firstNewMessageIdFor(DEEP_ROOM)(roomStore.getState())).toBe('m6')
@@ -711,7 +711,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     const full = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4), rmsg('m5', 's5', 5)]
     roomStore.getState().applyRemoteDisplayed(AHEAD_ROOM, 's4', full)
 
-    expect(roomStore.getState().roomMeta.get(AHEAD_ROOM)?.readPointer?.messageId).toBe('m4')
+    expect(roomStore.getState().roomMeta.get(AHEAD_ROOM)?.readPointer?.identity.messageId).toBe('m4')
     expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m5')
     expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(false)
   })
@@ -833,8 +833,8 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     roomStore.getState().markAsRead(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
-    expect(roomStore.getState().rooms.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
+    expect(roomStore.getState().rooms.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
   })
 
@@ -854,7 +854,7 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     roomStore.getState().markAsRead(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
   })
 
@@ -870,7 +870,7 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     roomStore.getState().markAsRead(ROOM)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
   })
 })
@@ -908,24 +908,24 @@ describe('roomStore.advanceReadPointer presence gate', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
     connectionStore.getState().setWindowVisible(true)
     roomStore.getState().advanceReadPointer(ROOM, 'm3')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
   })
 
   it('does not advance the read pointer while the window is unfocused', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
     connectionStore.getState().setWindowVisible(false)
     roomStore.getState().advanceReadPointer(ROOM, 'm3')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
   })
 
   it('resumes advancing once the window regains focus', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
     connectionStore.getState().setWindowVisible(false)
     roomStore.getState().advanceReadPointer(ROOM, 'm2')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
     connectionStore.getState().setWindowVisible(true)
     roomStore.getState().advanceReadPointer(ROOM, 'm3')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
   })
 })
 
@@ -971,7 +971,7 @@ describe('roomStore fresh-instance catch-up preserves the remote read position',
     roomStore.getState().mergeRoomMAMMessages(ROOM, archive(), {}, true, 'forward')
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m3')
+    expect(meta?.readPointer?.identity.messageId).toBe('m3')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
   })
 
@@ -996,7 +996,7 @@ describe('roomStore fresh-instance catch-up preserves the remote read position',
 
     roomStore.getState().mergeRoomMAMMessages(ROOM, archive(), {}, true, 'forward')
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m3')
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
   })
@@ -1073,7 +1073,7 @@ describe('roomStore pending-marker guard edges', () => {
     )
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m5')
+    expect(meta?.readPointer?.identity.messageId).toBe('m5')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
   })
 
@@ -1099,7 +1099,7 @@ describe('roomStore pending-marker guard edges', () => {
       {}, true, 'forward'
     )
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m1')
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
   })
@@ -1129,7 +1129,7 @@ describe('roomStore pending-marker guard edges', () => {
     roomStore.getState().mergeRoomMAMMessages(ROOM, page, {}, true, 'forward')
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer?.messageId).toBe('m2')
+    expect(meta?.readPointer?.identity.messageId).toBe('m2')
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
     expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(4)

--- a/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
@@ -137,7 +137,11 @@ describe('room read state persistence', () => {
     expect(persisted.get(ROOM)?.historyFloor).toBeInstanceOf(Date)
     // …and the pointer itself, not just the creation-time floor: a wiring that
     // only saved at addRoom would pass the floor assertion above on its own.
-    expect(persisted.get(ROOM)?.readPointer).toMatchObject({ messageId: 'm5', timestamp: new Date(5000) })
+    expect(persisted.get(ROOM)?.readPointer).toEqual({
+      order: { role: 'exact', timestamp: 5000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm5' } },
+      // The room reflected a stanza-id, so the position is publishable as-is.
+      identity: { state: 'addressable', messageId: 'm5', archiveId: 's-m5' },
+    })
   })
 
   // The one shape that can tell DISK apart from MEMORY, and so the only test
@@ -152,7 +156,7 @@ describe('room read state persistence', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify([
-        [DISK_ONLY_ROOM, { readPointer: { messageId: 'd7', timestamp: 7000 }, historyFloor: 1000 }],
+        [DISK_ONLY_ROOM, { readPointer: { order: { role: 'floor', timestamp: new Date(7000).getTime() }, identity: { state: 'local', messageId: 'd7' } }, historyFloor: 1000 }],
       ])
     )
 
@@ -161,7 +165,7 @@ describe('room read state persistence', () => {
     roomStore.getState().addRoom(makeRoom(DISK_ONLY_ROOM))
 
     const meta = roomStore.getState().roomMeta.get(DISK_ONLY_ROOM)
-    expect(meta?.readPointer).toEqual({ messageId: 'd7', timestamp: new Date(7000) })
+    expect(meta?.readPointer).toEqual({ order: { role: 'floor', timestamp: new Date(7000).getTime() }, identity: { state: 'local', messageId: 'd7' } })
     // …and the floor must come from disk rather than being restamped to now.
     expect(meta?.historyFloor).toEqual(new Date(1000))
   })
@@ -175,7 +179,10 @@ describe('room read state persistence', () => {
     roomStore.getState().addRoom(makeRoom(ROOM))
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer).toMatchObject({ messageId: 'm5', timestamp: new Date(5000) })
+    expect(meta?.readPointer).toEqual({
+      order: { role: 'exact', timestamp: 5000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm5' } },
+      identity: { state: 'addressable', messageId: 'm5', archiveId: 's-m5' },
+    })
   })
 
   // The cross-restart half of the "written once" rule: re-adding the room in a
@@ -199,11 +206,9 @@ describe('room read state persistence', () => {
     // The markReadToNewest save is the one under test, and it coalesced behind
     // addRoom's leading edge.
     flushThrottledStorage()
-    // toMatchObject: makeReadPointer also stamps a tiebreak onto the
-    // pointer; this assertion only cares about messageId/timestamp.
-    expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toMatchObject({
-      messageId: 'm2',
-      timestamp: new Date(2000),
+    expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toEqual({
+      order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' } },
+      identity: { state: 'addressable', messageId: 'm2', archiveId: 's-m2' },
     })
   })
 
@@ -235,7 +240,10 @@ describe('room read state persistence', () => {
     roomStore.getState().setBookmark(ROOM, { name: 'Room', nick: 'me', autojoin: true })
 
     const meta = roomStore.getState().roomMeta.get(ROOM)
-    expect(meta?.readPointer).toMatchObject({ messageId: 'm5', timestamp: new Date(5000) })
+    expect(meta?.readPointer).toEqual({
+      order: { role: 'exact', timestamp: 5000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm5' } },
+      identity: { state: 'addressable', messageId: 'm5', archiveId: 's-m5' },
+    })
     expect(meta?.historyFloor).toEqual(floor)
   })
 
@@ -249,16 +257,16 @@ describe('room read state persistence', () => {
   it('keeps the durable pointer when the snapshot Room carries a staler one', () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify([[ROOM, { readPointer: { messageId: 'm9', timestamp: 9000 }, historyFloor: 1000 }]])
+      JSON.stringify([[ROOM, { readPointer: { order: { role: 'floor', timestamp: new Date(9000).getTime() }, identity: { state: 'local', messageId: 'm9' } }, historyFloor: 1000 }]])
     )
     roomStore.getState().switchAccount(JID)
 
     // The snapshot was written before the last few advances landed.
-    roomStore.getState().addRoom({ ...makeRoom(ROOM), readPointer: { messageId: 'm5', timestamp: new Date(5000) } } as Room)
+    roomStore.getState().addRoom({ ...makeRoom(ROOM), readPointer: { order: { role: 'floor', timestamp: new Date(5000).getTime() }, identity: { state: 'local', messageId: 'm5' } } } as Room)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toEqual({ messageId: 'm9', timestamp: new Date(9000) })
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toEqual({ order: { role: 'floor', timestamp: new Date(9000).getTime() }, identity: { state: 'local', messageId: 'm9' } })
     // …and the durable row must not have been overwritten with the staler one.
-    expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toEqual({ messageId: 'm9', timestamp: new Date(9000) })
+    expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toEqual({ order: { role: 'floor', timestamp: new Date(9000).getTime() }, identity: { state: 'local', messageId: 'm9' } })
   })
 
   // Control for the same rule in the other direction: the snapshot is not being
@@ -266,13 +274,13 @@ describe('room read state persistence', () => {
   it('takes the snapshot pointer when it is ahead of the durable row', () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify([[ROOM, { readPointer: { messageId: 'm5', timestamp: 5000 }, historyFloor: 1000 }]])
+      JSON.stringify([[ROOM, { readPointer: { order: { role: 'floor', timestamp: new Date(5000).getTime() }, identity: { state: 'local', messageId: 'm5' } }, historyFloor: 1000 }]])
     )
     roomStore.getState().switchAccount(JID)
 
-    roomStore.getState().addRoom({ ...makeRoom(ROOM), readPointer: { messageId: 'm9', timestamp: new Date(9000) } } as Room)
+    roomStore.getState().addRoom({ ...makeRoom(ROOM), readPointer: { order: { role: 'floor', timestamp: new Date(9000).getTime() }, identity: { state: 'local', messageId: 'm9' } } } as Room)
 
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toEqual({ messageId: 'm9', timestamp: new Date(9000) })
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toEqual({ order: { role: 'floor', timestamp: new Date(9000).getTime() }, identity: { state: 'local', messageId: 'm9' } })
   })
 
   it('drops a removed room from the durable copy', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
@@ -91,7 +91,7 @@ describe('roomStore.resyncDividerToReadPointer', () => {
     seed({ lastSeen: 'm2', marker: 'm1', messages: [msg('m1'), msg('m2'), msg('m3')] })
     roomStore.getState().resyncDividerToReadPointer(JID)
     const meta = roomStore.getState().roomMeta.get(JID)!
-    expect(meta.readPointer?.messageId).toBe('m2')
+    expect(meta.readPointer?.identity.messageId).toBe('m2')
     expect(meta.unreadCount).toBe(0)
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3,7 +3,7 @@ import { roomStore, _resetRoomArchiveSavesForTesting, _resetRoomReadStateForTest
 import type { Room, RoomMessage, RoomMetadata } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { createRoom, createMessage } from './roomStore.testHelpers'
-import { makeReadPointer } from './shared/readPointer'
+import { makeReadPointer, type ReadPointer } from './shared/readPointer'
 import {
   flush as flushThrottledStorage,
   _resetForTesting as _resetThrottledStorageForTesting,
@@ -1175,9 +1175,9 @@ describe('roomStore', () => {
       const room = roomStore.getState().rooms.get('test@conference.example.com')
       const meta = roomStore.getState().roomMeta.get('test@conference.example.com')
       expect(room?.unreadCount).toBe(0)
-      expect(room?.readPointer?.messageId).toBe('msg-outgoing')
+      expect(room?.readPointer?.identity.messageId).toBe('msg-outgoing')
       expect(meta?.unreadCount).toBe(0)
-      expect(meta?.readPointer?.messageId).toBe('msg-outgoing')
+      expect(meta?.readPointer?.identity.messageId).toBe('msg-outgoing')
     })
 
     // PR C, D1 — the NEGATIVE control for the two tests above, and the vector
@@ -1216,9 +1216,9 @@ describe('roomStore', () => {
       const room = roomStore.getState().rooms.get(jid)
       const meta = roomStore.getState().roomMeta.get(jid)
       // Both assertions are reversals: pre-D1 these were 'reflected-from-another-device' and 0.
-      expect(meta?.readPointer?.messageId).toBe('prior-seen')
+      expect(meta?.readPointer?.identity.messageId).toBe('prior-seen')
       expect(meta?.unreadCount).toBe(4)
-      expect(room?.readPointer?.messageId).toBe('prior-seen')
+      expect(room?.readPointer?.identity.messageId).toBe('prior-seen')
       expect(room?.unreadCount).toBe(4)
     })
 
@@ -1435,7 +1435,7 @@ describe('roomStore', () => {
     })
 
     it('should preserve the read pointer when inactive room gets new message', () => {
-      const existing = { messageId: 'older', timestamp: new Date('2025-01-15T08:00:00Z') }
+      const existing: ReadPointer = { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } }
       roomStore.getState().addRoom(createRoom('test@conference.example.com', {
         readPointer: existing,
       }))
@@ -1462,7 +1462,7 @@ describe('roomStore', () => {
     // evidence (no `reportAtLiveEdge` call), so it stays in the "user doesn't
     // see the message" branch and the pointer is correctly left untouched.
     it('should NOT move the read pointer when an active room gets a new message without live-edge evidence', () => {
-      const existing = { messageId: 'older', timestamp: new Date('2025-01-15T08:00:00Z') }
+      const existing: ReadPointer = { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } }
       roomStore.getState().addRoom(createRoom('test@conference.example.com', {
         readPointer: existing,
       }))
@@ -1857,7 +1857,7 @@ describe('roomStore', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', {
         unreadCount: 2,
         mentionsCount: 1,
-        readPointer: { messageId: 'older', timestamp: new Date('2025-01-15T08:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } },
       }))
       roomStore.getState().addMessage('test@conference.example.com', {
         ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Hello'),
@@ -1873,7 +1873,7 @@ describe('roomStore', () => {
       roomStore.getState().markAsRead('test@conference.example.com')
 
       const room = roomStore.getState().rooms.get('test@conference.example.com')
-      expect(room?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: msgTimestamp })
+      expect(room?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: msgTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
     })
 
     // Replaces 'should set lastReadAt to current time when no messages exist'
@@ -1899,7 +1899,7 @@ describe('roomStore', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', {
         unreadCount: 0, // Already read
         mentionsCount: 0,
-        readPointer: { messageId: 'older', timestamp: new Date('2025-01-15T08:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: 'older' } },
       }))
 
       // Add a newer message
@@ -1917,7 +1917,7 @@ describe('roomStore', () => {
       roomStore.getState().markAsRead('test@conference.example.com')
 
       const room = roomStore.getState().rooms.get('test@conference.example.com')
-      expect(room?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: msgTimestamp })
+      expect(room?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: msgTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
     })
 
     it('should not trigger state update when called twice at the same read position (regression test for infinite loop)', () => {
@@ -1943,7 +1943,7 @@ describe('roomStore', () => {
       const roomAfterFirst = roomStore.getState().rooms.get('test@conference.example.com')
       expect(roomAfterFirst?.unreadCount).toBe(0)
       expect(roomAfterFirst?.mentionsCount).toBe(0)
-      expect(roomAfterFirst?.readPointer).toMatchObject({ messageId: 'msg1', timestamp: msgTimestamp })
+      expect(roomAfterFirst?.readPointer).toMatchObject({ order: { role: 'exact', timestamp: msgTimestamp.getTime() }, identity: { state: 'local', messageId: 'msg1' } })
 
       // Capture rooms Map reference after first markAsRead
       const roomsMapAfterFirst = roomStore.getState().rooms
@@ -1976,7 +1976,7 @@ describe('roomStore', () => {
         lastMessage: messages[2],
         unreadCount: 2,
         mentionsCount: 1,
-        readPointer: { messageId: 'm1', timestamp: messages[0].timestamp },
+        readPointer: { order: { role: 'floor', timestamp: new Date(messages[0].timestamp).getTime() }, identity: { state: 'local', messageId: 'm1' } },
       }))
       roomStore.setState((state) => {
         const newMarkers = new Map(state.firstNewMessageMarkers)
@@ -1987,7 +1987,7 @@ describe('roomStore', () => {
       roomStore.getState().markReadToNewest(roomJid)
 
       const meta = roomStore.getState().roomMeta.get(roomJid)
-      expect(meta?.readPointer?.messageId).toBe('m3')
+      expect(meta?.readPointer?.identity.messageId).toBe('m3')
       expect(meta?.unreadCount).toBe(0)
       expect(meta?.mentionsCount).toBe(0)
       expect(roomStore.getState().firstNewMessageMarkers.has(roomJid)).toBe(false)
@@ -2006,7 +2006,7 @@ describe('roomStore', () => {
         lastMessage: messages[2],
         unreadCount: 2,
         mentionsCount: 1,
-        readPointer: { messageId: 'm1', timestamp: messages[0].timestamp },
+        readPointer: { order: { role: 'floor', timestamp: new Date(messages[0].timestamp).getTime() }, identity: { state: 'local', messageId: 'm1' } },
       }))
       roomStore.setState((state) => {
         const newMarkers = new Map(state.firstNewMessageMarkers)
@@ -2048,7 +2048,7 @@ describe('roomStore', () => {
       roomStore.getState().markReadToNewest(roomJid)
 
       const meta = roomStore.getState().roomMeta.get(roomJid)
-      expect(meta?.readPointer?.messageId).toBe('m9')
+      expect(meta?.readPointer?.identity.messageId).toBe('m9')
       expect(meta?.unreadCount).toBe(0)
       expect(meta?.mentionsCount).toBe(0)
     })
@@ -2075,7 +2075,7 @@ describe('roomStore', () => {
       roomStore.getState().markAllRoomsRead()
 
       expect(roomStore.getState().roomMeta.get(unreadJoined)?.unreadCount).toBe(0)
-      expect(roomStore.getState().roomMeta.get(unreadJoined)?.readPointer?.messageId).toBe('u1')
+      expect(roomStore.getState().roomMeta.get(unreadJoined)?.readPointer?.identity.messageId).toBe('u1')
       // Clean room was already at 0 — no change expected (and no crash).
       expect(roomStore.getState().roomMeta.get(cleanJoined)?.unreadCount).toBe(0)
       // Unjoined room is skipped even though it has unread messages.
@@ -2516,11 +2516,7 @@ describe('roomStore', () => {
         const meta = new Map(state.roomMeta)
         meta.set(roomJid, {
           ...meta.get(roomJid)!,
-          readPointer: {
-            messageId: 'msg-150',
-            timestamp: new Date(150 * 60_000),
-            tiebreak: { kind: 'room', from: `${roomJid}/alice`, id: 'msg-150' },
-          },
+          readPointer: { order: { role: 'exact', timestamp: new Date(150 * 60_000).getTime(), tiebreak: { kind: 'room', from: `${roomJid}/alice`, id: 'msg-150' } }, identity: { state: 'local', messageId: 'msg-150' } },
         })
         return { roomMeta: meta }
       })
@@ -4613,7 +4609,7 @@ describe('roomStore', () => {
           ...meta.get(roomJid)!,
           unreadCount: 5,
           mentionsCount: 2,
-          readPointer: { messageId: 'm1', timestamp: new Date('2024-01-15T09:30:00Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T09:30:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
         })
         const rooms = new Map(state.rooms)
         rooms.set(roomJid, { ...rooms.get(roomJid)!, unreadCount: 5, mentionsCount: 2 })
@@ -4729,7 +4725,7 @@ describe('roomStore', () => {
         const meta = new Map(state.roomMeta)
         meta.set(roomJid, {
           ...meta.get(roomJid)!,
-          readPointer: { messageId: 'm1', timestamp: new Date('2024-01-15T09:30:00Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T09:30:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
           unreadCount: 5,
           mentionsCount: 1,
         })
@@ -4763,7 +4759,7 @@ describe('roomStore', () => {
         const meta = new Map(state.roomMeta)
         meta.set(roomJid, {
           ...meta.get(roomJid)!,
-          readPointer: { messageId: 'm1', timestamp: new Date('2024-01-15T09:30:00Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T09:30:00Z').getTime() }, identity: { state: 'local', messageId: 'm1' } },
           unreadCount: 0,
           mentionsCount: 0,
         })
@@ -6723,7 +6719,7 @@ describe('roomStore parity drift regressions', () => {
         roomMeta.set(roomJid, {
           ...roomMeta.get(roomJid)!,
           lastMessage: preview,
-          readPointer: { messageId: 'seen-1', timestamp: new Date('2024-01-15T09:00:00Z') },
+          readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T09:00:00Z').getTime() }, identity: { state: 'local', messageId: 'seen-1' } },
         })
         return { roomMeta }
       })
@@ -6733,7 +6729,7 @@ describe('roomStore parity drift regressions', () => {
       const meta = roomStore.getState().roomMeta.get(roomJid)
       expect(meta?.unreadCount).toBe(5)
       expect(meta?.lastMessage?.id).toBe('prev-1')
-      expect(meta?.readPointer?.messageId).toBe('seen-1')
+      expect(meta?.readPointer?.identity.messageId).toBe('seen-1')
     })
 
     it('updateRoom never recenters the window: windowAtLiveEdge survives a runtime update', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
@@ -43,13 +43,13 @@ export function createRoom(jid: string, options: Partial<Room> = {}): Room {
  * EXPLICITLY whenever a test advances a read pointer across two messages.
  *
  * NOT because a same-millisecond pair can never advance — read-state PR C
- * (task 1) changed exactly that. Two KEYED positions sharing a millisecond now
- * break the tie on the cache order key: `isAhead`
- * (shared/readPointer.ts, ~line 99) does it, and `advanceReadPointer` routes
- * through `onMessageSeen`'s keyed `mayAdvanceTo`, which does it too. The bare
- * "equal timestamps are NOT an advance" rule now applies ONLY when either side
- * is KEYLESS — i.e. a pointer migrated from the pre-#1081 `lastSeenMessageId` +
- * `lastReadAt` pair, whose timestamp cannot certify its own position.
+ * (task 1) changed exactly that. Two EXACT positions sharing a millisecond now
+ * break the tie on the cache order key: `isAhead` (shared/readPointer.ts) does
+ * it, and `advanceReadPointer` routes through `onMessageSeen`'s exact-order
+ * `mayAdvanceTo`, which does it too. The bare "equal timestamps are NOT an
+ * advance" rule now applies ONLY when either side is a FLOOR — i.e. a pointer
+ * migrated from the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair, whose
+ * timestamp cannot certify its own position.
  *
  * The reason to be explicit is that the ROOM tie-break is `(from, id)`. Under
  * fake timers `new Date()` returns the same instant every call, so the order of

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -39,9 +39,9 @@ import {
   pointerlessDefers,
   worthReconcilingOnDeactivate,
   isAfterBoundary,
-  makeCacheOrderKey,
+  exactPosition,
   isRenderableStoredMessage,
-  type OrderPosition,
+  type PointerOrder,
 } from './shared/readState'
 import {
   transientCounts,
@@ -1904,7 +1904,7 @@ export const roomStore = createStore<RoomState>()(
       }
       const result = noteTransient(
         scopeKey,
-        { position: { timestamp: messageToAdd.timestamp.getTime(), tiebreak: makeCacheOrderKey(messageToAdd, 'room') } },
+        { position: exactPosition(messageToAdd, 'room') },
         transientIdentity(identityFields, 'room'),
         transientAliases(identityFields, 'room')
       )
@@ -1996,6 +1996,10 @@ export const roomStore = createStore<RoomState>()(
           id: messageToAdd.id,
           from: messageToAdd.from,
           timestamp: messageToAdd.timestamp,
+          // The room-assigned archive id when the reflection carries one, so a
+          // pointer this arrival advances is `addressable` immediately rather
+          // than needing the publisher to look it back up.
+          stanzaId: messageToAdd.stanzaId,
           isOutgoing: messageToAdd.isOutgoing ?? false,
           isDelayed: messageToAdd.isDelayed,
           isMention: messageToAdd.isMention,
@@ -2400,7 +2404,7 @@ export const roomStore = createStore<RoomState>()(
     // below is computed AGAINST. Re-checked at the final commit (see that
     // guard's comment) to close a race the new allowActive trigger
     // (advanceReadPointer) makes materially more likely.
-    const pointerIdAtCompute = metaNow.readPointer?.messageId
+    const pointerIdAtCompute = metaNow.readPointer?.identity.messageId
     const unreadInputVersionAtCompute = roomUnreadInputVersion.get(roomJid) ?? 0
 
     const floor = computeFloor(metaNow.readPointer, metaNow.historyFloor)
@@ -2421,26 +2425,24 @@ export const roomStore = createStore<RoomState>()(
       if (record) get().clearRoomCoverage(roomJid, record.bottomId)
       return
     }
-    // The floor as an OrderPosition: when the floor came from the pointer,
-    // reuse the pointer's own order key so the comparison isn't blind to a
-    // coverage bottom sharing its exact millisecond; a historyFloor-derived
-    // floor has no such key (unresolved sorts conservatively).
-    const floorPos: OrderPosition = metaNow.readPointer
-      ? { timestamp: metaNow.readPointer.timestamp.getTime(), tiebreak: metaNow.readPointer.tiebreak }
-      : { timestamp: floor.getTime() }
+    // The boundary: the pointer's own order when there is one, so the
+    // comparison is not blind to a coverage bottom sharing its exact
+    // millisecond; a historyFloor-derived boundary knows only a millisecond and
+    // says so (unresolved sorts conservatively).
+    const floorPos: PointerOrder = metaNow.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
 
     // Task 9 safety net: this recompute is one of the "pointer advance /
     // content settled" triggers — bound the transient overlay's memory here
     // too, since not every trigger path calls pruneTransient directly.
     pruneTransient(roomTransientScopeKey(roomJid), floorPos)
 
-    // A BOUNDARY test: a keyless (migrated) floor reads as at-or-after its
+    // A BOUNDARY test: a FLOOR (migrated) boundary reads as at-or-after its
     // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
     if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
 
     const res = await messageCache.countRoomUnreadInArchive(roomJid, {
       floor,
-      pointer: metaNow.readPointer,
+      pointer: metaNow.readPointer?.order,
     })
     if (!recountContextIsCurrent()) return
     if (res === null) return // unavailable — IndexedDB error
@@ -2474,7 +2476,7 @@ export const roomStore = createStore<RoomState>()(
       // the newer, correct value — worst case this recompute under-acts
       // once; the next trigger (another arrival, deactivation, or
       // activation) re-derives it.
-      if (meta.readPointer?.messageId !== pointerIdAtCompute) return state
+      if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) return state
 
       // Rederive the divider (requirement 5): the boundary may have moved
       // since a marker was last parked here (a remote pointer advance).
@@ -2580,10 +2582,7 @@ export const roomStore = createStore<RoomState>()(
       // later recompute trigger. Pruning is a memory bound only:
       // transientCounts already excludes entries at/behind the boundary.
       if (updated.readPointer && updated.readPointer !== notifInput.readPointer) {
-        pruneTransient(roomTransientScopeKey(roomJid), {
-          timestamp: updated.readPointer.timestamp.getTime(),
-          tiebreak: updated.readPointer.tiebreak,
-        })
+        pruneTransient(roomTransientScopeKey(roomJid), updated.readPointer.order)
       }
 
       const newRooms = new Map(state.rooms)
@@ -2616,7 +2615,7 @@ export const roomStore = createStore<RoomState>()(
       // Skip update if already fully read: pointer at the computed newest id,
       // no unread/mentions, and no "new messages" divider to clear.
       const meta = state.roomMeta.get(roomJid)
-      const currentSeenMessageId = (meta?.readPointer ?? existing.readPointer)?.messageId
+      const currentSeenMessageId = (meta?.readPointer ?? existing.readPointer)?.identity.messageId
       const currentUnreadCount = meta?.unreadCount ?? existing.unreadCount
       const currentMentionsCount = meta?.mentionsCount ?? existing.mentionsCount
       if (
@@ -2637,10 +2636,7 @@ export const roomStore = createStore<RoomState>()(
       // Task 9: mark-all-read jumps the pointer straight to the newest
       // message — prune the overlay now rather than leaving every noted
       // entry to a later recompute trigger.
-      pruneTransient(roomTransientScopeKey(roomJid), {
-        timestamp: read.readPointer.timestamp.getTime(),
-        tiebreak: read.readPointer.tiebreak,
-      })
+      pruneTransient(roomTransientScopeKey(roomJid), read.readPointer.order)
 
       const committed = commitRoomUpdate(state, roomJid, read)
       if (!committed) return state
@@ -2841,7 +2837,7 @@ export const roomStore = createStore<RoomState>()(
       // would reposition the divider on every return). Gate + retry policy live
       // in shared/readMarkerSync.
       const foldOnce = (stage: string) => {
-        const lastSeenBefore = get().roomMeta.get(roomJid)?.readPointer?.messageId
+        const lastSeenBefore = get().roomMeta.get(roomJid)?.readPointer?.identity.messageId
         const fold = foldPendingRemoteDisplayed(
           mdsGate,
           roomJid,
@@ -2853,7 +2849,7 @@ export const roomStore = createStore<RoomState>()(
             roomJid,
             pendingStanzaId: fold.pending,
             lastSeenBefore,
-            lastSeenAfter: get().roomMeta.get(roomJid)?.readPointer?.messageId,
+            lastSeenAfter: get().roomMeta.get(roomJid)?.readPointer?.identity.messageId,
             resolved: fold.resolved,
           })
         } else if (fold.pending) {
@@ -2879,7 +2875,7 @@ export const roomStore = createStore<RoomState>()(
       // What a cache miss costs is CONTEXT: the latest slice is kept, the
       // divider lands wherever the boundary falls inside it, and MAM catch-up
       // heals the cache for the next open.
-      const pointer = get().roomMeta.get(roomJid)?.readPointer?.messageId
+      const pointer = get().roomMeta.get(roomJid)?.readPointer?.identity.messageId
       if (pointer) {
         const loaded = get().roomRuntime.get(roomJid)?.messages ?? get().rooms.get(roomJid)?.messages ?? []
         if (!loaded.some((m) => m.id === pointer)) {
@@ -2983,10 +2979,7 @@ export const roomStore = createStore<RoomState>()(
       // pruned-away entry was already excluded from transientCounts by the
       // boundary comparison, this just reclaims the memory.
       if (updated.readPointer) {
-        pruneTransient(roomTransientScopeKey(roomJid), {
-          timestamp: updated.readPointer.timestamp.getTime(),
-          tiebreak: updated.readPointer.tiebreak,
-        })
+        pruneTransient(roomTransientScopeKey(roomJid), updated.readPointer.order)
       }
 
       const newRooms = new Map(state.rooms)

--- a/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
@@ -28,6 +28,7 @@ import type { Room, RoomMessage } from '../core/types'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, getStorageScopeJid } from '../utils/storageScope'
 import { _clearAllTransientForTesting } from './shared/transientUnread'
+import type { ReadPointer } from './shared/readPointer'
 import {
   currentViewportGeneration,
   currentViewportEvidence,
@@ -115,7 +116,7 @@ function reportCurrent(roomJid: string, evidence: 'at-edge' | 'away'): void {
  * array in this lightweight test file).
  */
 function setPriorReadState(jid: string, unreadCount: number, priorMessageId: string): void {
-  const priorPointer = { messageId: priorMessageId, timestamp: new Date('2025-01-15T08:00:00Z') }
+  const priorPointer: ReadPointer = { order: { role: 'floor', timestamp: new Date('2025-01-15T08:00:00Z').getTime() }, identity: { state: 'local', messageId: priorMessageId } }
   roomStore.setState((state) => {
     const meta = state.roomMeta.get(jid)
     const room = state.rooms.get(jid)
@@ -189,9 +190,9 @@ describe('roomStore viewport-evidence gate (Task 11)', () => {
 
       const room = roomStore.getState().rooms.get('lounge@conference.example.com')
       expect(room?.unreadCount).toBe(0)
-      expect(room?.readPointer?.messageId).toBe(msg.id)
+      expect(room?.readPointer?.identity.messageId).toBe(msg.id)
       expect(roomStore.getState().roomMeta.get('lounge@conference.example.com')?.unreadCount).toBe(0)
-      expect(roomStore.getState().roomMeta.get('lounge@conference.example.com')?.readPointer?.messageId).toBe(msg.id)
+      expect(roomStore.getState().roomMeta.get('lounge@conference.example.com')?.readPointer?.identity.messageId).toBe(msg.id)
     })
 
     it('active + focused + UNKNOWN viewport (never reported): treated as not-at-edge, unread increases', () => {
@@ -278,7 +279,7 @@ describe('roomStore viewport-evidence gate (Task 11)', () => {
 
       const roomB = roomStore.getState().rooms.get(ROOM_B)
       expect(roomB?.unreadCount).toBe(0)
-      expect(roomB?.readPointer?.messageId).toBe(msg.id)
+      expect(roomB?.readPointer?.identity.messageId).toBe(msg.id)
     })
   })
 
@@ -312,7 +313,7 @@ describe('roomStore viewport-evidence gate (Task 11)', () => {
       roomStore.getState().addMessage(ROOM, msg)
       const roomAfterFreshReport = roomStore.getState().rooms.get(ROOM)
       expect(roomAfterFreshReport?.unreadCount).toBe(0)
-      expect(roomAfterFreshReport?.readPointer?.messageId).toBe(msg.id)
+      expect(roomAfterFreshReport?.readPointer?.identity.messageId).toBe(msg.id)
     })
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -315,13 +315,14 @@ describe('resolveCoverageBottom', () => {
   it('resolves a bottomId that is cached to its archive position', async () => {
     await messageCache.saveMessage(mockMessage({ stanzaId: 'archive-42', timestamp: new Date(9000) }))
     const out = await resolveCoverageBottom(CONV, { bottomId: 'archive-42' }, false)
-    expect(out).toEqual({ timestamp: 9000, tiebreak: { kind: 'chat', id: 'client-id-1' } })
+    expect(out).toEqual({ role: 'exact', timestamp: 9000, tiebreak: { kind: 'chat', id: 'client-id-1' } })
   })
 
   it('resolves a bottomId scoped to a room, distinct from the chat lookup', async () => {
     await messageCache.saveRoomMessages([mockRoomMessage({ stanzaId: 'archive-42', timestamp: new Date(7000) })])
     const out = await resolveCoverageBottom(ROOM, { bottomId: 'archive-42' }, true)
     expect(out).toEqual({
+      role: 'exact',
       timestamp: 7000,
       tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'client-id-1' },
     })

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -5,7 +5,7 @@
  * to reduce code duplication for common message array operations.
  */
 
-import { compareExact, makeCacheOrderKey } from './readState'
+import { compareExact, exactPosition } from './readState'
 
 /**
  * Generic interface for messages with a timestamp.
@@ -204,10 +204,7 @@ export function sortMessagesByTimestamp<T extends TimestampedMessage>(
   kind: 'chat' | 'room'
 ): T[] {
   return [...messages].sort((a, b) =>
-    compareExact(
-      { timestamp: a.timestamp.getTime(), tiebreak: makeCacheOrderKey(a, kind) },
-      { timestamp: b.timestamp.getTime(), tiebreak: makeCacheOrderKey(b, kind) }
-    )
+    compareExact(exactPosition(a, kind), exactPosition(b, kind))
   )
 }
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -52,7 +52,10 @@ function makeState(overrides: Partial<EntityNotificationState> = {}): EntityNoti
  * timestamp has to be that message's own.
  */
 function seen(id: string, timestamp: Date): ReadPointer {
-  return { messageId: id, timestamp }
+  // A FLOOR order: the shape this helper replaces carried a timestamp and no
+  // tie-break, so the position is known only to a millisecond. `local`, because
+  // no archive id was ever part of it.
+  return { order: { role: 'floor', timestamp: timestamp.getTime() }, identity: { state: 'local', messageId: id } }
 }
 
 /**
@@ -118,7 +121,7 @@ describe('onMessageReceived', () => {
       expect(result.unreadCount).toBe(0)
       expect(result.mentionsCount).toBe(0)
       expect(result.firstNewMessageId).toBeUndefined()
-      expect(result.readPointer).toMatchObject({ messageId: msg.id, timestamp: msg.timestamp })
+      expect(result.readPointer).toMatchObject({ order: { timestamp: msg.timestamp.getTime() }, identity: { messageId: msg.id } })
     })
 
     // Superseded by PR C, D1: the outgoing early return that used to clear
@@ -140,7 +143,7 @@ describe('onMessageReceived', () => {
       const state = makeState({ readPointer: seen('seen-1', new Date(1000)) })
       const msg = makeMsg({ isOutgoing: true })
       const result = onMessageReceived(state, msg, ACTIVE_VISIBLE, 'chat')
-      expect(result.readPointer).toMatchObject({ messageId: msg.id, timestamp: msg.timestamp })
+      expect(result.readPointer).toMatchObject({ order: { timestamp: msg.timestamp.getTime() }, identity: { messageId: msg.id } })
     })
 
     it('does not regress the read pointer for an older outgoing message', () => {
@@ -175,14 +178,14 @@ describe('onMessageReceived', () => {
       const result = onMessageReceived(state, msg, ACTIVE_VISIBLE, 'chat')
       expect(result.unreadCount).toBe(0)
       expect(result.mentionsCount).toBe(0)
-      expect(result.readPointer).toMatchObject({ messageId: msg.id, timestamp: msg.timestamp })
+      expect(result.readPointer).toMatchObject({ order: { timestamp: msg.timestamp.getTime() }, identity: { messageId: msg.id } })
     })
 
     it('advances the read pointer to the new message', () => {
       const state = makeState({ readPointer: seen('old-msg', new Date(1000)) })
       const msg = makeMsg({ id: 'new-msg' })
       const result = onMessageReceived(state, msg, ACTIVE_VISIBLE, 'chat')
-      expect(result.readPointer).toMatchObject({ messageId: 'new-msg', timestamp: msg.timestamp })
+      expect(result.readPointer).toMatchObject({ order: { timestamp: msg.timestamp.getTime() }, identity: { messageId: 'new-msg' } })
     })
 
     it('does not regress the read pointer for an older delayed arrival at the live edge', () => {
@@ -287,7 +290,7 @@ describe('onMessageReceived', () => {
       const state = makeState({ readPointer: priorPointer, unreadCount: 4 })
       const msg = makeMsg({ id: 'new-msg', timestamp: new Date('2025-01-15T09:00:00Z') })
       const result = onMessageReceived(state, msg, ACTIVE_VISIBLE, 'chat')
-      expect(result.readPointer).toMatchObject({ messageId: 'new-msg', timestamp: msg.timestamp })
+      expect(result.readPointer).toMatchObject({ order: { timestamp: msg.timestamp.getTime() }, identity: { messageId: 'new-msg' } })
       expect(result.unreadCount).toBe(0)
     })
 
@@ -437,14 +440,15 @@ describe('onActivate', () => {
   it('does not drag the read time forward to the newest loaded message', () => {
     const state = makeState({ readPointer: seenIn(messages, 'msg-2') })
     const result = onActivate(state, messages, 'chat')
-    expect(result.readPointer).toMatchObject({ messageId: 'msg-2', timestamp: new Date('2025-01-15T09:30:00Z') })
-    expect(result.readPointer?.timestamp).not.toEqual(new Date('2025-01-15T11:00:00Z'))
+    expect(result.readPointer?.identity.messageId).toBe('msg-2')
+    expect(result.readPointer?.order.timestamp).toBe(new Date('2025-01-15T09:30:00Z').getTime())
+    expect(result.readPointer?.order.timestamp).not.toBe(new Date('2025-01-15T11:00:00Z').getTime())
   })
 
   it('preserves the read pointer', () => {
     const state = makeState({ readPointer: seenIn(messages, 'msg-2') })
     const result = onActivate(state, messages, 'chat')
-    expect(result.readPointer?.messageId).toBe('msg-2')
+    expect(result.readPointer?.identity.messageId).toBe('msg-2')
   })
 
   // FIX 2: an empty slice gives onActivate nothing to derive a divider from —
@@ -775,7 +779,7 @@ describe('onMessageSeen atLiveEdge advance', () => {
     const state = { ...createInitialNotificationState(), readPointer: seen('evicted', new Date(500)) }
     const messages = [{ id: 'a', timestamp: new Date(1000) }, { id: 'b', timestamp: new Date(2000) }]
     const out = onMessageSeen(state, 'b', messages, 'chat', { atLiveEdge: true })
-    expect(out.readPointer).toMatchObject({ messageId: 'b', timestamp: new Date(2000) })
+    expect(out.readPointer).toMatchObject({ order: { timestamp: new Date(2000).getTime() }, identity: { messageId: 'b' } })
   })
   it('stays guarded off the live edge (window slid up — no regression)', () => {
     const state = { ...createInitialNotificationState(), readPointer: seen('newer-than-slice', new Date(9000)) }
@@ -812,7 +816,7 @@ describe('onDeactivate', () => {
     const result = onDeactivate(state)
     expect(result.unreadCount).toBe(3)
     expect(result.mentionsCount).toBe(1)
-    expect(result.readPointer?.messageId).toBe('seen-1')
+    expect(result.readPointer?.identity.messageId).toBe('seen-1')
   })
 })
 
@@ -863,7 +867,7 @@ describe('onMarkAsRead', () => {
     const state = makeState({ unreadCount: 3, readPointer: seen('seen-1', new Date(1000)) })
     const messages = [makeMsg({ id: 'seen-1', timestamp: new Date(1000) }), makeMsg({ id: 'newest-9', timestamp: new Date(9000) })]
     const result = onMarkAsRead(state, messages, 'chat', { windowAtLiveEdge: true, viewportAtLiveEdge: true })
-    expect(result.readPointer).toMatchObject({ messageId: 'newest-9', timestamp: new Date(9000) })
+    expect(result.readPointer).toMatchObject({ order: { timestamp: new Date(9000).getTime() }, identity: { messageId: 'newest-9' } })
     expect(result.unreadCount).toBe(0)
   })
 
@@ -874,7 +878,7 @@ describe('onMarkAsRead', () => {
     const messages = [makeMsg({ id: 'seen-1', timestamp: new Date(1000) }), makeMsg({ id: 'newest-9', timestamp: ts })]
     const result = onMarkAsRead(state, messages, 'chat', { windowAtLiveEdge: true, viewportAtLiveEdge: true })
     expect(result).not.toBe(state)
-    expect(result.readPointer).toMatchObject({ messageId: 'newest-9', timestamp: ts })
+    expect(result.readPointer).toMatchObject({ order: { timestamp: ts.getTime() }, identity: { messageId: 'newest-9' } })
   })
 
   it('returns same reference when the newest loaded message is already the current pointer', () => {
@@ -892,7 +896,7 @@ describe('onMarkAsRead — live-edge decision (PR C, D8)', () => {
   it('advances the pointer to the newest loaded message at the live edge', () => {
     const state = { unreadCount: 5, mentionsCount: 2, readPointer: undefined, firstNewMessageId: 'x' }
     const r = onMarkAsRead(state, [m('m1', 1000), m('m2', 2000)], 'chat', { windowAtLiveEdge: true, viewportAtLiveEdge: true })
-    expect(r.readPointer?.messageId).toBe('m2')
+    expect(r.readPointer?.identity.messageId).toBe('m2')
     expect(r.unreadCount).toBe(0)
     expect(r.mentionsCount).toBe(0)
     expect(r.firstNewMessageId).toBe('x')
@@ -953,7 +957,7 @@ describe('onClearMarker', () => {
     })
     const result = onClearMarker(state)
     expect(result.unreadCount).toBe(3)
-    expect(result.readPointer?.messageId).toBe('seen-1')
+    expect(result.readPointer?.identity.messageId).toBe('seen-1')
   })
 })
 
@@ -999,7 +1003,7 @@ describe('onWindowBecameVisible', () => {
     })
     const result = onWindowBecameVisible(state, true)
     expect(result.firstNewMessageId).toBe('marker-1')
-    expect(result.readPointer?.messageId).toBe('seen-1')
+    expect(result.readPointer?.identity.messageId).toBe('seen-1')
   })
 })
 
@@ -1018,19 +1022,19 @@ describe('onMessageSeen', () => {
 
   const pointerAt = (id: string): ReadPointer => {
     const found = messages.find((m) => m.id === id)!
-    return { messageId: found.id, timestamp: found.timestamp }
+    return { order: { role: 'floor', timestamp: found.timestamp.getTime() }, identity: { state: 'local', messageId: found.id } }
   }
 
   it('sets the read pointer when none exists', () => {
     const state = makeState()
     const result = onMessageSeen(state, 'msg-3', messages, 'chat')
-    expect(result.readPointer).toMatchObject({ messageId: 'msg-3', timestamp: new Date(3000) })
+    expect(result.readPointer).toMatchObject({ order: { timestamp: new Date(3000).getTime() }, identity: { messageId: 'msg-3' } })
   })
 
   it('advances forward', () => {
     const state = makeState({ readPointer: pointerAt('msg-2') })
     const result = onMessageSeen(state, 'msg-4', messages, 'chat')
-    expect(result.readPointer).toMatchObject({ messageId: 'msg-4', timestamp: new Date(4000) })
+    expect(result.readPointer).toMatchObject({ order: { timestamp: new Date(4000).getTime() }, identity: { messageId: 'msg-4' } })
   })
 
   it('does not go backwards', () => {
@@ -1078,7 +1082,7 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
       readPointer: makeReadPointer({ id: 'old', timestamp: new Date(500) }, 'chat'),
       firstNewMessageId: undefined }
     const r = onMessageSeen(state, 'm2', [m('m2', 2000)], 'chat')
-    expect(r.readPointer?.messageId).toBe('m2')
+    expect(r.readPointer?.identity.messageId).toBe('m2')
   })
 
   it('does NOT advance a KEYED pointer to a message behind it', () => {
@@ -1094,7 +1098,7 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
       readPointer: makeReadPointer({ id: 'm1', timestamp: new Date(1000) }, 'chat'),
       firstNewMessageId: undefined }
     const r = onMessageSeen(state, 'm2', [m('m1', 1000), m('m2', 1000)], 'chat')
-    expect(r.readPointer?.messageId).toBe('m2')
+    expect(r.readPointer?.identity.messageId).toBe('m2')
   })
 
   // OFF-SLICE + same millisecond: nothing but the cache order key can decide
@@ -1106,7 +1110,7 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
     const state = { unreadCount: 1, mentionsCount: 0,
       readPointer: makeReadPointer({ id: 'm1', timestamp: new Date(1000) }, 'chat'),
       firstNewMessageId: undefined }
-    expect(onMessageSeen(state, 'm2', [m('m2', 1000)], 'chat').readPointer?.messageId).toBe('m2')
+    expect(onMessageSeen(state, 'm2', [m('m2', 1000)], 'chat').readPointer?.identity.messageId).toBe('m2')
   })
 
   // NEGATIVE POLARITY — this is the forward-only guard itself. The keyed branch
@@ -1126,11 +1130,11 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
 
   // CONTROL: the keyless branch keeps its guard AND its escape hatch.
   it('refuses a KEYLESS pointer that is absent from the slice, unless at the live edge and newest', () => {
-    const state = { unreadCount: 4, mentionsCount: 0,
-      readPointer: { messageId: 'old', timestamp: new Date(500) }, firstNewMessageId: undefined }
+    const state: EntityNotificationState = { unreadCount: 4, mentionsCount: 0,
+      readPointer: { order: { role: 'floor', timestamp: new Date(500).getTime() }, identity: { state: 'local', messageId: 'old' } }, firstNewMessageId: undefined }
     expect(onMessageSeen(state, 'm1', [m('m1', 2000), m('m2', 3000)], 'chat')).toBe(state)
     const edge = onMessageSeen(state, 'm2', [m('m1', 2000), m('m2', 3000)], 'chat', { atLiveEdge: true })
-    expect(edge.readPointer?.messageId).toBe('m2')
+    expect(edge.readPointer?.identity.messageId).toBe('m2')
   })
 
   // ACCEPTED HAZARD — read this before "fixing" it.
@@ -1169,8 +1173,8 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
 
     // The observer reports a row in the MIDDLE of that window — not its newest.
     const advancedState = onMessageSeen(state, 'm255', slice, 'chat')
-    expect(advancedState.readPointer?.messageId).toBe('m255')
-    expect(advancedState.readPointer?.timestamp.getTime()).toBe(255_000)
+    expect(advancedState.readPointer?.identity.messageId).toBe('m255')
+    expect(advancedState.readPointer?.order.timestamp).toBe(255_000)
 
     // The consequence, made explicit: m200 was never rendered, yet it is now
     // behind the boundary — it no longer qualifies as the first new message,
@@ -1228,7 +1232,7 @@ describe('shouldNotifyConversation', () => {
         isActive: false,
         windowVisible: false,
         unreadCount: 1,
-        readPointer: { messageId: 'm5', timestamp: new Date() },
+        readPointer: { order: { role: 'floor', timestamp: new Date().getTime() }, identity: { state: 'local', messageId: 'm5' } },
       }),
     ).toBe(false)
   })
@@ -1388,7 +1392,7 @@ describe('lifecycle sequences', () => {
     expect(state.mentionsCount).toBe(0)
     expect(state.firstNewMessageId).toBeUndefined()
     // advanced to the outgoing message, timestamp included
-    expect(state.readPointer).toMatchObject({ messageId: 'out-1', timestamp: outgoing.timestamp })
+    expect(state.readPointer).toMatchObject({ order: { timestamp: outgoing.timestamp.getTime() }, identity: { messageId: 'out-1' } })
   })
 
   it('no spurious marker after user replies to a conversation', () => {
@@ -1407,15 +1411,15 @@ describe('lifecycle sequences', () => {
 
     // User sends reply-1 → the read pointer must advance
     state = onMessageReceived(state, msgs[2], ACTIVE_VISIBLE, 'chat')
-    expect(state.readPointer?.messageId).toBe('reply-1')
+    expect(state.readPointer?.identity.messageId).toBe('reply-1')
 
     // Incoming msg-3 arrives while user is viewing
     state = onMessageReceived(state, msgs[3], ACTIVE_VISIBLE, 'chat')
-    expect(state.readPointer?.messageId).toBe('msg-3')
+    expect(state.readPointer?.identity.messageId).toBe('msg-3')
 
     // User sends reply-2
     state = onMessageReceived(state, msgs[4], ACTIVE_VISIBLE, 'chat')
-    expect(state.readPointer?.messageId).toBe('reply-2')
+    expect(state.readPointer?.identity.messageId).toBe('reply-2')
 
     // User switches away and back
     state = onDeactivate(state)
@@ -1567,7 +1571,7 @@ describe('lifecycle sequences', () => {
     // User opens conversation → marker at m2
     state = onActivate(state, initialMessages, 'chat')
     expect(state.firstNewMessageId).toBe('m2')
-    expect(state.readPointer?.messageId).toBe('m1')
+    expect(state.readPointer?.identity.messageId).toBe('m1')
 
     // User scrolls and sees all messages via IntersectionObserver
     state = onMessageSeen(state, 'm3', initialMessages, 'chat')
@@ -1580,7 +1584,7 @@ describe('lifecycle sequences', () => {
     state = onMessageReceived(state, m5, ACTIVE_VISIBLE, 'chat')
 
     // the read pointer should have advanced to m5 (user sees each message)
-    expect(state.readPointer).toMatchObject({ messageId: 'm5', timestamp: m5.timestamp })
+    expect(state.readPointer).toMatchObject({ order: { timestamp: m5.timestamp.getTime() }, identity: { messageId: 'm5' } })
 
     // User switches away
     state = onDeactivate(state)
@@ -1596,7 +1600,7 @@ describe('lifecycle sequences', () => {
 
     // No new messages after m5 → no marker (not the stale marker at m2!)
     expect(state.firstNewMessageId).toBeUndefined()
-    expect(state.readPointer?.messageId).toBe('m5')
+    expect(state.readPointer?.identity.messageId).toBe('m5')
   })
 })
 
@@ -1623,7 +1627,7 @@ describe('readPointer is the whole read position (#1081)', () => {
     )
     // Whole-object assertion: a write that got the timestamp from anywhere but
     // the message itself fails here.
-    expect(out.readPointer).toMatchObject({ messageId: 'm1', timestamp: new Date(1000) })
+    expect(out.readPointer).toMatchObject({ order: { timestamp: new Date(1000).getTime() }, identity: { messageId: 'm1' } })
   })
 
   it('onMessageReceived writes the whole pointer when the user sees the message', () => {
@@ -1633,19 +1637,20 @@ describe('readPointer is the whole read position (#1081)', () => {
       { isActive: true, windowVisible: true, viewportAtLiveEdge: true },
       'chat'
     )
-    expect(out.readPointer).toMatchObject({ messageId: 'm2', timestamp: new Date(2000) })
+    expect(out.readPointer).toMatchObject({ order: { timestamp: new Date(2000).getTime() }, identity: { messageId: 'm2' } })
   })
 
   it('onMessageSeen resolves the timestamp from the messages array', () => {
     const messages = [msg('m1', 1000), msg('m2', 2000), msg('m3', 3000)]
-    const start = { ...base(), readPointer: { messageId: 'm1', timestamp: new Date(1000) } }
+    const start: EntityNotificationState = { ...base(), readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'm1' } } }
     const out = notifState.onMessageSeen(start, 'm3', messages, 'chat')
-    expect(out.readPointer).toMatchObject({ messageId: 'm3', timestamp: new Date(3000) })
+    expect(out.readPointer?.identity.messageId).toBe('m3')
+    expect(out.readPointer?.order.timestamp).toBe(3000)
   })
 
   it('onMessageSeen leaves the pointer put when it does not advance', () => {
     const messages = [msg('m1', 1000), msg('m2', 2000)]
-    const pointer = { messageId: 'm2', timestamp: new Date(2000) }
+    const pointer: ReadPointer = { order: { role: 'floor', timestamp: 2000 }, identity: { state: 'local', messageId: 'm2' } }
     const start = { ...base(), readPointer: pointer }
     const out = notifState.onMessageSeen(start, 'm1', messages, 'chat')
     expect(out.readPointer).toBe(pointer)
@@ -1661,7 +1666,7 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
   })
 
   it('onMessageReceived keeps the pointer put for an unseen incoming message', () => {
-    const pointer = { messageId: 'm1', timestamp: new Date(1000) }
+    const pointer: ReadPointer = { order: { role: 'floor', timestamp: 1000 }, identity: { state: 'local', messageId: 'm1' } }
     const start = { ...base(), readPointer: pointer }
     const out = notifState.onMessageReceived(start, msg('m2', 2000), { isActive: false, windowVisible: false }, 'chat')
     expect(out.readPointer).toBe(pointer)
@@ -1673,7 +1678,7 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
   // in this suite as a NEGATIVE case.
   it('onActivate never writes the pointer, stale id or not', () => {
     const messages = [msg('m1', 1000), msg('m2', 2000), msg('m3', 3000)]
-    const stale = { messageId: 'gone', timestamp: new Date(1500) }
+    const stale: ReadPointer = { order: { role: 'floor', timestamp: 1500 }, identity: { state: 'local', messageId: 'gone' } }
     const outStale = notifState.onActivate({ ...base(), readPointer: stale, unreadCount: 2 }, messages, 'chat')
     expect(outStale.firstNewMessageId).toBe('m2')
     expect(outStale.readPointer).toBe(stale)
@@ -1688,14 +1693,15 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
     const start = {
       ...base(),
       unreadCount: 3,
-      readPointer: { messageId: 'm1', timestamp: new Date(1000) },
-    }
+      readPointer: { order: { role: 'floor', timestamp: new Date(1000).getTime() }, identity: { state: 'local', messageId: 'm1' } },
+    } satisfies EntityNotificationState
     const out = notifState.onMarkAsRead(start, [msg('m1', 1000), msg('m3', 3000)], 'chat', { windowAtLiveEdge: true, viewportAtLiveEdge: true })
-    expect(out.readPointer).toMatchObject({ messageId: 'm3', timestamp: new Date(3000) })
+    expect(out.readPointer?.identity.messageId).toBe('m3')
+    expect(out.readPointer?.order.timestamp).toBe(3000)
   })
 
   it('onMarkAsRead leaves the pointer put when the window is off the live edge', () => {
-    const pointer = { messageId: 'm1', timestamp: new Date(1000) }
+    const pointer: ReadPointer = { order: { role: 'floor', timestamp: 1000 }, identity: { state: 'local', messageId: 'm1' } }
     const start = { ...base(), unreadCount: 3, readPointer: pointer }
     const out = notifState.onMarkAsRead(start, [msg('m1', 1000)], 'chat', { windowAtLiveEdge: false, viewportAtLiveEdge: true })
     expect(out.readPointer).toBe(pointer)
@@ -1720,8 +1726,10 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
     // across every call here would otherwise make it trivially match.
     const coherent = (st: EntityNotificationState, label: string) => {
       const p = st.readPointer
-      expect(`${label}: ${JSON.stringify(p && { messageId: p.messageId, timestamp: p.timestamp })}`).toBe(
-        `${label}: ${JSON.stringify(p && { messageId: p.messageId, timestamp: byId.get(p.messageId) })}`
+      expect(
+        `${label}: ${JSON.stringify(p && { messageId: p.identity.messageId, timestamp: p.order.timestamp })}`
+      ).toBe(
+        `${label}: ${JSON.stringify(p && { messageId: p.identity.messageId, timestamp: byId.get(p.identity.messageId)?.getTime() })}`
       )
     }
 
@@ -1746,7 +1754,7 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
     coherent(s, 'onWindowBecameVisible')
     s = notifState.onClearMarker(s)
     coherent(s, 'onClearMarker')
-    expect(s.readPointer?.messageId).toBe('m4')
+    expect(s.readPointer?.identity.messageId).toBe('m4')
   })
 })
 
@@ -1769,7 +1777,7 @@ describe('onMessageReceived — outgoing collapse (PR C, D1)', () => {
   it('advances the pointer on an outgoing message ONLY at the live edge', () => {
     const seen = onMessageReceived(base({ unreadCount: 5 }), out('m1', 1000),
       { isActive: true, windowVisible: true, viewportAtLiveEdge: true }, 'chat', { treatDelayedAsNew: true })
-    expect(seen.readPointer?.messageId).toBe('m1')
+    expect(seen.readPointer?.identity.messageId).toBe('m1')
     expect(seen.unreadCount).toBe(0)
   })
 
@@ -1821,7 +1829,7 @@ describe('onMessageReceived — outgoing collapse (PR C, D1)', () => {
       readPointer: makeReadPointer({ id: 'p0', from: 'r@c/alice', timestamp: new Date(500) }, 'room') })
     const r = onMessageReceived(state, { id: 'm1', from: 'r@c/imposter', timestamp: new Date(1000), isOutgoing: true, body: 'x' },
       { isActive: false, windowVisible: true, viewportAtLiveEdge: false }, 'room')
-    expect(r.readPointer?.messageId).toBe('p0')
+    expect(r.readPointer?.identity.messageId).toBe('p0')
     expect(r.unreadCount).toBe(6)
   })
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -26,9 +26,8 @@ import {
   mayAdvanceTo,
   computeFloor,
   isRenderableStoredMessage,
-  makeCacheOrderKey,
-  type ExactPosition,
-  type OrderPosition,
+  exactPosition,
+  type PointerOrder,
   type RenderabilityCheckFields,
 } from './readState'
 
@@ -53,12 +52,13 @@ export interface EntityNotificationState {
    *
    * Advances forward only, and only to a message present in the slice the
    * transition was given, so a pointer THESE transitions produce carries that
-   * message's own timestamp. Not a universal invariant of the type: pointers
-   * built by the #1081 migration from a legacy `lastSeenMessageId` + `lastReadAt`
-   * pair carry `lastReadAt`, which sits at or behind the named message
-   * deliberately — see `readPointer.ts`. Only `timestamp` is used for ordering,
-   * and nothing derives a message from it, so the two populations are
-   * interchangeable here. `undefined` until the entity is first read.
+   * message's own timestamp — so it is an `exact` order. Not a universal
+   * invariant of the type: pointers built by the #1081 migration from a legacy
+   * `lastSeenMessageId` + `lastReadAt` pair carry `lastReadAt` and are a `floor`,
+   * which sits at or behind the named message deliberately — see
+   * `readPointer.ts`. Only `order` is used for ordering, and nothing derives a
+   * message from it, so the two populations are interchangeable here.
+   * `undefined` until the entity is first read.
    *
    * REQUIRED, not optional, deliberately: several transitions build a fresh
    * object literal rather than spreading `state`, and an optional property
@@ -95,6 +95,16 @@ export interface NotificationMessage extends RenderabilityCheckFields {
   isMention?: boolean
   /** Sender's JID — feeds the ROOM cache order key's (from, id) tie-break. */
   from?: string
+  /**
+   * XEP-0359 archive id, when the server has assigned one.
+   *
+   * Threaded through so a pointer minted from this arrival is `addressable`
+   * immediately (see `makeReadPointer`) — the free convergence path for every
+   * peer message and every MUC reflection. A caller that narrows a real message
+   * into this shape and omits `stanzaId` does not break anything, but it does
+   * silently give up that convergence, so pass it.
+   */
+  stanzaId?: string
 }
 
 /** Context about the entity's current visibility and unread state. */
@@ -298,20 +308,17 @@ export function onActivate(
 
   let firstNewMessageId: string | undefined = undefined
   if (floor) {
-    const floorPos: OrderPosition = state.readPointer
-      ? { timestamp: state.readPointer.timestamp.getTime(), tiebreak: state.readPointer.tiebreak }
-      : { timestamp: floor.getTime() }
+    // The pointer's own order when there is one, so the comparison is not blind
+    // to a message sharing its exact millisecond; a historyFloor-derived
+    // boundary knows only a millisecond and says so.
+    const floorPos: PointerOrder = state.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
 
     for (const m of messages) {
       if (m.isOutgoing) continue
       if (!isRenderableStoredMessage(m)) continue
-      const pos: ExactPosition = {
-        timestamp: m.timestamp.getTime(),
-        tiebreak: makeCacheOrderKey(m, kind),
-      }
-      // The DIVIDER question: a keyless floor means at-or-after its
+      // The DIVIDER question: a `floor` boundary means at-or-after its
       // millisecond, placing the divider conservatively early (#1173).
-      if (isAfterBoundary(pos, floorPos)) {
+      if (isAfterBoundary(exactPosition(m, kind), floorPos)) {
         firstNewMessageId = m.id
         break
       }
@@ -372,7 +379,7 @@ export function onMarkAsRead(
     options.windowAtLiveEdge && options.viewportAtLiveEdge
       ? messages[messages.length - 1]
       : undefined
-  const seenUnchanged = newest === undefined || newest.id === state.readPointer?.messageId
+  const seenUnchanged = newest === undefined || newest.id === state.readPointer?.identity.messageId
   if (state.unreadCount === 0 && state.mentionsCount === 0 && seenUnchanged) {
     return state
   }
@@ -439,10 +446,10 @@ export function onWindowBecameVisible(
  * moving on a fabricated timestamp would push a forward-only floor past unread
  * messages for good.
  *
- * A KEYED current pointer (carries `tiebreak`) is ordered by cache
+ * An EXACT current pointer (`order.role === 'exact'`) is ordered by cache
  * POSITION via `mayAdvanceTo`, not by array index — its position is provable
  * without being resident in `messages` (PR C, D4). The off-slice guard and the
- * `atLiveEdge` escape hatch below apply only to a KEYLESS (migrated) pointer,
+ * `atLiveEdge` escape hatch below apply only to a FLOOR (migrated) pointer,
  * whose bare timestamp cannot certify a position.
  *
  * @param state - Current notification state
@@ -470,26 +477,21 @@ export function onMessageSeen(
   // No read position yet: any resolvable message is an advancement.
   if (!state.readPointer) return advanced()
 
-  // Keyed pointer: compare cache POSITIONS. The pointer no longer has to be
+  // EXACT pointer: compare cache POSITIONS. The pointer no longer has to be
   // resident, and a same-millisecond sibling that sorts after it is a genuine
   // advance. Safe against the resident array because PR B gave
   // `messageArrayUtils` the same tie-break, so array index and cache order
   // agree.
-  if (state.readPointer.tiebreak) {
-    const target = messages[newIdx]
+  const current = state.readPointer.order
+  if (current.role === 'exact') {
     // The ADVANCE question: never overtake at a shared millisecond (#1173).
-    return mayAdvanceTo(
-      { timestamp: target.timestamp.getTime(), tiebreak: makeCacheOrderKey(target, kind) },
-      { timestamp: state.readPointer.timestamp.getTime(), tiebreak: state.readPointer.tiebreak }
-    )
-      ? advanced()
-      : state
+    return mayAdvanceTo(exactPosition(messages[newIdx], kind), current) ? advanced() : state
   }
 
-  // Keyless (migrated) pointer: its timestamp proves nothing about its position,
+  // FLOOR (migrated) pointer: its timestamp proves nothing about its position,
   // so keep ordering by index — including the off-slice guard and the live-edge
   // escape hatch that stops it getting stuck.
-  const currentIdx = messages.findIndex((m) => m.id === state.readPointer!.messageId)
+  const currentIdx = messages.findIndex((m) => m.id === state.readPointer!.identity.messageId)
   if (currentIdx === -1) {
     if (options?.atLiveEdge && newIdx === messages.length - 1) return advanced()
     return state
@@ -519,7 +521,7 @@ export function shouldNotifyConversation(
   if (msg.isOutgoing) return false
   if (ctx.isActive && ctx.windowVisible) return false
   if ((ctx.unreadCount ?? 0) <= 0) return false
-  if (msg.id === ctx.readPointer?.messageId) return false
+  if (msg.id === ctx.readPointer?.identity.messageId) return false
   return true
 }
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './readMarkerSync'
 import type { NotificationMessage } from './notificationState'
-import { makeReadPointer } from './readPointer'
+import { makeReadPointer, type ReadPointer } from './readPointer'
 
 /**
  * XEP-0490 remote-read-position resolution — the state machine that both
@@ -32,10 +32,14 @@ const baseMeta = {
   pendingRemoteDisplayedStanzaId: undefined,
 }
 
-/** The read position naming `id`, carrying that message's own timestamp. */
-function seenIn(id: string) {
+/**
+ * The read position naming `id`, carrying that message's own timestamp as a
+ * FLOOR — the pre-#1081 migrated shape, which is what these cases exercise (the
+ * exact-order branch is covered by the `seenExactIn` cases below).
+ */
+function seenIn(id: string): ReadPointer {
   const found = messages.find((m) => m.id === id)!
-  return { messageId: found.id, timestamp: found.timestamp }
+  return { order: { role: 'floor', timestamp: found.timestamp.getTime() }, identity: { state: 'local', messageId: found.id } }
 }
 
 describe('resolveRemoteDisplayed', () => {
@@ -61,7 +65,13 @@ describe('resolveRemoteDisplayed', () => {
     // which is not what this test is about.
     expect(result).toMatchObject({
       kind: 'advanced',
-      readPointer: { messageId: 'm2', timestamp: new Date('2024-01-15T10:02:00Z') },
+      readPointer: {
+        order: { role: 'exact', timestamp: new Date('2024-01-15T10:02:00Z').getTime(), tiebreak: { kind: 'chat', id: 'm2' } },
+        // ADDRESSABLE, and free: the row was found BY the archive id the marker
+        // carried, so the minted pointer already holds its wire name — no
+        // lookup, no residency, nothing for the publisher to resolve.
+        identity: { state: 'addressable', messageId: 'm2', archiveId: 'arch-m2' },
+      },
     })
   })
 
@@ -78,7 +88,13 @@ describe('resolveRemoteDisplayed', () => {
     // Advanced to m2 → the first unseen incoming message after it is m3.
     expect(result).toMatchObject({
       kind: 'advanced-with-divider',
-      readPointer: { messageId: 'm2', timestamp: new Date('2024-01-15T10:02:00Z') },
+      readPointer: {
+        order: { role: 'exact', timestamp: new Date('2024-01-15T10:02:00Z').getTime(), tiebreak: { kind: 'chat', id: 'm2' } },
+        // ADDRESSABLE, and free: the row was found BY the archive id the marker
+        // carried, so the minted pointer already holds its wire name — no
+        // lookup, no residency, nothing for the publisher to resolve.
+        identity: { state: 'addressable', messageId: 'm2', archiveId: 'arch-m2' },
+      },
       firstNewMessageId: 'm3',
     })
   })
@@ -95,7 +111,10 @@ describe('resolveRemoteDisplayed', () => {
 
     expect(result).toMatchObject({
       kind: 'advanced-with-divider',
-      readPointer: { messageId: 'm3', timestamp: new Date('2024-01-15T10:03:00Z') },
+      readPointer: {
+        order: { role: 'exact', timestamp: new Date('2024-01-15T10:03:00Z').getTime(), tiebreak: { kind: 'chat', id: 'm3' } },
+        identity: { state: 'addressable', messageId: 'm3', archiveId: 'arch-m3' },
+      },
       firstNewMessageId: 'm2',
     })
   })
@@ -135,9 +154,9 @@ describe('resolveRemoteDisplayed', () => {
     // and reading that as "already read" would lose the remote position for
     // good, since the activation fold (which loads a wide enough slice) would
     // then have nothing left to apply.
-    const offSlicePointer = {
-      messageId: 'ties-m3',
-      timestamp: new Date('2024-01-15T10:03:00Z'),
+    const offSlicePointer: ReadPointer = {
+      order: { role: 'floor', timestamp: new Date('2024-01-15T10:03:00Z').getTime() },
+      identity: { state: 'local', messageId: 'ties-m3' },
     }
 
     const result = resolveRemoteDisplayed(
@@ -163,7 +182,7 @@ describe('resolveRemoteDisplayed', () => {
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'may-lag-its-timestamp', timestamp: new Date('2024-01-15T11:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T11:00:00Z').getTime() }, identity: { state: 'local', messageId: 'may-lag-its-timestamp' } },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -182,7 +201,7 @@ describe('resolveRemoteDisplayed', () => {
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'older-than-slice', timestamp: new Date(0) },
+        readPointer: { order: { role: 'floor', timestamp: new Date(0).getTime() }, identity: { state: 'local', messageId: 'older-than-slice' } },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -201,7 +220,7 @@ describe('resolveRemoteDisplayed', () => {
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'may-name-a-newer-message', timestamp: new Date('2024-01-15T09:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T09:00:00Z').getTime() }, identity: { state: 'local', messageId: 'may-name-a-newer-message' } },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -220,7 +239,7 @@ describe('resolveRemoteDisplayed', () => {
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'ties-m3', timestamp: new Date('2024-01-15T10:03:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T10:03:00Z').getTime() }, identity: { state: 'local', messageId: 'ties-m3' } },
       },
       messages,
       undefined,
@@ -238,7 +257,7 @@ describe('resolveRemoteDisplayed', () => {
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'may-lag-its-timestamp', timestamp: new Date('2024-01-15T11:00:00Z') },
+        readPointer: { order: { role: 'floor', timestamp: new Date('2024-01-15T11:00:00Z').getTime() }, identity: { state: 'local', messageId: 'may-lag-its-timestamp' } },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -260,9 +279,9 @@ describe('resolveRemoteDisplayed', () => {
       msg('m4', '2024-01-15T10:04:00Z'),
     ]
     const latestPage = fullHistory.slice(2)
-    let readPointer = {
-      messageId: 'm1',
-      timestamp: new Date('2024-01-15T10:01:00Z'),
+    let readPointer: ReadPointer = {
+      order: { role: 'floor', timestamp: new Date('2024-01-15T10:01:00Z').getTime() },
+      identity: { state: 'local', messageId: 'm1' },
     }
     let pending: string | undefined = 'arch-m3'
     let firstNewMessageId: string | undefined = 'm2'
@@ -317,7 +336,7 @@ describe('resolveRemoteDisplayed', () => {
     )
 
     expect(fold).toEqual({ pending: 'arch-m3', attempted: true, resolved: true })
-    expect(readPointer.messageId).toBe('m3')
+    expect(readPointer.identity.messageId).toBe('m3')
     expect(firstNewMessageId).toBe('m4')
     expect(pending).toBeUndefined()
   })
@@ -336,7 +355,7 @@ describe('resolveRemoteDisplayed — position resolution (PR C, D3)', () => {
       undefined, 's2', 'chat', { isActive: false }
     )
     expect(r.kind).toBe('advanced')
-    expect(r.kind === 'advanced' && r.readPointer.messageId).toBe('m2')
+    expect(r.kind === 'advanced' && r.readPointer.identity.messageId).toBe('m2')
   })
 
   // Branch 2 — the widening. The local pointer's message is NOT in the slice.
@@ -348,7 +367,7 @@ describe('resolveRemoteDisplayed — position resolution (PR C, D3)', () => {
       undefined, 's2', 'chat', { isActive: false }
     )
     expect(r.kind).toBe('advanced')
-    expect(r.kind === 'advanced' && r.readPointer.messageId).toBe('m2')
+    expect(r.kind === 'advanced' && r.readPointer.identity.messageId).toBe('m2')
   })
 
   it('does NOT advance a KEYED pointer when the marker is behind it', () => {
@@ -376,7 +395,7 @@ describe('resolveRemoteDisplayed — position resolution (PR C, D3)', () => {
   // NOT provable and must keep stashing.
   it('stashes a KEYLESS pointer that is absent from the slice', () => {
     const r = resolveRemoteDisplayed(
-      { unreadCount: 3, mentionsCount: 0, readPointer: { messageId: 'old', timestamp: new Date(500) } },
+      { unreadCount: 3, mentionsCount: 0, readPointer: { order: { role: 'floor', timestamp: new Date(500).getTime() }, identity: { state: 'local', messageId: 'old' } } },
       [msg('m2', 2000, 's2')],
       undefined, 's2', 'chat', { isActive: false }
     )

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -9,7 +9,7 @@
 
 import type { NotificationMessage } from './notificationState'
 import * as notifState from './notificationState'
-import { mayAdvanceTo, makeCacheOrderKey } from './readState'
+import { mayAdvanceTo, exactPosition } from './readState'
 import { makeReadPointer, type ReadPointer } from './readPointer'
 
 /** The notification-relevant slice of a conversation/room metadata entry. */
@@ -57,19 +57,24 @@ export type RemoteDisplayedResolution =
  * Decide whether the remote marker `match` is a forward advance over `current`.
  *
  * Three branches (read-state PR C, D3), because the no-pointer case is NOT the
- * same as the keyless one:
+ * same as the floor one:
  *
  * - **No pointer** — any resolvable marker is an advance. This is what the code
  *   did before PR C (an undefined pointer made the residency check vacuously
  *   true, so `onMessageSeen` took its own no-pointer path); it is preserved
  *   explicitly so it cannot be lost by refactoring.
- * - **Keyed pointer** — decide by cache position, with no residency
- *   requirement. The key certifies that the pointer's timestamp is its named
- *   message's own, which is exactly the guarantee the old comment here said we
- *   lacked.
- * - **Keyless (migrated) pointer** — its timestamp is `lastReadAt`, which can
+ * - **Exact pointer** — decide by cache position, with no residency
+ *   requirement. An exact order certifies that the pointer's timestamp is its
+ *   named message's own, which is exactly the guarantee the old comment here
+ *   said we lacked.
+ * - **Floor (migrated) pointer** — its timestamp is `lastReadAt`, which can
  *   sit on EITHER side of the message it names, so nothing is provable from it.
  *   Keep the resident-index path, and stash when the pointer is off-slice.
+ *
+ * `match` is the resolved local row for an inbound XEP-0490 marker, so it
+ * carries the archive id we just matched on: `makeReadPointer` mints an
+ * `addressable` pointer from it directly. That archive id is bound by IDENTITY
+ * — it is the very id this row was found by — never by position.
  */
 function resolveAdvance<T extends NotificationMessage & { stanzaId?: string }>(
   current: ReadPointer | undefined,
@@ -81,16 +86,13 @@ function resolveAdvance<T extends NotificationMessage & { stanzaId?: string }>(
 ): ReadPointer | 'no-advance' | 'undecidable' {
   if (!current) return makeReadPointer(match, kind)
 
-  if (current.tiebreak) {
+  if (current.order.role === 'exact') {
     // The ADVANCE question — never overtake at a shared millisecond (#1173).
-    const ahead = mayAdvanceTo(
-      { timestamp: match.timestamp.getTime(), tiebreak: makeCacheOrderKey(match, kind) },
-      { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
-    )
+    const ahead = mayAdvanceTo(exactPosition(match, kind), current.order)
     return ahead ? makeReadPointer(match, kind) : 'no-advance'
   }
 
-  if (!messages.some((m) => m.id === current.messageId)) return 'undecidable'
+  if (!messages.some((m) => m.id === current.identity.messageId)) return 'undecidable'
 
   const updated = notifState.onMessageSeen(
     {
@@ -104,7 +106,7 @@ function resolveAdvance<T extends NotificationMessage & { stanzaId?: string }>(
     kind
   )
   const next = updated.readPointer
-  return next && next.messageId !== current.messageId ? next : 'no-advance'
+  return next && next.identity.messageId !== current.identity.messageId ? next : 'no-advance'
 }
 
 export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaId?: string }>(

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -1,30 +1,84 @@
 import { describe, it, expect } from 'vitest'
 import {
   makeReadPointer,
+  withArchiveId,
   isAhead,
   advance,
   serializeReadPointer,
   deserializeReadPointer,
 } from './readPointer'
 import type { ReadPointer } from './readPointer'
-import { isAfterBoundary, isValidCacheOrderKey } from './readState'
+import { isAfterBoundary, type CacheOrderKey } from './readState'
 
 const at = (ms: number) => new Date(ms)
 
+/** An `exact` + `local` pointer, the shape every migrated keyed pointer enters as. */
+const exactLocal = (messageId: string, timestamp: number, tiebreak: CacheOrderKey): ReadPointer => ({
+  order: { role: 'exact', timestamp, tiebreak },
+  identity: { state: 'local', messageId },
+})
+
 describe('makeReadPointer', () => {
-  it('captures the id and timestamp of the message it names, plus its cache order key', () => {
+  it('captures the order and the LOCAL name of a message with no archive id', () => {
     expect(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')).toEqual({
-      messageId: 'm1',
-      timestamp: at(1000),
-      tiebreak: { kind: 'chat', id: 'm1' },
+      order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat', id: 'm1' } },
+      identity: { state: 'local', messageId: 'm1' },
+    })
+  })
+
+  it('captures the WIRE name too when the message carries an archive id', () => {
+    expect(makeReadPointer({ id: 'm1', timestamp: at(1000), stanzaId: 'archive-1' }, 'chat')).toEqual({
+      order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat', id: 'm1' } },
+      identity: { state: 'addressable', messageId: 'm1', archiveId: 'archive-1' },
     })
   })
 
   it('round-trips a room pointer with its tiebreak', () => {
     const p = makeReadPointer({ id: 'm1', from: 'r@c/alice', timestamp: at(1000) }, 'room')
-    expect(p.tiebreak).toEqual({ kind: 'room', from: 'r@c/alice', id: 'm1' })
-    expect(deserializeReadPointer(serializeReadPointer(p))!.tiebreak)
-      .toEqual({ kind: 'room', from: 'r@c/alice', id: 'm1' })
+    expect(p.order).toEqual({ role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', from: 'r@c/alice', id: 'm1' } })
+    expect(deserializeReadPointer(serializeReadPointer(p))!.order).toEqual(p.order)
+  })
+
+  it('binds the wire name to the message it NAMES, never to a neighbour', () => {
+    // The constraint that keeps the anchor defect from reappearing at a new
+    // site: the archive id comes from the same object the id and timestamp do.
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000), stanzaId: 'archive-1' }, 'chat')
+    expect(p.identity).toEqual({ state: 'addressable', messageId: 'm1', archiveId: 'archive-1' })
+  })
+})
+
+describe('withArchiveId — forward NAME convergence', () => {
+  it('promotes a local pointer and leaves the order identical BY REFERENCE', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const enriched = withArchiveId(p, 'archive-1')
+    expect(enriched.order).toBe(p.order)
+    expect(enriched.identity).toEqual({ state: 'addressable', messageId: 'm1', archiveId: 'archive-1' })
+  })
+
+  it('cannot move the cursor: the enriched pointer is neither ahead nor behind', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const enriched = withArchiveId(p, 'archive-1')
+    expect(isAhead(enriched, p)).toBe(false)
+    expect(isAhead(p, enriched)).toBe(false)
+    expect(advance(p, enriched)).toBe(p)
+  })
+
+  it('refuses a FLOOR pointer — its name and order already disagree', () => {
+    const migrated: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'm4' },
+    }
+    expect(withArchiveId(migrated, 'archive-4')).toBe(migrated)
+  })
+
+  it('refuses an empty archive id rather than minting an unpublishable name', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    expect(withArchiveId(p, '')).toBe(p)
+  })
+
+  it('never re-names an already-addressable pointer', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000), stanzaId: 'archive-1' }, 'chat')
+    expect(withArchiveId(p, 'archive-999')).toBe(p)
   })
 })
 
@@ -43,13 +97,13 @@ describe('isAhead', () => {
     expect(isAhead(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'), current)).toBe(false)
   })
 
-  it('breaks a same-millisecond tie when BOTH pointers are keyed (chat: id order)', () => {
+  it('breaks a same-millisecond tie when BOTH orders are exact (chat: id order)', () => {
     const current = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
     const candidate = makeReadPointer({ id: 'm2', timestamp: at(1000) }, 'chat')
     expect(isAhead(candidate, current)).toBe(true)
   })
 
-  it('is NOT ahead when both are keyed and the candidate sorts LOWER at the same ms', () => {
+  it('is NOT ahead when both are exact and the candidate sorts LOWER at the same ms', () => {
     const current = makeReadPointer({ id: 'm2', timestamp: at(1000) }, 'chat')
     const candidate = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
     expect(isAhead(candidate, current)).toBe(false)
@@ -62,32 +116,48 @@ describe('isAhead', () => {
     expect(isAhead(candidate, current)).toBe(true)
   })
 
+  it('ignores identity entirely — a wire name is not a position', () => {
+    const local = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const addressable = makeReadPointer({ id: 'm1', timestamp: at(1000), stanzaId: 'archive-1' }, 'chat')
+    expect(isAhead(addressable, local)).toBe(false)
+    expect(isAhead(local, addressable)).toBe(false)
+  })
+
   // CONTROL for the polarity inversion (#1173). The COUNTING comparator,
-  // `isAfterBoundary`, reads a MISSING key on the boundary as at-or-after its
-  // millisecond — safe for a floor (under-advance -> over-count) and UNSAFE for
-  // a pointer, where it would let any keyed candidate overtake a migrated
-  // keyless pointer at the same millisecond. Substituting it here passes every
-  // test above and fails these two.
+  // `isAfterBoundary`, reads a FLOOR boundary as at-or-after its millisecond —
+  // safe for counting (over-count) and UNSAFE for a pointer, where it would let
+  // any exact candidate overtake a migrated floor pointer at the same
+  // millisecond. Substituting it here passes every test above and fails these
+  // two.
   //
   // That substitution no longer compiles — `isAfterBoundary` takes an
-  // `ExactPosition` row, which a possibly-keyless pointer is not — so these two
-  // are now a second line of defence rather than the only one. Keep both: the
-  // type guard pins the SHAPE, these pin the BEHAVIOUR. See
+  // `ExactPosition` row, which a possibly-floor pointer order is not — so these
+  // two are now a second line of defence rather than the only one. Keep both:
+  // the type guard pins the SHAPE, these pin the BEHAVIOUR. See
   // `readState.enforcement.test.ts`.
-  it('is NOT ahead at an equal ms when the CURRENT pointer is keyless (migrated)', () => {
-    const current: ReadPointer = { messageId: 'legacy', timestamp: at(1000) }
+  it('is NOT ahead at an equal ms when the CURRENT pointer is a floor (migrated)', () => {
+    const current: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'legacy' },
+    }
     const candidate = makeReadPointer({ id: 'm2', timestamp: at(1000) }, 'chat')
     expect(isAhead(candidate, current)).toBe(false)
   })
 
-  it('is NOT ahead at an equal ms when the CANDIDATE is keyless', () => {
+  it('is NOT ahead at an equal ms when the CANDIDATE is a floor', () => {
     const current = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    const candidate: ReadPointer = { messageId: 'legacy', timestamp: at(1000) }
+    const candidate: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'legacy' },
+    }
     expect(isAhead(candidate, current)).toBe(false)
   })
 
-  it('still compares by millisecond when a keyless pointer is genuinely older/newer', () => {
-    const current: ReadPointer = { messageId: 'legacy', timestamp: at(1000) }
+  it('still compares by millisecond when a floor pointer is genuinely older/newer', () => {
+    const current: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'legacy' },
+    }
     expect(isAhead(makeReadPointer({ id: 'm2', timestamp: at(2000) }, 'chat'), current)).toBe(true)
     expect(isAhead(makeReadPointer({ id: 'm2', timestamp: at(500) }, 'chat'), current)).toBe(false)
   })
@@ -114,24 +184,45 @@ describe('advance', () => {
 })
 
 describe('serialization', () => {
-  it('round-trips through JSON', () => {
+  it('round-trips a local pointer through JSON', () => {
     const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    const raw = JSON.parse(JSON.stringify(serializeReadPointer(p)))
-    expect(deserializeReadPointer(raw)).toEqual(p)
+    expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
   })
 
-  // Two on-disk encodings of `timestamp` both need to keep loading: epoch ms
-  // (serializeReadPointer's own output, used by room read-state storage) and
-  // ISO strings (what a chat pointer riding inside `conversationMeta` becomes
-  // after a plain `JSON.stringify` turns its `Date` into a string, #1081).
-  // Deserializing the wrong encoding must never silently drop every existing
-  // pointer.
-  it('accepts an ISO string timestamp', () => {
-    const iso = new Date(1000).toISOString()
-    expect(deserializeReadPointer({ messageId: 'm1', timestamp: iso })).toEqual({
-      messageId: 'm1',
-      timestamp: at(1000),
-    })
+  it('round-trips an ADDRESSABLE pointer, wire name included', () => {
+    const p = makeReadPointer({ id: 'm1', from: 'r@c/alice', timestamp: at(1000), stanzaId: 'archive-1' }, 'room')
+    expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
+  })
+
+  it('round-trips a FLOOR pointer, which has no tiebreak to write', () => {
+    const p: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'legacy' },
+    }
+    expect(serializeReadPointer(p).order).toEqual({ role: 'floor', timestamp: 1000 })
+    expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
+  })
+
+  // The chat storage blob is a plain `JSON.stringify` of the LIVE object rather
+  // than a call to `serializeReadPointer`, so the two writers must produce the
+  // same readable shape. The only difference is the tie-break's redundant `id`,
+  // which the blob keeps and hydration ignores.
+  it('reads the chat blob (a plain JSON.stringify of the live pointer) identically', () => {
+    const p = makeReadPointer({ id: 'm1', from: 'r@c/alice', timestamp: at(1000), stanzaId: 'archive-1' }, 'room')
+    const viaBlob = deserializeReadPointer(JSON.parse(JSON.stringify(p)))
+    const viaSerializer = deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))
+    expect(viaBlob).toEqual(p)
+    expect(viaBlob).toEqual(viaSerializer)
+  })
+
+  it('omits the tie-break id from what it writes', () => {
+    const chat = serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))
+    const room = serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room'))
+    expect(chat.order).toEqual({ role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat' } })
+    expect(room.order).toEqual({ role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', from: 'room@x/nick' } })
+    for (const s of [chat, room]) {
+      expect(JSON.parse(JSON.stringify(s)).order.tiebreak).not.toHaveProperty('id')
+    }
   })
 
   // Storage is untrusted input: a corrupt entry must yield "no pointer",
@@ -140,305 +231,291 @@ describe('serialization', () => {
     ['null', null],
     ['undefined', undefined],
     ['a string', 'nonsense'],
-    ['a missing messageId', { timestamp: 1000 }],
-    ['a missing timestamp', { messageId: 'm1' }],
-    ['a non-numeric, non-string timestamp', { messageId: 'm1', timestamp: true }],
-    ['a string timestamp that is not a valid date', { messageId: 'm1', timestamp: 'later' }],
+    ['an order with no identity', { order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat' } } }],
+    ['an identity with no messageId', { order: { role: 'floor', timestamp: 1000 }, identity: { state: 'local' } }],
+    ['an empty messageId', { order: { role: 'floor', timestamp: 1000 }, identity: { state: 'local', messageId: '' } }],
+    ['an order with no timestamp', { order: { role: 'floor' }, identity: { state: 'local', messageId: 'm' } }],
+    [
+      'a non-numeric, non-string timestamp',
+      { order: { role: 'floor', timestamp: true }, identity: { state: 'local', messageId: 'm' } },
+    ],
+    [
+      'a string timestamp that is not a date',
+      { order: { role: 'floor', timestamp: 'later' }, identity: { state: 'local', messageId: 'm' } },
+    ],
+    ['a non-object order', { order: 'floor', identity: { state: 'local', messageId: 'm' } }],
   ])('returns undefined for %s', (_label, raw) => {
     expect(deserializeReadPointer(raw)).toBeUndefined()
   })
 
-  // The persisted key is untrusted input too: a malformed one must not ride
-  // through into ordering comparisons. Dropping only the key (not the whole
-  // pointer) keeps the id/timestamp that are otherwise fine.
-  it('drops a malformed persisted tiebreak instead of trusting it', () => {
-    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, tiebreak: { kind: 'room', id: 'x' } })
-    expect(back!.tiebreak).toBeUndefined() // missing `from` → invalid → dropped
-    expect(back!.messageId).toBe('m') // the pointer itself survives
-  })
-
-  // A pointer migrated from the pre-#1081 legacy fields has no message
-  // position to derive a key from — absence here is legitimate, not corrupt.
-  it('a legacy pointer with no key deserializes with tiebreak undefined', () => {
-    expect(deserializeReadPointer({ messageId: 'm', timestamp: 1000 })!.tiebreak).toBeUndefined()
-  })
-})
-
-// The tie-break's `id` IS `messageId` — the same message named twice. Storing
-// them independently made a disagreement representable on disk, and the
-// ordering scan trusts the key as the at-or-behind boundary, so an inconsistent
-// restored pointer could select a row that is actually AHEAD — the
-// unrecoverable direction for a forward-only position. The on-disk form now
-// omits the id entirely, which makes the disagreement unrepresentable rather
-// than merely rejected.
-describe('serialization: the tie-break id is not persisted', () => {
-  it('omits `id` from a persisted chat key', () => {
-    const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    expect(serializeReadPointer(p).tiebreak).toEqual({ kind: 'chat' })
-  })
-
-  it('omits `id` from a persisted room key but keeps `from` (the room tie-break needs it)', () => {
-    const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    expect(serializeReadPointer(p).tiebreak).toEqual({ kind: 'room', from: 'room@x/nick' })
-  })
-
-  it('no persisted pointer carries an id beside the messageId', () => {
-    const chat = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    const room = makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    for (const p of [chat, room]) {
-      const onDisk = JSON.parse(JSON.stringify(serializeReadPointer(p)))
-      expect(onDisk.tiebreak).not.toHaveProperty('id')
-    }
-  })
-
-  it('hydration reconstructs the key id from messageId, so the round trip is unchanged in memory', () => {
-    const chat = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    const room = makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    for (const p of [chat, room]) {
-      expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
-    }
-  })
-
-  // Compatibility 1 — old data, new build. Any persisted `id` is ignored and
-  // `messageId` is used instead. Lossless: they were always the same value.
-  it('reads a legacy on-disk key that still carries its id (lossless)', () => {
-    expect(
-      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 'm1' } })
-    ).toEqual({ messageId: 'm1', timestamp: at(1000), tiebreak: { kind: 'chat', id: 'm1' } })
-
-    expect(
-      deserializeReadPointer({
-        messageId: 'm2',
-        timestamp: 1000,
-        archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm2' },
-      })
-    ).toEqual({
-      messageId: 'm2',
-      timestamp: at(1000),
-      tiebreak: { kind: 'room', from: 'room@x/nick', id: 'm2' },
-    })
-  })
-
-  it('accepts a legacy chat key with a non-string id because messageId is authoritative', () => {
-    expect(
-      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 42 } })
-    ).toEqual({
-      messageId: 'm1',
-      timestamp: at(1000),
-      tiebreak: { kind: 'chat', id: 'm1' },
-    })
-  })
-
-  // Compatibility 3 — inconsistent legacy data. This is the defect being
-  // closed: a stored pointer whose persisted id disagreed with `messageId` now
-  // resolves to `messageId`, so the boundary can no longer name a different
-  // (possibly newer) row than the pointer does.
-  it('resolves an inconsistent legacy key to messageId, not to the persisted id', () => {
+  // The persisted order is untrusted too: an `exact` claim whose tie-break comes
+  // back unusable degrades to a FLOOR rather than being trusted or dropped. Same
+  // instinct as before the identity variant — over-count, the safe direction —
+  // now expressed as a role rather than as a missing field.
+  it('degrades exact -> floor when the persisted tiebreak is unusable', () => {
     const back = deserializeReadPointer({
-      messageId: 'm1',
-      timestamp: 1000,
-      archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
-    })
-    expect(back!.tiebreak).toEqual({ kind: 'chat', id: 'm1' })
-
-    const roomBack = deserializeReadPointer({
-      messageId: 'm1',
-      timestamp: 1000,
-      archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm9-ahead' },
-    })
-    expect(roomBack!.tiebreak).toEqual({ kind: 'room', from: 'room@x/nick', id: 'm1' })
-  })
-
-  // ...and the disagreement cannot be written back out either: what a
-  // re-persist emits carries no id at all, so the inconsistency does not
-  // survive a load/save cycle in any form.
-  it('cannot write the disagreement back out', () => {
-    const back = deserializeReadPointer({
-      messageId: 'm1',
-      timestamp: 1000,
-      archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
+      order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', id: 'x' } }, // no `from`
+      identity: { state: 'local', messageId: 'm' },
     })!
-    expect(JSON.stringify(serializeReadPointer(back))).not.toContain('m9-ahead')
+    expect(back.order).toEqual({ role: 'floor', timestamp: 1000 })
+    expect(back.identity.messageId).toBe('m') // the pointer itself survives
   })
 
-  // Compatibility 2 — new data, old build. An older build validates the
-  // persisted key with `isValidCacheOrderKey`, which requires
-  // `typeof k.id === 'string'`. The id-less form fails that guard, so an old
-  // build DROPS the key and degrades to the documented at-or-after-timestamp
-  // fallback, which over-counts — the safe, recoverable direction. Asserted
-  // here rather than assumed, because shipping a format an older build
-  // mis-read in the unsafe direction would be unrecoverable. Since the on-disk
-  // rename, an old build does not even find this value; the guard is asserted
-  // anyway so the id-less form stays independently unreadable by it.
-  it('an old build drops the new id-less key rather than mis-reading it', () => {
-    const chat = serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))
-    const room = serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room'))
-    expect(isValidCacheOrderKey(chat.tiebreak)).toBe(false)
-    expect(isValidCacheOrderKey(room.tiebreak)).toBe(false)
-  })
-
-  // The pointer itself must still load on an old build: only the key degrades.
-  it('leaves messageId and timestamp readable in the old on-disk shape', () => {
-    const onDisk = JSON.parse(
-      JSON.stringify(serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')))
-    )
-    expect(onDisk.messageId).toBe('m1')
-    expect(onDisk.timestamp).toBe(1000)
-  })
-
-  // A key whose `kind` is unrecognisable, or a room key with no usable `from`,
-  // still yields no key at all — storage stays untrusted input.
   it.each([
     ['an unknown kind', { kind: 'nope' }],
     ['a room key with no from', { kind: 'room' }],
     ['a room key with a non-string from', { kind: 'room', from: 7 }],
     ['a non-object key', 'chat'],
-  ])('drops %s', (_label, tiebreak) => {
-    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, tiebreak })
-    expect(back!.tiebreak).toBeUndefined()
-    expect(back!.messageId).toBe('m')
+    ['no key at all', undefined],
+  ])('degrades exact -> floor for %s', (_label, tiebreak) => {
+    const back = deserializeReadPointer({
+      order: { role: 'exact', timestamp: 1000, tiebreak },
+      identity: { state: 'local', messageId: 'm' },
+    })!
+    expect(back.order.role).toBe('floor')
+    expect(back.identity.messageId).toBe('m')
+  })
+
+  // An `addressable` claim with no usable archive id hydrates as `local`.
+  // Degraded is the state that always has a defined meaning; a pointer whose
+  // wire name is `undefined` at the publisher is not a state at all.
+  it.each([
+    ['a missing archiveId', undefined],
+    ['an empty archiveId', ''],
+    ['a non-string archiveId', 42],
+  ])('hydrates an addressable claim with %s as local', (_label, archiveId) => {
+    const back = deserializeReadPointer({
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'addressable', messageId: 'm', archiveId },
+    })!
+    expect(back.identity).toEqual({ state: 'local', messageId: 'm' })
+  })
+
+  it('ignores an archiveId riding on a `local` identity', () => {
+    const back = deserializeReadPointer({
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'm', archiveId: 'archive-1' },
+    })!
+    expect(back.identity).toEqual({ state: 'local', messageId: 'm' })
   })
 })
 
-// The on-disk property is now `tiebreak`, matching the in-memory field. The
-// historical name `archiveOrderKey` is still READ, never written — see the
-// removal condition documented at the fallback in `deserializeReadPointer`.
-describe('the on-disk tie-break property', () => {
-  it('writes only `tiebreak`, never the historical name', () => {
-    expect(JSON.stringify(serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))))
-      .toBe('{"messageId":"m1","timestamp":1000,"tiebreak":{"kind":"chat"}}')
+/**
+ * THE MIGRATION (§5.4 of the design). Three populations, and the invariant that
+ * governs all of them: **no stored position moves**. Not the timestamp, not the
+ * tie-break, not the name. A read pointer is forward-only, so a position moved
+ * forward here is unrecoverable and a position moved backward re-notifies the
+ * user about messages they read.
+ *
+ * The fixtures below are the ACTUAL on-disk shapes shipped builds wrote, each
+ * traced to the commit that produced it — not shapes invented to match the
+ * reader. Verify one against its commit before changing it.
+ */
+describe('migration from the pre-identity on-disk shapes', () => {
+  /** Epoch ms of a real persisted pointer, kept as a literal so drift is visible. */
+  const T = 1785400698528
 
-    expect(
-      JSON.stringify(
-        serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'))
-      )
-    ).toBe('{"messageId":"m2","timestamp":2000,"tiebreak":{"kind":"room","from":"room@x/nick"}}')
-  })
+  // ── POPULATION 1: keyed pointers (the bulk) ───────────────────────────────
+  // Shape change only. `exact` order preserved, tie-break id reconstructed from
+  // `messageId` exactly as the previous reader already did, and identity `local`
+  // because NO archive id was ever stored in any of these formats.
+  const KEYED_FIXTURES: Array<[string, unknown]> = [
+    // `ef2faa19` (#1208) — the currently shipped room-read-state / snapshot form.
+    ['#1208 room read state: `tiebreak`, id dropped', { messageId: 'm4', timestamp: T, tiebreak: { kind: 'chat' } }],
+    // `7780a8b1` (#1196) — id dropped, still under the historical name.
+    [
+      '#1196 room read state: `archiveOrderKey`, id dropped',
+      { messageId: 'm4', timestamp: T, archiveOrderKey: { kind: 'chat' } },
+    ],
+    // Pre-#1196 — the key carried its own copy of the id. Ignored, not read.
+    [
+      'pre-#1196: the key still carries its redundant id',
+      { messageId: 'm4', timestamp: T, archiveOrderKey: { kind: 'chat', id: 'm4' } },
+    ],
+    // The chat blob at every one of those builds: a plain `JSON.stringify` of the
+    // live object, so `timestamp` is an ISO string and the key keeps its id.
+    [
+      'chat blob: ISO timestamp, key keeps its id',
+      { messageId: 'm4', timestamp: new Date(T).toISOString(), tiebreak: { kind: 'chat', id: 'm4' } },
+    ],
+  ]
 
-  it('never writes the historical name to disk', () => {
-    const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
-    expect(JSON.stringify(serializeReadPointer(p))).not.toContain('archiveOrderKey')
-  })
-
-  // Rename compatibility 1 — NEW build, OLD data. A pointer written under the
-  // historical name is found by the fallback and hydrates identically to one
-  // written under the new name. Lossless: nothing degrades, nothing is rewritten.
-  it.each([
-    ['chat', { kind: 'chat' }, { kind: 'chat', id: 'm1' }],
-    ['room', { kind: 'room', from: 'room@x/nick' }, { kind: 'room', from: 'room@x/nick', id: 'm1' }],
-  ])('reads a %s pointer stored under the historical name (lossless)', (_label, onDiskKey, expected) => {
-    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: onDiskKey })).toEqual({
-      messageId: 'm1',
-      timestamp: at(1000),
-      tiebreak: expected,
-    })
-    // ...and identically to the same key stored under the new name.
-    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: onDiskKey })).toEqual(
-      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, tiebreak: onDiskKey })
+  it.each(KEYED_FIXTURES)('migrates %s without moving the position', (_label, raw) => {
+    expect(deserializeReadPointer(raw)).toEqual(
+      exactLocal('m4', T, { kind: 'chat', id: 'm4' })
     )
+  })
+
+  it('migrates a keyed ROOM pointer, keeping the `from` it cannot reconstruct', () => {
+    expect(
+      deserializeReadPointer({ messageId: 'm4', timestamp: T, tiebreak: { kind: 'room', from: 'room@x/nick' } })
+    ).toEqual(exactLocal('m4', T, { kind: 'room', from: 'room@x/nick', id: 'm4' }))
+  })
+
+  it('enters `local`, never `addressable`: no archive id was ever stored', () => {
+    for (const [, raw] of KEYED_FIXTURES) {
+      expect(deserializeReadPointer(raw)!.identity.state).toBe('local')
+    }
+  })
+
+  // The anchor defect (#1196), still closed by the new reader: a stored key
+  // whose id disagreed with `messageId` resolves to `messageId`, so the boundary
+  // cannot name a different — possibly NEWER — row than the pointer does.
+  it('resolves an inconsistent legacy key to messageId, not to the persisted id', () => {
+    expect(
+      deserializeReadPointer({
+        messageId: 'm4',
+        timestamp: T,
+        archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
+      })!.order
+    ).toEqual({ role: 'exact', timestamp: T, tiebreak: { kind: 'chat', id: 'm4' } })
+  })
+
+  it('cannot write the disagreement back out', () => {
+    const back = deserializeReadPointer({
+      messageId: 'm4',
+      timestamp: T,
+      archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
+    })!
+    expect(JSON.stringify(serializeReadPointer(back))).not.toContain('m9-ahead')
   })
 
   it('prefers `tiebreak` when a blob somehow carries both names', () => {
     expect(
       deserializeReadPointer({
-        messageId: 'm1',
-        timestamp: 1000,
+        messageId: 'm4',
+        timestamp: T,
         tiebreak: { kind: 'chat' },
         archiveOrderKey: { kind: 'room', from: 'stale@x/nick' },
-      })!.tiebreak
-    ).toEqual({ kind: 'chat', id: 'm1' })
+      })!.order
+    ).toEqual({ role: 'exact', timestamp: T, tiebreak: { kind: 'chat', id: 'm4' } })
   })
 
-  // Rename compatibility 3 — new build writes, new build reads. Unchanged.
-  it('round-trips a pointer written and read by this build', () => {
-    for (const p of [
-      makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'),
-      makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'),
-    ]) {
-      expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
+  // ── POPULATION 2: keyless legacy pointers ─────────────────────────────────
+  // `baa1601b` (#1081) wrote `{ messageId, timestamp }` and nothing else, and
+  // the #1081 migration still mints that pair from `lastSeenMessageId` +
+  // `lastReadAt`. Its timestamp is `lastReadAt`, which sits at or BEHIND the
+  // message it names — so the position is genuinely a FLOOR and the type now
+  // says so.
+  it('migrates the #1081 keyless pointer to a FLOOR without moving it', () => {
+    expect(deserializeReadPointer({ messageId: 'm4', timestamp: T })).toEqual({
+      order: { role: 'floor', timestamp: T },
+      identity: { state: 'local', messageId: 'm4' },
+    })
+  })
+
+  it('migrates the keyless chat-blob variant (ISO timestamp) identically', () => {
+    expect(deserializeReadPointer({ messageId: 'm4', timestamp: new Date(T).toISOString() })).toEqual({
+      order: { role: 'floor', timestamp: T },
+      identity: { state: 'local', messageId: 'm4' },
+    })
+  })
+
+  // Why they can NEVER converge, asserted rather than left as prose: resolving
+  // the named message's real timestamp is what convergence would need, and that
+  // could move the floor FORWARD on a forward-only pointer. `withArchiveId`
+  // refuses them outright, so no future enrichment path can do it by accident.
+  it('a migrated FLOOR pointer can never acquire a wire name', () => {
+    const migrated = deserializeReadPointer({ messageId: 'm4', timestamp: T })!
+    expect(withArchiveId(migrated, 'archive-4')).toBe(migrated)
+    expect(migrated.identity.state).toBe('local')
+  })
+
+  // ...and how they self-heal instead: any fresh exact pointer at a later
+  // millisecond is ahead, so the first genuine read in that entity replaces it.
+  it('a migrated FLOOR pointer self-heals on the next genuine read', () => {
+    const migrated = deserializeReadPointer({ messageId: 'm4', timestamp: T })!
+    const fresh = makeReadPointer({ id: 'm5', timestamp: at(T + 1), stanzaId: 'archive-5' }, 'chat')
+    expect(advance(migrated, fresh)).toBe(fresh)
+  })
+
+  // ── POPULATION 3: pointerless entities ────────────────────────────────────
+  it('leaves a pointerless entity pointerless', () => {
+    expect(deserializeReadPointer(undefined)).toBeUndefined()
+    expect(deserializeReadPointer(null)).toBeUndefined()
+  })
+
+  // ── THE INVARIANT, stated once over every population ──────────────────────
+  it('moves NO stored position, for any fixture', () => {
+    const all: unknown[] = [
+      ...KEYED_FIXTURES.map(([, raw]) => raw),
+      { messageId: 'm4', timestamp: T },
+      { messageId: 'm4', timestamp: T, tiebreak: { kind: 'room', from: 'room@x/nick' } },
+      { messageId: 'm4', timestamp: T, archiveOrderKey: { kind: 'chat', id: 'm9-ahead' } },
+    ]
+    for (const raw of all) {
+      const back = deserializeReadPointer(raw)!
+      expect(back.order.timestamp).toBe(T)
+      expect(back.identity.messageId).toBe('m4')
+      // And the tie-break, when there is one, still names the pointer's own
+      // message — never the persisted id, never a neighbour.
+      if (back.order.role === 'exact') expect(back.order.tiebreak.id).toBe('m4')
     }
   })
 })
 
-// Rename compatibility 2 — OLD build, NEW data. This is the direction that
-// matters: an older build looks for `archiveOrderKey` and only for that, so it
-// finds nothing. Asserted against a replica of that build's read rather than
-// assumed, because a format an old build mis-read in the UNSAFE direction (an
-// over-advanced forward-only pointer) would be unrecoverable.
-describe('an old build reading the renamed on-disk form', () => {
-  /**
-   * How every build before the rename read the tie-break: `raw.archiveOrderKey`
-   * through the hydration step. Both halves are reproduced here — a test that
-   * only asserted "the property is absent" would not show what the absence
-   * COSTS, which is the whole compatibility claim.
-   */
-  const oldBuildRead = (raw: Record<string, unknown>): ReadPointer | undefined => {
-    const { messageId, timestamp, archiveOrderKey } = raw as {
-      messageId?: string
-      timestamp?: number
-      archiveOrderKey?: unknown
+/**
+ * OLD BUILD, NEW DATA. This is the direction that matters: a format an older
+ * build mis-read in the UNSAFE direction (an over-advanced forward-only
+ * pointer) would be unrecoverable, so the degrade is asserted against a replica
+ * of that build's reader rather than assumed.
+ *
+ * The degrade is LARGER than the previous step's: every build before this one
+ * looks for a TOP-LEVEL `messageId` and `timestamp`, finds neither under
+ * `order` / `identity`, and reads NO POINTER at all — where the previous format
+ * still gave it a name and a timestamp and cost only the tie-break. That is the
+ * deliberate price of keeping exactly ONE copy of the name on disk: writing the
+ * flat fields alongside the nested ones would re-create the two-names-that-can-
+ * disagree shape this series exists to remove.
+ */
+describe('an old build reading the identity-variant on-disk form', () => {
+  /** How `deserializeReadPointer` read a blob at `ef2faa19` (#1208). */
+  const oldBuildRead = (raw: Record<string, unknown>): { messageId: string; timestamp: Date } | undefined => {
+    const { messageId, timestamp } = raw as { messageId?: unknown; timestamp?: unknown }
+    if (typeof messageId !== 'string' || messageId.length === 0) return undefined
+    if (typeof timestamp === 'number' && Number.isFinite(timestamp)) return { messageId, timestamp: new Date(timestamp) }
+    if (typeof timestamp === 'string') {
+      const parsed = new Date(timestamp)
+      return Number.isNaN(parsed.getTime()) ? undefined : { messageId, timestamp: parsed }
     }
-    if (typeof messageId !== 'string' || typeof timestamp !== 'number') return undefined
-    // The old hydration reconstructed the id from `messageId` exactly as today's
-    // does; what it could not do is look under any other property name.
-    const k = archiveOrderKey && typeof archiveOrderKey === 'object' ? (archiveOrderKey as Record<string, unknown>) : undefined
-    const tiebreak =
-      k?.kind === 'chat'
-        ? ({ kind: 'chat', id: messageId } as const)
-        : k?.kind === 'room' && typeof k.from === 'string'
-          ? ({ kind: 'room', from: k.from, id: messageId } as const)
-          : undefined
-    return { messageId, timestamp: new Date(timestamp), ...(tiebreak ? { tiebreak } : {}) }
+    return undefined
   }
 
   const onDisk = (p: ReadPointer) => JSON.parse(JSON.stringify(serializeReadPointer(p)))
 
-  it('still loads the read position itself — only the tie-break is lost', () => {
+  it('reads NO pointer at all, rather than a wrong one', () => {
     for (const p of [
       makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'),
-      makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'),
+      makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000), stanzaId: 'archive-2' }, 'room'),
     ]) {
-      const seen = oldBuildRead(onDisk(p))!
-      expect(seen.messageId).toBe(p.messageId)
-      expect(seen.timestamp).toEqual(p.timestamp)
-      expect(seen.tiebreak).toBeUndefined()
+      expect(oldBuildRead(onDisk(p))).toBeUndefined()
     }
   })
 
-  // The consequence, stated as behaviour rather than as a missing property: a
-  // keyless pointer cannot be overtaken by a same-millisecond candidate, so the
-  // forward-only position UNDER-advances. That is the at-or-after-timestamp
-  // fallback — it over-counts unread, which a read clears. The unsafe direction
-  // would be an over-advanced pointer, which nothing can recover.
-  it('degrades in the over-count direction, never the over-advance direction', () => {
+  // The consequence, stated as behaviour rather than as a missing property. With
+  // no pointer at all, an old build derives its floor from the entity's
+  // `historyFloor` instead, which counts MORE messages as unread — the
+  // recoverable direction, cleared by reading. Nothing it can do publishes an
+  // over-advanced XEP-0490 position, because it has no position to publish.
+  it('degrades toward over-counting, never toward over-advancing', () => {
     const stored = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
-    const seenByOldBuild = oldBuildRead(onDisk(stored))!
-    const sameMsCandidate = makeReadPointer({ id: 'm2-later-id', timestamp: at(1000) }, 'chat')
+    expect(oldBuildRead(onDisk(stored))).toBeUndefined()
 
-    // A keyed candidate sharing the millisecond does NOT overtake the keyless
-    // pointer the old build restored.
-    expect(isAhead(sameMsCandidate, seenByOldBuild)).toBe(false)
-    expect(advance(seenByOldBuild, sameMsCandidate)).toBe(seenByOldBuild)
-
-    // And the counting side of the same degradation: against the KEYLESS
-    // boundary an old build restored, the very message the pointer names still
-    // reads as after the boundary — so it is counted unread again. That is the
-    // at-or-after-timestamp over-count, which a read clears. `stored` comes from
-    // `makeReadPointer`, which always resolves a tie-break, so it is an
-    // ExactPosition; only the boundary may be keyless.
-    expect(
-      isAfterBoundary(
-        { timestamp: stored.timestamp.getTime(), tiebreak: stored.tiebreak! },
-        { timestamp: seenByOldBuild.timestamp.getTime(), tiebreak: seenByOldBuild.tiebreak }
-      )
-    ).toBe(true)
+    // What "no pointer" means for the counting question: with no boundary, every
+    // row from the history floor counts. Modelled here with the weakest boundary
+    // that build could construct — a bare millisecond at the floor.
+    expect(isAfterBoundary({ role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat', id: 'm1' } }, { role: 'floor', timestamp: 1000 })).toBe(true)
   })
 
-  // The old build's own key guard would have rejected the value anyway (the
-  // id-less form shipped in the previous step), so nothing about the rename
-  // makes it MORE likely to mis-read the key: it has no key to read at all.
-  it('has no key to validate at all', () => {
-    expect(isValidCacheOrderKey(onDisk(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')).archiveOrderKey))
-      .toBe(false)
+  // And the reverse direction stays lossless, which is what actually protects an
+  // upgrading user: a new build reads every shape an old build ever wrote.
+  it('is one-way: the NEW build still reads everything the old one wrote', () => {
+    for (const raw of [
+      { messageId: 'm4', timestamp: 1785400698528, tiebreak: { kind: 'chat' } },
+      { messageId: 'm4', timestamp: 1785400698528, archiveOrderKey: { kind: 'chat', id: 'm4' } },
+      { messageId: 'm4', timestamp: 1785400698528 },
+    ]) {
+      expect(deserializeReadPointer(raw)).toBeDefined()
+    }
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -1,21 +1,64 @@
 /**
  * The read pointer — where the user has read to.
  *
+ * A read position has ONE order and TWO names, and they answer different
+ * questions:
+ *
+ * - **order** — `(timestamp, tiebreak)`. The only comparable data. Local,
+ *   derived from the message cache's own cursor order, and never rewritten.
+ * - **local name** — `messageId`. Resolves against the cache and the DOM, which
+ *   is keyed by it. Every pointer has one.
+ * - **wire name** — the XEP-0359 archive id. The only cross-device identity, and
+ *   the only thing XEP-0490 can publish. NOT every pointer has one.
+ *
+ * The archive id cannot replace the order: XEP-0313 §6.2 makes archive ids
+ * opaque strings that carry no ordering and are unique only per archive. And the
+ * order cannot address the wire: a receiver MUST ignore an id it cannot find,
+ * and the tie-break holds the CLIENT message id. So the pointer carries both,
+ * minted together from one message, never independently writable.
+ *
+ * "We cannot address this position yet" is therefore a STATE
+ * ({@link PointerIdentity}'s `local` variant), not an absent field each consumer
+ * rediscovers. Every consumer must handle it to compile.
+ *
  * This replaces the `lastSeenMessageId` + `lastReadAt` pair, which were two
  * independent fields describing one fact and drifted apart in practice (issue
- * #1081): `lastReadAt` meant "timestamp of the newest LOADED message when I last
- * activated", not "the timestamp of the message I read up to". Nothing stopped a
- * writer from moving one and not the other.
- *
- * Here they are one object. You cannot write half of it. The timestamp is
- * denormalised from the message the id names, which is what keeps ordering
- * comparisons synchronous and O(1) — the message cache is then needed only for
- * counting, not for deciding which of two positions is further along.
+ * #1081). Here they are one object. You cannot write half of it. The timestamp
+ * is denormalised from the message the name identifies, which is what keeps
+ * ordering comparisons synchronous and O(1) — the message cache is then needed
+ * only for counting, not for deciding which of two positions is further along.
  *
  * All functions here are pure.
  */
 
-import { mayAdvanceTo, makeCacheOrderKey, type CacheOrderKey } from './readState'
+import { mayAdvanceTo, exactPosition, type CacheOrderKey, type PointerOrder } from './readState'
+
+/**
+ * How a read position can be NAMED.
+ *
+ * `messageId` is on both variants — it always exists, and it is the pointer's
+ * ONE local name. `archiveId` exists only on `addressable`, so reaching for it
+ * forces the consumer to say what it does when the position has no wire name.
+ *
+ * - **`addressable`** — the named message carried an XEP-0359 archive id when
+ *   the pointer was minted. Publishable as-is: the XEP-0490 publisher reads
+ *   `archiveId` and is done, with no lookup, no residency requirement and no
+ *   cache read.
+ * - **`local`** — degraded, and EXPLICITLY so. The archive id genuinely does not
+ *   exist yet (or, for the user's own 1:1 sends, may never: the server does not
+ *   echo them back, so the only id they ever have is a client-generated
+ *   `origin-id`, which is not publishable). No model can conjure one. What the
+ *   variant buys is that the state is named once instead of being rediscovered
+ *   at each consumer, and that the publisher's at-or-behind fallback (#1189) is
+ *   the DEFINITION of this branch rather than a patch bolted onto it.
+ *
+ * XEP-0359's `by` is deliberately NOT stored: it is a function of the entity
+ * (`isRoom(jid) ? jid : ownBareJid()`), so storing it would be a second
+ * derivable copy of something the publisher already knows.
+ */
+export type PointerIdentity =
+  | { readonly state: 'addressable'; readonly messageId: string; readonly archiveId: string }
+  | { readonly state: 'local'; readonly messageId: string }
 
 /**
  * Where the user has read to. Written atomically or not at all.
@@ -23,60 +66,58 @@ import { mayAdvanceTo, makeCacheOrderKey, type CacheOrderKey } from './readState
  * ONE deliberate exception to "the timestamp is the message's own": pointers
  * built by the #1081 migration from a legacy `lastSeenMessageId` + `lastReadAt`
  * PAIR carry `lastReadAt` as the timestamp, which is not necessarily the
- * timestamp of the message `messageId` names. That is the status quo preserved
- * exactly — `lastReadAt` is the floor today's unread derivation already counts
- * from, and it is at or behind the named message. Do not "fix" this by resolving
- * the message's real timestamp: that could move the floor FORWARD, and the
- * pointer is forward-only, so a position lost that way is unrecoverable. Only
- * `timestamp` is used for ordering; nothing derives a message from it.
+ * timestamp of the message the identity names. Those pointers carry a
+ * `role: 'floor'` order, which says exactly that: "at least here". That is the
+ * status quo preserved exactly — `lastReadAt` is the floor today's unread
+ * derivation already counts from, and it is at or behind the named message. Do
+ * not "fix" this by resolving the message's real timestamp: that could move the
+ * floor FORWARD, and the pointer is forward-only, so a position lost that way is
+ * unrecoverable. Only `order` is used for ordering; nothing derives a message
+ * from it.
  */
 export interface ReadPointer {
-  /** Client message id of the newest message the user has read. */
-  messageId: string
-  /** Timestamp OF that message (see the migration caveat above). */
-  timestamp: Date
-  /**
-   * The message cache's tie-break key for `messageId`, for counting unread
-   * strictly-after a POSITION rather than a timestamp alone (two messages can
-   * share a millisecond). OPTIONAL, deliberately: a pointer migrated from the
-   * pre-#1081 legacy `lastSeenMessageId` + `lastReadAt` pair has only a
-   * timestamp and no resolvable message position, so the key is legitimately
-   * absent — counting then falls back to at-or-after-timestamp, which can
-   * over-count the equal-ms set (the safe direction) rather than under-count.
-   */
-  tiebreak?: CacheOrderKey
+  /** Where this position sits in message-cache order. NEVER rewritten. */
+  readonly order: PointerOrder
+  /** What this position is called — locally, and on the wire when we can. */
+  readonly identity: PointerIdentity
 }
 
 /**
- * The tie-break as it is written to disk: everything the key needs EXCEPT its
- * `id`, which is `messageId` and is reconstructed at hydration.
+ * The order as it is written to disk: everything the tie-break needs EXCEPT its
+ * `id`, which is `identity.messageId` and is reconstructed at hydration.
  *
- * The id was stored twice — once as `messageId`, once inside the key — and
- * nothing checked the two agreed. Since the ordering scan trusts the key as the
+ * The id was stored twice — once as the name, once inside the key — and nothing
+ * checked the two agreed. Since the ordering scan trusts the key as the
  * at-or-behind boundary, a disagreeing restored pointer could select a row that
  * is actually AHEAD of the read position, which is the unrecoverable direction
  * for a forward-only pointer. Not persisting the second copy makes that
  * disagreement unrepresentable rather than merely rejected at read time.
  *
- * `from` stays: it is the room cache's `(from, id)` tie-break component
- * and is NOT derivable from the pointer.
+ * `from` stays: it is the room cache's `(from, id)` tie-break component and is
+ * NOT derivable from the pointer.
  */
 export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
+
+export type SerializedPointerOrder =
+  | { role: 'exact'; timestamp: number; tiebreak: SerializedCacheOrderKey }
+  | { role: 'floor'; timestamp: number }
 
 /**
  * JSON-safe form for localStorage.
  *
- * The persisted property is `tiebreak`, matching the in-memory field. Builds
- * before this one wrote it as `archiveOrderKey` — a name that was always wrong
- * (the key never held an archive id; it is the IndexedDB cursor tie-break built
- * from the CLIENT message id). Those blobs are still READ, by the fallback in
- * {@link deserializeReadPointer}, which is where the condition for eventually
- * deleting that tolerance is recorded.
+ * Mirrors the in-memory shape, which matters because the two persistence paths
+ * do NOT agree on how they write: room read state and the state snapshot call
+ * {@link serializeReadPointer}, while a chat pointer riding inside
+ * `conversationMeta` is written by a plain `JSON.stringify` of the live object.
+ * Keeping the serialized shape structurally identical to the live one means
+ * both paths produce the SAME on-disk shape, so {@link deserializeReadPointer}
+ * has one current format to read rather than two. The only difference the
+ * explicit serializer makes is dropping the tie-break's redundant `id`; the
+ * blob path leaves it in, and hydration ignores it either way.
  */
 export interface SerializedReadPointer {
-  messageId: string
-  timestamp: number
-  tiebreak?: SerializedCacheOrderKey
+  order: SerializedPointerOrder
+  identity: PointerIdentity
 }
 
 /** The minimal message shape a pointer can be built from. */
@@ -85,6 +126,16 @@ export interface PointerSource {
   /** Sender's JID — needed for the ROOM cache order key's (from, id) tie-break. */
   from?: string
   timestamp: Date
+  /**
+   * The message's XEP-0359 archive id, when it has one.
+   *
+   * This is what makes the minted pointer `addressable`, and taking it from the
+   * SAME message the pointer names is what binds the wire name to this position
+   * by IDENTITY. Never source it from a neighbouring row, a timestamp match, or
+   * a shared `origin-id`: that would give a correctly-ordered pointer a FOREIGN
+   * name, which is the defect this whole shape exists to make unrepresentable.
+   */
+  stanzaId?: string
 }
 
 /**
@@ -93,12 +144,49 @@ export interface PointerSource {
  * the two kinds break same-millisecond ties differently (see
  * {@link CacheOrderKey}) — the caller (chat store vs. room store) always
  * knows which, and must say so.
+ *
+ * The identity is `addressable` exactly when the message already carries an
+ * archive id. That is the free convergence path: every peer message, and every
+ * MUC reflection, mints an immediately publishable pointer. A message with no
+ * archive id mints `local`, which is honest rather than degraded-by-omission.
  */
 export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): ReadPointer {
   return {
-    messageId: message.id,
-    timestamp: message.timestamp,
-    tiebreak: makeCacheOrderKey(message, kind),
+    order: exactPosition(message, kind),
+    identity: message.stanzaId
+      ? { state: 'addressable', messageId: message.id, archiveId: message.stanzaId }
+      : { state: 'local', messageId: message.id },
+  }
+}
+
+/**
+ * Forward NAME convergence: attach a now-known archive id to a `local` pointer.
+ *
+ * Three rules, and each of them is load-bearing:
+ *
+ * 1. **It touches `identity` only.** `order` is carried by reference, so
+ *    convergence cannot move the cursor — the pointer names a position it
+ *    already held, it does not acquire a new one.
+ * 2. **The caller must bind by IDENTITY.** `archiveId` has to come from the very
+ *    message `identity.messageId` names. Matching by timestamp, or by an
+ *    `origin-id` two rows share, would attach a foreign wire name to a correct
+ *    order — the same defect at a new site. The repository's existing
+ *    enrichment machinery (`backfillArchiveIds`) is already identity-keyed;
+ *    keep it that way.
+ * 3. **A `floor` pointer is never enriched.** Its name and its order already
+ *    disagree — `lastReadAt` can sit behind the message it names — so giving it
+ *    a wire name would widen a visible inconsistency instead of fixing one.
+ *
+ * Returns `pointer` BY REFERENCE when nothing changes, so Zustand selectors can
+ * skip the re-render.
+ */
+export function withArchiveId(pointer: ReadPointer, archiveId: string): ReadPointer {
+  if (pointer.identity.state === 'addressable') return pointer
+  if (pointer.order.role === 'floor') return pointer
+  if (archiveId.length === 0) return pointer
+  return {
+    order: pointer.order,
+    identity: { state: 'addressable', messageId: pointer.identity.messageId, archiveId },
   }
 }
 
@@ -106,27 +194,28 @@ export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): 
  * Is `candidate` strictly further along than `current`?
  *
  * This is the ADVANCE question, so it is answered by {@link mayAdvanceTo}: a
- * same-millisecond tie is broken by the cache order key ONLY when both sides
- * carry one (read-state PR C, D2), and otherwise it refuses to move. A key is
- * what certifies that a pointer's timestamp is its named message's own —
- * pointers built by `makeReadPointer` always have one, while a pointer migrated
- * from the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair carries
- * `lastReadAt` and no key at all.
+ * same-millisecond tie is broken by the cache order key ONLY when both sides are
+ * `exact` (read-state PR C, D2), and otherwise it refuses to move. An exact
+ * order is what certifies that a pointer's timestamp is its named message's
+ * own — pointers built by `makeReadPointer` always have one, while a pointer
+ * migrated from the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair carries
+ * `lastReadAt` and is a `floor`.
  *
  * The counting question's comparator (`isAfterBoundary`) has the OPPOSITE
- * missing-key rule and must never be substituted here — it would let any keyed
- * candidate overtake a migrated keyless pointer sharing its millisecond,
+ * floor rule and must never be substituted here — it would let any exact
+ * candidate overtake a migrated floor pointer sharing its millisecond,
  * advancing a forward-only position past messages nothing has proven were read.
  * That used to be guarded by this comment alone (#1173); it is now guarded by
- * the type — `isAfterBoundary` takes an `ExactPosition` row, which a pointer,
- * being possibly keyless, is not. See `readState.enforcement.test.ts`.
+ * the type — `isAfterBoundary` takes an `ExactPosition` row, which a pointer's
+ * order, being possibly a floor, is not. See `readState.enforcement.test.ts`.
+ *
+ * Identity plays NO part here. A pointer is not further along for having
+ * acquired a wire name, which is why {@link withArchiveId} cannot move a cursor
+ * even in principle.
  */
 export function isAhead(candidate: ReadPointer, current: ReadPointer | undefined): boolean {
   if (!current) return true
-  return mayAdvanceTo(
-    { timestamp: candidate.timestamp.getTime(), tiebreak: candidate.tiebreak },
-    { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
-  )
+  return mayAdvanceTo(candidate.order, current.order)
 }
 
 /**
@@ -143,36 +232,46 @@ export function advance(current: ReadPointer | undefined, candidate: ReadPointer
  * {@link SerializedCacheOrderKey}). The in-memory key keeps its full shape;
  * only the on-disk form omits the redundant `id`.
  *
- * An OLDER build reading this format finds no tie-break at all: it looks only
- * under `archiveOrderKey` (and would reject this id-less key anyway, via
- * `isValidCacheOrderKey`'s `typeof k.id === 'string'` requirement). It
- * therefore degrades to the at-or-after-timestamp fallback, which over-counts
- * rather than under-counts — the safe, recoverable direction, since a keyless
- * pointer can only UNDER-advance. The `messageId` and `timestamp` it needs are
- * untouched. Asserted in `readPointer.test.ts` against a replica of that
- * build's read, not assumed.
+ * An OLDER build reading this format looks for a TOP-LEVEL `messageId` and
+ * `timestamp`, finds neither under `order` / `identity`, and reads NO POINTER at
+ * all. That degrades in the safe direction and is asserted rather than assumed
+ * (`readPointer.test.ts`): with no pointer, `computeFloor` falls back to the
+ * entity's `historyFloor`, which over-counts unread and publishes nothing to the
+ * XEP-0490 node — never an over-advanced forward-only position. It is a larger
+ * degrade than the previous format's (which kept the name and timestamp and lost
+ * only the tie-break), and it is the deliberate price of having exactly ONE copy
+ * of the name on disk: writing the legacy top-level fields alongside the nested
+ * ones would re-create the two-names-that-can-disagree shape this series exists
+ * to remove.
  */
 export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointer {
-  const key = pointer.tiebreak
+  const { order } = pointer
   return {
-    messageId: pointer.messageId,
-    timestamp: pointer.timestamp.getTime(),
-    // The on-disk name is `tiebreak`, the same as in memory. `archiveOrderKey`
-    // is read back but never written — see {@link deserializeReadPointer}.
-    ...(key ? { tiebreak: key.kind === 'room' ? { kind: 'room', from: key.from } : { kind: 'chat' } } : {}),
+    order:
+      order.role === 'exact'
+        ? {
+            role: 'exact',
+            timestamp: order.timestamp,
+            tiebreak:
+              order.tiebreak.kind === 'room'
+                ? { kind: 'room', from: order.tiebreak.from }
+                : { kind: 'chat' },
+          }
+        : { role: 'floor', timestamp: order.timestamp },
+    identity: pointer.identity,
   }
 }
 
 /**
- * Rebuild the tie-break from an untrusted persisted key, taking the id from
- * `messageId` — the pointer's one name for the message it points at.
+ * Rebuild the tie-break from an untrusted persisted key, taking the id from the
+ * identity's `messageId` — the pointer's one name for the message it points at.
  *
- * Any `id` still on disk (every key written before this format) is IGNORED
- * rather than read: it was always the same value, so ignoring it is lossless
- * for consistent data and is exactly the fix for inconsistent data. What
- * remains validated is what cannot be reconstructed: the `kind` discriminant,
- * and `from` for a room key. Anything else yields no key at all, which degrades
- * to the at-or-after-timestamp fallback (over-count, the safe direction).
+ * Any `id` still on disk (every key written by the chat blob's plain
+ * `JSON.stringify`) is IGNORED rather than read: it was always the same value,
+ * so ignoring it is lossless for consistent data and is exactly the fix for
+ * inconsistent data. What remains validated is what cannot be reconstructed: the
+ * `kind` discriminant, and `from` for a room key. Anything else yields no key at
+ * all, which degrades the order to a `floor` (over-count, the safe direction).
  */
 function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | undefined {
   if (!raw || typeof raw !== 'object') return undefined
@@ -183,68 +282,143 @@ function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | 
 }
 
 /**
- * Rebuild a pointer from untrusted storage. Anything malformed yields
- * `undefined` — "no pointer" — rather than a pointer holding an Invalid Date,
- * which would poison every comparison it touched with silent `false`.
+ * Epoch ms from either encoding found on disk.
  *
- * Accepts `timestamp` as either epoch ms (the on-disk form `serializeReadPointer`
- * writes) or an ISO string (what a chat pointer riding inside `conversationMeta`
- * becomes after a plain `JSON.stringify` turns its `Date` into a string). Both
- * encodings exist on disk today — this is the one place that reads either back.
- * {@link serializeReadPointer} writes epoch ms; the chat storage blob writes an
- * ISO string through its plain `JSON.stringify`.
+ * Epoch ms is what {@link serializeReadPointer} writes and what the live
+ * `order.timestamp` already is. An ISO string is what a chat pointer written
+ * BEFORE this shape became a plain `JSON.stringify` of a `Date`. Both exist on
+ * disk; this is the one place that reads either back.
+ */
+function hydrateTimestamp(raw: unknown): number | undefined {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : undefined
+  if (typeof raw === 'string') {
+    const parsed = new Date(raw).getTime()
+    return Number.isNaN(parsed) ? undefined : parsed
+  }
+  return undefined
+}
+
+/**
+ * Rebuild the CURRENT (nested) on-disk shape.
  *
- * The tie-break is likewise accepted under either name — `tiebreak` (what we
- * write) or the historical `archiveOrderKey` — and the condition for eventually
- * dropping that second name is recorded at the fallback itself.
+ * The order's `role` is not trusted from disk any further than it can be
+ * honoured: an `exact` order whose tie-break comes back unusable degrades to a
+ * `floor` rather than being dropped, which preserves the pointer's name and
+ * timestamp and costs only an over-count. A `floor` claiming a tie-break is
+ * simply read as the floor it says it is.
  *
- * `tiebreak` is rebuilt by {@link hydrateCacheOrderKey} — never taken
- * verbatim — and DROPPED when what it carries is unusable. Storage is untrusted
- * input, so a corrupt key must not ride through into ordering comparisons.
- * Dropping it alone (keeping the rest of the pointer) is deliberate: it degrades
- * to the at-or-after-timestamp fallback, which can over-count rather than
- * under-count (safe direction), without discarding a message id and timestamp
- * that are otherwise fine.
+ * The identity's `archiveId` is required for the `addressable` state and
+ * ignored everywhere else, so a blob claiming `addressable` without one hydrates
+ * as `local` — degraded, which is the state that always has a defined meaning,
+ * rather than a pointer whose wire name is `undefined` at the publisher.
+ */
+function hydrateNested(raw: Record<string, unknown>): ReadPointer | undefined {
+  const rawOrder = raw.order
+  const rawIdentity = raw.identity
+  if (!rawOrder || typeof rawOrder !== 'object') return undefined
+  if (!rawIdentity || typeof rawIdentity !== 'object') return undefined
+
+  const identityFields = rawIdentity as Record<string, unknown>
+  const messageId = identityFields.messageId
+  if (typeof messageId !== 'string' || messageId.length === 0) return undefined
+
+  const orderFields = rawOrder as Record<string, unknown>
+  const timestamp = hydrateTimestamp(orderFields.timestamp)
+  if (timestamp === undefined) return undefined
+
+  const tiebreak =
+    orderFields.role === 'exact' ? hydrateCacheOrderKey(orderFields.tiebreak, messageId) : undefined
+
+  const archiveId = identityFields.archiveId
+  return {
+    order: tiebreak ? { role: 'exact', timestamp, tiebreak } : { role: 'floor', timestamp },
+    identity:
+      identityFields.state === 'addressable' && typeof archiveId === 'string' && archiveId.length > 0
+        ? { state: 'addressable', messageId, archiveId }
+        : { state: 'local', messageId },
+  }
+}
+
+/**
+ * Rebuild the PRE-IDENTITY flat shape — the migration, and the only place it
+ * happens.
+ *
+ * Two of the three populations §5.4 of the design names live here, and neither
+ * moves a stored position by so much as a millisecond:
+ *
+ * - **Keyed pointers (the bulk)** — `{ messageId, timestamp, tiebreak }` (or the
+ *   older `archiveOrderKey` under the same rules). Shape change only: the
+ *   timestamp is carried verbatim, the tie-break's id is reconstructed from
+ *   `messageId` exactly as the previous format already did, and the order stays
+ *   `exact`. They enter as `local` because NO archive id was ever stored — there
+ *   is nothing to promote them with, and inventing one is the foreign-name
+ *   defect. They converge the first time the position advances onto a message
+ *   that carries an archive id.
+ * - **Keyless legacy pointers** — the #1081 migration's
+ *   `{ messageId, lastReadAt }`, which never had a tie-break. They become
+ *   `floor`, which is what they always meant. They can never converge, and that
+ *   is honest rather than a defect: converging one means resolving the named
+ *   message's real timestamp, which could move the floor FORWARD on a
+ *   forward-only pointer. They self-heal instead, the first time the user reads
+ *   in that entity — any fresh `exact` pointer is ahead, and `advance` takes it.
+ *
+ * (The third population, pointerless entities, has nothing to migrate: no
+ * pointer in, no pointer out.)
+ */
+function hydrateLegacyFlat(raw: Record<string, unknown>): ReadPointer | undefined {
+  const messageId = raw.messageId
+  if (typeof messageId !== 'string' || messageId.length === 0) return undefined
+  const timestamp = hydrateTimestamp(raw.timestamp)
+  if (timestamp === undefined) return undefined
+
+  // The tie-break was written under `tiebreak`, and under `archiveOrderKey`
+  // before the on-disk rename — a name that was always wrong (the key never held
+  // an archive id; it is the IndexedDB cursor tie-break built from the CLIENT
+  // message id). Both are read here and neither is written any more.
+  const tiebreak = hydrateCacheOrderKey(raw.tiebreak ?? raw.archiveOrderKey, messageId)
+
+  return {
+    order: tiebreak ? { role: 'exact', timestamp, tiebreak } : { role: 'floor', timestamp },
+    // No archive id was EVER stored in this format, so every migrated pointer
+    // enters degraded. This is the whole migration: a shape change, and an
+    // honest starting identity.
+    identity: { state: 'local', messageId },
+  }
+}
+
+/**
+ * Rebuild a pointer from untrusted storage — the ONE site that owns validity.
+ *
+ * Every persisted pointer enters through here (room read state, the state
+ * snapshot, and the chat blob), and what it returns has type-level invariants:
+ * an order that is exactly one of `exact` / `floor`, and an identity that is
+ * exactly one of `addressable` / `local`. No consumer re-checks, and none can:
+ * there is no "half-valid" pointer left to check for. Per-consumer validation is
+ * precisely the per-site patching this shape exists to end.
+ *
+ * Anything malformed yields `undefined` — "no pointer" — rather than a pointer
+ * holding an Invalid Date or a name with no position, which would poison every
+ * comparison it touched with silent `false`.
+ *
+ * The current nested shape is tried first; anything else falls through to the
+ * pre-identity flat migration. The discriminator is the presence of `order`,
+ * which the flat shape never had.
+ *
+ * REMOVABLE WHEN storage still holding the flat shape no longer matters, which
+ * is a bounded condition rather than "forever": every writer re-serializes the
+ * WHOLE blob, not the row that changed — `saveRoomReadState` stringifies the
+ * entire room map, the chat persist adapter re-emits every `conversationMeta`
+ * entry, and the state snapshot re-serializes every room. So the FIRST persist
+ * any build from this one onwards performs converts the entire account, not
+ * merely the conversation that was read; an account opened once after upgrading
+ * is fully converted, dormant ones are not. Deleting this branch then costs
+ * those dormant entities their read position entirely — they fall back to the
+ * history floor and over-count, the recoverable direction, but the user does
+ * lose the position. Remove it only once that trade is acceptable for the oldest
+ * storage still in the field.
  */
 export function deserializeReadPointer(raw: unknown): ReadPointer | undefined {
   if (!raw || typeof raw !== 'object') return undefined
-  const { messageId, timestamp, tiebreak, archiveOrderKey } = raw as {
-    messageId?: unknown
-    timestamp?: unknown
-    tiebreak?: unknown
-    archiveOrderKey?: unknown
-  }
-  if (typeof messageId !== 'string' || messageId.length === 0) return undefined
-  // Same shape as the `timestamp` tolerance above: this is the one place that
-  // reads either name back. We still only ever WRITE `tiebreak`; the
-  // `archiveOrderKey` branch is read-only tolerance for blobs written before the
-  // on-disk rename.
-  //
-  // REMOVABLE WHEN storage still holding the old name no longer matters, which
-  // is a bounded condition rather than "forever": every writer re-serializes the
-  // WHOLE blob, not the row that changed — `saveRoomReadState` stringifies the
-  // entire room map, the chat persist adapter re-emits every `conversationMeta`
-  // entry, and the state snapshot re-serializes every room. So the FIRST persist
-  // any build from this one onwards performs sheds `archiveOrderKey` for the
-  // entire account, not merely for the conversation that was read; an account
-  // opened once after upgrading is fully converted, dormant ones are not.
-  // Deleting this branch then costs those dormant pointers their tie-break and
-  // nothing else — `messageId` and `timestamp` still load, so they degrade to
-  // the at-or-after-timestamp fallback (over-count, the recoverable direction),
-  // never to a lost read position. Remove it once that trade is acceptable for
-  // the oldest storage still in the field.
-  const validKey = hydrateCacheOrderKey(tiebreak ?? archiveOrderKey, messageId)
-
-  if (typeof timestamp === 'number') {
-    return Number.isFinite(timestamp)
-      ? { messageId, timestamp: new Date(timestamp), ...(validKey ? { tiebreak: validKey } : {}) }
-      : undefined
-  }
-  if (typeof timestamp === 'string') {
-    const parsed = new Date(timestamp)
-    return Number.isNaN(parsed.getTime())
-      ? undefined
-      : { messageId, timestamp: parsed, ...(validKey ? { tiebreak: validKey } : {}) }
-  }
-  return undefined
+  const fields = raw as Record<string, unknown>
+  return fields.order !== undefined ? hydrateNested(fields) : hydrateLegacyFlat(fields)
 }

--- a/packages/fluux-sdk/src/stores/shared/readState.enforcement.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.enforcement.test.ts
@@ -1,14 +1,28 @@
 /**
- * Type-level enforcement of the two ordering questions (#1173).
+ * Type-level enforcement of the read-position model.
  *
  * The `@ts-expect-error` directives below are consumed by `npm run typecheck`,
  * not by vitest: an UNUSED `@ts-expect-error` is itself error TS2578, so each
  * directive fails the build the moment the call it guards starts compiling.
- * That is the whole point of this file. The rule it pins used to live only in a
- * doc comment on `isAhead`, and mutation testing during #1170 twice reduced a
- * positional comparison on this same code path to a key-blind `>=` with the
- * entire suite green. A comment does not survive a refactor that also deletes
- * its controls; a compile error does.
+ * That is the whole point of this file. The rules pinned here used to live only
+ * in doc comments, and mutation testing during #1170 twice reduced a positional
+ * comparison on this same code path to a key-blind `>=` with the entire suite
+ * green. A comment does not survive a refactor that also deletes its controls;
+ * a compile error does.
+ *
+ * Two families are pinned:
+ *
+ * - **ORDER** (#1173) — the counting question and the advance question have
+ *   opposite floor rules, so their comparators must not be interchangeable.
+ * - **IDENTITY** — a read position has a local name always and a wire name only
+ *   sometimes, so "we cannot address this position yet" is a state every
+ *   consumer must handle rather than an absence each one rediscovers.
+ *
+ * Each directive was counter-verified by widening the thing it guards (making
+ * `tiebreak` optional again, putting `archiveId` on both identity variants,
+ * dropping `readonly`) and confirming that THAT directive — and only that one —
+ * is then reported as unused. A directive that stays consumed under the widening
+ * it is supposed to catch is testing something else.
  *
  * Do not "fix" a failure here by widening a signature or deleting a directive.
  * A directive reported as unused means the guard it stands for is gone.
@@ -20,44 +34,104 @@ import {
   mayAdvanceTo,
   makeCacheOrderKey,
   type ExactPosition,
-  type OrderPosition,
+  type FloorPosition,
+  type PointerOrder,
 } from './readState'
+import { makeReadPointer, withArchiveId, type PointerIdentity, type ReadPointer } from './readPointer'
 
 /** An archive row: its tie-break is always resolvable, so it orders exactly. */
-const row: ExactPosition = { timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm1' }, 'chat') }
-const laterRow: ExactPosition = { timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm2' }, 'chat') }
+const row: ExactPosition = { role: 'exact', timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm1' }, 'chat') }
+const laterRow: ExactPosition = { role: 'exact', timestamp: 1000, tiebreak: makeCacheOrderKey({ id: 'm2' }, 'chat') }
 
 /**
  * What a #1081-migrated pointer's position actually is: a bare millisecond with
  * no provable position inside it. This is the value the whole issue is about.
  */
-const keyless: OrderPosition = { timestamp: 1000 }
+const floor: FloorPosition = { role: 'floor', timestamp: 1000 }
+
+/** The two identity states, as a consumer would receive them. */
+const addressable: PointerIdentity = { state: 'addressable', messageId: 'm1', archiveId: 'archive-1' }
+const local: PointerIdentity = { state: 'local', messageId: 'm1' }
 
 /**
- * NEVER CALLED. These calls exist only to be typechecked — running them would
- * dereference a tie-break that is absent by construction, which is precisely
+ * NEVER CALLED. These declarations exist only to be typechecked — running them
+ * would dereference fields that are absent by construction, which is precisely
  * what the compiler now refuses to let production code do.
  */
 function _rejectedAtCompileTime(): void {
-  // @ts-expect-error #1173: a keyless position has no tie-break to compare with.
-  compareExact(keyless, row)
+  // ── ORDER (#1173) ────────────────────────────────────────────────────────
+  // @ts-expect-error #1173: a floor position has no tie-break to compare with.
+  compareExact(floor, row)
   // @ts-expect-error #1173: ...and the same holds on the right-hand side.
-  compareExact(row, keyless)
+  compareExact(row, floor)
 
-  // THE unsafe call the issue is about. `isAfterBoundary` reads a missing
-  // tie-break on the BOUNDARY as at-or-after (over-count — safe for counting);
-  // reusing it to ask "may the pointer advance?" is exactly what would let a
-  // keyed candidate overtake a keyless pointer at the same millisecond. Its
-  // `row` parameter is exact, so a pointer position — which may be keyless —
-  // cannot be passed as one, and the reduction does not compile.
-  // @ts-expect-error #1173: `isAfterBoundary` orders an archive ROW; a pointer is not one.
-  isAfterBoundary(keyless, row)
+  // THE unsafe call the issue is about. `isAfterBoundary` reads a FLOOR
+  // boundary as at-or-after (over-count — safe for counting); reusing it to ask
+  // "may the pointer advance?" is exactly what would let an exact candidate
+  // overtake a floor pointer at the same millisecond. Its `row` parameter is
+  // exact, so a pointer position — which may be a floor — cannot be passed as
+  // one, and the reduction does not compile.
+  // @ts-expect-error #1173: `isAfterBoundary` orders an archive ROW; a pointer's order is not one.
+  isAfterBoundary(floor, row)
+
+  // A floor cannot be silently promoted to an exact position: the tie-break it
+  // would need is the thing it does not have.
+  // @ts-expect-error a FloorPosition has no tiebreak, so it cannot become exact by spreading.
+  const _promoted: ExactPosition = { ...floor, role: 'exact' }
+  void _promoted
+
+  // ── IDENTITY ─────────────────────────────────────────────────────────────
+  // The degraded state, made unignorable. Reading the wire name without first
+  // narrowing on `state` is the mistake the XEP-0490 publisher used to make
+  // implicitly, by looking a name up and quietly doing nothing when it failed.
+  // No type annotation on purpose: the directive must bite because the PROPERTY
+  // does not exist on this variant, not because `string | undefined` fails to
+  // assign to `string`. Adding an optional `archiveId` to the 'local' variant
+  // frees this directive, which is exactly the widening it is here to catch.
+  // @ts-expect-error `archiveId` exists only on the 'addressable' variant.
+  void local.archiveId
+  // Narrowing is what makes it legal, so the branch has to be written down.
+  const _narrowed: string | undefined =
+    addressable.state === 'addressable' ? addressable.archiveId : undefined
+  void _narrowed
+
+  // THE ANCHOR (#1208's shape, now at the type level). A pointer has exactly ONE
+  // name field, and it lives inside `identity`. A second copy beside the order
+  // is what used to be able to disagree with it on disk.
+  const _twoNames: ReadPointer = {
+    order: row,
+    identity: local,
+    // @ts-expect-error the pointer has exactly ONE name, and it is `identity.messageId`.
+    messageId: 'm1',
+  }
+  void _twoNames
+
+  // Reading the name off the order is likewise not a thing. Unannotated for the
+  // same reason as above: this must fail on existence, not on nullability.
+  // @ts-expect-error `messageId` is not part of a position; only `identity` names anything.
+  void row.messageId
+
+  // A FLOOR order has no `tiebreak` PROPERTY at all — not an optional one — so
+  // nothing can read a key off it and nothing can smuggle one in.
+  // @ts-expect-error a FloorPosition has no `tiebreak`.
+  void floor.tiebreak
+
+  // ── CONVERGENCE CANNOT MOVE THE CURSOR ───────────────────────────────────
+  // `order` is readonly on the pointer, and its fields are readonly too, so
+  // enrichment cannot reach in and move a position while it renames one.
+  const pointer = makeReadPointer({ id: 'm1', timestamp: new Date(1000) }, 'chat')
+  // @ts-expect-error `order` is readonly: a pointer's position is never rewritten in place.
+  pointer.order = floor
+  // @ts-expect-error ...and neither is the timestamp inside it.
+  pointer.order.timestamp = 60_000
+  // @ts-expect-error ...nor the identity, which only `withArchiveId` replaces wholesale.
+  pointer.identity = addressable
 }
 
 describe('the two ordering questions', () => {
   it('keeps the compile-time guard referenced (see _rejectedAtCompileTime)', () => {
     // The guard above is enforced by `npm run typecheck`, not by this runner:
-    // each of its three directives fails the build with TS2578 (an unused
+    // each of its directives fails the build with TS2578 (an unused
     // suppression) the moment the call it guards starts compiling.
     expect(typeof _rejectedAtCompileTime).toBe('function')
   })
@@ -66,16 +140,72 @@ describe('the two ordering questions', () => {
     expect(compareExact(row, laterRow)).toBeLessThan(0)
   })
 
-  it('answers the advance question conservatively for a keyless candidate', () => {
-    // `mayAdvanceTo` accepts the keyless side precisely because it must answer
+  it('answers the advance question conservatively for a floor candidate', () => {
+    // `mayAdvanceTo` accepts the floor side precisely because it must answer
     // for it — and its answer is "no".
-    expect(mayAdvanceTo(keyless, row)).toBe(false)
+    expect(mayAdvanceTo(floor, row)).toBe(false)
   })
 
   it('gives the two questions OPPOSITE answers at an equal millisecond', () => {
     // The single fact this whole split exists to keep visible. Same row, same
-    // keyless counterpart, same millisecond, deliberately opposite results.
-    expect(isAfterBoundary(row, keyless)).toBe(true) // over-count — safe for counting
-    expect(mayAdvanceTo(row, keyless)).toBe(false) // never overtake — safe for advancing
+    // floor counterpart, same millisecond, deliberately opposite results.
+    expect(isAfterBoundary(row, floor)).toBe(true) // over-count — safe for counting
+    expect(mayAdvanceTo(row, floor)).toBe(false) // never overtake — safe for advancing
+  })
+})
+
+describe('the identity variant', () => {
+  it('mints `addressable` from a message that carries an archive id', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: new Date(1000), stanzaId: 'archive-1' }, 'chat')
+    expect(p.identity).toEqual({ state: 'addressable', messageId: 'm1', archiveId: 'archive-1' })
+  })
+
+  it('mints `local` from a message that does not — the own-1:1-send resting state', () => {
+    const p = makeReadPointer({ id: 'own-1', timestamp: new Date(1000) }, 'chat')
+    expect(p.identity).toEqual({ state: 'local', messageId: 'own-1' })
+  })
+
+  it('enrichment replaces the identity and carries the order BY REFERENCE', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: new Date(1000) }, 'chat')
+    const enriched = withArchiveId(p, 'archive-1')
+    expect(enriched.identity).toEqual({ state: 'addressable', messageId: 'm1', archiveId: 'archive-1' })
+    // The cursor did not move, and could not have: it is the same object.
+    expect(enriched.order).toBe(p.order)
+  })
+
+  it('never enriches a FLOOR pointer — its name and order already disagree', () => {
+    const migrated: ReadPointer = {
+      order: { role: 'floor', timestamp: 1000 },
+      identity: { state: 'local', messageId: 'm4' },
+    }
+    expect(withArchiveId(migrated, 'archive-4')).toBe(migrated)
+  })
+
+  it('leaves an already-addressable pointer alone, by reference', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: new Date(1000), stanzaId: 'archive-1' }, 'chat')
+    expect(withArchiveId(p, 'archive-999')).toBe(p)
+  })
+
+  /**
+   * §11.1 of the design, stated rather than papered over: the type separates
+   * NAME from ORDER and makes the order readonly, so nothing can move a position
+   * in place. It does NOT make the order immutable against RECONSTRUCTION — a
+   * consumer can still build a fresh pointer with a different timestamp. That
+   * stays a review concern; what the model buys is that doing it is visible,
+   * because you have to name `order` to do it.
+   */
+  it('cannot stop a caller REBUILDING a position — only mutating one', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: new Date(1000) }, 'chat')
+    const rebuilt: ReadPointer = { order: { role: 'floor', timestamp: 61_000 }, identity: p.identity }
+    expect(rebuilt.order.timestamp).toBe(61_000)
+  })
+})
+
+describe('PointerOrder is a closed discriminated union', () => {
+  it('narrows exhaustively on `role`', () => {
+    const describeOrder = (o: PointerOrder): string =>
+      o.role === 'exact' ? `exact:${o.tiebreak.kind}` : `floor:${o.timestamp}`
+    expect(describeOrder(row)).toBe('exact:chat')
+    expect(describeOrder(floor)).toBe('floor:1000')
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.test.ts
@@ -5,71 +5,71 @@ import {
   isAfterBoundary,
   makeCacheOrderKey,
   mayAdvanceTo,
+  type ExactPosition,
   pointerlessDefers,
-  isValidCacheOrderKey,
 } from './readState'
 import { makeReadPointer } from './readPointer'
 
 describe('compareExact', () => {
   it('orders by timestamp first', () => {
-    const a = { timestamp: 1, tiebreak: makeCacheOrderKey({ id: 'z' }, 'chat') }
-    const b = { timestamp: 2, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+    const a: ExactPosition = { role: 'exact', timestamp: 1, tiebreak: makeCacheOrderKey({ id: 'z' }, 'chat') }
+    const b: ExactPosition = { role: 'exact', timestamp: 2, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
     expect(compareExact(a, b)).toBeLessThan(0) // timestamp wins over the tie-break
   })
   it('room ties break by (from, id)', () => {
-    const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/al', id: 'z' }, 'room') }
-    const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/bo', id: 'a' }, 'room') }
+    const a: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/al', id: 'z' }, 'room') }
+    const b: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/bo', id: 'a' }, 'room') }
     expect(compareExact(a, b)).toBeLessThan(0) // 'al' < 'bo' wins over id
   })
   it('chat ties break by id ONLY, ignoring from', () => {
-    const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'zed@x', id: 'a' }, 'chat') }
-    const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'amy@x', id: 'b' }, 'chat') }
+    const a: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'zed@x', id: 'a' }, 'chat') }
+    const b: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'amy@x', id: 'b' }, 'chat') }
     expect(compareExact(a, b)).toBeLessThan(0) // id 'a' < 'b'; `from` must not participate
   })
 })
 
 /**
  * The one fact these two describe-blocks exist to keep apart (#1173): at an
- * equal millisecond a MISSING tie-break means the OPPOSITE thing depending on
+ * equal millisecond a FLOOR position means the OPPOSITE thing depending on
  * which question is asked. Both rules predate this split; only one of them was
  * ever written down as code.
  */
 describe('isAfterBoundary — the counting/divider question', () => {
-  const row = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+  const row: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
 
-  it("counts a row at a KEYLESS boundary's own millisecond as after it (over-count, safe)", () => {
+  it("counts a row at a FLOOR boundary's own millisecond as after it (over-count, safe)", () => {
     // The old `compareOrder` phrasing of this same fact was "a missing key
     // sorts BEFORE a present one at an equal timestamp". Read from the row's
     // side, that is exactly "the row is after the boundary".
-    expect(isAfterBoundary(row, { timestamp: 5 })).toBe(true)
+    expect(isAfterBoundary(row, { role: 'floor', timestamp: 5 })).toBe(true)
   })
-  it('still orders by timestamp against a keyless boundary', () => {
-    expect(isAfterBoundary(row, { timestamp: 6 })).toBe(false)
-    expect(isAfterBoundary(row, { timestamp: 4 })).toBe(true)
+  it('still orders by timestamp against a floor boundary', () => {
+    expect(isAfterBoundary(row, { role: 'floor', timestamp: 6 })).toBe(false)
+    expect(isAfterBoundary(row, { role: 'floor', timestamp: 4 })).toBe(true)
   })
   it('uses the tie-break when the boundary has one', () => {
-    expect(isAfterBoundary(row, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
-    expect(isAfterBoundary(row, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
+    expect(isAfterBoundary(row, { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
+    expect(isAfterBoundary(row, { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
   })
 })
 
 describe('mayAdvanceTo — the advance/seen question', () => {
-  const candidate = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
+  const candidate: ExactPosition = { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
 
-  it('refuses to overtake a KEYLESS current position at an equal millisecond', () => {
+  it('refuses to overtake a FLOOR current position at an equal millisecond', () => {
     // The inverse of the boundary rule above, on identical inputs.
-    expect(mayAdvanceTo(candidate, { timestamp: 5 })).toBe(false)
+    expect(mayAdvanceTo(candidate, { role: 'floor', timestamp: 5 })).toBe(false)
   })
-  it('refuses to advance from a KEYLESS candidate at an equal millisecond', () => {
-    expect(mayAdvanceTo({ timestamp: 5 }, candidate)).toBe(false)
+  it('refuses to advance from a FLOOR candidate at an equal millisecond', () => {
+    expect(mayAdvanceTo({ role: 'floor', timestamp: 5 }, candidate)).toBe(false)
   })
   it('still advances by strict millisecond when the timestamps differ', () => {
-    expect(mayAdvanceTo({ timestamp: 6 }, { timestamp: 5 })).toBe(true)
-    expect(mayAdvanceTo({ timestamp: 4 }, { timestamp: 5 })).toBe(false)
+    expect(mayAdvanceTo({ role: 'floor', timestamp: 6 }, { role: 'floor', timestamp: 5 })).toBe(true)
+    expect(mayAdvanceTo({ role: 'floor', timestamp: 4 }, { role: 'floor', timestamp: 5 })).toBe(false)
   })
   it('uses the tie-break when both sides have one', () => {
-    expect(mayAdvanceTo(candidate, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
-    expect(mayAdvanceTo(candidate, { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
+    expect(mayAdvanceTo(candidate, { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'b' }, 'chat') })).toBe(false)
+    expect(mayAdvanceTo(candidate, { role: 'exact', timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'A' }, 'chat') })).toBe(true)
   })
 })
 
@@ -86,12 +86,4 @@ describe('computeFloor', () => {
 describe('pointerlessDefers', () => {
   it('defers pointerless with a real persisted count', () => expect(pointerlessDefers(undefined, 3)).toBe(true))
   it('allows a pointerless zero (genuinely fresh)', () => expect(pointerlessDefers(undefined, 0)).toBe(false))
-})
-
-describe('isValidCacheOrderKey', () => {
-  it('rejects untrusted shapes', () => {
-    expect(isValidCacheOrderKey({ kind: 'room', id: 'x' })).toBe(false) // missing from
-    expect(isValidCacheOrderKey({ kind: 'nope', id: 'x' })).toBe(false)
-    expect(isValidCacheOrderKey({ kind: 'chat', id: 'x' })).toBe(true)
-  })
 })

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -44,34 +44,68 @@ export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'cha
 }
 
 /**
- * A position in message-cache order: a timestamp, optionally refined by a key.
+ * A position that is exactly located in message-cache order: a timestamp
+ * refined by the tie-break that resolves its millisecond.
  *
- * The tie-break is optional because a pointer migrated from the pre-#1081
- * `lastSeenMessageId` + `lastReadAt` pair carries only a millisecond, with no
- * provable position inside it. Such a value is a FLOOR — it means "at least
- * here", not "exactly here".
+ * Every real message yields one, because {@link makeCacheOrderKey} always
+ * produces a key — use {@link exactPosition} rather than assembling the literal.
  *
- * {@link ExactPosition} is the refinement that does mean "exactly here". Prefer
- * it wherever a position is genuinely resolvable — every message resolves to
- * one, because {@link makeCacheOrderKey} always produces a key — so that the
- * compiler, rather than a comment, is what keeps a floor out of a comparison
- * that assumes exactness.
+ * `role` is not redundant with the presence of `tiebreak`: it is what makes
+ * {@link PointerOrder} a DISCRIMINATED union, so narrowing reads as
+ * `order.role === 'floor'` at every consumer instead of as an incidental
+ * "the optional field happens to be missing" test. A weaker position cannot be
+ * passed where an exact one is required (#1173).
  */
-export interface OrderPosition {
-  timestamp: number
-  tiebreak?: CacheOrderKey
+export interface ExactPosition {
+  readonly role: 'exact'
+  readonly timestamp: number
+  readonly tiebreak: CacheOrderKey
 }
 
 /**
- * A position whose tie-break is known, so it can be ordered exactly against
- * another such position.
+ * A position known only to a millisecond: "at least here", not "exactly here".
  *
- * An `OrderPosition` is deliberately NOT assignable to this (#1173): the only
- * way to obtain one is to actually have a tie-break, which in practice means
- * the position came from a message rather than from a bare `lastReadAt`.
+ * This is what a pointer migrated from the pre-#1081 `lastSeenMessageId` +
+ * `lastReadAt` pair carries — `lastReadAt` sits at or behind the message the
+ * pointer names, with no provable position inside its millisecond. It is also
+ * where an {@link ExactPosition} degrades when its persisted tie-break comes
+ * back unusable: dropping to a floor over-counts (the safe direction) rather
+ * than trusting a key we cannot rebuild.
+ *
+ * Deliberately has NO `tiebreak` property at all rather than an optional one:
+ * with `role` discriminating, `order.tiebreak` does not typecheck on this
+ * variant, so nothing can read a key off a floor and nothing can smuggle one in.
  */
-export interface ExactPosition extends OrderPosition {
-  tiebreak: CacheOrderKey
+export interface FloorPosition {
+  readonly role: 'floor'
+  readonly timestamp: number
+}
+
+/**
+ * Where a read pointer sits in message-cache order — see {@link ReadPointer}.
+ *
+ * The two variants are the two things a stored position can honestly claim, and
+ * every comparator below answers them differently on purpose. Note that
+ * `readonly` here stops a position being MUTATED, not rebuilt: a consumer can
+ * still construct a fresh order object with a different timestamp. Never moving
+ * a stored position stays a review concern (`readPointer.ts`), which the type
+ * makes visible — you have to name `order` — rather than impossible.
+ */
+export type PointerOrder = ExactPosition | FloorPosition
+
+/**
+ * The exact cache-order position of a real message.
+ *
+ * The one place the `{ role, timestamp, tiebreak }` literal is assembled, so
+ * the kind-discriminated tie-break rule (see {@link CacheOrderKey}) cannot be
+ * re-spelled slightly differently at one of the many sites that need a row's
+ * position.
+ */
+export function exactPosition(
+  msg: { from?: string; id: string; timestamp: Date },
+  kind: 'chat' | 'room'
+): ExactPosition {
+  return { role: 'exact', timestamp: msg.timestamp.getTime(), tiebreak: makeCacheOrderKey(msg, kind) }
 }
 
 /**
@@ -81,7 +115,7 @@ export interface ExactPosition extends OrderPosition {
  *
  * Private, and takes the KEYS rather than the positions, so it cannot be
  * mistaken for a general comparator over positions and cannot be reached with a
- * keyless one. The three functions below are the only entry points.
+ * floor one. The three functions below are the only entry points.
  */
 function compareTiebreak(a: CacheOrderKey, b: CacheOrderKey): number {
   if (a.kind === 'room' && b.kind === 'room') {
@@ -96,12 +130,12 @@ function compareTiebreak(a: CacheOrderKey, b: CacheOrderKey): number {
  * the tie-break. This is the comparator for ordering messages against each
  * other: sorting a resident array, picking the newest of a candidate set.
  *
- * It deliberately has no answer for a keyless position, because there is no
+ * It deliberately has no answer for a floor position, because there is no
  * single right one. The two questions the codebase actually asks —
- * {@link isAfterBoundary} and {@link mayAdvanceTo} — have OPPOSITE
- * missing-tie-break rules, so a comparator that picked one of them would be
- * silently wrong at every call site that meant the other. That was #1173.
- * Passing a possibly-keyless `OrderPosition` here does not compile.
+ * {@link isAfterBoundary} and {@link mayAdvanceTo} — have OPPOSITE floor rules,
+ * so a comparator that picked one of them would be silently wrong at every call
+ * site that meant the other. That was #1173.
+ * Passing a possibly-floor {@link PointerOrder} here does not compile.
  */
 export function compareExact(a: ExactPosition, b: ExactPosition): number {
   if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
@@ -111,39 +145,46 @@ export function compareExact(a: ExactPosition, b: ExactPosition): number {
 /**
  * "Is this row after the read boundary?" — the COUNTING and DIVIDER question.
  *
- * A missing tie-break on the BOUNDARY means AT-OR-AFTER its timestamp: every
- * row sharing the boundary's millisecond, including the boundary's own message,
- * counts as after it. That over-counts by up to the same-millisecond sibling
- * set, which is the recoverable direction — an over-count clears the moment the
- * user reads, while an under-count hides a message permanently.
+ * A FLOOR boundary means AT-OR-AFTER its timestamp: every row sharing the
+ * boundary's millisecond, including the boundary's own message, counts as after
+ * it. That over-counts by up to the same-millisecond sibling set, which is the
+ * recoverable direction — an over-count clears the moment the user reads, while
+ * an under-count hides a message permanently.
  *
  * `row` is an {@link ExactPosition} because an archive row always resolves to
  * one. That is not a formality: it is what stops this function from being used
  * to answer the advance question, where this same rule is unsafe (#1173).
  */
-export function isAfterBoundary(row: ExactPosition, boundary: OrderPosition): boolean {
+export function isAfterBoundary(row: ExactPosition, boundary: PointerOrder): boolean {
+  if (boundary.role === 'floor') return row.timestamp >= boundary.timestamp // over-count (safe)
   if (row.timestamp !== boundary.timestamp) return row.timestamp > boundary.timestamp
-  if (!boundary.tiebreak) return true // at-or-after timestamp → over-count (safe)
   return compareTiebreak(row.tiebreak, boundary.tiebreak) > 0
 }
 
 /**
  * "May the read pointer advance to this?" — the ADVANCE and SEEN question.
  *
- * A missing tie-break on EITHER side means STRICT MILLISECOND: never overtake.
- * The key is what certifies that a pointer's timestamp is its named message's
- * own, so when either side lacks one, nothing about their relative order within
- * a shared millisecond is provable. The read pointer is forward-only, so a
+ * A FLOOR on EITHER side means STRICT MILLISECOND: never overtake. An exact
+ * position certifies that a timestamp is its named message's own, so when
+ * either side is only a floor, nothing about their relative order within a
+ * shared millisecond is provable. The read pointer is forward-only, so a
  * position given away here is unrecoverable; refusing to move merely
  * over-counts, which the user clears by reading.
+ *
+ * `candidate` is a {@link PointerOrder} rather than an `ExactPosition` because
+ * a pointer migrated from the legacy pair really is a floor and really does get
+ * offered as a candidate (`advance`, the #1081 backfill) — the floor rule below
+ * is the answer for it, not a signature to tighten away.
  *
  * This is the exact inverse of {@link isAfterBoundary}'s rule, on purpose. The
  * two questions are not interchangeable — that is why they are two functions
  * (#1173) rather than one comparator with a warning attached to it.
  */
-export function mayAdvanceTo(candidate: OrderPosition, current: OrderPosition): boolean {
+export function mayAdvanceTo(candidate: PointerOrder, current: PointerOrder): boolean {
+  if (candidate.role === 'floor' || current.role === 'floor') {
+    return candidate.timestamp > current.timestamp // strict ms → never overtake (safe)
+  }
   if (candidate.timestamp !== current.timestamp) return candidate.timestamp > current.timestamp
-  if (!candidate.tiebreak || !current.tiebreak) return false // strict ms → never overtake (safe)
   return compareTiebreak(candidate.tiebreak, current.tiebreak) > 0
 }
 
@@ -157,7 +198,7 @@ export function mayAdvanceTo(candidate: OrderPosition, current: OrderPosition): 
  * read position.
  */
 export function computeFloor(pointer: ReadPointer | undefined, historyFloor: Date | undefined): Date | undefined {
-  return pointer ? pointer.timestamp : historyFloor
+  return pointer ? new Date(pointer.order.timestamp) : historyFloor
 }
 
 /**
@@ -187,27 +228,6 @@ export function worthReconcilingOnDeactivate(
 ): boolean {
   if (!meta) return false
   return meta.readPointer !== undefined || meta.unreadCount > 0
-}
-
-/**
- * Runtime guard for a `CacheOrderKey` read back from untrusted storage.
- *
- * No longer on the hydration path: `deserializeReadPointer` rebuilds the key
- * and takes its `id` from `messageId` instead of validating a persisted one.
- * It is kept because it describes an OLDER build's second line of defence
- * against today's on-disk form: since the tie-break's rename that build no
- * longer even finds the property (it reads `archiveOrderKey` only), and the
- * `typeof k.id === 'string'` requirement here would reject the id-less key had
- * it found one. Either way it degrades to the at-or-after-timestamp fallback
- * (over-count, the safe direction) rather than mis-reading the key. Both halves
- * of that compatibility claim are asserted in `readPointer.test.ts`.
- */
-export function isValidCacheOrderKey(v: unknown): v is CacheOrderKey {
-  if (!v || typeof v !== 'object') return false
-  const k = v as Record<string, unknown>
-  if (k.kind === 'chat') return typeof k.id === 'string'
-  if (k.kind === 'room') return typeof k.id === 'string' && typeof k.from === 'string'
-  return false
 }
 
 /**

--- a/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
@@ -41,11 +41,7 @@ describe('room read-state persistence', () => {
 
     const restored = loadRoomReadState(JID)
     expect(restored.get('room@conf.example.com')).toEqual({
-      readPointer: {
-        messageId: 'm7',
-        timestamp: at(7000),
-        tiebreak: { kind: 'room', from: 'room@conf.example.com/alice', id: 'm7' },
-      },
+      readPointer: { order: { role: 'exact', timestamp: new Date(at(7000)).getTime(), tiebreak: { kind: 'room', from: 'room@conf.example.com/alice', id: 'm7' } }, identity: { state: 'local', messageId: 'm7' } },
       historyFloor: at(100),
     })
   })
@@ -145,12 +141,12 @@ describe('room read-state persistence', () => {
     expect(loadRoomReadState(JID).has('r@c')).toBe(false)
   })
 
-  // The tie-break's on-disk rename at the room persistence surface. Rows written
-  // by a build before the rename carry `archiveOrderKey` and must still load
-  // with their key intact — losing it here would silently downgrade a real read
-  // position to the at-or-after-timestamp fallback for every room of every
-  // account that upgraded.
-  it('loads a room row written under the historical tie-break name', () => {
+  // The pre-identity flat shapes at the room persistence surface. Rows written
+  // by an earlier build carry `archiveOrderKey` (or `tiebreak`) beside a
+  // top-level name, and must still load with their key intact — losing it here
+  // would silently downgrade a real read position to the at-or-after-timestamp
+  // fallback for every room of every account that upgraded.
+  it('migrates a room row written under the historical tie-break name', () => {
     localStorage.setItem(
       getRoomReadStateStorageKey(JID),
       JSON.stringify([
@@ -159,16 +155,16 @@ describe('room read-state persistence', () => {
     )
 
     expect(loadRoomReadState(JID).get('r@c')?.readPointer).toEqual({
-      messageId: 'm7',
-      timestamp: at(7000),
-      tiebreak: { kind: 'room', from: 'r@c/alice', id: 'm7' },
+      order: { role: 'exact', timestamp: 7000, tiebreak: { kind: 'room', from: 'r@c/alice', id: 'm7' } },
+      // `local`: no archive id was ever stored in that format.
+      identity: { state: 'local', messageId: 'm7' },
     })
   })
 
-  // ...and the evidence behind the fallback's removal condition: a save
-  // re-serializes the WHOLE map, so one write sheds the historical name for
-  // every room of the account, not only the room whose pointer moved.
-  it('a single save rewrites every room under the new name', () => {
+  // ...and the evidence behind the migration branch's removal condition: a save
+  // re-serializes the WHOLE map, so one write converts every room of the
+  // account, not only the room whose pointer moved.
+  it('a single save rewrites every room in the nested shape', () => {
     localStorage.setItem(
       getRoomReadStateStorageKey(JID),
       JSON.stringify([
@@ -187,12 +183,12 @@ describe('room read-state persistence', () => {
 
     const written = localStorage.getItem(getRoomReadStateStorageKey(JID))!
     expect(written).not.toContain('archiveOrderKey')
-    expect(written).toContain('tiebreak')
-    // The untouched room kept its position; only the property name changed.
+    expect(written).toContain('"identity"')
+    expect(written).toContain('"order"')
+    // The untouched room kept its position; only the shape changed.
     expect(loadRoomReadState(JID).get('untouched@c')?.readPointer).toEqual({
-      messageId: 'm2',
-      timestamp: at(2000),
-      tiebreak: { kind: 'room', from: 'untouched@c/bob', id: 'm2' },
+      order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'room', from: 'untouched@c/bob', id: 'm2' } },
+      identity: { state: 'local', messageId: 'm2' },
     })
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/transientUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/transientUnread.test.ts
@@ -22,7 +22,7 @@ import { makeCacheOrderKey, type ExactPosition } from './readState'
  * message, so in production its tie-break always resolves (#1173).
  */
 const FIXTURE_TIEBREAK = makeCacheOrderKey({ from: 'fixture@x', id: 'fixture' }, 'room')
-const posAt = (timestamp: number): ExactPosition => ({ timestamp, tiebreak: FIXTURE_TIEBREAK })
+const posAt = (timestamp: number): ExactPosition => ({ role: 'exact', timestamp, tiebreak: FIXTURE_TIEBREAK })
 
 // Fresh scope per test: entityIds are unique so no state leaks between tests
 // (the module holds module-level state, matching the always-on lifetime the
@@ -42,7 +42,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
 
     note(msg, 10)
     // simulate deactivate + reactivate: nothing is called; the entry must remain
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1)
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(1)
   })
 
   it('re-noting the same logical message after a stanzaId arrives does not double-count', () => {
@@ -53,7 +53,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
 
     note(msg, 10)
     note({ ...msg, stanzaId: 'S1' }, 10) // same logical message, higher identity tier
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1) // NOT 2
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(1) // NOT 2
   })
 
   it('removeTransient resolves a retraction that references only the stanza-id', () => {
@@ -64,7 +64,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
 
     note({ ...msg, stanzaId: 'S1' }, 10)
     removeTransient(K, roomStanzaKey(K.entityId, 'S1'))
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(0)
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(0)
   })
 
   it('two room messages with the SAME id but different senders count as two', () => {
@@ -74,7 +74,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
 
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'dup' }, 10)
     note({ roomJid: K.entityId, from: `${K.entityId}/bo`, id: 'dup' }, 11)
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(2)
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(2)
   })
 
   it('a partial pointer advance drops only the passed entries', () => {
@@ -84,7 +84,7 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
 
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'a' }, 10)
     note({ roomJid: K.entityId, from: `${K.entityId}/al`, id: 'b' }, 20)
-    expect(transientCounts(K, { timestamp: 15 }).unread).toBe(1) // only the t=20 one remains unread
+    expect(transientCounts(K, { role: 'floor', timestamp: 15 }).unread).toBe(1) // only the t=20 one remains unread
   })
 
   it('returns added:false when an alias merges into an existing entry', () => {
@@ -102,11 +102,11 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     // Two copies land separately (no shared tier yet), then a copy carrying BOTH tiers arrives.
     noteTransient(K, { position: posAt(10) }, 'origin-key-O', ['origin-key-O'])
     noteTransient(K, { position: posAt(10) }, 'stanza-key-S', ['stanza-key-S'])
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(2)
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(2)
 
     const r = noteTransient(K, { position: posAt(10) }, 'stanza-key-S', ['stanza-key-S', 'origin-key-O']) // bridges both
     expect(r).toEqual({ added: false, requiresRecount: true }) // nothing added, but 2 -> 1
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1) // coalesced, not 2
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(1) // coalesced, not 2
   })
 
   it('a plain alias registration reports no semantic change', () => {
@@ -144,8 +144,8 @@ describe('transientUnread — room lifecycle, identity, and alias cases', () => 
     // A boundary of 10 sits strictly between the earliest (5) and tier-a's own
     // original position (20): correct behaviour reads 0 (5 <= 10, already
     // passed); "keep the first match's own position" would wrongly read 1.
-    expect(transientCounts(K, { timestamp: 10 }).unread).toBe(0)
-    expect(transientCounts(K, { timestamp: 4 }).unread).toBe(1) // the surviving entry (at 5) still exists
+    expect(transientCounts(K, { role: 'floor', timestamp: 10 }).unread).toBe(0)
+    expect(transientCounts(K, { role: 'floor', timestamp: 4 }).unread).toBe(1) // the surviving entry (at 5) still exists
   })
 })
 
@@ -159,8 +159,8 @@ describe('transientUnread — scope isolation', () => {
       'k-a',
     ])
 
-    expect(transientCounts(accountA, { timestamp: 5 }).unread).toBe(1)
-    expect(transientCounts(accountB, { timestamp: 5 }).unread).toBe(0)
+    expect(transientCounts(accountA, { role: 'floor', timestamp: 5 }).unread).toBe(1)
+    expect(transientCounts(accountB, { role: 'floor', timestamp: 5 }).unread).toBe(0)
   })
 
   it('chat and room kinds under the same entityId are independent scopes', () => {
@@ -170,8 +170,8 @@ describe('transientUnread — scope isolation', () => {
 
     noteTransient(chatKey, { position: posAt(10) }, transientIdentity({ id: 'c1' }, 'chat'), transientAliases({ id: 'c1' }, 'chat'))
 
-    expect(transientCounts(chatKey, { timestamp: 5 }).unread).toBe(1)
-    expect(transientCounts(roomKey, { timestamp: 5 }).unread).toBe(0)
+    expect(transientCounts(chatKey, { role: 'floor', timestamp: 5 }).unread).toBe(1)
+    expect(transientCounts(roomKey, { role: 'floor', timestamp: 5 }).unread).toBe(0)
   })
 })
 
@@ -184,8 +184,8 @@ describe('transientUnread — chat identity (bare id, no tiers)', () => {
   it('counts a noted chat message as unread until the boundary passes it', () => {
     const K = freshScopeKey('chat')
     noteTransient(K, { position: posAt(10) }, transientIdentity({ id: 'm1' }, 'chat'), transientAliases({ id: 'm1' }, 'chat'))
-    expect(transientCounts(K, { timestamp: 5 }).unread).toBe(1)
-    expect(transientCounts(K, { timestamp: 15 }).unread).toBe(0)
+    expect(transientCounts(K, { role: 'floor', timestamp: 5 }).unread).toBe(1)
+    expect(transientCounts(K, { role: 'floor', timestamp: 15 }).unread).toBe(0)
   })
 })
 
@@ -214,8 +214,8 @@ describe('transientUnread — pruneTransient', () => {
     const K = freshScopeKey()
     noteTransient(K, { position: posAt(10) }, 'a', ['a'])
 
-    expect(pruneTransient(K, { timestamp: 10 })).toEqual({ removed: 0 })
-    expect(transientCounts(K, { timestamp: 10 }).unread).toBe(1)
+    expect(pruneTransient(K, { role: 'floor', timestamp: 10 })).toEqual({ removed: 0 })
+    expect(transientCounts(K, { role: 'floor', timestamp: 10 }).unread).toBe(1)
   })
 
   it('removed aliases can no longer resolve for removeTransient', () => {

--- a/packages/fluux-sdk/src/stores/shared/transientUnread.ts
+++ b/packages/fluux-sdk/src/stores/shared/transientUnread.ts
@@ -1,4 +1,4 @@
-import { compareExact, isAfterBoundary, type ExactPosition, type OrderPosition } from './readState'
+import { compareExact, isAfterBoundary, type ExactPosition, type PointerOrder } from './readState'
 import { roomCanonicalKey, roomIdentityKeys, type RoomIdentityFields } from '../../utils/roomMessageIdentity'
 
 /**
@@ -198,7 +198,7 @@ export function noteTransient(key: ScopeKey, entry: TransientEntry, identity: st
  * logical message counts exactly once regardless of how many aliases it is
  * known under. A `undefined` boundary counts everything (no floor yet).
  */
-export function transientCounts(key: ScopeKey, boundary: OrderPosition | undefined): { unread: number } {
+export function transientCounts(key: ScopeKey, boundary: PointerOrder | undefined): { unread: number } {
   const scope = getScope(key)
   if (!scope) return { unread: 0 }
   let unread = 0
@@ -213,7 +213,7 @@ export function transientCounts(key: ScopeKey, boundary: OrderPosition | undefin
  * them). A memory bound, not a correctness mechanism — {@link transientCounts}
  * already excludes them from the count without this ever being called.
  */
-export function pruneTransient(key: ScopeKey, boundary: OrderPosition): { removed: number } {
+export function pruneTransient(key: ScopeKey, boundary: PointerOrder): { removed: number } {
   const scope = getScope(key)
   if (!scope) return { removed: 0 }
   let removed = 0

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1431,7 +1431,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 2 })
   })
@@ -1444,7 +1444,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1457,7 +1457,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1470,7 +1470,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: t,
-      pointer: { timestamp: t, tiebreak: { kind: 'chat', id: 'm1' } },
+      pointer: { role: 'exact', timestamp: t.getTime(), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1508,7 +1508,7 @@ describe('countUnreadInArchive (chat)', () => {
     // unread sibling being silently dropped. m3 (a later timestamp) counts regardless.
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: t,
-      pointer: { timestamp: t },
+      pointer: { role: 'floor', timestamp: t.getTime() },
     })
     expect(res).toEqual({ unread: 3 })
   })
@@ -1539,7 +1539,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 2 })
   })
@@ -1552,7 +1552,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1565,7 +1565,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1578,7 +1578,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: t,
-      pointer: { timestamp: t, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm1' } },
+      pointer: { role: 'exact', timestamp: t.getTime(), tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1592,7 +1592,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     // Same over-count rationale as the chat case: both same-ms rows (m1, m2) resolve
     // as "after" an unresolved pointer position; m3 counts regardless of the key.
-    const res = await messageCache.countRoomUnreadInArchive(ROOM, { floor: t, pointer: { timestamp: t } })
+    const res = await messageCache.countRoomUnreadInArchive(ROOM, { floor: t, pointer: { role: 'floor', timestamp: t.getTime() } })
     expect(res).toEqual({ unread: 3 })
   })
 

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -15,9 +15,9 @@ import {
   makeCacheOrderKey,
   isAfterBoundary,
   isRenderableStoredMessage,
-  type CacheOrderKey,
   type ExactPosition,
-  type OrderPosition,
+  exactPosition,
+  type PointerOrder,
 } from '../stores/shared/readState'
 
 const DB_NAME = 'fluux-message-cache'
@@ -848,20 +848,22 @@ export interface UnreadCountArgs {
   /** Cursor start: the read pointer's timestamp, or the entity's history watermark. */
   floor: Date
   /**
-   * The read pointer's position, for a strict-after-POSITION test rather than a
-   * timestamp-only test — two messages can share a millisecond. When
-   * `tiebreak` is omitted (a pointer migrated from the pre-#1081 legacy
-   * fields), {@link isAfterBoundary} reads the boundary as at-or-after its
-   * timestamp — so every row at the pointer's exact millisecond, including the
-   * pointer's own message, resolves as "after" the pointer and gets counted.
-   * That is
+   * The read pointer's ORDER, for a strict-after-POSITION test rather than a
+   * timestamp-only test — two messages can share a millisecond. Identity plays
+   * no part in counting, so this deliberately takes `readPointer.order` rather
+   * than the pointer: nothing here can reach for a name.
+   *
+   * A `floor` order (a pointer migrated from the pre-#1081 legacy fields) makes
+   * {@link isAfterBoundary} read the boundary as at-or-after its timestamp — so
+   * every row at the pointer's exact millisecond, including the pointer's own
+   * message, resolves as "after" the pointer and gets counted. That is
    * at-or-after-TIMESTAMP semantics, not strict-after-timestamp: it over-counts
    * by up to the same-ms sibling set, which is the safe direction (an
    * over-count clears the moment the user reads; an under-count would hide a
    * message permanently). Omitting `pointer` entirely counts everything from
    * `floor`.
    */
-  pointer?: { timestamp: Date; tiebreak?: CacheOrderKey }
+  pointer?: PointerOrder
   /** Cap on the reported `unread` count. Default {@link DEFAULT_UNREAD_CAP}. */
   unreadCap?: number
 }
@@ -872,21 +874,16 @@ export interface ArchiveCount {
   unread: number
 }
 
-/** The pointer's position as an `OrderPosition`, or `undefined` when there is no pointer. */
-function toPointerPosition(pointer: UnreadCountArgs['pointer']): OrderPosition | undefined {
-  return pointer ? { timestamp: pointer.timestamp.getTime(), tiebreak: pointer.tiebreak } : undefined
-}
-
 /**
  * Whether an archive row sorts strictly after the read boundary. No pointer
  * means everything from `floor` counts.
  *
- * This is the COUNTING question, so it uses {@link isAfterBoundary} — a keyless
- * pointer means at-or-after its millisecond, which over-counts (safe). Never
+ * This is the COUNTING question, so it uses {@link isAfterBoundary} — a `floor`
+ * boundary means at-or-after its millisecond, which over-counts (safe). Never
  * hand-roll this comparison, and never substitute the advance comparator: its
- * missing-key rule is the opposite one (#1173).
+ * floor rule is the opposite one (#1173).
  */
-function isStrictlyAfterPointer(position: ExactPosition, pointerPosition: OrderPosition | undefined): boolean {
+function isStrictlyAfterPointer(position: ExactPosition, pointerPosition: PointerOrder | undefined): boolean {
   return pointerPosition ? isAfterBoundary(position, pointerPosition) : true
 }
 
@@ -921,7 +918,7 @@ export async function countUnreadInArchive(
     const index = tx.store.index('conv_timestamp')
     const range = IDBKeyRange.bound([conversationId, floor.getTime()], [conversationId, Number.MAX_SAFE_INTEGER])
 
-    const pointerPosition = toPointerPosition(pointer)
+    const pointerPosition = pointer
     let unread = 0
 
     let cursor = await index.openCursor(range, 'next')
@@ -931,6 +928,7 @@ export async function countUnreadInArchive(
         const message = deserializeMessage(stored)
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
           const position: ExactPosition = {
+            role: 'exact',
             timestamp: stored.timestamp,
             tiebreak: makeCacheOrderKey(message, 'chat'),
           }
@@ -1339,7 +1337,7 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
     const index = tx.store.index('room_ts_from_id')
     const range = IDBKeyRange.bound([roomJid, floor.getTime(), '', ''], [roomJid, Infinity, '￿', '￿'])
 
-    const pointerPosition = toPointerPosition(pointer)
+    const pointerPosition = pointer
     let unread = 0
 
     let cursor = await index.openCursor(range, 'next')
@@ -1349,6 +1347,7 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
         const message = deserializeRoomMessage(stored)
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
           const position: ExactPosition = {
+            role: 'exact',
             timestamp: stored.timestamp,
             tiebreak: makeCacheOrderKey(message, 'room'),
           }
@@ -1395,10 +1394,7 @@ export async function resolveArchivePosition(
     ? await getRoomMessageByStanzaId(entityId, archiveId)
     : await getMessageByStanzaId(archiveId)
   if (!message) return null
-  return {
-    timestamp: message.timestamp.getTime(),
-    tiebreak: makeCacheOrderKey(message, isRoom ? 'room' : 'chat'),
-  }
+  return exactPosition(message, isRoom ? 'room' : 'chat')
 }
 
 /**

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2720,15 +2720,28 @@ test.describe('Jump-to-last-read pill', () => {
       const dividerId = msgs[dIdx].id
       const pointerId = msgs[pIdx].id
       const expectedTargetId = msgs[targetIdx].id
-      // One read position, written whole: id, the named message's own timestamp, and the archive
-      // order key (#1081) — the literal shape `makeReadPointer` writes. The key is not optional
-      // decoration here: every stress-room message shares one millisecond, so a KEYLESS pointer
-      // cannot certify its position at all and the divider correctly falls back to "the whole
-      // slice is after the boundary". Only a migrated pre-#1081 pointer is ever keyless.
+      // One read position, written whole — the literal shape `makeReadPointer`
+      // writes: an EXACT order (the named message's own timestamp plus the cache
+      // tie-break) and an identity naming it. The exact role is not optional
+      // decoration here: every stress-room message shares one millisecond, so a
+      // FLOOR order cannot certify its position at all and the divider correctly
+      // falls back to "the whole slice is after the boundary". Only a migrated
+      // pre-#1081 pointer is ever a floor.
+      //
+      // `local`, because a demo message carries no archive id — and the divider
+      // does not care: identity names a position, it never orders one.
+      //
+      // NOTE: this file is not covered by `npm run typecheck` (the root tsconfig
+      // has `files: []`, and the app's `include` covers apps/fluux/scripts, not
+      // this one), so a stale pointer shape here compiles and fails only as a
+      // browser-side timeout. Keep it in step with `ReadPointer` by hand.
       const readPointer = {
-        messageId: pointerId,
-        timestamp: msgs[pIdx].timestamp,
-        tiebreak: { kind: 'room', from: msgs[pIdx].from ?? '', id: pointerId },
+        order: {
+          role: 'exact',
+          timestamp: msgs[pIdx].timestamp.getTime(),
+          tiebreak: { kind: 'room', from: msgs[pIdx].from ?? '', id: pointerId },
+        },
+        identity: { state: 'local', messageId: pointerId },
       }
       const roomMeta = new Map(s.roomMeta)
       const meta = roomMeta.get(jid)


### PR DESCRIPTION
A read position has one ORDER and two NAMES: the client message id, which orders, counts, scrolls and renders, and the XEP-0359 archive id, which is the only thing XEP-0490 can publish. The pointer stored only the first and re-derived the second at each consumer, with no shared answer for what happens when that derivation fails — so "we cannot address this position yet" was an absence each call site rediscovered.

`ReadPointer` becomes `{ order, identity }`, both discriminated unions:

```ts
order     'exact' (timestamp + cache tie-break) | 'floor' (timestamp only)
identity  'addressable' (messageId + archiveId) | 'local' (messageId only)
```

The degraded state is now something the compiler forces every consumer to handle.

## What it buys

The XEP-0490 publisher reads `identity.archiveId` directly for an addressable pointer — no residency requirement, no cache read, no await — and takes the #1189 at-or-behind fallback for a local one, which becomes the *definition* of that branch rather than a patch bolted onto it. Every peer message and every MUC reflection mints an addressable pointer, so that is the common path.

Enrichment (`withArchiveId`) replaces the identity and carries the order **by reference**, so convergence cannot move the cursor. It binds by identity, never by position, and refuses a `floor` pointer, whose name and order already disagree.

## Migration

At the single hydration site, moving no stored position:

| Population | Becomes |
| --- | --- |
| Keyed pointers (the bulk) | shape change only; enter `local`, since no archive id was ever stored, and converge on the next read |
| Keyless legacy pointers | `floor` — what `lastReadAt` always meant. They cannot converge, which is honest: resolving the named message's real timestamp could move a forward-only floor forward |
| Pointerless entities | unchanged |

The pre-identity flat shapes stay readable, so an upgrading account loses nothing. Fixtures are the actual on-disk shapes shipped builds wrote, each traced to the commit that produced it.

An older build reading the new shape finds no top-level `messageId`, reads no pointer, and falls back to the entity's history floor: it over-counts unread and publishes nothing — never an over-advanced forward-only position. That degrade is larger than the previous step's, and it is the deliberate price of keeping exactly one copy of the name on disk; writing the flat fields alongside the nested ones would re-create the two-names-that-can-disagree shape this work removes.

## A correction worth recording

An earlier framing of this change said *all* migrated pointers enter `local`. That was imprecise, and review caught it.

The `local`-always rule belongs to the **persisted-shape migration** in `deserializeReadPointer`, where it holds absolutely because nothing on disk ever held an archive id — promoting there would mean inventing one. `migrateReadPointer` (the #1081 legacy `lastSeenMessageId` / `lastReadAt` resolution) is a different path: it mints a whole pointer from one real row, which is `makeReadPointer`'s contract, not enrichment-by-position. The distinction is worth keeping.

Within that path the two branches now differ by **how the row was located**:

- **Resolved by identifier** — keeps the row's archive id and mints `addressable`. The row was found *by its identifier*, so "I know exactly which archived message this is" is earned.
- **Resolved by timestamp** — mints `local`, order unchanged. Two messages can share a millisecond, so a timestamp-located row can be the wrong message. The pointer is internally consistent either way, but an `addressable` identity would assert an exactness we never established, and the publisher would then send that archive id to the user's other devices as an exact read position — forward-only and unrecoverable. `local` claims exactness only where we have it, and costs nothing lasting: the pointer still converges through the normal paths.

## Scope notes

- **The #1175/#1195 residency machinery is kept, not removed.** An addressable pointer resolves by a field read, but a local one still needs the archive — and the local population is exactly the 1:1-resting-on-an-own-send case #1175 and #1189 exist for, since the server never echoes our own sends. Three tests pin that split.
- `withArchiveId` has no production caller yet. Convergence is live via the mint and the inbound XEP-0490 path; enrichment on `backfillArchiveIds` is deliberately left for a follow-up, because adding a `conversationMeta` write to that branch would fire the MDS publisher on every MAM/carbon backfill.
- `isValidCacheOrderKey` is deleted: it described an older build's defence against the id-less key, and under the nested shape that build never reaches a key at all.
- Most of the diff is mechanical test-fixture migration; keyed fixtures became `exact`, keyless became `floor`, mirroring the migration rule.

## Breaking change

`ReadPointer` and `makeReadPointer` change shape on the SDK's public surface (`src/index.ts`). `@fluux/sdk` is not published to npm — verified, not assumed — so the only consumer is this repository's app, which needs no change: it reads one projected string.
