### PR TITLE
feat(sdk): record why an unread recount declined to commit

### DIFF
--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -10,6 +10,10 @@ import {
 } from './install'
 import { CTX, METRIC, resetValuesForTesting } from './values'
 import { hasAnomalySignalHandler, signalAnomaly } from '../utils/anomalySignal'
+import {
+  recordRecountDeferral,
+  resetRecountDeferralsForTesting,
+} from '../../../../packages/fluux-sdk/src/stores/shared/recountDiagnostics'
 
 type WindowWithSink = Record<string, unknown> & { __fluuxAnomalies?: string[] }
 const w = () => window as unknown as WindowWithSink
@@ -129,6 +133,72 @@ describe('attach and detach', () => {
     install()()
     expect(remove).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
     remove.mockRestore()
+  })
+})
+
+describe('recount deferrals reach the digest', () => {
+  // Issue #1211: the badge staying stale is already reported; these say WHY. Both in
+  // one digest is what turns "the badge was wrong" into an attribution.
+  beforeEach(() => {
+    resetRecountDeferralsForTesting()
+  })
+
+  /**
+   * Record one deferral.
+   *
+   * The app's `@fluux/sdk` mock has no real store, so the deferral is recorded
+   * directly. That the STORES call this at all is covered where it belongs, in
+   * `recountDiagnostics.test.ts` against the real chatStore and roomStore; what this
+   * suite owns is the fold from cumulative tallies to per-window deltas.
+   */
+  function provokeRoomDeferral(): void {
+    recordRecountDeferral('room', 'no-meta')
+  }
+
+  /**
+   * Flush through the visibility handler rather than calling `flushDigest`.
+   *
+   * The fold lives on the digest TRIGGERS, so a direct recorder call would skip it
+   * and the assertions below would be testing nothing.
+   */
+  function forceDigest(): void {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+  }
+
+  it('reports a deferral as a counter delta, not a running total', async () => {
+    // The SDK counts for the life of the process while a digest describes one
+    // window. Re-reporting the total would make every window after the first
+    // over-count, and a quiet window indistinguishable from a busy one.
+    install()
+    await whenReady()
+
+    provokeRoomDeferral()
+    provokeRoomDeferral()
+    forceDigest()
+
+    provokeRoomDeferral()
+    forceDigest()
+
+    const digests = records().filter((r) => r.kind === 'digest')
+    const key = 'recount.deferred.room.no-meta'
+    expect(digests[0].counters[key]).toBe(2)
+    expect(digests[1].counters[key]).toBe(1)
+  })
+
+  it('omits a reason that never fired', async () => {
+    // Control: a digest listing every reason at zero would bury the one that matters,
+    // and would make the tally useless for attributing a stale badge.
+    install()
+    await whenReady()
+    provokeRoomDeferral()
+    forceDigest()
+
+    const digest = records().filter((r) => r.kind === 'digest').pop()
+    expect(digest.counters['recount.deferred.room.no-meta']).toBe(1)
+    expect(digest.counters['recount.deferred.room.coverage-missing']).toBeUndefined()
+    expect(digest.counters['recount.deferred.chat.no-meta']).toBeUndefined()
   })
 })
 

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -15,7 +15,7 @@
  *
  * @module Anomaly/Install
  */
-import { chatStore, getStorageScopeJid, roomStore } from '@fluux/sdk'
+import { chatStore, getStorageScopeJid, readRecountDeferrals, roomStore } from '@fluux/sdk'
 import { clearAnomalySignalHandler, setAnomalySignalHandler } from '../utils/anomalySignal'
 import type { ViewportKind } from '../utils/viewportAtBottom'
 import { isTauri } from '../utils/tauri'
@@ -25,7 +25,7 @@ import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
 import { createPluginFsWriter, createTauriSink } from './sinks/tauri'
-import { ID, initTokenizer } from './values'
+import { ID, RECOUNT_METRIC, initTokenizer } from './values'
 
 const DIGEST_INTERVAL_MS = 5 * 60 * 1000
 /**
@@ -115,6 +115,37 @@ function readWindowAtLiveEdge(kind: ViewportKind, id: string): boolean {
   return kind === 'room'
     ? (roomStore.getState().roomRuntime.get(id)?.windowAtLiveEdge ?? false)
     : (chatStore.getState().windowAtLiveEdge.get(id) ?? false)
+}
+
+/**
+ * Cumulative deferral tallies as of the last digest, so each window reports a delta.
+ *
+ * The SDK counts for the life of the process; a digest describes one window. Without
+ * this the same deferrals would be re-reported every five minutes and a quiet window
+ * would look identical to a busy one.
+ */
+const lastDeferrals = new Map<string, number>()
+
+/**
+ * Fold the SDK's recount-deferral tallies into the recorder before a digest.
+ *
+ * Why the anomaly log rather than a store subscription: these say why an unread badge
+ * kept a stale value, and the badge staying stale is what
+ * `read-state/unread-survives-focus` already reports. Having both in the same digest
+ * is what turns "the badge was wrong" into "the badge was wrong BECAUSE coverage was
+ * missing" (issue #1211).
+ */
+function foldRecountDeferrals(rec: Recorder): void {
+  for (const [key, total] of Object.entries(readRecountDeferrals())) {
+    const previous = lastDeferrals.get(key) ?? 0
+    if (total <= previous) continue
+    const metric = RECOUNT_METRIC[key]
+    // An unknown key means the SDK grew a reason this build has no constant for.
+    // Dropping it is right: a counter name is a closed registry, and inventing one
+    // from a string that crossed a package boundary is the hole that registry closes.
+    if (metric) rec.count(metric, total - previous)
+    lastDeferrals.set(key, total)
+  }
 }
 
 function runtime(): Recorder {
@@ -234,12 +265,18 @@ export function install(): () => void {
       ),
     )
 
-    digestTimer = setInterval(() => rec.flushDigest(DIGEST_INTERVAL_MS), DIGEST_INTERVAL_MS)
+    digestTimer = setInterval(() => {
+      foldRecountDeferrals(rec)
+      rec.flushDigest(DIGEST_INTERVAL_MS)
+    }, DIGEST_INTERVAL_MS)
 
     const onVisibility = () => {
       // Best effort: the WebView gives no guarantee that asynchronous I/O completes
       // during teardown, so a missing trailing digest is normal and never a signal.
-      if (document.visibilityState === 'hidden') rec.flushDigest(DIGEST_INTERVAL_MS)
+      if (document.visibilityState === 'hidden') {
+        foldRecountDeferrals(rec)
+        rec.flushDigest(DIGEST_INTERVAL_MS)
+      }
     }
     document.addEventListener('visibilitychange', onVisibility)
     detachListener = () => document.removeEventListener('visibilitychange', onVisibility)
@@ -288,6 +325,7 @@ export function resetInstallForTesting(): void {
   sessionRetryMs = SESSION_RETRY_MS
   attachments = 0
   attachRefs = 0
+  lastDeferrals.clear()
 }
 
 /** Diagnostic: how many times `install()` actually attached. */

--- a/apps/fluux/src/anomaly/values.test.ts
+++ b/apps/fluux/src/anomaly/values.test.ts
@@ -12,6 +12,7 @@ import {
   localRef,
   localRefOverflowCount,
   METRIC,
+  RECOUNT_METRIC,
   releaseRef,
   resetValuesForTesting,
   retainOpaque,
@@ -31,7 +32,13 @@ beforeEach(async () => {
 
 describe('registries', () => {
   it('recognises constants from every registry', () => {
-    for (const value of [TAG.focus, ID.sessionStart, CTX.conv, COUNTER.rejectedValue]) {
+    for (const value of [
+      TAG.focus,
+      ID.sessionStart,
+      CTX.conv,
+      COUNTER.rejectedValue,
+      RECOUNT_METRIC['room:pointer-changed'],
+    ]) {
       expect(isOpaque(value)).toBe(true)
     }
   })

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -169,6 +169,45 @@ export const METRIC = Object.freeze({
 })
 
 /**
+ * Counter names for `recomputeUnread*` deferrals (issue #1211).
+ *
+ * Built from two literal unions rather than writing out every kind/reason pair. That
+ * is still a CLOSED registry in the sense that matters: every part is a literal in
+ * this file, so no caller data can reach a counter name. The alternative — accepting
+ * the SDK's reason string directly — would be a free-text path into the log.
+ *
+ * Dotted, so `values.test.ts`'s slash-form parity check correctly treats them as
+ * application metrics rather than invariant ids.
+ */
+const RECOUNT_DEFERRAL_REASONS = [
+  'active-skipped',
+  'no-meta',
+  'pointerless-defer',
+  'pending-remote-displayed',
+  'no-floor',
+  'mam-not-caught-up',
+  'context-changed',
+  'coverage-missing',
+  'coverage-unresolvable',
+  'coverage-short-of-floor',
+  'cache-unavailable',
+  'recount-superseded',
+  'input-version-changed',
+  'pointer-changed',
+] as const
+
+export const RECOUNT_METRIC: Readonly<Record<string, Opaque>> = Object.freeze(
+  Object.fromEntries(
+    (['chat', 'room'] as const).flatMap((kind) =>
+      RECOUNT_DEFERRAL_REASONS.map((reason) => [
+        `${kind}:${reason}`,
+        mint(`recount.deferred.${kind}.${reason}`, 'counter'),
+      ]),
+    ),
+  ),
+)
+
+/**
  * The reserved set, enforced by the recorder's `count()`.
  *
  * Private for the same reason as VALUE_KINDS: `ReadonlySet` is a compile-time type

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -44,6 +44,45 @@ Counter names (digest only, not invariant ids):
 | `recorder/dropped-not-ready` | Records refused because the tokenizer had no key yet | A few at startup are normal. Sustained means the tokenizer never initialised — check `fluux.log` for the warning |
 | `recorder/sink-write-failed` | A sidecar append failed | Check `fluux.log` — failures mirror there, because a broken sink cannot report itself |
 
+## Recount deferrals
+
+`recount.deferred.<chat|room>.<reason>`, in the digest counters.
+
+An unread recount is a chain of about twenty guards, most of which decline to count
+rather than risk a wrong number. Each is correct alone, but from outside the store they
+are indistinguishable: the badge simply keeps its old value. These tallies say which
+guard stood down, so a stale badge can be attributed instead of guessed at (issue
+#1211).
+
+Read them **alongside** `read-state/unread-survives-focus`. That record flags the stale
+badge episode; these counters show which guards deferred during the same window.
+
+The counters are aggregate deltas for one digest window, split by chat or room but
+carrying no entity id. Use the kind and timing to correlate them with an observed
+badge; recounts for other entities in the same window can contribute to the tally.
+
+| reason | Meaning |
+|---|---|
+| `active-skipped` | The entity was active and the caller did not opt in |
+| `no-meta` | No metadata for the entity |
+| `pointerless-defer` | No read position ever established; a bare zero cannot be trusted |
+| `pending-remote-displayed` | A remote XEP-0490 position is still resolving |
+| `no-floor` | Neither a read pointer nor a history floor to count from |
+| `mam-not-caught-up` | History is partial, so any count would under-report |
+| `context-changed` | Cache epoch or storage scope moved underneath |
+| `coverage-missing` | No coverage record, so the archive bottom is unknown |
+| `coverage-unresolvable` | The coverage bottom no longer resolves in the archive |
+| `coverage-short-of-floor` | Coverage does not reach back to the floor |
+| `cache-unavailable` | The archive count failed — an IndexedDB error |
+| `recount-superseded` | Another recount for the same entity overtook this one |
+| `input-version-changed` | Message inputs changed mid-recount, for example through a live arrival or MAM merge |
+| `pointer-changed` | The read pointer moved while the recount was in flight |
+
+`input-version-changed` is the one to watch for #1211: `addMessage` bumps that version
+on **every** arrival, so an active room that keeps receiving can invalidate each recount
+with the traffic that made it necessary. A high tally during the affected window
+supports that attribution; a high `coverage-missing` points elsewhere entirely.
+
 ## Detector families
 
 Each entry below is added by the stage that introduces it.

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -101,6 +101,15 @@ export { rebuildSearchIndex, clearSearchIndex, parseSearchQuery } from './utils/
 export type { RebuildProgress, ParsedQuery } from './utils/searchIndex'
 export { buildScopedStorageKey, getStorageScopeJid } from './utils/storageScope'
 
+// Read-only diagnostic: why an unread recount declined to commit (issue #1211).
+// A tally of reasons — no entity ids or unread totals — so a dev build can
+// attribute a stale badge instead of guessing which of ~20 guards stood down.
+export { readRecountDeferrals } from './stores/shared/recountDiagnostics'
+export type {
+  RecountDeferralReason,
+  RecountEntityKind,
+} from './stores/shared/recountDiagnostics'
+
 // Fine-grained metadata subscription hooks (Phase 6)
 export {
   // Chat metadata hooks

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -16,6 +16,7 @@ import { chatStore } from './chatStore'
 import { noteTransient, removeTransient, transientIdentity, transientAliases, clearTransientScope, transientCounts, type ScopeKey } from './shared/transientUnread'
 import { _resetStorageScopeForTesting, getStorageScopeJid, setStorageScopeJid } from '../utils/storageScope'
 import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
+import { readRecountDeferrals, resetRecountDeferralsForTesting } from './shared/recountDiagnostics'
 import type { Message, Conversation } from '../core/types'
 
 vi.mock('../utils/messageCache', async (importOriginal) => {
@@ -110,6 +111,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ;(messageCache as unknown as { _resetDBForTesting?: () => void })._resetDBForTesting?.()
     localStorageMock.clear()
     chatStore.getState().reset()
+    resetRecountDeferralsForTesting()
     chatStore.getState().addConversation(createConversation(CID))
     // mockClear() only resets call history, never the base implementation set
     // by vi.fn(actual.countUnreadInArchive) above, so it stays real by default.
@@ -556,6 +558,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
     expect(chatStore.getState().getConversationCoverage(CID)).toBeUndefined()
+    expect(readRecountDeferrals()['chat:coverage-unresolvable']).toBe(1)
   })
 
   // FIX 4 (final whole-branch review, Minor (r)): the coverage gate's fourth
@@ -732,6 +735,8 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     // A (slow) resolved LAST but must be discarded — B's result stands.
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
+    expect(readRecountDeferrals()['chat:recount-superseded']).toBe(1)
+    expect(readRecountDeferrals()['chat:context-changed']).toBeUndefined()
   })
 
   it('discards a recount whose archive snapshot predates a live arrival', async () => {
@@ -761,6 +766,8 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
     expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(6)
+    expect(readRecountDeferrals()['chat:input-version-changed']).toBe(1)
+    expect(readRecountDeferrals()['chat:context-changed']).toBeUndefined()
   })
 
   // Was 'rejects a guard-pass pointer write after the account scope changes',
@@ -770,7 +777,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // remaining await, the archive count. Nothing else about the recount context
   // changes across the swap here (no switchAccount, so the cache epoch, the
   // recount version, the input version and the pointer are all identical),
-  // which makes the storage-scope term of `recountContextIsCurrent` the single
+    // which makes the storage-scope term of `recountContextDeferral` the single
   // load-bearing guard: drop it and the account-A result of 55 overwrites 7.
   it('rejects a recount commit after the account scope changes', async () => {
     const accountA = 'account-a@example.com'
@@ -824,6 +831,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     expect(getStorageScopeJid()).toBe(accountB)
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(7)
+    expect(readRecountDeferrals()['chat:context-changed']).toBe(1)
     // Control for the isolation above: `stale` is the ONLY archive count this
     // test may produce. A second one means a deferred recount slipped in, which
     // is exactly how the seeded 7 used to get overwritten with a real 0.
@@ -887,6 +895,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // clobber it.
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
     expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('u1')
+    expect(readRecountDeferrals()['chat:pointer-changed']).toBe(1)
   })
 
   // ---------------------------------------------------------------------

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -60,6 +60,10 @@ import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
+import {
+  recordRecountDeferral,
+  type RecountDeferralReason,
+} from './shared/recountDiagnostics'
 import { flushKey, flush as flushThrottledStorage } from './shared/throttledStorage'
 import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per conversation; rest live in IndexedDB + MAM).
@@ -2530,15 +2534,18 @@ export const chatStore = createStore<ChatState>()(
       },
 
       recomputeUnreadForConversation: async (conversationId, options) => {
+        // Passive diagnostic — see the room twin and #1211.
+        const defer = (reason: RecountDeferralReason): void =>
+          recordRecountDeferral('chat', reason)
         const allowActive = options?.allowActive ?? false
         // Active conversation counts are usually reconciled by their own
         // synchronous path (Task 11's live-edge convergence) — skip here to
         // avoid a redundant race, UNLESS the caller explicitly opted in
         // (FIX 3: a remote XEP-0490 advance on the active entity, which that
         // convergence path never runs for).
-        if (!allowActive && get().activeConversationId === conversationId) return
+        if (!allowActive && get().activeConversationId === conversationId) return defer('active-skipped')
         const meta0 = get().conversationMeta.get(conversationId)
-        if (!meta0) return
+        if (!meta0) return defer('no-meta')
 
         // Pointerless-with-a-trusted-nonzero-count stands down: a bare zero
         // derived for an entity that has never established a read position
@@ -2546,7 +2553,7 @@ export const chatStore = createStore<ChatState>()(
         // overwrite was accumulated live. Checked against the state as it
         // stood at entry, before any awaits. Repeated below — see the
         // "Defer conditions" comment there before breaking either copy.
-        if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return
+        if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return defer('pointerless-defer')
 
         // Latest-wins (requirement 3): bumped before the first await and
         // re-checked immediately before every commit below, so a slow recount
@@ -2556,11 +2563,16 @@ export const chatStore = createStore<ChatState>()(
         const cacheEpochAtStart = chatCacheEpoch
         const storageScopeAtStart = getStorageScopeJid()
         const unreadInputVersionAtStart = chatUnreadInputVersion.get(conversationId) ?? 0
-        const recountContextIsCurrent = () =>
-          chatCacheEpoch === cacheEpochAtStart &&
-          getStorageScopeJid() === storageScopeAtStart &&
-          chatRecountVersion.get(conversationId) === version &&
-          (chatUnreadInputVersion.get(conversationId) ?? 0) === unreadInputVersionAtStart
+        const recountContextDeferral = (): RecountDeferralReason | undefined => {
+          if (chatCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
+            return 'context-changed'
+          }
+          if (chatRecountVersion.get(conversationId) !== version) return 'recount-superseded'
+          if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtStart) {
+            return 'input-version-changed'
+          }
+          return undefined
+        }
 
         // --- Defer conditions ---------------------------------------------
         //
@@ -2590,9 +2602,9 @@ export const chatStore = createStore<ChatState>()(
         // from its `historyFloor` creation watermark, and a cross-device reply
         // moves the read position only through XEP-0490.
         const metaNow = get().conversationMeta.get(conversationId)
-        if (!metaNow) return
-        if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return
-        if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return
+        if (!metaNow) return defer('no-meta')
+        if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
+        if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
         // final-fix-2: snapshot the pointer identity the archive-derived
         // count below is computed AGAINST. Re-checked at the final commit
@@ -2602,22 +2614,23 @@ export const chatStore = createStore<ChatState>()(
         const unreadInputVersionAtCompute = chatUnreadInputVersion.get(conversationId) ?? 0
 
         const floor = computeFloor(metaNow.readPointer, metaNow.historyFloor)
-        if (!floor) return
+        if (!floor) return defer('no-floor')
 
         // --- Coverage gate: every uncertain branch defers (requirement 4) -
         const mam = mamState.getMAMQueryState(get().mamQueryStates, conversationId)
-        if (!isCaughtUpForCounting(mam)) return
+        if (!isCaughtUpForCounting(mam)) return defer('mam-not-caught-up')
 
         const record = get().conversationCoverage.get(conversationId)
         const bottom = await resolveCoverageBottom(conversationId, record, false)
-        if (!recountContextIsCurrent()) return
-        if (bottom === 'missing') return
+        const coverageContextDeferral = recountContextDeferral()
+        if (coverageContextDeferral) return defer(coverageContextDeferral)
+        if (bottom === 'missing') return defer('coverage-missing')
         if (bottom === 'unresolvable') {
           // Invalidate the stale record so a later merge can re-establish it,
           // guarded on the SAME bottomId so a record that already moved on
           // (a concurrent merge) is not clobbered.
           if (record) get().clearConversationCoverage(conversationId, record.bottomId)
-          return
+          return defer('coverage-unresolvable')
         }
         // The boundary: the pointer's own order when there is one, so the
         // comparison is not blind to a coverage bottom sharing its exact
@@ -2632,29 +2645,36 @@ export const chatStore = createStore<ChatState>()(
 
         // A BOUNDARY test: a FLOOR (migrated) boundary reads as at-or-after its
         // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
-        if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
+        if (isAfterBoundary(bottom, floorPos)) return defer('coverage-short-of-floor') // coverage doesn't reach the floor
 
         const res = await messageCache.countUnreadInArchive(conversationId, {
           floor,
           pointer: metaNow.readPointer?.order,
         })
-        if (!recountContextIsCurrent()) return
-        if (res === null) return // unavailable — IndexedDB error
+        const countContextDeferral = recountContextDeferral()
+        if (countContextDeferral) return defer(countContextDeferral)
+        if (res === null) return defer('cache-unavailable') // unavailable — IndexedDB error
 
         // --- Latest-wins commit (requirement 3) ---------------------------
-        if (chatRecountVersion.get(conversationId) !== version) return
-        if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtCompute) return
+        if (chatRecountVersion.get(conversationId) !== version) return defer('recount-superseded')
+        if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtCompute) {
+          return defer('input-version-changed')
+        }
 
         const transient = transientCounts(chatTransientScopeKey(conversationId), floorPos)
         const unreadCount = Math.min(999, res.unread + transient.unread)
 
         set((state) => {
-          if (!recountContextIsCurrent()) return state
-          if (chatRecountVersion.get(conversationId) !== version) return state
-          if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtCompute) return state
-          if (!allowActive && state.activeConversationId === conversationId) return state
+          const commitContextDeferral = recountContextDeferral()
+          if (commitContextDeferral) { defer(commitContextDeferral); return state }
+          if (chatRecountVersion.get(conversationId) !== version) { defer('recount-superseded'); return state }
+          if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtCompute) {
+            defer('input-version-changed')
+            return state
+          }
+          if (!allowActive && state.activeConversationId === conversationId) { defer('active-skipped'); return state }
           const meta = state.conversationMeta.get(conversationId)
-          if (!meta) return state
+          if (!meta) { defer('no-meta'); return state }
 
           // final-fix-2: `res.unread` was derived against `pointerIdAtCompute`
           // (metaNow.readPointer, captured before the coverage-bottom and
@@ -2670,7 +2690,10 @@ export const chatStore = createStore<ChatState>()(
           // the newer, correct value — worst case this recompute under-acts
           // once; the next trigger (another arrival, deactivation, or
           // activation) re-derives it.
-          if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) return state
+          if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) {
+            defer('pointer-changed')
+            return state
+          }
 
           // Rederive the divider (requirement 5): the boundary may have moved
           // since a marker was last parked here (a remote pointer advance).

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -19,6 +19,7 @@ import { IDBFactory } from 'fake-indexeddb'
 import { roomStore, _resetRoomReadStateForTesting } from './roomStore'
 import { noteTransient, removeTransient, transientIdentity, transientAliases, clearTransientScope, transientCounts, type ScopeKey } from './shared/transientUnread'
 import { _resetStorageScopeForTesting, getStorageScopeJid, setStorageScopeJid } from '../utils/storageScope'
+import { readRecountDeferrals, resetRecountDeferralsForTesting } from './shared/recountDiagnostics'
 import type { Room, RoomMessage } from '../core/types'
 
 vi.mock('../utils/messageCache', async (importOriginal) => {
@@ -128,6 +129,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     localStorageMock.clear()
     roomStore.getState().reset()
     _resetRoomReadStateForTesting()
+    resetRecountDeferralsForTesting()
     roomStore.getState().addRoom(createRoom(ROOM))
     // mockClear() only resets call history, never the base implementation set
     // by vi.fn(actual.countRoomUnreadInArchive) above, so it stays real by default.
@@ -460,6 +462,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
     expect(roomStore.getState().getRoomCoverage(ROOM)).toBeUndefined()
+    expect(readRecountDeferrals()['room:coverage-unresolvable']).toBe(1)
   })
 
   // FIX 4 (final whole-branch review, Minor (r)): the coverage gate's fourth
@@ -642,6 +645,8 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     // A (slow) resolved LAST but must be discarded — B's result stands.
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
+    expect(readRecountDeferrals()['room:recount-superseded']).toBe(1)
+    expect(readRecountDeferrals()['room:context-changed']).toBeUndefined()
   })
 
   it('discards a recount whose archive snapshot predates a live arrival', async () => {
@@ -671,6 +676,8 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
     expect(roomStore.getState().rooms.get(ROOM)?.unreadCount).toBe(6)
+    expect(readRecountDeferrals()['room:input-version-changed']).toBe(1)
+    expect(readRecountDeferrals()['room:context-changed']).toBeUndefined()
   })
 
   // Was 'rejects a guard-pass pointer write after the account scope changes',
@@ -680,7 +687,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // remaining await, the archive count. Nothing else about the recount context
   // changes across the swap here (no switchAccount, so the cache epoch, the
   // recount version, the input version and the pointer are all identical),
-  // which makes the storage-scope term of `recountContextIsCurrent` the single
+  // which makes the storage-scope term of `recountContextDeferral` the single
   // load-bearing guard: drop it and the account-A result of 55 overwrites 7.
   it('rejects a recount commit after the account scope changes', async () => {
     const accountA = 'account-a@example.com'
@@ -715,6 +722,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     expect(getStorageScopeJid()).toBe(accountB)
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(7)
+    expect(readRecountDeferrals()['room:context-changed']).toBe(1)
   })
 
   // final-fix-2: the race the re-reviewer flagged, room twin of
@@ -771,6 +779,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // The direct write's fresher, correct state survives untouched.
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
     expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('u1')
+    expect(readRecountDeferrals()['room:pointer-changed']).toBe(1)
   })
 
   // ---------------------------------------------------------------------

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -74,6 +74,10 @@ import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
+import {
+  recordRecountDeferral,
+  type RecountDeferralReason,
+} from './shared/recountDiagnostics'
 import { schedule, flush as flushThrottledStorage } from './shared/throttledStorage'
 import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per room; rest live in IndexedDB + MAM). Read via
@@ -2336,13 +2340,16 @@ export const roomStore = createStore<RoomState>()(
 
   recomputeUnreadForRoom: async (roomJid, options) => {
     const allowActive = options?.allowActive ?? false
+    // Passive diagnostic: every guard below declines to COUNT, and from outside the
+    // store they are indistinguishable — the badge just keeps its old value. See #1211.
+    const defer = (reason: RecountDeferralReason): void => recordRecountDeferral('room', reason)
     // Active room counts are usually reconciled by their own synchronous path
     // (Task 11's live-edge convergence) — skip here to avoid a redundant
     // race, UNLESS the caller explicitly opted in (FIX 3: a remote XEP-0490
     // advance on the active room, which that convergence path never runs for).
-    if (!allowActive && get().activeRoomJid === roomJid) return
+    if (!allowActive && get().activeRoomJid === roomJid) return defer('active-skipped')
     const meta0 = get().roomMeta.get(roomJid)
-    if (!meta0) return
+    if (!meta0) return defer('no-meta')
 
     // Pointerless-with-a-trusted-nonzero-count stands down — see chatStore's
     // `recomputeUnreadForConversation` for the full rationale (mirrored here
@@ -2351,7 +2358,7 @@ export const roomStore = createStore<RoomState>()(
     // against the state as it stood at entry, before any awaits. Repeated
     // below — see the "Defer conditions" comment there before breaking either
     // copy.
-    if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return
+    if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return defer('pointerless-defer')
 
     // Latest-wins (requirement 3): bumped before the first await and
     // re-checked immediately before every commit below, so a slow recount
@@ -2361,11 +2368,16 @@ export const roomStore = createStore<RoomState>()(
     const cacheEpochAtStart = roomCacheEpoch
     const storageScopeAtStart = getStorageScopeJid()
     const unreadInputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
-    const recountContextIsCurrent = () =>
-      roomCacheEpoch === cacheEpochAtStart &&
-      getStorageScopeJid() === storageScopeAtStart &&
-      roomRecountVersion.get(roomJid) === version &&
-      (roomUnreadInputVersion.get(roomJid) ?? 0) === unreadInputVersionAtStart
+    const recountContextDeferral = (): RecountDeferralReason | undefined => {
+      if (roomCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
+        return 'context-changed'
+      }
+      if (roomRecountVersion.get(roomJid) !== version) return 'recount-superseded'
+      if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtStart) {
+        return 'input-version-changed'
+      }
+      return undefined
+    }
 
     // --- Defer conditions -----------------------------------------------
     //
@@ -2396,9 +2408,9 @@ export const roomStore = createStore<RoomState>()(
     // `historyFloor` creation watermark, and a reply sent from another device
     // moves the read position only through XEP-0490.
     const metaNow = get().roomMeta.get(roomJid)
-    if (!metaNow) return
-    if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return
-    if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return
+    if (!metaNow) return defer('no-meta')
+    if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
+    if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
     // final-fix-2: snapshot the pointer identity the archive-derived count
     // below is computed AGAINST. Re-checked at the final commit (see that
@@ -2408,22 +2420,23 @@ export const roomStore = createStore<RoomState>()(
     const unreadInputVersionAtCompute = roomUnreadInputVersion.get(roomJid) ?? 0
 
     const floor = computeFloor(metaNow.readPointer, metaNow.historyFloor)
-    if (!floor) return
+    if (!floor) return defer('no-floor')
 
     // --- Coverage gate: every uncertain branch defers (requirement 4) -
     const mam = mamState.getMAMQueryState(get().mamQueryStates, roomJid)
-    if (!isCaughtUpForCounting(mam)) return
+    if (!isCaughtUpForCounting(mam)) return defer('mam-not-caught-up')
 
     const record = get().roomCoverage.get(roomJid)
     const bottom = await resolveCoverageBottom(roomJid, record, true)
-    if (!recountContextIsCurrent()) return
-    if (bottom === 'missing') return
+    const coverageContextDeferral = recountContextDeferral()
+    if (coverageContextDeferral) return defer(coverageContextDeferral)
+    if (bottom === 'missing') return defer('coverage-missing')
     if (bottom === 'unresolvable') {
       // Invalidate the stale record so a later merge can re-establish it,
       // guarded on the SAME bottomId so a record that already moved on (a
       // concurrent merge) is not clobbered.
       if (record) get().clearRoomCoverage(roomJid, record.bottomId)
-      return
+      return defer('coverage-unresolvable')
     }
     // The boundary: the pointer's own order when there is one, so the
     // comparison is not blind to a coverage bottom sharing its exact
@@ -2438,29 +2451,38 @@ export const roomStore = createStore<RoomState>()(
 
     // A BOUNDARY test: a FLOOR (migrated) boundary reads as at-or-after its
     // millisecond, so an equal-ms bottom counts as not reaching it (#1173).
-    if (isAfterBoundary(bottom, floorPos)) return // coverage doesn't reach the floor
+    if (isAfterBoundary(bottom, floorPos)) return defer('coverage-short-of-floor') // coverage doesn't reach the floor
 
     const res = await messageCache.countRoomUnreadInArchive(roomJid, {
       floor,
       pointer: metaNow.readPointer?.order,
     })
-    if (!recountContextIsCurrent()) return
-    if (res === null) return // unavailable — IndexedDB error
+    const countContextDeferral = recountContextDeferral()
+    if (countContextDeferral) return defer(countContextDeferral)
+    if (res === null) return defer('cache-unavailable') // unavailable — IndexedDB error
 
     // --- Latest-wins commit (requirement 3) ---------------------------
-    if (roomRecountVersion.get(roomJid) !== version) return
-    if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtCompute) return
+    if (roomRecountVersion.get(roomJid) !== version) return defer('recount-superseded')
+    if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtCompute) {
+      return defer('input-version-changed')
+    }
 
     const transient = transientCounts(roomTransientScopeKey(roomJid), floorPos)
     const unreadCount = Math.min(999, res.unread + transient.unread)
 
     set((state) => {
-      if (!recountContextIsCurrent()) return state
-      if (roomRecountVersion.get(roomJid) !== version) return state
-      if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtCompute) return state
-      if (!allowActive && state.activeRoomJid === roomJid) return state
+      // The commit-time twins of the guards above. A recount can pass every
+      // pre-commit check and still be superseded during the final `set`.
+      const commitContextDeferral = recountContextDeferral()
+      if (commitContextDeferral) { defer(commitContextDeferral); return state }
+      if (roomRecountVersion.get(roomJid) !== version) { defer('recount-superseded'); return state }
+      if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtCompute) {
+        defer('input-version-changed')
+        return state
+      }
+      if (!allowActive && state.activeRoomJid === roomJid) { defer('active-skipped'); return state }
       const meta = state.roomMeta.get(roomJid)
-      if (!meta) return state
+      if (!meta) { defer('no-meta'); return state }
 
       // final-fix-2: `res.unread` was derived against `pointerIdAtCompute`
       // (metaNow.readPointer, captured before the coverage-bottom and
@@ -2476,7 +2498,10 @@ export const roomStore = createStore<RoomState>()(
       // the newer, correct value — worst case this recompute under-acts
       // once; the next trigger (another arrival, deactivation, or
       // activation) re-derives it.
-      if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) return state
+      if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) {
+        defer('pointer-changed')
+        return state
+      }
 
       // Rederive the divider (requirement 5): the boundary may have moved
       // since a marker was last parked here (a remote pointer advance).

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  readRecountDeferrals,
+  recordRecountDeferral,
+  resetRecountDeferralsForTesting,
+} from './recountDiagnostics'
+import { chatStore } from '../chatStore'
+import { roomStore } from '../roomStore'
+
+beforeEach(() => {
+  resetRecountDeferralsForTesting()
+})
+
+describe('recountDiagnostics', () => {
+  it('tallies by kind and reason', () => {
+    recordRecountDeferral('room', 'coverage-missing')
+    recordRecountDeferral('room', 'coverage-missing')
+    recordRecountDeferral('chat', 'coverage-missing')
+
+    expect(readRecountDeferrals()).toEqual({
+      'room:coverage-missing': 2,
+      'chat:coverage-missing': 1,
+    })
+  })
+
+  it('keeps chat and room separate', () => {
+    // The two stores run the same guard chain against different state. Merging them
+    // would hide that a stale badge is specific to one kind — which is exactly the
+    // question issue #1211 asks.
+    recordRecountDeferral('room', 'input-version-changed')
+    recordRecountDeferral('chat', 'no-floor')
+
+    const tallies = readRecountDeferrals()
+    expect(Object.keys(tallies).sort()).toEqual([
+      'chat:no-floor',
+      'room:input-version-changed',
+    ])
+  })
+
+  it('is cumulative, leaving windowing to the reader', () => {
+    recordRecountDeferral('room', 'mam-not-caught-up')
+    expect(readRecountDeferrals()['room:mam-not-caught-up']).toBe(1)
+    recordRecountDeferral('room', 'mam-not-caught-up')
+    expect(readRecountDeferrals()['room:mam-not-caught-up']).toBe(2)
+  })
+
+  it('returns a copy, so a reader cannot mutate the tallies', () => {
+    recordRecountDeferral('room', 'no-meta')
+    const snapshot = readRecountDeferrals()
+    snapshot['room:no-meta'] = 999
+    snapshot['room:injected'] = 1
+
+    expect(readRecountDeferrals()).toEqual({ 'room:no-meta': 1 })
+  })
+
+  it('starts empty and resets', () => {
+    expect(readRecountDeferrals()).toEqual({})
+    recordRecountDeferral('chat', 'cache-unavailable')
+    resetRecountDeferralsForTesting()
+    expect(readRecountDeferrals()).toEqual({})
+  })
+})
+
+
+describe('the stores actually report their deferrals', () => {
+  // The tally is worthless if the guards never call it. These assert the wiring at
+  // the cheapest reachable guard in each store; the remaining guards are behind
+  // coverage and MAM state that a unit test cannot stage honestly.
+  beforeEach(() => {
+    resetRecountDeferralsForTesting()
+  })
+
+  it('records a room recount that found no metadata', async () => {
+    await roomStore.getState().recomputeUnreadForRoom('never-seen@conf.example', {
+      allowActive: true,
+    })
+    expect(readRecountDeferrals()['room:no-meta']).toBe(1)
+  })
+
+  it('records a conversation recount that found no metadata', async () => {
+    await chatStore.getState().recomputeUnreadForConversation('never-seen@example', {
+      allowActive: true,
+    })
+    expect(readRecountDeferrals()['chat:no-meta']).toBe(1)
+  })
+
+  it('records the active-room skip, which is a different reason entirely', () => {
+    // Distinguishing "skipped because active" from "counted and committed" is the
+    // whole point: both leave the badge unchanged.
+    roomStore.setState({ activeRoomJid: 'active@conf.example' })
+    void roomStore.getState().recomputeUnreadForRoom('active@conf.example')
+    expect(readRecountDeferrals()['room:active-skipped']).toBe(1)
+    roomStore.setState({ activeRoomJid: null })
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
@@ -1,0 +1,98 @@
+/**
+ * Why an unread recount declined to commit.
+ *
+ * `recomputeUnreadForRoom` and `recomputeUnreadForConversation` are a chain of
+ * about twenty guards, most of which defer rather than count. Every one of them is
+ * correct in isolation — an uncertain count is worse than a stale one — but from
+ * outside the store they are indistinguishable: the badge simply keeps its old
+ * value, and nothing says which guard stood down or how often.
+ *
+ * That gap is issue #1211, where a MUC badge stays up while its room is open and
+ * clears only on switching away. Two guards are plausible causes and neither is
+ * observable, so the bug cannot be attributed without guessing.
+ *
+ * This is a COUNTER, not a log: it records reasons and tallies, never entity ids,
+ * message ids or unread totals. Nothing here can identify a conversation, so the
+ * tallies are safe to read from anywhere and safe to write to a diagnostic sidecar.
+ *
+ * It is deliberately passive. Nothing in the store reads these numbers back, so a
+ * miscount can change no behaviour.
+ *
+ * @module Stores/Shared/RecountDiagnostics
+ */
+
+/**
+ * The distinct ways a recount can end without committing.
+ *
+ * A closed union so a new guard cannot be added silently: adding one means naming
+ * it here, and a name is what makes the tally readable.
+ */
+export type RecountDeferralReason =
+  /** Skipped because the entity is active and the caller did not opt in. */
+  | 'active-skipped'
+  /** No metadata for the entity — nothing to correct. */
+  | 'no-meta'
+  /** No read position was ever established, and a bare zero cannot be trusted. */
+  | 'pointerless-defer'
+  /** A remote XEP-0490 position is still being resolved. */
+  | 'pending-remote-displayed'
+  /** Neither a read pointer nor a history floor to count from. */
+  | 'no-floor'
+  /** MAM has not caught up, so any count would be derived from partial history. */
+  | 'mam-not-caught-up'
+  /** Cache epoch or storage scope moved under this recount. */
+  | 'context-changed'
+  /** No coverage record for the entity, so the archive bottom is unknown. */
+  | 'coverage-missing'
+  /** A coverage record exists but its bottom no longer resolves in the archive. */
+  | 'coverage-unresolvable'
+  /** Coverage does not reach back to the floor, so the count would under-report. */
+  | 'coverage-short-of-floor'
+  /** The archive count itself was unavailable — an IndexedDB error. */
+  | 'cache-unavailable'
+  /** Another recount for the same entity started while this one was awaiting. */
+  | 'recount-superseded'
+  /**
+   * Message inputs changed while this recount was awaiting, so its result describes
+   * a state that no longer exists.
+   *
+   * The interesting one for #1211: `addMessage` bumps this version on EVERY
+   * arrival, so an active room that keeps receiving can invalidate each recount
+   * with the traffic that made it necessary.
+   */
+  | 'input-version-changed'
+  /** The read pointer moved while the recount was in flight. */
+  | 'pointer-changed'
+
+export type RecountEntityKind = 'chat' | 'room'
+
+const tallies = new Map<string, number>()
+
+function key(kind: RecountEntityKind, reason: RecountDeferralReason): string {
+  return `${kind}:${reason}`
+}
+
+/** Record one deferral. Cheap enough for the hot path; no allocation beyond the key. */
+export function recordRecountDeferral(
+  kind: RecountEntityKind,
+  reason: RecountDeferralReason,
+): void {
+  const k = key(kind, reason)
+  tallies.set(k, (tallies.get(k) ?? 0) + 1)
+}
+
+/**
+ * A snapshot of the tallies so far, keyed `<kind>:<reason>`.
+ *
+ * CUMULATIVE for the process — a caller wanting per-window figures must diff
+ * against its own previous read, which is what the anomaly digest already does for
+ * its other health counters. Returning a copy so a reader cannot mutate the source.
+ */
+export function readRecountDeferrals(): Record<string, number> {
+  return Object.fromEntries(tallies)
+}
+
+/** Test-only. */
+export function resetRecountDeferralsForTesting(): void {
+  tallies.clear()
+}


### PR DESCRIPTION
`recomputeUnreadForRoom` and `recomputeUnreadForConversation` are a chain of about twenty guards, most of which defer rather than risk a wrong number. Each is right on its own, but from outside the store they are indistinguishable: the badge keeps its old value and nothing says which guard stood down.

That gap is issue #1211 — a MUC badge stays up while its room is open and clears only on switching away. Two guards are plausible causes, a missing coverage record and an arrival bumping the unread input version mid-recount, and neither is observable, so the bug cannot be attributed without guessing.

Each guard now tallies a named reason, exposed read-only as `readRecountDeferrals()` and folded into the anomaly digest as per-window deltas under `recount.deferred.<chat|room>.<reason>`. Paired with the existing `read-state/unread-survives-focus` record, which says the badge *was* wrong, these say why the correction never landed.