### PR TITLE
refactor(read-state): consolidate the pointerlessDefers guards to one snapshot (#1174)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-read-state-b-unread-count-derivation.md
+++ b/docs/superpowers/plans/2026-07-23-read-state-b-unread-count-derivation.md
@@ -431,15 +431,17 @@ it('removeTransient reports whether anything was removed', () => {
 
 **The derivation:**
 1. **Discard the legacy count.** At every site that calls `recomputeCountsFromPointer`, keep its `readPointer` (and its guard behavior) but **do not write its `unreadCount`/`mentionsCount`**. This is what makes `deferred` preserve the last *trusted* value rather than a provisional one.
-2. Bump a **per-entity recount version** (`recountVersion.set(id, v+1)`) and capture `v` before any await.
-3. Defer conditions: un-migrated legacy read state **or** pending remote marker ⇒ `deferred`; `pointerlessDefers(readPointer, unreadCount)` ⇒ `deferred`.
-4. `floor = computeFloor(readPointer, historyFloor)`; `!floor` ⇒ `deferred`.
-5. Coverage: `if (!isCaughtUpForCounting(mam)) return deferred`; `bottom = await resolveCoverageBottom(...)`; `'missing'` ⇒ `deferred`; `'unresolvable'` ⇒ invalidate the record + `deferred`; `compareOrder(bottom, floorPos) > 0` ⇒ `deferred`.
-6. `res = await countUnreadInArchive(id, { floor, pointer: readPointer })`; `null` ⇒ `unavailable`.
-7. **Latest-wins commit:** re-read the version; if `recountVersion.get(id) !== v`, **discard** (a newer recount owns the result). Otherwise:
+2. The current defer snapshot, guard cardinality, and recount-version ordering are owned by the
+   `Defer conditions` blocks in `chatStore.recomputeUnreadForConversation` and
+   `roomStore.recomputeUnreadForRoom`; this implementation plan is not authoritative for their
+   post-PR-B placement.
+3. `floor = computeFloor(readPointer, historyFloor)`; `!floor` ⇒ `deferred`.
+4. Coverage: `if (!isCaughtUpForCounting(mam)) return deferred`; `bottom = await resolveCoverageBottom(...)`; `'missing'` ⇒ `deferred`; `'unresolvable'` ⇒ invalidate the record + `deferred`; `compareOrder(bottom, floorPos) > 0` ⇒ `deferred`.
+5. `res = await countUnreadInArchive(id, { floor, pointer: readPointer })`; `null` ⇒ `unavailable`.
+6. **Latest-wins commit:** re-read the version; if `recountVersion.get(id) !== v`, **discard** (a newer recount owns the result). Otherwise:
    - `unreadCount = min(999, res.unread + transient.unread)` — commits unconditionally on `exact`.
    - **`mentionsCount` is NOT written.** Archive recounts never touch it — it stays on the live `+1` path, cleared only by explicit read / mark-read. See the Global Constraints for why (MAM never sets `isMention`, so a scan would zero a correctly live-counted mention).
-8. **Reconcile the divider.** Follow the authoritative repositioning and zero-count preservation
+7. **Reconcile the divider.** Follow the authoritative repositioning and zero-count preservation
    contract in the [acceptance
    spec](../specs/2026-07-23-read-state-unread-count-single-source-acceptance.md).
 

--- a/docs/superpowers/plans/2026-07-28-read-state-c-writer-restriction.md
+++ b/docs/superpowers/plans/2026-07-28-read-state-c-writer-restriction.md
@@ -1452,9 +1452,9 @@ Update the module doc-comment's reference to `recomputeCountsFromPointer` (~line
 
 In `chatStore.recomputeUnreadForConversation`, delete the entire `--- Legacy guard pass ---`
 block: the `resident` / `slice` fetch, the `if (!recountContextIsCurrent()) return`, and the
-`if (slice.length > 0) { set(...) }`. **Keep** the `--- Defer conditions ---` block below it
-unchanged, and keep the `afterGuard` read (rename the local to `meta1` if you prefer, but do not
-change what it reads).
+`if (slice.length > 0) { set(...) }`. The current defer snapshot, guard cardinality, and
+recount-version ordering were superseded after this plan; their authoritative contract is the
+`Defer conditions` block in each recount implementation.
 
 `slice` is also used by the divider rederivation near the end of the function. Replace that use
 with the resident array:

--- a/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
+++ b/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
@@ -304,11 +304,12 @@ for no gain in correctness. This closes the second item carried from PR B's revi
 and the shared floor make the divider and the count answer the same question, but the count
 only *answers* it on an `exact` outcome. `recomputeUnreadForConversation` /
 `recomputeUnreadForRoom` stand down — leaving the persisted count in place — in each of these
-states, in this order:
+states. The implementations own the current check order:
 
 1. the entity is active and the caller did not pass `allowActive`;
-2. `pointerlessDefers` — no pointer *and* a non-zero persisted count. Checked **twice**: at
-   entry against the pre-await meta, and again against the freshly re-read meta;
+2. `pointerlessDefers`; its predicate is owned by `stores/shared/readState.ts`, while the
+   current snapshot and guard placement are owned by the `Defer conditions` blocks in the two
+   recount implementations;
 3. a pending inbound XEP-0490 marker (`pendingRemoteDisplayedStanzaId !== undefined`);
 4. `computeFloor` yields nothing — neither a pointer nor a `historyFloor`;
 5. MAM catch-up is not complete for the entity (`isCaughtUpForCounting`);
@@ -400,8 +401,8 @@ it, exactly two residual states could still reach it, and neither is protective:
   protection but an active defect — below.
 
 Every state in which a bare derived zero could not be trusted is still caught by
-`pointerlessDefers`, which is unconditional (`!pointer && persistedUnread > 0`) and runs both
-at entry and against the freshly re-read meta.
+`pointerlessDefers`. Its predicate is authoritative in `stores/shared/readState.ts`; the two
+recount implementations own its current snapshot and call placement.
 
 **The live bug it fixed.** `scheduleReadPointerBackfill` leaves an entry in its `pending` set
 whenever `migrateReadPointer` resolves nothing — a `lastSeenMessageId` the cache never held, or
@@ -419,8 +420,9 @@ it can never retire a legacy pair or move a read position.
 **Two invariants the analysis rests on**, both re-verified against the code:
 
 1. **`pointerlessDefers` covers every pointerless entity carrying a non-zero persisted count**,
-   unconditionally (no scope, coverage, or account qualifier) and at both check points. So
-   removing the legacy defer cannot expose a trusted count to a bare derived zero.
+   unconditionally (no scope, coverage, or account qualifier). The helper and the two recount
+   implementations are authoritative for its current predicate and call placement. Removing
+   the legacy defer therefore cannot expose a trusted count to a bare derived zero.
 2. **A pre-#1081 conversation's `historyFloor` never sits *behind* its legacy read position.**
    `historyFloor` and `readPointer` shipped in the same commit (`baa1601b`), so no pre-#1081
    blob carries a floor at all; restore never invents one (`deserializeState` reads only what

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -450,6 +450,10 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     seedCoverage('anchor-stanza')
     setMeta({ unreadCount: 6, readPointer: undefined, historyFloor: new Date(500) })
 
+    // Cleared right before the controlled call so the rehydrate fixture's own
+    // cold-start recount — which defers at this same guard — cannot be mistaken
+    // for the deferral this test asserts.
+    resetRecountDeferralsForTesting()
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
@@ -457,6 +461,12 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // the derivation before it ever reads the archive, not merely produce a
     // count that happens to match the seed.
     expect(vi.mocked(messageCache.countUnreadInArchive)).not.toHaveBeenCalled()
+    // #1174 + #1214: proves the `pointerless-defer` reason is still emitted,
+    // and still reachable, now that the duplicate guard is gone. (It does NOT
+    // pin the number of call sites: a guard that returns emits once whether
+    // there is one copy or two. What makes the single site matter is that the
+    // reason now has exactly one origin, so a recorded defer is unambiguous.)
+    expect(readRecountDeferrals()['chat:pointerless-defer']).toBe(1)
   })
 
   // #1174: this used to seed `historyFloor: new Date(0)` against a coverage
@@ -487,6 +497,12 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // derivation before it ever reads the archive, not merely produce a count
     // that happens to match the seed.
     expect(vi.mocked(messageCache.countUnreadInArchive)).not.toHaveBeenCalled()
+    // #1174 + #1214: proves the `pointerless-defer` reason is still emitted,
+    // and still reachable, now that the duplicate guard is gone. (It does NOT
+    // pin the number of call sites: a guard that returns emits once whether
+    // there is one copy or two. What makes the single site matter is that the
+    // reason now has exactly one origin, so a recorded defer is unambiguous.)
+    expect(readRecountDeferrals()['chat:pointerless-defer']).toBe(1)
   })
 
   // The reviewer's control (requirement 1), rewritten for PR C's D6 deletion.

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -372,7 +372,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // pointer, for the rest of the session.
   //
   // Nothing else in the chain can produce the asserted 2: the pointer is real
-  // (so neither `pointerlessDefers` check fires and `computeFloor` has a floor),
+  // (so the `pointerlessDefers` check does not fire and `computeFloor` has a floor),
   // `pendingRemoteDisplayedStanzaId` is unset, the conversation is not active,
   // and coverage is caught-up AND resolvable to a row BELOW the floor. Any
   // surviving defer would leave the sharply different persisted 7 in place.

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -953,8 +953,8 @@ function scheduleReadPointerBackfill(
         // `historyFloor`. That is NOT the common case here, though: this backfill
         // only ever enqueues pointerless conversations, and a pre-#1081 restore
         // typically carries a non-zero persisted `unreadCount`. For that shape,
-        // `pointerlessDefers` stands the recount down at entry, before
-        // `historyFloor` is ever consulted, and the badge stays stale until the
+        // `pointerlessDefers` stands the recount down before `historyFloor` is
+        // ever consulted, and the badge stays stale until the
         // pointer itself resolves. With a persisted zero (or no floor at all),
         // `if (!floor) return` defers it too, as it does everywhere.
         //
@@ -2544,21 +2544,60 @@ export const chatStore = createStore<ChatState>()(
         // (FIX 3: a remote XEP-0490 advance on the active entity, which that
         // convergence path never runs for).
         if (!allowActive && get().activeConversationId === conversationId) return defer('active-skipped')
-        const meta0 = get().conversationMeta.get(conversationId)
-        if (!meta0) return defer('no-meta')
 
+        // --- Defer conditions ---------------------------------------------
+        //
+        // ONE snapshot, read once, and every defer below decided against it —
+        // the same object the derivation itself computes from. Do NOT add a
+        // second `get()` and a second copy of a guard up here (#1174). Two
+        // reads make "which snapshot did we check?" answerable two ways, and
+        // they make each copy unfalsifiable: both read the same state and
+        // evaluate the same pure predicate, so disabling one leaves the other
+        // deferring and the whole suite green. With one read, deleting the
+        // guard fails a test.
+        //
+        // The duplicate this replaced was justified as being "the correct check
+        // the moment anything above it starts to await". That was not true:
+        // both copies sat on the same side of every await, so the duplication
+        // straddled nothing — it bought a coincidence, not a defence.
+        //
+        // Every guard here still sits ABOVE the first await
+        // (`resolveCoverageBottom` below), so nothing can move underneath them
+        // while they run. State that moves AFTER them is caught on the far side
+        // by `recountContextDeferral()` and by the `pointerIdAtCompute`
+        // re-check at the final commit. That is where a post-await guard
+        // belongs — so if an await is ever inserted above this block, the fix
+        // is a re-check after THAT await, not a second copy on this side.
+        //
+        // One guard also means ONE emission site for the `pointerless-defer`
+        // reason (#1214), so a recorded pointerless defer is unambiguous about
+        // which check produced it.
+        //
         // Pointerless-with-a-trusted-nonzero-count stands down: a bare zero
         // derived for an entity that has never established a read position
         // cannot be told apart from a real "all read", and the count it would
-        // overwrite was accumulated live. Checked against the state as it
-        // stood at entry, before any awaits. Repeated below — see the
-        // "Defer conditions" comment there before breaking either copy.
-        if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return defer('pointerless-defer')
+        // overwrite was accumulated live.
+        //
+        // This derivation NEVER writes the read pointer (read-state PR C, D6).
+        // The pointer-writing recount that used to run here — snapping a
+        // pointerless entity to the newest message, and advancing the pointer
+        // onto any outgoing message in range — is gone: both were inferences
+        // about what the user had read, and the pointer is forward-only, so a
+        // wrong inference is unrecoverable. A pointerless entity now counts
+        // from its `historyFloor` creation watermark, and a cross-device reply
+        // moves the read position only through XEP-0490.
+        const metaNow = get().conversationMeta.get(conversationId)
+        if (!metaNow) return defer('no-meta')
+        if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
+        if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
-        // Latest-wins (requirement 3): bumped before the first await and
-        // re-checked immediately before every commit below, so a slow recount
-        // that resolves after a faster, newer one for the SAME conversation is
-        // discarded instead of overwriting the newer (correct) result.
+        // Latest-wins (requirement 3): bumped once this call is committed to
+        // running — AFTER the defers above, so a call that stands down cannot
+        // cancel a recount already in flight for the same conversation — and
+        // still before the first await, then re-checked immediately before
+        // every commit below, so a slow recount that resolves after a faster,
+        // newer one for the SAME conversation is discarded instead of
+        // overwriting the newer (correct) result.
         const version = bumpChatRecountVersion(conversationId)
         const cacheEpochAtStart = chatCacheEpoch
         const storageScopeAtStart = getStorageScopeJid()
@@ -2573,38 +2612,6 @@ export const chatStore = createStore<ChatState>()(
           }
           return undefined
         }
-
-        // --- Defer conditions ---------------------------------------------
-        //
-        // `metaNow` re-reads state that `meta0` above already read, and today
-        // that re-read is REDUNDANT: everything between the two `get()` calls is
-        // synchronous, so both see the same state. (The `await
-        // messageCache.getMessages` that once justified re-reading lived in the
-        // guard pass deleted in PR C.) That applies to `pointerlessDefers` and
-        // to `pendingRemoteDisplayedStanzaId` alike — neither flag has anything
-        // to change across.
-        //
-        // Kept deliberately, as belt and braces: these are the correct checks
-        // the moment anything above them starts to await, and deleting them
-        // would turn that future insertion into a silent correctness change.
-        //
-        // CONSEQUENCE FOR VERIFICATION: a deliberate break of ONE
-        // `pointerlessDefers` check is UNFALSIFIABLE — the other copy still
-        // defers and the suite stays green. Any break-check of that guard must
-        // disable BOTH (the entry check and this one) at the same time.
-        //
-        // This derivation NEVER writes the read pointer (read-state PR C, D6).
-        // The pointer-writing recount that used to run here — snapping a
-        // pointerless entity to the newest message, and advancing the pointer
-        // onto any outgoing message in range — is gone: both were inferences
-        // about what the user had read, and the pointer is forward-only, so a
-        // wrong inference is unrecoverable. A pointerless entity now counts
-        // from its `historyFloor` creation watermark, and a cross-device reply
-        // moves the read position only through XEP-0490.
-        const metaNow = get().conversationMeta.get(conversationId)
-        if (!metaNow) return defer('no-meta')
-        if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
-        if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
         // final-fix-2: snapshot the pointer identity the archive-derived
         // count below is computed AGAINST. Re-checked at the final commit

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -391,6 +391,12 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // derivation before it ever reads the archive, not merely produce a count
     // that happens to match the seed.
     expect(vi.mocked(messageCache.countRoomUnreadInArchive)).not.toHaveBeenCalled()
+    // #1174 + #1214: proves the `pointerless-defer` reason is still emitted,
+    // and still reachable, now that the duplicate guard is gone. (It does NOT
+    // pin the number of call sites: a guard that returns emits once whether
+    // there is one copy or two. What makes the single site matter is that the
+    // reason now has exactly one origin, so a recorded defer is unambiguous.)
+    expect(readRecountDeferrals()['room:pointerless-defer']).toBe(1)
   })
 
   // The reviewer's control (requirement 1, mirrored from Task 7), rewritten

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -366,7 +366,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // anchor at t=500, which put the coverage bottom ABOVE the floor — so
   // `isAfterBoundary` deferred the recount before `pointerlessDefers` could
   // matter, and the surviving count proved the coverage gate had fired, not
-  // the guard. Both room `pointerlessDefers` call sites could be deleted with
+  // the guard — every room `pointerlessDefers` call site could be deleted with
   // this test still green. The coverage-gate branch it was really exercising
   // already has its own unambiguous test ("a resolved coverage bottom sitting
   // above the floor defers"), so this one is repaired to test what it names:

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -366,10 +366,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // anchor at t=500, which put the coverage bottom ABOVE the floor — so
   // `isAfterBoundary` deferred the recount before `pointerlessDefers` could
   // matter, and the surviving count proved the coverage gate had fired, not
-  // the guard — every room `pointerlessDefers` call site could be deleted with
-  // this test still green. The coverage-gate branch it was really exercising
-  // already has its own unambiguous test ("a resolved coverage bottom sitting
-  // above the floor defers"), so this one is repaired to test what it names:
+  // the guard — both former room `pointerlessDefers` call sites could be deleted
+  // with this test still green. The coverage-gate branch it was really
+  // exercising already has its own unambiguous test ("a resolved coverage
+  // bottom sitting above the floor defers"), so this one is repaired to test
+  // what it names:
   // the bottom (400) now sits BELOW the floor (500), leaving the guard as the
   // ONLY thing that can stand this recount down. Counterpart to chatStore's
   // "NONZERO persisted count still defers via pointerlessDefers".

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2348,55 +2348,39 @@ export const roomStore = createStore<RoomState>()(
     // race, UNLESS the caller explicitly opted in (FIX 3: a remote XEP-0490
     // advance on the active room, which that convergence path never runs for).
     if (!allowActive && get().activeRoomJid === roomJid) return defer('active-skipped')
-    const meta0 = get().roomMeta.get(roomJid)
-    if (!meta0) return defer('no-meta')
-
-    // Pointerless-with-a-trusted-nonzero-count stands down — see chatStore's
-    // `recomputeUnreadForConversation` for the full rationale (mirrored here
-    // verbatim): a bare zero derived for a room that has never established a
-    // read position cannot be told apart from a real "all read". Checked
-    // against the state as it stood at entry, before any awaits. Repeated
-    // below — see the "Defer conditions" comment there before breaking either
-    // copy.
-    if (pointerlessDefers(meta0.readPointer, meta0.unreadCount)) return defer('pointerless-defer')
-
-    // Latest-wins (requirement 3): bumped before the first await and
-    // re-checked immediately before every commit below, so a slow recount
-    // that resolves after a faster, newer one for the SAME room is discarded
-    // instead of overwriting the newer (correct) result.
-    const version = bumpRoomRecountVersion(roomJid)
-    const cacheEpochAtStart = roomCacheEpoch
-    const storageScopeAtStart = getStorageScopeJid()
-    const unreadInputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
-    const recountContextDeferral = (): RecountDeferralReason | undefined => {
-      if (roomCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
-        return 'context-changed'
-      }
-      if (roomRecountVersion.get(roomJid) !== version) return 'recount-superseded'
-      if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtStart) {
-        return 'input-version-changed'
-      }
-      return undefined
-    }
 
     // --- Defer conditions -----------------------------------------------
     //
-    // `metaNow` re-reads state that `meta0` above already read, and today that
-    // re-read is REDUNDANT: everything between the two `get()` calls is
-    // synchronous, so both see the same state. (The `await
-    // messageCache.getMessages` that once justified re-reading lived in the
-    // guard pass deleted in PR C.) That applies to `pointerlessDefers` and to
-    // `pendingRemoteDisplayedStanzaId` alike — neither flag has anything to
-    // change across.
+    // ONE snapshot, read once, and every defer below decided against it — the
+    // same object the derivation itself computes from. Do NOT add a second
+    // `get()` and a second copy of a guard up here (#1174). Two reads make
+    // "which snapshot did we check?" answerable two ways, and they make each
+    // copy unfalsifiable: both read the same state and evaluate the same pure
+    // predicate, so disabling one leaves the other deferring and the whole
+    // suite green. With one read, deleting the guard fails a test.
     //
-    // Kept deliberately, as belt and braces: these are the correct checks the
-    // moment anything above them starts to await, and deleting them would turn
-    // that future insertion into a silent correctness change.
+    // The duplicate this replaced was justified as being "the correct check the
+    // moment anything above it starts to await". That was not true: both copies
+    // sat on the same side of every await, so the duplication straddled nothing
+    // — it bought a coincidence, not a defence.
     //
-    // CONSEQUENCE FOR VERIFICATION: a deliberate break of ONE
-    // `pointerlessDefers` check is UNFALSIFIABLE — the other copy still defers
-    // and the suite stays green. Any break-check of that guard must disable
-    // BOTH (the entry check and this one) at the same time.
+    // Every guard here still sits ABOVE the first await
+    // (`resolveCoverageBottom` below), so nothing can move underneath them
+    // while they run. State that moves AFTER them is caught on the far side by
+    // `recountContextDeferral()` and by the `pointerIdAtCompute` re-check at
+    // the final commit. That is where a post-await guard belongs — so if an
+    // await is ever inserted above this block, the fix is a re-check after THAT
+    // await, not a second copy on this side.
+    //
+    // One guard also means ONE emission site for the `pointerless-defer` reason
+    // (#1214), so a recorded pointerless defer is unambiguous about which check
+    // produced it.
+    //
+    // Pointerless-with-a-trusted-nonzero-count stands down — see chatStore's
+    // `recomputeUnreadForConversation` for the full rationale (mirrored here
+    // verbatim): a bare zero derived for a room that has never established a
+    // read position cannot be told apart from a real "all read", and the count
+    // it would overwrite was accumulated live.
     //
     // This derivation NEVER writes the read pointer (read-state PR C, D6).
     // The pointer-writing recount that used to run here — snapping a
@@ -2411,6 +2395,27 @@ export const roomStore = createStore<RoomState>()(
     if (!metaNow) return defer('no-meta')
     if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
     if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
+
+    // Latest-wins (requirement 3): bumped once this call is committed to
+    // running — AFTER the defers above, so a call that stands down cannot
+    // cancel a recount already in flight for the same room — and still before
+    // the first await, then re-checked immediately before every commit below,
+    // so a slow recount that resolves after a faster, newer one for the SAME
+    // room is discarded instead of overwriting the newer (correct) result.
+    const version = bumpRoomRecountVersion(roomJid)
+    const cacheEpochAtStart = roomCacheEpoch
+    const storageScopeAtStart = getStorageScopeJid()
+    const unreadInputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
+    const recountContextDeferral = (): RecountDeferralReason | undefined => {
+      if (roomCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
+        return 'context-changed'
+      }
+      if (roomRecountVersion.get(roomJid) !== version) return 'recount-superseded'
+      if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtStart) {
+        return 'input-version-changed'
+      }
+      return undefined
+    }
 
     // final-fix-2: snapshot the pointer identity the archive-derived count
     // below is computed AGAINST. Re-checked at the final commit (see that


### PR DESCRIPTION
Both unread recount paths read the store twice and evaluated `pointerlessDefers` against each read. The two reads were separated by nothing but synchronous code, so they always saw the same object and the two guards always agreed — which made a deliberate break of either one unfalsifiable: disable one and the other still defers, leaving the suite green.

No behavioural test can close that gap, because there is no state in which the two copies disagree. The redundancy *is* what makes the check unenforceable, so this removes the redundancy rather than adding a check.

The justification the code gave for keeping both copies does not survive inspection. It claimed they would become the correct checks "the moment anything above them starts to await" — but both copies sat on the same side of every await; the first is `resolveCoverageBottom`, well below them. The duplication straddled nothing. It bought a coincidence, not a defence.

## What changed

Mirrored on `recomputeUnreadForConversation` and `recomputeUnreadForRoom`:

- Deleted the `meta0` read and the entry `pointerlessDefers` guard.
- Moved the recount version bump, the epoch/scope/input-version snapshots and the `recountContextIsCurrent` closure below the surviving guards.

Net: one `get()`, one snapshot, one guard, evaluated against exactly the object the derivation computes from. "Which snapshot did we check?" no longer has two answers.

`recountContextIsCurrent()` and the pointer-identity re-check at the final commit are untouched — those are what actually protect against state moving after the guards, and the comment block now says so, including where a post-await guard belongs if an await is ever inserted above the block.

## Behaviour change

Moving the version bump below the defers means **a call that stands down no longer cancels a recount already in flight** for the same conversation or room. Concretely this is the `pendingRemoteDisplayedStanzaId` defer — the pointerless defer already stood down above the bump, so it never bumped.

That cancellation was a side effect of where the bump happened to sit, not a designed invalidation. An in-flight recount is still discarded whenever the cache epoch, storage scope, recount version or unread-input version moves.

## Falsifiability, verified by breaking it

Each store now has exactly one `pointerlessDefers` call site, and removing it fails a test — which it did not before:

| Break | Result |
|---|---|
| chat guard removed | `un-migrated legacy read state with a NONZERO persisted count still defers via pointerlessDefers` fails (`expected 3 to be 6`), as does `a pointerless conversation with a nonzero persisted count defers at pointerlessDefers, not at the coverage gate` |
| room guard removed | `a pointerless room with a nonzero persisted count defers at pointerlessDefers, not at the coverage gate` fails (`expected 3 to be 6`) |

Closes #1174

## Rebased onto #1214

#1214 landed while this was validating and added `defer(...)` reason recording at both guard sites. Resolved toward it: the entry guard is deleted **including** its `defer('pointerless-defer')` call, the surviving `metaNow` guard keeps its own, and the relocated block adopts #1214's `recountContextDeferral()` in place of the old `recountContextIsCurrent()`.

Two things worth stating rather than assuming.

**No test in #1214 exercised the entry guard.** Its new assertions cover `coverage-unresolvable`, `recount-superseded`, `context-changed`, `input-version-changed` and `pointer-changed`. `pointerless-defer` had no assertion anywhere in the repo — it appeared only at the four guard sites, the reason union, the app allow-list and the docs table. So nothing was relying on the entry guard, and nothing now passes by coincidence for having been silently redirected to the surviving one.

**The reason is still emitted and still reachable**, and that is now tested rather than asserted in prose. The three tests that reach the guard assert `pointerless-defer` on both paths. The tallies were checked against main's duplicate-guard code and are identical (the chat rehydrate fixture runs its own cold-start recount that defers at the same guard, so that test clears the counter immediately before the controlled call), which confirms the consolidation changes the diagnostic's output not at all.

This is the one improvement #1214 could not get on its own: with a single guard, `pointerless-defer` has exactly **one** emission site, so a recorded pointerless defer is no longer ambiguous about which check produced it. Note the assertions do not *pin* the site count — a guard that returns emits once whether there are one or two copies — which is precisely why the structure, not a test, is what makes this unambiguous.

Falsifiability was re-proven on the rebased tree: one guard per store, and commenting it out fails the same three tests (`expected 3 to be 6`).
