### PR TITLE
feat: report entity warming that keeps failing

### DIFF
--- a/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
@@ -10,6 +10,23 @@ import type { AnomalySignal } from '../../utils/anomalySignal'
 
 /** The prose the monitors emit is not tested here — see each monitor's own suite. */
 describe('recordForSignal', () => {
+  it('maps a persistent warm failure as recorder health, carrying the run length', () => {
+    const record = recordForSignal({
+      name: 'recorder/entity-warm-failing',
+      consecutiveFailures: 7,
+    })
+
+    expect(record?.id.s).toBe('recorder/entity-warm-failing')
+    // `suspect`, not `bug`: the client is fine, the LOG is degraded — records are
+    // still written, they just name no entity.
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(0)
+    expect(record?.observed).toBe(7)
+    // No ctx on purpose: the only context worth having is which conversation, and
+    // its token is exactly what is failing to resolve.
+    expect(record?.ctx).toEqual([])
+  })
+
   it('maps an overlap to a bug against the healthy count, not the threshold', () => {
     const record = recordForSignal({
       name: 'scroll/reassert-overlap',
@@ -169,6 +186,7 @@ describe('every fan-out record survives the privacy gate', () => {
   })
 
   const SIGNALS: AnomalySignal[] = [
+    { name: 'recorder/entity-warm-failing', consecutiveFailures: 3 },
     { name: 'scroll/reassert-overlap', active: 2, threshold: 2 },
     { name: 'scroll/reassert-nonconverging', label: 'marker', writes: 41, threshold: 40 },
     { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },
@@ -458,6 +476,7 @@ describe('FANOUT_IDS', () => {
     const produced = new Set(
       (
         [
+          { name: 'recorder/entity-warm-failing', consecutiveFailures: 3 },
           { name: 'scroll/reassert-overlap', active: 2, threshold: 2 },
           { name: 'scroll/reassert-nonconverging', label: 'marker', writes: 41, threshold: 40 },
           { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },

--- a/apps/fluux/src/anomaly/detectors/signalRecords.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.ts
@@ -131,6 +131,21 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
         ctx: [],
       }
 
+    case 'recorder/entity-warm-failing':
+      // About the LOG, not the app — hence the `recorder/` family. Records are still
+      // being written for this conversation; they simply name `c:unresolved` and
+      // cannot be correlated, so the instrument is degraded rather than the client.
+      //
+      // No ctx: the only context worth having is which conversation, and the token
+      // for it is precisely what is failing to resolve.
+      return {
+        id: ID.entityWarmFailing,
+        sev: 'suspect',
+        expected: 0,
+        observed: signal.consecutiveFailures,
+        ctx: [],
+      }
+
     case 'read-state/unread-survives-focus':
       // `suspect`, not `bug`, on its first outing: the app marks read on focus
       // regain, so a count lingering for the hold window is more likely a
@@ -234,6 +249,7 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
  * being unreachable — a registry row for something that can never appear.
  */
 export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
+  ID.entityWarmFailing,
   ID.reassertOverlap,
   ID.reassertNonConverging,
   ID.resizeLoop,

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -15,9 +15,21 @@ import {
   registerViewportBottomRef,
 } from '../../utils/viewportAtBottom'
 import { initTokenizer, resetValuesForTesting, tokenSync } from '../values'
+import { warmConversation, warmRoom } from '../identity'
 import { recordForSignal } from './signalRecords'
 
 const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
+
+// The warm is the only thing these suites stub: a rejection is otherwise reachable
+// only by breaking WebCrypto itself.
+vi.mock('../identity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../identity')>()
+  return {
+    ...actual,
+    warmConversation: vi.fn(actual.warmConversation),
+    warmRoom: vi.fn(actual.warmRoom),
+  }
+})
 
 /** A world in the failing state for both timed detectors. */
 function world(overrides: Partial<TickWorld> = {}): TickWorld {
@@ -322,5 +334,130 @@ describe('browserWorld readings', () => {
       document.body.appendChild(wrapper)
     }
     expect(w.fabShown()).toBe(true)
+  })
+})
+
+describe('entity warming that keeps failing', () => {
+  // `warmToken` is a no-op before the tokenizer holds its key, and the tick skips the
+  // whole block until then — so anything reaching the catch is a genuine crypto
+  // failure, not startup. The retry is correct and stays; what was missing is any
+  // way to know it is happening. Records keep being written for the conversation,
+  // they simply name `c:unresolved` forever and nothing says why.
+
+  const FAILING = { kind: 'conversation' as const, id: 'warm-fails@x.tld' }
+
+  beforeEach(async () => {
+    // Restore REAL warming before each case. A `mockRejectedValue` set by one test
+    // otherwise leaks into the next, and the control below — the one asserting
+    // silence on a healthy session — would then be passing or failing for reasons
+    // that have nothing to do with the code under test.
+    const actual = await vi.importActual<typeof import('../identity')>('../identity')
+    vi.mocked(warmConversation).mockImplementation(actual.warmConversation)
+    vi.mocked(warmRoom).mockImplementation(actual.warmRoom)
+  })
+
+  /** A tick whose warm always rejects. */
+  function failingTick(): ReturnType<typeof startDetectorTick> {
+    vi.mocked(warmConversation).mockRejectedValue(new Error('subtle.sign failed'))
+    return startDetectorTick(
+      world({
+        activeConversation: () => FAILING,
+        // Healthy on every other axis, so nothing else can report.
+        unreadCount: () => 0,
+        fabShown: () => false,
+      }),
+    )
+  }
+
+  async function tick(t: ReturnType<typeof startDetectorTick>): Promise<void> {
+    t.sample()
+    await t.warmSettled()
+  }
+
+  it('stays silent below the threshold', async () => {
+    // A single hiccup must not cry wolf: crypto failures are likelier to arrive in
+    // correlated bursts than as isolated events.
+    await initTokenizer()
+    const t = failingTick()
+    await tick(t)
+    await tick(t)
+    t.stop()
+
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toEqual([])
+  })
+
+  it('reports once the failures are consecutive and sustained', async () => {
+    await initTokenizer()
+    const t = failingTick()
+    await tick(t)
+    await tick(t)
+    await tick(t)
+    t.stop()
+
+    const reports = seen.filter((s) => s.name === 'recorder/entity-warm-failing')
+    expect(reports).toHaveLength(1)
+    expect(reports[0]).toMatchObject({ consecutiveFailures: 3 })
+  })
+
+  it('reports once per episode, not once per tick', async () => {
+    // Latched. The recorder's per-id cooldown would coalesce repeats anyway, but a
+    // coalesced repeat still counts as a suppression, which would read as frequency
+    // information this signal does not have.
+    await initTokenizer()
+    const t = failingTick()
+    for (let i = 0; i < 10; i++) await tick(t)
+    t.stop()
+
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toHaveLength(1)
+  })
+
+  it('reports again after a recovery and a fresh run of failures', async () => {
+    // The latch must not be permanent, or a second outage in the same session is
+    // invisible.
+    await initTokenizer()
+    let failing = true
+    vi.mocked(warmConversation).mockImplementation(async () => {
+      if (failing) throw new Error('subtle.sign failed')
+    })
+    const t = startDetectorTick(
+      world({
+        activeConversation: () => (failing ? FAILING : { kind: 'conversation', id: 'ok@x.tld' }),
+        unreadCount: () => 0,
+        fabShown: () => false,
+      }),
+    )
+    for (let i = 0; i < 3; i++) await tick(t)
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toHaveLength(1)
+
+    failing = false
+    await tick(t) // succeeds -> resets the run and the latch
+
+    failing = true
+    for (let i = 0; i < 3; i++) await tick(t)
+    t.stop()
+
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toHaveLength(2)
+  })
+
+  it('says nothing at all when warming always succeeds', async () => {
+    // THE control. This signal is being added to find out whether the failure ever
+    // happens in the field, so its silence has to be trustworthy: a healthy session
+    // must produce nothing, or the answer is unreadable.
+    await initTokenizer()
+    const t = startDetectorTick(world({ unreadCount: () => 0, fabShown: () => false }))
+    for (let i = 0; i < 10; i++) await tick(t)
+    t.stop()
+
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toEqual([])
+  })
+
+  it('stays silent before the tokenizer is ready, however long that takes', async () => {
+    // Not a failure: the block is skipped entirely, so no attempt is made and none
+    // can fail. Startup must never look like an outage.
+    const t = failingTick()
+    for (let i = 0; i < 10; i++) await tick(t)
+    t.stop()
+
+    expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toEqual([])
   })
 })

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -30,6 +30,18 @@ import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
 const TICK_MS = 1000
 const MAX_SAMPLE_GAP_TICKS = 5
 
+/**
+ * Consecutive warm failures before the condition is reported.
+ *
+ * Startup is already excluded — the block below is skipped entirely until the
+ * tokenizer holds its key — so anything reaching the catch is a real
+ * `crypto.subtle` failure rather than a not-yet. Three ticks is three seconds: long
+ * enough that one hiccup stays silent, short enough to still be reported while the
+ * session is alive. A higher number would buy nothing, since the latch means a
+ * sustained outage reports once either way.
+ */
+const WARM_FAILURE_THRESHOLD = 3
+
 /** The FAB's marker attribute, shared with the scroll e2e suite. */
 const FAB_SELECTOR = '[data-fab="scroll-to-bottom"]'
 
@@ -129,6 +141,18 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
   let warmInFlight: string | null = null
   /** The most recent warm, so a test can await exactly what it started. */
   let pendingWarm: Promise<void> = Promise.resolve()
+  /**
+   * Warms that have failed back to back.
+   *
+   * The retry is deliberate and stays; what this adds is knowing it is happening. A
+   * warm that keeps failing leaves every record for the conversation naming
+   * `c:unresolved` — present, but impossible to correlate — and until now nothing
+   * said so. Nobody knows whether this occurs in the field, because nothing would
+   * have reported it, so the first thing the signal buys is finding out.
+   */
+  let consecutiveWarmFailures = 0
+  /** Reported for the current run of failures; cleared by the next success. */
+  let warmFailureReported = false
 
   function sample(): void {
     const now = world.now()
@@ -148,10 +172,25 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
         pendingWarm = (active.kind === 'room' ? warmRoom(active.id) : warmConversation(active.id))
           .then(() => {
             warmedFor = target
+            // A success ends the run, so a LATER outage in the same session is
+            // reported again rather than being swallowed by a stale latch.
+            consecutiveWarmFailures = 0
+            warmFailureReported = false
           })
           .catch(() => {
-            // Swallowed so a failed warm cannot surface as an unhandled rejection.
-            // `warmedFor` stays unset, so the next tick retries.
+            // Still swallowed so a failed warm cannot surface as an unhandled
+            // rejection, and `warmedFor` stays unset so the next tick retries. What
+            // changes is that the failure is no longer invisible.
+            consecutiveWarmFailures++
+            if (!warmFailureReported && consecutiveWarmFailures >= WARM_FAILURE_THRESHOLD) {
+              warmFailureReported = true
+              // `signalAnomaly` contains its own throw, so a handler fault cannot
+              // re-enter this chain as a rejection.
+              signalAnomaly({
+                name: 'recorder/entity-warm-failing',
+                consecutiveFailures: consecutiveWarmFailures,
+              })
+            }
           })
           .finally(() => {
             if (warmInFlight === target) warmInFlight = null

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -110,6 +110,7 @@ export const TAG = Object.freeze({
 export const ID = Object.freeze({
   sessionStart: mint('recorder/session-start', 'id'),
   ceilingReached: mint('recorder/ceiling-reached', 'id'),
+  entityWarmFailing: mint('recorder/entity-warm-failing', 'id'),
   reassertOverlap: mint('scroll/reassert-overlap', 'id'),
   reassertNonConverging: mint('scroll/reassert-nonconverging', 'id'),
   resizeLoop: mint('scroll/resize-loop', 'id'),

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -70,6 +70,11 @@ export type AnomalySignal =
       thresholdMs: number
     }
   | {
+      name: 'recorder/entity-warm-failing'
+      /** How many warms in a row had failed when this was reported. */
+      consecutiveFailures: number
+    }
+  | {
       name: 'read-state/unread-survives-focus'
       /** Which conversation, so the record adapter can use the right token namespace. */
       kind: 'conversation' | 'room'

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -33,6 +33,7 @@ These describe the recorder itself, not the app.
 |---|---|---|
 | `recorder/session-start` | One per session, written once the tokenizer holds its key | Its absence means the runtime never installed. Its `tokenKeyId` opens the session's token space |
 | `recorder/ceiling-reached` | 500 records or 2 MB in one session; recording stopped | Something fired in a loop. Find the last repeated `id` before it |
+| `recorder/entity-warm-failing` | Entity tokenisation has failed `observed` times in a row. Records for that conversation are still written but name `c:unresolved`, so they cannot be correlated | The tokenizer holds its key (startup is excluded), so this is a real `crypto.subtle` failure. Reported once per episode and again only after a recovery — its absence is meaningful |
 
 Counter names (digest only, not invariant ids):
 

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -396,10 +396,9 @@ Cost accepted: a `LocalRef` does not correlate across sessions. For message and 
 is the correct scope anyway — cross-session correlation of a single stanza is not a question the
 review asks. Entity identity keeps cross-session stability via `Token`.
 
-**`c:unresolved` remains possible only for the entity class** — a genuinely new JID recorded in the
-same tick it is first observed. It is rare rather than routine, counted as
-`recorder/token-unresolved`, and the review skill **must never correlate two `c:unresolved` values
-with each other**; they are explicitly not an identity.
+**`c:unresolved` remains possible only for the entity class.** Its current causes and recorder-health
+signals are owned by `docs/ANOMALY_INVARIANTS.md`. The review skill **must never correlate two
+`c:unresolved` values with each other**; they are explicitly not an identity.
 
 - **Key persistence:** 32 random bytes from `crypto.getRandomValues`, generated once and stored in
   `localStorage` under `fluux:anomaly-token-key`. Never derived from account identity, so the token
@@ -420,8 +419,8 @@ with each other**; they are explicitly not an identity.
   synchronous, so a background tokenizer subscribes to conversation, roster and room lifecycle
   events and populates a bounded LRU (`Map`, 500 entries, keyed by `ns + '\0' + value`) *ahead of
   use*. Crumb recording does a synchronous `Map.get`. A miss emits `c:unresolved` — never the raw
-  value — and schedules tokenization so later crumbs resolve. The ephemeral class bypasses this
-  entirely via `LocalRef`, which is why the sentinel stays rare.
+  value — and schedules tokenization so later crumbs can resolve. The ephemeral class bypasses this
+  entirely via `LocalRef`, keeping the sentinel scoped to entity-resolution misses.
 
 **Recursive serialization limits.** Max depth 2, max 50 array entries, applied in the serializer —
 belt-and-braces against a malformed record shape, not the privacy mechanism itself.

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -216,6 +216,7 @@ test.describe('anomaly runtime', () => {
 
     const detectorRecords = await page.evaluate(() => {
       const ids = new Set([
+        'recorder/entity-warm-failing',
         'read-state/unread-survives-focus',
         'scroll/fab-at-live-edge',
         'scroll/jump-target-miss',
@@ -230,6 +231,98 @@ test.describe('anomaly runtime', () => {
       detectorRecords,
       'a detector fired on a healthy demo session — it is miswired, not finding bugs',
     ).toEqual([])
+  })
+
+  test('a sustained entity-warm failure reaches the anomaly log', async ({ page }) => {
+    // Entity warming can fail in production only when WebCrypto itself rejects.
+    // Override that one operation before the app boots so the real detector,
+    // installer, recorder, serializer, and memory sink all remain in the path.
+    await page.addInitScript(() => {
+      const realSign = crypto.subtle.sign.bind(crypto.subtle)
+      Object.defineProperty(window, '__forcedHmacSignCalls', {
+        configurable: true,
+        value: 0,
+        writable: true,
+      })
+      Object.defineProperty(crypto.subtle, 'sign', {
+        configurable: true,
+        value(
+          algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+          key: CryptoKey,
+          data: BufferSource,
+        ) {
+          const name = typeof algorithm === 'string' ? algorithm : algorithm.name
+          if (name === 'HMAC') {
+            ;(window as unknown as { __forcedHmacSignCalls: number }).__forcedHmacSignCalls++
+            return Promise.reject(new Error('forced HMAC sign failure'))
+          }
+          return realSign(algorithm, key, data)
+        },
+      })
+    })
+
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    await openDemoRoom(page)
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __forcedHmacSignCalls: number }).__forcedHmacSignCalls,
+          ),
+        {
+          timeout: 15_000,
+          message: 'the browser never attempted three forced HMAC warm failures',
+        },
+      )
+      .toBeGreaterThanOrEqual(3)
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+              .map((line) => JSON.parse(line) as { id?: string })
+              .some((record) => record.id === 'recorder/entity-warm-failing'),
+          ),
+        {
+          timeout: 15_000,
+          message: 'the sustained warm failure never reached the anomaly log',
+        },
+      )
+      .toBe(true)
+
+    const record = await page.evaluate(
+      () =>
+        (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+          .find((candidate) => candidate.id === 'recorder/entity-warm-failing')!,
+    )
+
+    expect(record).toMatchObject({
+      kind: 'anomaly',
+      id: 'recorder/entity-warm-failing',
+      sev: 'suspect',
+      expected: 0,
+      observed: 3,
+      ctx: {},
+    })
+    expect(record.tokenKeyId).toMatch(/^[0-9a-f]{8}$/)
+    expect(record.sid).toBeTruthy()
   })
 
   test('the sampler is actually running, so the control above means something', async ({


### PR DESCRIPTION
Follow-up to the warm-latch fix in #1192. The retry contract there is deliberate and unchanged — this closes the observability gap it left, which was only visible *because* that fix made the failure path well-defined.

## The gap

A warm that fails for any reason other than "tokenizer not ready" retried once a second, indefinitely, and was reported nowhere. Detection kept working and records kept being written; they simply named `c:unresolved` for that conversation forever — present, but impossible to correlate, with nothing saying why.

In a system whose whole purpose is to surface silent problems, its own entity resolution failed silently.

## The signal

Three consecutive failures emit `recorder/entity-warm-failing` (`suspect`), with `observed` carrying the run length. Latched until a success, so a sustained outage reports once and a later one still reports again.

Startup cannot trigger it: the warm block is skipped entirely until the tokenizer holds its key, so anything reaching the catch is a real `crypto.subtle` failure rather than a not-yet.

The retry itself is untouched — `warmedFor` still stays unset, the rejection is still swallowed, no unhandled rejection is reintroduced.

## Why a record rather than a counter

Silence has to be trustworthy here. **Nobody knows whether this failure occurs in the field**, because nothing would have reported it — so the first thing this buys is not a repair, it is finding out whether the problem exists at all.

Zero records is a cleaner answer than zero in a digest counter, which arrives only every five minutes, sits among four siblings that are almost always zero, and may never flush at all in a short session that fails and exits.

`recorder/token-unresolved` did already move when this happened, but it also moves for the benign pre-warm race it was built for, under registry guidance saying "rare is fine" — the wrong instruction for exactly the sustained case. This reports the cause at the failure site instead of another symptom.

## Threshold

Three ticks is three seconds: long enough that a single hiccup stays silent, short enough to be reported while the session is alive. A higher number buys nothing, since the latch means a sustained outage reports once either way. It is a judgement with no field data behind it — which is the point — and cheap to change once there is some.

## Testing

An end-to-end check rejects HMAC signing before the app boots, so the whole real path is exercised: detector, installer, recorder, serializer and sink. The healthy-session control lists the new id too, so a session that never fails must still produce nothing.
