### PR TITLE
refactor(scroll): centralize directional history window coordination

### DIFF
--- a/apps/fluux/src/components/conversation/directionalHistoryWindowCoordinator.test.ts
+++ b/apps/fluux/src/components/conversation/directionalHistoryWindowCoordinator.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DirectionalHistoryWindowCoordinator,
+  type BeginDirectionalHistoryInput,
+} from './directionalHistoryWindowCoordinator'
+
+function input(
+  overrides: Partial<BeginDirectionalHistoryInput> = {},
+): BeginDirectionalHistoryInput {
+  return {
+    conversationId: 'room-a',
+    direction: 'older',
+    mode: 'automatic',
+    now: 1_000,
+    loaderAvailable: true,
+    loading: false,
+    historyComplete: false,
+    windowAtLiveEdge: true,
+    travelledAway: false,
+    capture: () => ({
+      anchorMessageId: 'message-8',
+      anchorOffsetFromTop: -12,
+      distanceFromBottom: 640,
+      firstMessageId: 'message-1',
+      messageCount: 20,
+    }),
+    ...overrides,
+  }
+}
+
+describe('DirectionalHistoryWindowCoordinator', () => {
+  it('owns the automatic cooldown while genuine boundary travel may bypass it', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(500)
+
+    const first = coordinator.begin(input())
+    const blocked = coordinator.begin(input({ now: 1_200 }))
+    const travelled = coordinator.begin(input({
+      now: 1_200,
+      travelledAway: true,
+    }))
+
+    expect(first.kind).toBe('started')
+    expect(blocked).toEqual({ kind: 'blocked', reason: 'cooldown' })
+    expect(travelled.kind).toBe('started')
+    if (travelled.kind === 'started') {
+      expect(travelled.clearTravel).toBe(true)
+      expect(travelled.snapshot.requestId).not.toBe(
+        first.kind === 'started' ? first.snapshot.requestId : -1,
+      )
+    }
+  })
+
+  it('owns direction-specific availability and explicit older-load eligibility', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(500)
+    let captures = 0
+
+    expect(coordinator.begin(input({
+      loaderAvailable: false,
+      capture: () => {
+        captures += 1
+        return input().capture()
+      },
+    }))).toEqual({
+      kind: 'blocked',
+      reason: 'unavailable',
+    })
+    expect(captures).toBe(0)
+    expect(coordinator.begin(input({ loading: true }))).toEqual({
+      kind: 'blocked',
+      reason: 'loading',
+    })
+    expect(coordinator.begin(input({ historyComplete: true }))).toEqual({
+      kind: 'blocked',
+      reason: 'history-complete',
+    })
+    expect(coordinator.begin(input({
+      direction: 'newer',
+      windowAtLiveEdge: true,
+    }))).toEqual({ kind: 'blocked', reason: 'live-edge' })
+
+    const explicit = coordinator.begin(input({
+      mode: 'explicit',
+      now: 10,
+    }))
+    expect(explicit.kind).toBe('started')
+    if (explicit.kind === 'started') {
+      expect(explicit.clearTravel).toBe(false)
+    }
+  })
+
+  it('blocks automatic older loads briefly after an applied restore', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(500)
+    const started = coordinator.begin(input())
+    expect(started.kind).toBe('started')
+    if (started.kind !== 'started') return
+
+    coordinator.markRestored(started.snapshot.requestId, 1_100)
+
+    expect(coordinator.begin(input({
+      now: 1_200,
+      travelledAway: true,
+    }))).toEqual({ kind: 'blocked', reason: 'recently-restored' })
+    expect(coordinator.begin(input({
+      now: 1_601,
+      travelledAway: true,
+    })).kind).toBe('started')
+  })
+
+  it('bounds a no-shift snapshot to the exact load that armed it', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(0)
+    coordinator.enterConversation('room-a', true)
+    const first = coordinator.begin(input({ mode: 'explicit', now: 1 }))
+    const second = coordinator.begin(input({ mode: 'explicit', now: 2 }))
+    expect(first.kind).toBe('started')
+    expect(second.kind).toBe('started')
+    if (first.kind !== 'started' || second.kind !== 'started') return
+    coordinator.attachGeneration(first.snapshot.requestId, 10)
+    coordinator.attachGeneration(second.snapshot.requestId, 11)
+
+    coordinator.markLoadSettled(first.snapshot.requestId)
+    expect(coordinator.releaseSettledWithoutShift({
+      requestId: first.snapshot.requestId,
+      conversationId: 'room-a',
+      firstMessageId: 'message-1',
+    })).toEqual({ kind: 'none' })
+    expect(coordinator.activeSnapshot('room-a')?.requestId).toBe(
+      second.snapshot.requestId,
+    )
+
+    coordinator.markLoadSettled(second.snapshot.requestId)
+    expect(coordinator.releaseSettledWithoutShift({
+      requestId: second.snapshot.requestId,
+      conversationId: 'room-a',
+      firstMessageId: 'message-1',
+    })).toMatchObject({
+      kind: 'cancel',
+      generation: 11,
+      snapshot: { requestId: second.snapshot.requestId },
+    })
+  })
+
+  it('keeps an in-flight snapshot for the shift it produces, then ignores settlement', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(0)
+    coordinator.enterConversation('room-a', true)
+    const started = coordinator.begin(input({ mode: 'explicit' }))
+    expect(started.kind).toBe('started')
+    if (started.kind !== 'started') return
+    coordinator.attachGeneration(started.snapshot.requestId, 12)
+
+    expect(coordinator.observeWindow({
+      conversationId: 'room-a',
+      firstMessageId: 'older-1',
+    })).toMatchObject({
+      kind: 'reconcile',
+      generation: 12,
+      snapshot: { requestId: started.snapshot.requestId },
+    })
+    expect(coordinator.isPendingWindowShift('room-a', 'older-1')).toBe(true)
+    coordinator.markRestored(started.snapshot.requestId, 1_100)
+    coordinator.markLoadSettled(started.snapshot.requestId)
+    expect(coordinator.releaseSettledWithoutShift({
+      requestId: started.snapshot.requestId,
+      conversationId: 'room-a',
+      firstMessageId: 'older-1',
+    })).toEqual({ kind: 'none' })
+  })
+
+  it('does not let a departed conversation settle or observe into the active conversation', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(0)
+    coordinator.enterConversation('room-a', true)
+    const departed = coordinator.begin(input({ mode: 'explicit' }))
+    expect(departed.kind).toBe('started')
+    if (departed.kind !== 'started') return
+    coordinator.attachGeneration(departed.snapshot.requestId, 12)
+
+    coordinator.enterConversation('room-b', false)
+
+    expect(coordinator.activeSnapshot('room-a')).toBeNull()
+    expect(coordinator.activeSnapshot('room-b')).toBeNull()
+    expect(coordinator.markLoadSettled(departed.snapshot.requestId)).toBe(false)
+    expect(coordinator.releaseSettledWithoutShift({
+      requestId: departed.snapshot.requestId,
+      conversationId: 'room-a',
+      firstMessageId: 'message-1',
+    })).toEqual({ kind: 'none' })
+    expect(coordinator.observeWindow({
+      conversationId: 'room-a',
+      firstMessageId: 'older-1',
+    })).toEqual({ kind: 'none' })
+
+    const active = coordinator.begin(input({
+      conversationId: 'room-b',
+      direction: 'newer',
+      mode: 'explicit',
+      windowAtLiveEdge: false,
+      now: 2_000,
+    }))
+    expect(active.kind).toBe('started')
+    if (active.kind !== 'started') return
+
+    expect(coordinator.markLoadSettled(departed.snapshot.requestId)).toBe(false)
+    expect(coordinator.activeSnapshot('room-b')?.requestId).toBe(
+      active.snapshot.requestId,
+    )
+  })
+
+  it('cancels only on a false-to-true live-window transition', () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(0)
+    coordinator.enterConversation('room-a', false)
+    const started = coordinator.begin(input({
+      mode: 'explicit',
+      direction: 'newer',
+      windowAtLiveEdge: false,
+    }))
+    expect(started.kind).toBe('started')
+    if (started.kind !== 'started') return
+    coordinator.attachGeneration(started.snapshot.requestId, 13)
+
+    expect(coordinator.observeLiveEdge('room-a', false)).toEqual({
+      kind: 'none',
+    })
+    expect(coordinator.observeLiveEdge('room-a', true)).toMatchObject({
+      kind: 'cancel',
+      generation: 13,
+    })
+    expect(coordinator.observeLiveEdge('room-a', true)).toEqual({
+      kind: 'none',
+    })
+  })
+
+  it('owns invocation settlement for promises and synchronous failures', async () => {
+    const coordinator = new DirectionalHistoryWindowCoordinator(0)
+    const started = coordinator.begin(input({ mode: 'explicit' }))
+    expect(started.kind).toBe('started')
+    if (started.kind !== 'started') return
+    let resolve!: () => void
+    const promise = new Promise<void>((done) => { resolve = done })
+    const settled: number[] = []
+
+    coordinator.invokeLoad(
+      started.snapshot,
+      () => promise,
+      (requestId) => settled.push(requestId),
+    )
+    expect(settled).toEqual([])
+    resolve()
+    await promise
+    await Promise.resolve()
+    expect(settled).toEqual([started.snapshot.requestId])
+    expect(coordinator.activeSnapshot('room-a')?.loadSettled).toBe(true)
+
+    const throwing = coordinator.begin(input({ mode: 'explicit', now: 2_000 }))
+    expect(throwing.kind).toBe('started')
+    if (throwing.kind !== 'started') return
+    expect(() => coordinator.invokeLoad(
+      throwing.snapshot,
+      () => { throw new Error('load failed') },
+      (requestId) => settled.push(requestId),
+    )).toThrow('load failed')
+    expect(settled).toContain(throwing.snapshot.requestId)
+  })
+})

--- a/apps/fluux/src/components/conversation/directionalHistoryWindowCoordinator.ts
+++ b/apps/fluux/src/components/conversation/directionalHistoryWindowCoordinator.ts
@@ -1,0 +1,328 @@
+export const DIRECTIONAL_HISTORY_COOLDOWN_MS = 500
+
+export type DirectionalHistoryDirection = 'older' | 'newer'
+export type DirectionalHistoryLoadMode = 'automatic' | 'explicit'
+
+export interface DirectionalHistoryCapture {
+  anchorMessageId: string
+  anchorOffsetFromTop: number
+  distanceFromBottom: number
+  firstMessageId: string
+  messageCount: number
+}
+
+export interface DirectionalHistorySnapshot {
+  requestId: number
+  conversationId: string
+  direction: DirectionalHistoryDirection
+  anchorMessageId: string
+  anchorOffsetFromTop: number
+  distanceFromBottom: number
+  oldFirstId: string
+  oldMessageCount: number
+  generation?: number
+  restored: boolean
+  restoredAt?: number
+  loadSettled: boolean
+}
+
+export interface BeginDirectionalHistoryInput {
+  conversationId: string
+  direction: DirectionalHistoryDirection
+  mode: DirectionalHistoryLoadMode
+  now: number
+  loaderAvailable: boolean
+  loading: boolean
+  historyComplete: boolean
+  windowAtLiveEdge: boolean
+  travelledAway: boolean
+  capture: () => DirectionalHistoryCapture
+}
+
+export type DirectionalHistoryBlockReason =
+  | 'unavailable'
+  | 'loading'
+  | 'history-complete'
+  | 'live-edge'
+  | 'cooldown'
+  | 'recently-restored'
+
+export type BeginDirectionalHistoryResult =
+  | {
+      kind: 'started'
+      snapshot: DirectionalHistorySnapshot
+      clearTravel: boolean
+    }
+  | { kind: 'blocked'; reason: DirectionalHistoryBlockReason }
+
+export type DirectionalHistoryReleaseDecision =
+  | { kind: 'none' }
+  | { kind: 'cleared'; snapshot: DirectionalHistorySnapshot }
+  | {
+      kind: 'cancel'
+      snapshot: DirectionalHistorySnapshot
+      generation: number
+    }
+
+export type DirectionalHistoryWindowDecision =
+  | { kind: 'none' }
+  | { kind: 'waiting'; snapshot: DirectionalHistorySnapshot }
+  | { kind: 'dropped'; snapshot: DirectionalHistorySnapshot }
+  | {
+      kind: 'reconcile'
+      snapshot: DirectionalHistorySnapshot
+      generation: number
+    }
+
+/** Value-only policy owner for directional history window loads. */
+export class DirectionalHistoryWindowCoordinator {
+  private nextRequestId = 1
+  private lastLoadAt = 0
+  private lastRestoreAt: number | null = null
+  private currentConversationId: string | null = null
+  private previousWindowAtLiveEdge: boolean | undefined = true
+  private active: DirectionalHistorySnapshot | null = null
+
+  constructor(
+    private readonly cooldownMs = DIRECTIONAL_HISTORY_COOLDOWN_MS,
+  ) {}
+
+  begin(input: BeginDirectionalHistoryInput): BeginDirectionalHistoryResult {
+    if (!input.loaderAvailable) {
+      return { kind: 'blocked', reason: 'unavailable' }
+    }
+    if (input.loading) return { kind: 'blocked', reason: 'loading' }
+    if (input.direction === 'older' && input.historyComplete) {
+      return { kind: 'blocked', reason: 'history-complete' }
+    }
+    if (input.direction === 'newer' && input.windowAtLiveEdge) {
+      return { kind: 'blocked', reason: 'live-edge' }
+    }
+    if (
+      input.mode === 'automatic' &&
+      input.direction === 'older' &&
+      this.lastRestoreAt !== null &&
+      input.now - this.lastRestoreAt < this.cooldownMs
+    ) {
+      return { kind: 'blocked', reason: 'recently-restored' }
+    }
+    if (
+      input.mode === 'automatic' &&
+      input.now - this.lastLoadAt <= this.cooldownMs &&
+      !input.travelledAway
+    ) {
+      return { kind: 'blocked', reason: 'cooldown' }
+    }
+
+    this.lastLoadAt = input.now
+    const capture = input.capture()
+    const snapshot: DirectionalHistorySnapshot = {
+      requestId: this.nextRequestId++,
+      conversationId: input.conversationId,
+      direction: input.direction,
+      anchorMessageId: capture.anchorMessageId,
+      anchorOffsetFromTop: capture.anchorOffsetFromTop,
+      distanceFromBottom: capture.distanceFromBottom,
+      oldFirstId: capture.firstMessageId,
+      oldMessageCount: capture.messageCount,
+      restored: false,
+      loadSettled: false,
+    }
+    if (this.currentConversationId !== input.conversationId) {
+      this.currentConversationId = input.conversationId
+      this.previousWindowAtLiveEdge = input.windowAtLiveEdge
+    }
+    this.active = snapshot
+    return {
+      kind: 'started',
+      snapshot,
+      clearTravel: input.mode === 'automatic',
+    }
+  }
+
+  enterConversation(
+    conversationId: string,
+    windowAtLiveEdge: boolean | undefined,
+  ): void {
+    this.currentConversationId = conversationId
+    this.previousWindowAtLiveEdge = windowAtLiveEdge
+    this.active = null
+  }
+
+  suppressAutomaticLoads(now: number): void {
+    this.lastLoadAt = now
+  }
+
+  attachGeneration(requestId: number, generation: number): boolean {
+    if (this.active?.requestId !== requestId) return false
+    this.active.generation = generation
+    return true
+  }
+
+  activeSnapshot(conversationId: string): DirectionalHistorySnapshot | null {
+    return this.currentConversationId === conversationId
+      ? this.active
+      : null
+  }
+
+  isPendingWindowShift(
+    conversationId: string,
+    firstMessageId: string,
+  ): boolean {
+    const snapshot = this.activeSnapshot(conversationId)
+    return Boolean(
+      snapshot &&
+      !snapshot.restored &&
+      snapshot.oldFirstId !== firstMessageId,
+    )
+  }
+
+  markLoadSettled(requestId: number): boolean {
+    if (this.active?.requestId !== requestId) return false
+    this.active.loadSettled = true
+    return true
+  }
+
+  invokeLoad(
+    snapshot: DirectionalHistorySnapshot,
+    run: () => unknown,
+    onSettled: (requestId: number) => void,
+  ): void {
+    let didSettle = false
+    const settle = () => {
+      if (didSettle) return
+      didSettle = true
+      this.markLoadSettled(snapshot.requestId)
+      onSettled(snapshot.requestId)
+    }
+
+    let result: unknown
+    try {
+      result = run()
+    } catch (error) {
+      settle()
+      throw error
+    }
+    const thenable = result as PromiseLike<unknown> | null | undefined
+    if (typeof thenable?.then === 'function') {
+      thenable.then(settle, settle)
+    } else {
+      settle()
+    }
+  }
+
+  releaseSettledWithoutShift(input: {
+    requestId: number
+    conversationId: string
+    firstMessageId: string
+  }): DirectionalHistoryReleaseDecision {
+    const snapshot = this.active
+    if (
+      !snapshot ||
+      snapshot.requestId !== input.requestId ||
+      snapshot.conversationId !== input.conversationId ||
+      this.currentConversationId !== input.conversationId ||
+      snapshot.restored ||
+      !snapshot.loadSettled ||
+      snapshot.oldFirstId !== input.firstMessageId
+    ) {
+      return { kind: 'none' }
+    }
+    if (snapshot.generation === undefined) {
+      this.active = null
+      return { kind: 'cleared', snapshot }
+    }
+    return {
+      kind: 'cancel',
+      snapshot,
+      generation: snapshot.generation,
+    }
+  }
+
+  observeLiveEdge(
+    conversationId: string,
+    windowAtLiveEdge: boolean | undefined,
+  ): DirectionalHistoryReleaseDecision {
+    if (this.currentConversationId !== conversationId) {
+      this.enterConversation(conversationId, windowAtLiveEdge)
+      return { kind: 'none' }
+    }
+    const returnedToLiveEdge =
+      this.previousWindowAtLiveEdge === false && windowAtLiveEdge === true
+    this.previousWindowAtLiveEdge = windowAtLiveEdge
+    const snapshot = this.active
+    if (
+      !returnedToLiveEdge ||
+      !snapshot ||
+      snapshot.conversationId !== conversationId ||
+      snapshot.restored
+    ) {
+      return { kind: 'none' }
+    }
+    if (snapshot.generation === undefined) {
+      this.active = null
+      return { kind: 'cleared', snapshot }
+    }
+    return {
+      kind: 'cancel',
+      snapshot,
+      generation: snapshot.generation,
+    }
+  }
+
+  observeWindow(input: {
+    conversationId: string
+    firstMessageId: string
+  }): DirectionalHistoryWindowDecision {
+    const snapshot = this.active
+    if (
+      !snapshot ||
+      snapshot.conversationId !== input.conversationId ||
+      this.currentConversationId !== input.conversationId ||
+      snapshot.restored
+    ) {
+      return { kind: 'none' }
+    }
+    if (snapshot.oldFirstId === input.firstMessageId) {
+      return { kind: 'waiting', snapshot }
+    }
+    if (snapshot.generation === undefined) {
+      this.active = null
+      return { kind: 'dropped', snapshot }
+    }
+    return {
+      kind: 'reconcile',
+      snapshot,
+      generation: snapshot.generation,
+    }
+  }
+
+  markRestored(
+    requestId: number,
+    now: number,
+  ): DirectionalHistorySnapshot | null {
+    if (this.active?.requestId !== requestId) return null
+    this.active.restored = true
+    this.active.restoredAt = now
+    this.lastRestoreAt = now
+    return this.active
+  }
+
+  finishPosition(requestId: number): void {
+    if (
+      this.active?.requestId === requestId &&
+      !this.active.restored
+    ) {
+      this.active = null
+    }
+  }
+
+  expireRestored(requestId: number, restoredAt: number): void {
+    if (
+      this.active?.requestId === requestId &&
+      this.active.restoredAt === restoredAt
+    ) {
+      this.active = null
+    }
+  }
+}

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -39,6 +39,13 @@ const scrollPersistenceAdapterSource = readFileSync(
   ),
   'utf8',
 )
+const directionalWindowCoordinatorSource = readFileSync(
+  resolve(
+    process.cwd(),
+    'src/components/conversation/directionalHistoryWindowCoordinator.ts',
+  ),
+  'utf8',
+)
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -50,6 +57,8 @@ const directMessageListWrite =
   /\bscrollRef\.current\.(?:scrollTo\s*\(|scrollTop\s*=)/
 const directScrollPersistenceCall =
   /\bscrollStateManager\.(?:clearSavedScrollState|saveScrollPosition|leaveConversation|markAsLeft|isInitialized|enterConversation|getSavedScrollTop|getSavedAnchor|getSavedReadPositionId)\s*\(/
+const browserOrPixelAuthority =
+  /\b(?:HTMLElement|Element|MessageVirtualizer|requestAnimationFrame|cancelAnimationFrame|scrollIntoView|scrollTo)\b|\.scrollTop\s*=/
 
 function interfaceMemberNames(
   sourceText: string,
@@ -128,6 +137,29 @@ describe('live message-list scroll ownership', () => {
     expect(scrollPersistenceAdapterSource).not.toMatch(
       /\.scrollTop\s*=/,
     )
+  })
+
+  it('keeps directional window coordination value-only and outside positioning ownership', () => {
+    expect(directionalWindowCoordinatorSource).not.toMatch(
+      browserOrPixelAuthority,
+    )
+    expect(directionalWindowCoordinatorSource).not.toMatch(
+      /from ['"]\.\/positioningController['"]/,
+    )
+    expect(hookSource).not.toMatch(
+      /\b(?:prependRef|lastLoadTimeRef|lastRestoreTimeRef|prevWindowAtLiveEdgeRef)\b/,
+    )
+  })
+
+  it('would reject a directional coordinator that schedules or writes pixels', () => {
+    const competingOwner = `
+      class DirectionalHistoryWindowCoordinator {
+        settle(scroller: HTMLElement) {
+          requestAnimationFrame(() => { scroller.scrollTop = 0 })
+        }
+      }
+    `
+    expect(competingOwner).toMatch(browserOrPixelAuthority)
   })
 
   it('persists the outgoing viewport before resetting the session for entry', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,9 +3,9 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position, unread-marker, explicit-target, live-edge, media-preservation,
- *    directional-history, and resident-top policy/retry ownership lives in
- *    PositioningController; browser writes stay imperative in leased hook executors
+ * 2. PositioningController owns every live-list positioning generation. Directional window-load
+ *    eligibility/lifetime lives in a value-only coordinator; browser writes stay imperative in
+ *    leased hook executors
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -43,6 +43,12 @@ import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 import { ViewportSession } from './viewportSession'
 import { ScrollPersistenceAdapter } from './scrollPersistenceAdapter'
+import {
+  DIRECTIONAL_HISTORY_COOLDOWN_MS,
+  DirectionalHistoryWindowCoordinator,
+  type DirectionalHistoryReleaseDecision,
+  type DirectionalHistorySnapshot,
+} from './directionalHistoryWindowCoordinator'
 import {
   PositioningController,
   type DirectionalHistoryExecutor,
@@ -128,9 +134,7 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 // on purpose: a tall last message can measure taller than the estimate and leave the view a
 // AT_BOTTOM_THRESHOLD is imported from scrollStateManager (shared with wasAtBottom persistence).
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
-const LOAD_COOLDOWN_MS = 500 // minimum time between load triggers
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
-const PREPEND_COOLDOWN_MS = 500 // time to keep prepend flag after restore (prevents re-trigger)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
 // How long a jumped-to message keeps its highlight tint, for both the controller-owned live path
 // and the scoped static-preview path (they must flash identically).
@@ -390,20 +394,6 @@ export interface UseMessageListScrollResult {
   scrollToMarker: () => void
 }
 
-interface DirectionalHistorySnapshot {
-  anchorMessageId: string
-  anchorOffsetFromTop: number
-  distanceFromBottom: number
-  oldFirstId: string
-  oldMessageCount: number
-  generation?: number
-  restored?: boolean
-  restoredAt?: number
-  /** Whether the load this snapshot was armed for has finished running (delivered or not). It is
-   *  what bounds the snapshot's claim on the next window shift — see runDirectionalHistoryLoad. */
-  loadSettled?: boolean
-}
-
 // ============================================================================
 // HOOK
 // ============================================================================
@@ -490,6 +480,11 @@ export function useMessageListScroll({
   const scrollPersistenceRef = useRef<ScrollPersistenceAdapter | null>(null)
   if (scrollPersistenceRef.current === null) {
     scrollPersistenceRef.current = new ScrollPersistenceAdapter()
+  }
+  const directionalWindowRef =
+    useRef<DirectionalHistoryWindowCoordinator | null>(null)
+  if (directionalWindowRef.current === null) {
+    directionalWindowRef.current = new DirectionalHistoryWindowCoordinator()
   }
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
@@ -609,25 +604,16 @@ export function useMessageListScroll({
       },
     })
   }
-  // Track prepend (loading older messages)
-  // When we load older messages, we save the anchor element position BEFORE the load,
-  // then restore it AFTER React renders the new messages.
-  // Using element-based positioning is more reliable than pure scroll math.
-  const prependRef = useRef<DirectionalHistorySnapshot | null>(null)
-  // Frames on which settled-without-shift snapshots are released (see runDirectionalHistoryLoad).
+  // Browser frames on which the value-only directional coordinator is told to adjudicate a load
+  // that settled without shifting the resident window. The coordinator owns request identity and
+  // cancellation policy; this hook retains only the browser scheduling mechanism until the browser
+  // adapter extraction in the next architecture slice.
   // A set, not a single slot: two loads can be in flight across a fast re-trigger and settle in
-  // either order, so one snapshot's frame must never displace another's. Cancelled on unmount.
+  // either order, so one request's frame must never displace another's. Cancelled on unmount.
   // Same lazy-ref idiom as pinBottomClaim below — stable identity, no per-render allocation.
   const directionalReleaseFramesRef = useRef<Set<number> | null>(null)
   const directionalReleaseFrames = () =>
     (directionalReleaseFramesRef.current ??= new Set<number>())
-
-  // Throttling/cooldown
-  const lastLoadTimeRef = useRef(0)
-  const lastRestoreTimeRef = useRef(0) // Track when we last restored position
-  // Tracks the previous windowAtLiveEdge so we can detect the false→true transition (returning to
-  // the live edge) and drop a stale prepend/append anchor — see the effect below.
-  const prevWindowAtLiveEdgeRef = useRef(windowAtLiveEdge)
 
   // Media load batching (for images, videos, link previews)
   // When multiple media elements load in quick succession, we batch them and apply
@@ -684,11 +670,6 @@ export function useMessageListScroll({
   // ==========================================================================
   // HELPERS
   // ==========================================================================
-
-  const canLoadMore = !isHistoryComplete && !isLoadingOlder && !!onScrollToTop
-  // Sliding window: load-newer is possible only when the window is slid up (windowAtLiveEdge === false)
-  // — otherwise the resident bottom IS the live edge and there is nothing newer to fetch.
-  const canLoadNewer = windowAtLiveEdge === false && !isLoadingNewer && !!onLoadNewer
 
   const getDistanceFromBottom = (el: HTMLElement) =>
     el.scrollHeight - el.scrollTop - el.clientHeight
@@ -1561,11 +1542,11 @@ export function useMessageListScroll({
     // first-id change, because at the resident bound an insertion evicts the oldest row and so
     // moves the first id too. This effect is declared before the directional restore effect, so
     // the snapshot is still unrestored here when its load genuinely lands.
-    const pendingDirectional = prependRef.current
     const directionalLoad =
-      !!pendingDirectional &&
-      !pendingDirectional.restored &&
-      pendingDirectional.oldFirstId !== firstMessageId
+      directionalWindowRef.current?.isPendingWindowShift(
+        conversationId,
+        firstMessageId ?? '',
+      ) ?? false
     const residentChanged =
       tracked.messageCount !== messageCount || tracked.firstMessageId !== firstMessageId
 
@@ -1737,28 +1718,25 @@ export function useMessageListScroll({
         complete: (request, outcome) => {
           if (activeConversationIdRef.current !== request.conversationId) return
           if (outcome === 'applied') {
-            saved.restored = true
-            saved.restoredAt = Date.now()
-            lastRestoreTimeRef.current = saved.restoredAt
+            const restored = directionalWindowRef.current?.markRestored(
+              saved.requestId,
+              Date.now(),
+            )
+            const restoredAt = restored?.restoredAt
+            if (restoredAt === undefined) return
             prevMessageCountRef.current = messageCountRef.current
             viewportSessionRef.current?.recordProgrammaticWrite(
               request.conversationId,
-              saved.restoredAt,
+              restoredAt,
             )
             setTimeout(() => {
-              if (
-                prependRef.current === saved &&
-                prependRef.current.restoredAt === saved.restoredAt
-              ) {
-                debugLog('DIRECTIONAL HISTORY CLEAR')
-                prependRef.current = null
-              }
-            }, PREPEND_COOLDOWN_MS)
-          } else if (
-            !saved.restored &&
-            prependRef.current === saved
-          ) {
-            prependRef.current = null
+              directionalWindowRef.current?.expireRestored(
+                saved.requestId,
+                restoredAt,
+              )
+            }, DIRECTIONAL_HISTORY_COOLDOWN_MS)
+          } else {
+            directionalWindowRef.current?.finishPosition(saved.requestId)
           }
           if (outcome !== 'applied') {
             viewportSessionRef.current?.recordProgrammaticWrite(
@@ -2329,7 +2307,7 @@ export function useMessageListScroll({
   ])
 
   const scrollToTopImpl = useCallback(() => {
-    lastLoadTimeRef.current = Date.now() // prevent auto-load trigger
+    directionalWindowRef.current?.suppressAutomaticLoads(Date.now())
     if (staticMode) {
       // Search/stranger previews intentionally own neither a controller conversation nor live-list
       // persistence. Preserve their isolated one-shot Home behavior inside this scroller; routing
@@ -2484,21 +2462,94 @@ export function useMessageListScroll({
     return null
   }
 
+  const applyDirectionalReleaseDecision = useCallback(
+    (decision: DirectionalHistoryReleaseDecision) => {
+      if (decision.kind !== 'cancel') return
+      debugLog('DIRECTIONAL HISTORY RELEASE (without window shift)', {
+        requestId: decision.snapshot.requestId,
+        oldFirstId: decision.snapshot.oldFirstId,
+        oldMessageCount: decision.snapshot.oldMessageCount,
+        messageCount: liveWindowRef.current.messageCount,
+        generation: decision.generation,
+      })
+      positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
+        conversationId: decision.snapshot.conversationId,
+        generation: decision.generation,
+      })
+    },
+    [],
+  )
+
+  const scheduleDirectionalHistorySettlement = (requestId: number) => {
+    const frames = directionalReleaseFrames()
+    // The handle is only known AFTER requestAnimationFrame returns, but the callback can run
+    // BEFORE it does — jsdom suites stub rAF synchronously. Track it only while genuinely pending.
+    let frame: number | null = null
+    let pending = true
+    frame = requestAnimationFrame(() => {
+      pending = false
+      if (frame !== null) frames.delete(frame)
+      const activeConversationId = activeConversationIdRef.current
+      applyDirectionalReleaseDecision(
+        directionalWindowRef.current?.releaseSettledWithoutShift({
+          requestId,
+          conversationId: activeConversationId,
+          firstMessageId: liveWindowRef.current.firstMessageId ?? '',
+        }) ?? { kind: 'none' },
+      )
+    })
+    if (pending) frames.add(frame)
+  }
+
   const beginDirectionalHistoryLoad = (
     scroller: HTMLDivElement,
+    direction: 'older' | 'newer',
+    mode: 'automatic' | 'explicit',
   ): {
     saved: DirectionalHistorySnapshot
     anchor: { id: string; offsetFromTop: number } | null
-  } => {
-    const anchor = findAnchorElement()
-    const saved: DirectionalHistorySnapshot = {
-      anchorMessageId: anchor?.id ?? '',
-      anchorOffsetFromTop: anchor?.offsetFromTop ?? 0,
-      distanceFromBottom: getDistanceFromBottom(scroller),
-      oldFirstId: firstMessageId ?? '',
-      oldMessageCount: messageCount,
+  } | null => {
+    let anchor: { id: string; offsetFromTop: number } | null = null
+    const result = directionalWindowRef.current?.begin({
+      conversationId,
+      direction,
+      mode,
+      now: Date.now(),
+      loaderAvailable:
+        direction === 'older' ? Boolean(onScrollToTop) : Boolean(onLoadNewer),
+      loading:
+        direction === 'older' ? Boolean(isLoadingOlder) : Boolean(isLoadingNewer),
+      historyComplete: Boolean(isHistoryComplete),
+      windowAtLiveEdge: windowAtLiveEdge !== false,
+      travelledAway:
+        viewportSessionRef.current?.hasTravelledAway(
+          conversationId,
+          direction === 'older' ? 'top' : 'bottom',
+        ) ?? false,
+      capture: () => {
+        anchor = findAnchorElement()
+        return {
+          anchorMessageId: anchor?.id ?? '',
+          anchorOffsetFromTop: anchor?.offsetFromTop ?? 0,
+          distanceFromBottom: getDistanceFromBottom(scroller),
+          firstMessageId: firstMessageId ?? '',
+          messageCount,
+        }
+      },
+    })
+    if (!result || result.kind === 'blocked') {
+      if (result?.reason === 'recently-restored') {
+        debugLog('LOAD BLOCKED (recently restored)')
+      }
+      return null
     }
-    prependRef.current = saved
+    if (result.clearTravel) {
+      viewportSessionRef.current?.clearTravel(
+        conversationId,
+        direction === 'older' ? 'top' : 'bottom',
+      )
+    }
+    const saved = result.snapshot
     const request = runScrollShadowSafely({
       event: 'directional-history-capture',
       conversationId,
@@ -2517,173 +2568,78 @@ export function useMessageListScroll({
         executor: createDirectionalHistoryExecutor(saved),
       }) ?? null,
     })
-    saved.generation = request?.generation
+    if (request) {
+      directionalWindowRef.current?.attachGeneration(
+        saved.requestId,
+        request.generation,
+      )
+    }
     return { saved, anchor }
   }
 
-  /**
-   * Drop a directional snapshot whose load is over and which never saw the window shift it was
-   * armed for. Guarded so it is a no-op the moment anything else has taken the snapshot over: the
-   * batch landed and restored it, a newer load replaced it, or the conversation changed.
-   *
-   * Going through `cancelDirectionalHistoryWithoutShift` (the same primitive the returned-to-live-
-   * edge case uses) matters twice over: it clears the controller's pending `history-preservation`
-   * request, which the positioning model treats as a position the reader is still waiting to reach
-   * — while it stands, EVERY ambient layout preservation (insertion, divider) is refused.
-   */
-  const releaseUnshiftedDirectionalHistory = (
-    saved: DirectionalHistorySnapshot,
-    ownerConversationId: string,
-  ) => {
-    if (prependRef.current !== saved || saved.restored) return
-    if (activeConversationIdRef.current !== ownerConversationId) return
-    // The window DID shift after all — the restore effect owns this snapshot, not us.
-    if ((liveWindowRef.current.firstMessageId ?? '') !== saved.oldFirstId) return
-
-    debugLog('DIRECTIONAL HISTORY RELEASE (settled without a window shift)', {
-      oldFirstId: saved.oldFirstId,
-      oldMessageCount: saved.oldMessageCount,
-      messageCount: liveWindowRef.current.messageCount,
-      generation: saved.generation,
-    })
-    if (saved.generation !== undefined) {
-      positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
-        conversationId: ownerConversationId,
-        generation: saved.generation,
-      })
-    }
-    if (prependRef.current === saved) prependRef.current = null
-  }
-
-  /**
-   * Run the load a snapshot was armed for, and bound the snapshot's lifetime to it.
-   *
-   * The snapshot's whole purpose is to catch the window shift its load produces, and it recognises
-   * that shift as a `firstMessageId` change. A load that settles WITHOUT delivering rows — an
-   * exhausted archive, a query that returns only duplicates, a fetch that bails before it starts —
-   * never produces one, so the restore effect just keeps waiting. Left armed, the snapshot claims
-   * the next first-id change from ANY source (a live arrival evicting the oldest row at the
-   * resident bound is one) and restores the reader to a position that stopped meaning anything
-   * loads ago; meanwhile its pending controller request blocks insertion preservation outright.
-   *
-   * So the loader's own promise is the snapshot's deadline. Releasing is deferred one frame, and
-   * re-checked when it fires: a commit that delivers the batch takes the snapshot first, which is
-   * what keeps successful pagination — the case this must never break — restoring as before.
-   */
   const runDirectionalHistoryLoad = (
     saved: DirectionalHistorySnapshot,
-    ownerConversationId: string,
     run: () => unknown,
   ): void => {
-    const settle = () => {
-      saved.loadSettled = true
-      const frames = directionalReleaseFrames()
-      // The handle is only known AFTER requestAnimationFrame returns, but the callback can run
-      // BEFORE it does — jsdom suites stub rAF to invoke synchronously. So the handle is a
-      // reassignable `let` the callback reads defensively (a `const` closed over here would be in
-      // its temporal dead zone), and it is tracked for cancellation only if a frame is really
-      // pending. Run synchronously, there is nothing to cancel and nothing to track.
-      let frame: number | null = null
-      let pending = true
-      frame = requestAnimationFrame(() => {
-        pending = false
-        if (frame !== null) frames.delete(frame)
-        releaseUnshiftedDirectionalHistory(saved, ownerConversationId)
-      })
-      if (pending) frames.add(frame)
-    }
-
-    let result: unknown
-    try {
-      result = run()
-    } catch (error) {
-      settle()
-      throw error
-    }
-    const thenable = result as PromiseLike<unknown> | null | undefined
-    if (typeof thenable?.then === 'function') {
-      thenable.then(settle, settle)
-      return
-    }
-    settle()
+    directionalWindowRef.current?.invokeLoad(
+      saved,
+      run,
+      scheduleDirectionalHistorySettlement,
+    )
   }
 
   const triggerLoadOlder = () => {
-    if (!canLoadMore) return
     const scroller = scrollerRef.current
     if (!scroller) return
+    const started = beginDirectionalHistoryLoad(
+      scroller,
+      'older',
+      'automatic',
+    )
+    if (!started) return
+    const { saved, anchor } = started
 
-    const now = Date.now()
-    const cooldownOk = now - lastLoadTimeRef.current > LOAD_COOLDOWN_MS
-    const recentlyRestored = now - lastRestoreTimeRef.current < LOAD_COOLDOWN_MS
+    debugLog('PREPEND START', {
+      anchor,
+      distanceFromBottom: saved.distanceFromBottom,
+      scrollHeight: scroller.scrollHeight,
+      scrollTop: scroller.scrollTop,
+      clientHeight: scroller.clientHeight,
+      firstMessageId,
+      messageCount,
+    })
 
-    // Don't trigger if we just restored scroll position (prevents rapid re-loading)
-    if (recentlyRestored) {
-      debugLog('LOAD BLOCKED (recently restored)', {
-        timeSinceRestore: now - lastRestoreTimeRef.current,
-      })
-      return
-    }
-
-    if (
-      cooldownOk ||
-      viewportSessionRef.current?.hasTravelledAway(conversationId, 'top')
-    ) {
-      lastLoadTimeRef.current = now
-      viewportSessionRef.current?.clearTravel(conversationId, 'top')
-
-      const { saved, anchor } = beginDirectionalHistoryLoad(scroller)
-
-      debugLog('PREPEND START', {
-        anchor,
-        distanceFromBottom: saved.distanceFromBottom,
-        scrollHeight: scroller.scrollHeight,
-        scrollTop: scroller.scrollTop,
-        clientHeight: scroller.clientHeight,
-        firstMessageId,
-        messageCount,
-      })
-
-      runDirectionalHistoryLoad(saved, conversationId, () => onScrollToTop?.())
-    }
+    runDirectionalHistoryLoad(saved, () => onScrollToTop?.())
   }
 
-  // Sliding window: mirror of triggerLoadOlder for the newer direction. Fires when the reader
-  // scrolls back down to the bottom of a slid-up window (canLoadNewer gates on windowAtLiveEdge ===
-  // false). Loading newer APPENDS a batch and EVICTS the oldest (opposite end), so it shifts every
+  // Sliding window: mirror of triggerLoadOlder for the newer direction. The coordinator permits it
+  // only when the reader is in a slid-up window. Loading newer APPENDS a batch and EVICTS the
+  // oldest (opposite end), so it shifts every
   // offset up; we save the same anchor prepend uses and let the shared restore effect hold the
   // viewport steady. The evicted rows are the OLDEST — far above the viewport — so the top-visible
   // anchor survives, making the anchor-based restore direction-agnostic.
   const triggerLoadNewer = () => {
-    if (!canLoadNewer) return
     const scroller = scrollerRef.current
     if (!scroller) return
-
-    const now = Date.now()
-    const cooldownOk = now - lastLoadTimeRef.current > LOAD_COOLDOWN_MS
-    if (
-      !cooldownOk &&
-      !viewportSessionRef.current?.hasTravelledAway(conversationId, 'bottom')
-    ) {
-      return
-    }
-
-    lastLoadTimeRef.current = now
-    viewportSessionRef.current?.clearTravel(conversationId, 'bottom')
-
-    const { saved } = beginDirectionalHistoryLoad(scroller)
-
-    runDirectionalHistoryLoad(saved, conversationId, () => onLoadNewer?.())
+    const started = beginDirectionalHistoryLoad(
+      scroller,
+      'newer',
+      'automatic',
+    )
+    if (!started) return
+    runDirectionalHistoryLoad(started.saved, () => onLoadNewer?.())
   }
 
   const handleLoadEarlier = () => {
-    if (!canLoadMore) return
     const scroller = scrollerRef.current
     if (!scroller) return
-
-    lastLoadTimeRef.current = Date.now()
-
-    const { saved, anchor } = beginDirectionalHistoryLoad(scroller)
+    const started = beginDirectionalHistoryLoad(
+      scroller,
+      'older',
+      'explicit',
+    )
+    if (!started) return
+    const { saved, anchor } = started
 
     debugLog('LOAD EARLIER', {
       anchor,
@@ -2695,7 +2651,7 @@ export function useMessageListScroll({
       messageCount,
     })
 
-    runDirectionalHistoryLoad(saved, conversationId, () => onScrollToTop?.())
+    runDirectionalHistoryLoad(saved, () => onScrollToTop?.())
   }
 
   // ==========================================================================
@@ -3030,9 +2986,9 @@ export function useMessageListScroll({
       triggerLoadOlder()
     }
 
-    // Sliding window: when the window is slid up (canLoadNewer ⇒ windowAtLiveEdge === false),
-    // reaching the resident bottom means newer messages exist in cache below — load them. Gated by
-    // canLoadNewer, so at the live edge this is inert and bottom-stick is unchanged.
+    // Sliding window: when the window is slid up, reaching the resident bottom means newer
+    // messages exist in cache below. The coordinator rejects this at the live edge, where
+    // bottom-stick remains authoritative.
     if (distFromBottom <= LOAD_NEWER_THRESHOLD && !staticMode) triggerLoadNewer()
   }
 
@@ -3124,7 +3080,10 @@ export function useMessageListScroll({
     hasInitializedRef.current = false
     userHasScrolledSinceMarkerRef.current = false
     viewportSessionRef.current?.enterConversation(conversationId)
-    prependRef.current = null
+    directionalWindowRef.current?.enterConversation(
+      conversationId,
+      windowAtLiveEdge,
+    )
     pendingSyncedLiveEdgeRef.current = null
     setShowScrollToBottom(false)
     setMarkerAboveViewport(false)
@@ -3319,6 +3278,7 @@ export function useMessageListScroll({
     readPointerId,
     staticMode,
     targetMessageId,
+    windowAtLiveEdge,
   ])
 
   // Zero-unread twin of the divider-clear settle below. The old local position may be restored
@@ -3606,33 +3566,17 @@ export function useMessageListScroll({
   // ==========================================================================
   // EFFECT: Returned to the live edge → drop any stale directional-load anchor.
   // ==========================================================================
-  // A directional load that returns NOTHING never changes firstMessageId, so the restore effect
-  // below never fires. `runDirectionalHistoryLoad` is what releases the snapshot in that case, on
-  // the load's own settlement; this effect stays as the semantic signal for one specific shape of
-  // it — load-newer hitting the tail, where windowAtLiveEdge flips false→true with a stashed
-  // (never-restored) anchor and the reader is demonstrably back at the live edge, whether or not
-  // that load has finished running. Clearing on the false→true TRANSITION
-  // targets exactly "we just returned to the live edge": normal under-cap load-older keeps
-  // windowAtLiveEdge true (no transition) and a slide keeps it false, so their in-flight restores
-  // are untouched. This is a passive useEffect so it runs AFTER the restore useLayoutEffect — a
-  // load-newer that both slides AND reaches the tail in one batch still restores first, then this
-  // clears the already-`restored` ref harmlessly.
+  // Feed the value-only window transition to the coordinator. This passive effect still runs after
+  // the layout restore, so a newer load that shifts and reaches the tail in one commit reconciles
+  // first; a no-shift tail load releases only its own generation.
   useEffect(() => {
-    if (windowAtLiveEdge === true && prevWindowAtLiveEdgeRef.current === false) {
-      const saved = prependRef.current
-      if (saved && !saved.restored) {
-        if (saved.generation !== undefined) {
-          positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
-            conversationId,
-            generation: saved.generation,
-          })
-        } else {
-          prependRef.current = null
-        }
-      }
-    }
-    prevWindowAtLiveEdgeRef.current = windowAtLiveEdge
-  }, [conversationId, windowAtLiveEdge])
+    applyDirectionalReleaseDecision(
+      directionalWindowRef.current?.observeLiveEdge(
+        conversationId,
+        windowAtLiveEdge,
+      ) ?? { kind: 'none' },
+    )
+  }, [applyDirectionalReleaseDecision, conversationId, windowAtLiveEdge])
 
   // EFFECT: Prepend complete (older messages loaded)
   // ==========================================================================
@@ -3644,11 +3588,13 @@ export function useMessageListScroll({
   useLayoutEffect(() => {
     if (staticMode) return
     const scroller = scrollerRef.current
-    const saved = prependRef.current
-    if (!scroller || !saved) return
-
-    // Already restored? Skip.
-    if (saved.restored) return
+    if (!scroller) return
+    const decision = directionalWindowRef.current?.observeWindow({
+      conversationId,
+      firstMessageId: firstMessageId ?? '',
+    }) ?? { kind: 'none' as const }
+    if (decision.kind === 'none') return
+    const saved = decision.snapshot
 
     // A directional load (older OR newer) landed iff the FIRST message id changed. Sliding window:
     // a load-older OR load-newer at the resident cap prepends/appends a batch AND evicts the
@@ -3658,28 +3604,23 @@ export function useMessageListScroll({
     // direction-agnostic (it repositions the top-visible anchor, which survives either eviction —
     // the evicted rows are at the far, off-screen end). Under the cap, load-older still changes
     // firstId AND grows the count, so this is unchanged for the common case.
-    const firstIdChanged = firstMessageId !== saved.oldFirstId
-
-    // Waiting is bounded: the snapshot is released once the load that armed it settles without
-    // delivering a shift (runDirectionalHistoryLoad), so this branch cannot hold it indefinitely.
-    if (!firstIdChanged) {
+    if (decision.kind === 'waiting') {
       debugLog('PREPEND WAITING', {
         messageCount,
         oldMessageCount: saved.oldMessageCount,
         firstMessageId,
         oldFirstId: saved.oldFirstId,
         loadSettled: Boolean(saved.loadSettled),
-        firstIdChanged,
+        firstIdChanged: false,
       })
       return
     }
 
-    if (saved.generation === undefined) {
+    if (decision.kind === 'dropped') {
       debugLog('DIRECTIONAL HISTORY DROPPED (controller unavailable)', {
         oldFirstId: saved.oldFirstId,
         firstMessageId,
       })
-      prependRef.current = null
       return
     }
 
@@ -3688,7 +3629,7 @@ export function useMessageListScroll({
     // clamp recovery, and the full late-measurement frame budget.
     positioningControllerRef.current?.reconcileDirectionalHistory({
       conversationId,
-      generation: saved.generation,
+      generation: decision.generation,
       executor: createDirectionalHistoryExecutor(saved),
     })
 

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -70,6 +70,17 @@ viewport-session snapshots and owns entry reads, throttled continuous saves, lea
 decisions, and explicit saved-position clearing. The adapter rejects stale-room snapshots and
 controller-owned scroll events and has no DOM, virtualizer, scheduler, or pixel-write capability.
 
+Directional history windowing is mediated by a value-only
+`DirectionalHistoryWindowCoordinator`. It owns older/newer availability, cooldown and travel
+eligibility, monotonic load identity, anchor/distance facts, loader invocation, no-shift completion,
+and false-to-true live-window cleanup. A loader promise bounds only the snapshot that invoked it:
+settlement from an older superseded load cannot release the current request, while an in-flight
+load keeps its snapshot until its own first-id shift can reconcile. Conversation entry drops the
+departed conversation's snapshot, and delayed settlement or window observation from that snapshot
+cannot mutate the active conversation. The hook currently supplies the DOM measurements and
+one-frame browser settlement callback; the coordinator imports no DOM, virtualizer, frame
+scheduler, positioning controller, or pixel-write capability.
+
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while
 remeasurement moves the target makes convergence samples unreliable and recreates scroll fighting.
@@ -481,7 +492,7 @@ kinetic scrolling and stale-paint behavior.
      top/bottom travel latches.
    - [x] Move enter/leave/save/clear behavior and throttling behind a persistence adapter consuming
      viewport-session snapshots.
-   - [ ] Extract directional history load eligibility, invocation, and completion into a window
+   - [x] Extract directional history load eligibility, invocation, and completion into a window
      coordinator that owns no positioning.
    - [ ] Move DOM/virtualizer reconciliation mechanics behind explicit browser adapters.
    - [ ] Leave the React hook as thin lifecycle orchestration.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -1,5 +1,9 @@
 # Resident-Top Controller Implementation Plan
 
+> **Historical execution note:** This completed plan records the pre-Step-7 hook mechanics. The
+> current ownership and history-window contract is
+> `docs/2026-07-23-scroll-positioning-contract.md`; do not execute this plan again.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Complete scroll-positioning migration step 6 by moving Home / resident-top navigation from a hook-owned smooth write to a generation-aware controller-owned one-shot animation with leased observation.

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -1,5 +1,9 @@
 # Resident-Top Controller Migration Design
 
+> **Historical design note:** This records the pre-Step-7 hook mechanics used during the
+> resident-top migration. The current ownership and history-window contract is
+> `docs/2026-07-23-scroll-positioning-contract.md`.
+
 ## Goal
 
 Complete scroll-positioning migration step 6 by making the generation-aware


### PR DESCRIPTION
Centralizes older and newer history-window eligibility, request sequencing, and load settlement in a conversation-scoped value-only coordinator. Browser geometry and pixel writes remain under the existing positioning controller, while stale or superseded loads can no longer release the active room's anchor. Adds focused race and ownership coverage and updates the scroll ownership contract.