### PR TITLE
refactor(scroll): extract directional history browser adapter

### DIFF
--- a/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MessageVirtualizer, VirtualWindowItem } from './messageVirtualizer'
+import type { PositionExecutionLease, PositionFrameLoop } from './positioningController'
+import { pixelOffset, type DirectionalHistoryRequest } from './scrollPositionModel'
+import { DirectionalHistoryBrowserAdapter } from './directionalHistoryBrowserAdapter'
+
+function scrollerHarness(input: {
+  scrollTop?: number
+  scrollHeight?: number
+  clientHeight?: number
+} = {}) {
+  let scrollTop = input.scrollTop ?? 300
+  const scrollHeight = input.scrollHeight ?? 2_000
+  const clientHeight = input.clientHeight ?? 500
+  let reflowReads = 0
+  const scroller = document.createElement('div')
+  Object.defineProperties(scroller, {
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value },
+    },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    clientHeight: { configurable: true, get: () => clientHeight },
+    offsetHeight: {
+      configurable: true,
+      get: () => {
+        reflowReads += 1
+        return clientHeight
+      },
+    },
+  })
+  scroller.getBoundingClientRect = () => ({
+    top: 0,
+    bottom: clientHeight,
+    left: 0,
+    right: 600,
+    width: 600,
+    height: clientHeight,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+  return {
+    scroller,
+    get scrollTop() { return scrollTop },
+    set scrollTop(value: number) { scrollTop = value },
+    get reflowReads() { return reflowReads },
+  }
+}
+
+function virtualizerHarness(
+  scroller: HTMLElement,
+  input: {
+    index?: number | null
+    offset?: () => number | null
+    items?: VirtualWindowItem[]
+  } = {},
+) {
+  const index = input.index === undefined ? 2 : input.index
+  const items = input.items ?? [{ index: 2, start: 900, size: 80, key: 'anchor' }]
+  const scrollToOffset = vi.fn((offset: number) => {
+    scroller.scrollTop = offset
+  })
+  const virtualizer: MessageVirtualizer = {
+    getVirtualItems: () => items,
+    getTotalSize: () => 2_000,
+    itemCount: 10,
+    getOffsetForMessageId: vi.fn(input.offset ?? (() => 900)),
+    getIndexForMessageId: vi.fn(() => index),
+    ensureMessageMounted: vi.fn(async () => {}),
+    measureElement: vi.fn(),
+    scrollToOffset,
+    scrollToIndex: vi.fn(),
+    beginAnimatedScrollToOffset: vi.fn(),
+  }
+  return { virtualizer, scrollToOffset }
+}
+
+function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
+  const controller = new AbortController()
+  return {
+    conversationId: 'room-a',
+    generation: 7,
+    operation: 1,
+    signal: controller.signal,
+    isCurrent,
+    markApplied: () => true,
+    settle: () => true,
+  }
+}
+
+function request(overrides: Partial<DirectionalHistoryRequest> = {}): DirectionalHistoryRequest {
+  return {
+    generation: 7,
+    conversationId: 'room-a',
+    source: { kind: 'history-preservation', reason: 'window-shift' },
+    desired: {
+      kind: 'anchor',
+      messageId: 'anchor',
+      placement: { kind: 'top-offset', offsetPx: pixelOffset(40) },
+    },
+    onUnavailable: {
+      kind: 'distance-from-bottom',
+      distancePx: pixelOffset(200),
+    },
+    ...overrides,
+  }
+}
+
+function adapterHarness(input: {
+  scroller: HTMLElement | null
+  virtualizer?: MessageVirtualizer
+  activeConversationId?: string
+  requestFrame?: (callback: () => void) => number
+  cancelFrame?: (id: number) => void
+}) {
+  const loop: PositionFrameLoop = {
+    schedule: vi.fn(),
+    recordFrame: vi.fn(),
+    finish: vi.fn(),
+  }
+  const beginLoop = vi.fn(() => loop)
+  const adapter = new DirectionalHistoryBrowserAdapter({
+    getScroller: () => input.scroller,
+    getVirtualizer: () => input.virtualizer,
+    getActiveConversationId: () => input.activeConversationId ?? 'room-a',
+    beginLoop,
+    requestFrame: input.requestFrame ?? (() => 1),
+    cancelFrame: input.cancelFrame ?? (() => {}),
+  })
+  return { adapter, beginLoop, loop }
+}
+
+describe('DirectionalHistoryBrowserAdapter', () => {
+  it('captures the visual virtualizer anchor rather than trusting DOM order', () => {
+    const viewport = scrollerHarness({ scrollTop: 300 })
+    const firstWrapper = document.createElement('div')
+    firstWrapper.dataset.index = '1'
+    const anchorRow = document.createElement('div')
+    anchorRow.dataset.messageId = 'message-8'
+    firstWrapper.append(anchorRow)
+    viewport.scroller.append(firstWrapper)
+    const { virtualizer } = virtualizerHarness(viewport.scroller, {
+      items: [
+        { index: 0, start: 100, size: 100, key: 'old' },
+        { index: 1, start: 320, size: 80, key: 'message-8' },
+      ],
+    })
+    const { adapter } = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    })
+
+    expect(adapter.capture('message-1', 20)).toEqual({
+      anchor: { id: 'message-8', offsetFromTop: 20 },
+      facts: {
+        anchorMessageId: 'message-8',
+        anchorOffsetFromTop: 20,
+        distanceFromBottom: 1_200,
+        firstMessageId: 'message-1',
+        messageCount: 20,
+      },
+      geometry: {
+        scrollTop: 300,
+        scrollHeight: 2_000,
+        clientHeight: 500,
+      },
+    })
+  })
+
+  it('uses the resident first message at scrollTop zero even with a stale virtual window', () => {
+    const viewport = scrollerHarness({ scrollTop: 0 })
+    const staleWrapper = document.createElement('div')
+    staleWrapper.dataset.index = '9'
+    const staleRow = document.createElement('div')
+    staleRow.dataset.messageId = 'stale-message'
+    staleWrapper.append(staleRow)
+    viewport.scroller.append(staleWrapper)
+    const { virtualizer } = virtualizerHarness(viewport.scroller, {
+      offset: () => 24,
+      items: [{ index: 9, start: 900, size: 80, key: 'stale-message' }],
+    })
+    const { adapter } = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    })
+
+    expect(adapter.capture('message-1', 20)?.anchor).toEqual({
+      id: 'message-1',
+      offsetFromTop: 24,
+    })
+  })
+
+  it('positions through the virtualizer and waits through a temporary missing anchor', () => {
+    const viewport = scrollerHarness()
+    let offset: number | null = 900
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller, {
+      offset: () => offset,
+    })
+    const { adapter, beginLoop, loop } = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    })
+    const complete = vi.fn()
+    const executor = adapter.createExecutor(complete)
+    const currentLease = lease()
+
+    expect(executor.beginLoop(currentLease)).toBe(loop)
+    expect(beginLoop).toHaveBeenCalledWith(currentLease)
+    expect(executor.positionFrame(request(), currentLease)).toEqual({
+      kind: 'positioned',
+      scrollTop: 860,
+      wrote: true,
+      reassert: true,
+    })
+    expect(scrollToOffset).toHaveBeenCalledWith(860)
+    expect(viewport.reflowReads).toBe(2)
+
+    offset = null
+    scrollToOffset.mockClear()
+    expect(executor.positionFrame(request(), currentLease)).toEqual({
+      kind: 'positioned',
+      scrollTop: 860,
+      wrote: false,
+      reassert: true,
+    })
+    expect(scrollToOffset).not.toHaveBeenCalled()
+
+    executor.complete(request(), 'settled')
+    expect(complete).toHaveBeenCalledWith(request(), 'settled')
+  })
+
+  it('uses distance-from-bottom once when the initial anchor is absent', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller, {
+      offset: () => null,
+    })
+    const { adapter } = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    })
+
+    expect(adapter.createExecutor(vi.fn()).positionFrame(request(), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 1_300,
+      wrote: true,
+      reassert: false,
+    })
+    expect(scrollToOffset).toHaveBeenCalledWith(1_300)
+  })
+
+  it('uses the mounted element path and restores overflow ownership without a virtualizer', () => {
+    const viewport = scrollerHarness()
+    const anchor = document.createElement('div')
+    anchor.dataset.messageId = 'anchor'
+    Object.defineProperty(anchor, 'offsetTop', {
+      configurable: true,
+      get: () => 900,
+    })
+    viewport.scroller.append(anchor)
+    const { adapter } = adapterHarness({ scroller: viewport.scroller })
+
+    expect(adapter.createExecutor(vi.fn()).positionFrame(request(), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 860,
+      wrote: true,
+      reassert: false,
+    })
+    expect(viewport.reflowReads).toBe(2)
+    expect(viewport.scroller.style.overflowY).toBe('')
+  })
+
+  it('preserves the exact target-shift and geometry-drift thresholds', () => {
+    const viewport = scrollerHarness()
+    let offset = 900
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller, {
+      offset: () => offset,
+    })
+    const executor = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    }).adapter.createExecutor(vi.fn())
+    const currentLease = lease()
+    executor.positionFrame(request(), currentLease)
+    scrollToOffset.mockClear()
+
+    offset = 902
+    expect(executor.positionFrame(request(), currentLease)).toMatchObject({ wrote: false })
+    expect(scrollToOffset).not.toHaveBeenCalled()
+
+    viewport.scrollTop = 856
+    expect(executor.positionFrame(request(), currentLease)).toMatchObject({ wrote: true })
+    expect(scrollToOffset).toHaveBeenCalledWith(862)
+    scrollToOffset.mockClear()
+
+    offset = 905
+    expect(executor.positionFrame(request(), currentLease)).toMatchObject({ wrote: true })
+    expect(scrollToOffset).toHaveBeenCalledWith(865)
+  })
+
+  it('rejects a stale lease or departed conversation before reading or writing geometry', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller)
+    const departed = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+      activeConversationId: 'room-b',
+    }).adapter.createExecutor(vi.fn())
+
+    expect(departed.positionFrame(request(), lease())).toEqual({ kind: 'unavailable' })
+    expect(scrollToOffset).not.toHaveBeenCalled()
+    expect(viewport.reflowReads).toBe(0)
+
+    const stale = adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    }).adapter.createExecutor(vi.fn())
+    expect(stale.positionFrame(request(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    expect(scrollToOffset).not.toHaveBeenCalled()
+    expect(viewport.reflowReads).toBe(0)
+  })
+
+  it('cancels every pending settlement frame while synchronous frames never leak', () => {
+    const viewport = scrollerHarness()
+    const callbacks = new Map<number, () => void>()
+    const cancelled: number[] = []
+    let nextFrame = 0
+    const { adapter } = adapterHarness({
+      scroller: viewport.scroller,
+      requestFrame: (callback) => {
+        const id = ++nextFrame
+        callbacks.set(id, callback)
+        return id
+      },
+      cancelFrame: (id) => cancelled.push(id),
+    })
+    const first = vi.fn()
+    const second = vi.fn()
+    adapter.scheduleSettlement(first)
+    adapter.scheduleSettlement(second)
+    callbacks.get(1)?.()
+    expect(first).toHaveBeenCalledOnce()
+    expect(second).not.toHaveBeenCalled()
+
+    adapter.dispose()
+    expect(cancelled).toEqual([2])
+    const afterDispose = vi.fn()
+    adapter.scheduleSettlement(afterDispose)
+    expect(afterDispose).not.toHaveBeenCalled()
+    expect(nextFrame).toBe(2)
+
+    const syncCancelled: number[] = []
+    const sync = adapterHarness({
+      scroller: viewport.scroller,
+      requestFrame: (callback) => {
+        callback()
+        return 9
+      },
+      cancelFrame: (id) => syncCancelled.push(id),
+    }).adapter
+    const settled = vi.fn()
+    sync.scheduleSettlement(settled)
+    sync.dispose()
+    expect(settled).toHaveBeenCalledOnce()
+    expect(syncCancelled).toEqual([])
+  })
+})

--- a/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.ts
@@ -1,0 +1,274 @@
+import type { DirectionalHistoryCapture } from './directionalHistoryWindowCoordinator'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  DirectionalHistoryExecutor,
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+
+export interface DirectionalHistoryBrowserCapture {
+  anchor: { id: string; offsetFromTop: number } | null
+  facts: DirectionalHistoryCapture
+  geometry: {
+    scrollTop: number
+    scrollHeight: number
+    clientHeight: number
+  }
+}
+
+export interface DirectionalHistoryBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getActiveConversationId: () => string
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  requestFrame: (callback: () => void) => number
+  cancelFrame: (id: number) => void
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+/**
+ * Browser-only mechanics for directional history preservation.
+ *
+ * The window coordinator decides whether and how long a load owns a snapshot, while the
+ * positioning controller owns generations and convergence. This adapter only captures current
+ * DOM/virtualizer geometry, performs writes under the controller lease, and owns the one-frame
+ * browser settlement callbacks that are cancelled on teardown.
+ */
+export class DirectionalHistoryBrowserAdapter {
+  private readonly settlementFrames = new Set<number>()
+  private disposed = false
+
+  constructor(private readonly options: DirectionalHistoryBrowserAdapterOptions) {}
+
+  isAvailable(): boolean {
+    return this.options.getScroller() !== null
+  }
+
+  capture(
+    firstMessageId: string,
+    messageCount: number,
+  ): DirectionalHistoryBrowserCapture | null {
+    const scroller = this.options.getScroller()
+    if (!scroller) return null
+    const virtualizer = this.options.getVirtualizer()
+    const { scrollTop, scrollHeight, clientHeight } = scroller
+    let anchor: DirectionalHistoryBrowserCapture['anchor'] = null
+
+    if (virtualizer) {
+      if (scrollTop === 0 && firstMessageId) {
+        anchor = {
+          id: firstMessageId,
+          offsetFromTop:
+            virtualizer.getOffsetForMessageId(firstMessageId) ?? 0,
+        }
+      } else {
+        for (const item of virtualizer.getVirtualItems()) {
+          const viewportOffset = item.start - scrollTop
+          if (viewportOffset < -item.size / 2) continue
+          const wrapper = scroller.querySelector(
+            `[data-index="${item.index}"]`,
+          )
+          const message = wrapper?.querySelector(
+            '[data-message-id]',
+          ) as HTMLElement | null
+          const messageId = message?.dataset.messageId
+          if (!messageId) continue
+          anchor = { id: messageId, offsetFromTop: viewportOffset }
+          break
+        }
+        if (!anchor && firstMessageId) {
+          anchor = {
+            id: firstMessageId,
+            offsetFromTop:
+              (virtualizer.getOffsetForMessageId(firstMessageId) ?? 0) -
+              scrollTop,
+          }
+        }
+      }
+    } else {
+      const messages = scroller.querySelectorAll('[data-message-id]')
+      const scrollerRect = scroller.getBoundingClientRect()
+      for (const message of messages) {
+        const element = message as HTMLElement
+        const rect = element.getBoundingClientRect()
+        if (rect.top - scrollerRect.top < -rect.height / 2) continue
+        const messageId = element.dataset.messageId
+        if (!messageId) continue
+        anchor = {
+          id: messageId,
+          offsetFromTop: element.offsetTop - scrollTop,
+        }
+        break
+      }
+      if (!anchor) {
+        const first = messages[0] as HTMLElement | undefined
+        const messageId = first?.dataset.messageId
+        if (first && messageId) {
+          anchor = {
+            id: messageId,
+            offsetFromTop: first.offsetTop - scrollTop,
+          }
+        }
+      }
+    }
+
+    const geometry = { scrollTop, scrollHeight, clientHeight }
+    const result = {
+      anchor,
+      facts: {
+        anchorMessageId: anchor?.id ?? '',
+        anchorOffsetFromTop: anchor?.offsetFromTop ?? 0,
+        distanceFromBottom: scrollHeight - scrollTop - clientHeight,
+        firstMessageId,
+        messageCount,
+      },
+      geometry,
+    }
+    this.options.log?.('DIRECTIONAL HISTORY CAPTURE', result)
+    return result
+  }
+
+  createExecutor(
+    complete: DirectionalHistoryExecutor['complete'],
+  ): DirectionalHistoryExecutor {
+    let initialized = false
+    let previousTarget = 0
+    let usedFallback = false
+
+    return {
+      reachability: (desired) => {
+        const scroller = this.options.getScroller()
+        const virtualizer = this.options.getVirtualizer()
+        return deriveReachabilityForDesired({
+          desired,
+          hasRows: Boolean(
+            (virtualizer && virtualizer.itemCount > 0) ||
+            scroller?.querySelector('[data-message-id]'),
+          ),
+          windowAtLiveEdge: true,
+          virtualizer,
+          scroller,
+          loadAround: 'unavailable',
+          canRecenter: false,
+        })
+      },
+      beginLoop: (lease) => this.options.beginLoop(lease),
+      positionFrame: (request, lease) => {
+        if (
+          !lease.isCurrent() ||
+          this.options.getActiveConversationId() !== request.conversationId
+        ) {
+          return { kind: 'unavailable' }
+        }
+        const scroller = this.options.getScroller()
+        if (!scroller) return { kind: 'unavailable' }
+        const virtualizer = this.options.getVirtualizer()
+
+        if (!initialized) {
+          // Preserve both reads from the former pre-paint path: first flush the current layout,
+          // then force the overflow-hidden layout that cancels WebKit momentum.
+          void scroller.offsetHeight
+          cancelKineticScroll(scroller)
+        }
+
+        let target: number | null = null
+        let usedMethod = 'none'
+        if (request.desired.messageId) {
+          const virtualOffset =
+            virtualizer?.getOffsetForMessageId(request.desired.messageId) ??
+            null
+          if (virtualOffset !== null) {
+            target = virtualOffset - request.desired.placement.offsetPx
+            usedMethod = 'virtualizer-offset'
+          } else {
+            const anchor = scroller.querySelector(
+              `[data-message-id="${CSS.escape(request.desired.messageId)}"]`,
+            ) as HTMLElement | null
+            if (anchor) {
+              target = anchor.offsetTop - request.desired.placement.offsetPx
+              usedMethod = 'element-based'
+            }
+          }
+        }
+
+        if (target === null) {
+          if (initialized) {
+            return {
+              kind: 'positioned',
+              scrollTop: scroller.scrollTop,
+              wrote: false,
+              reassert: Boolean(virtualizer && !usedFallback),
+            }
+          }
+          target =
+            scroller.scrollHeight -
+            scroller.clientHeight -
+            request.onUnavailable.distancePx
+          usedMethod = 'distance-from-bottom'
+          usedFallback = true
+        }
+
+        const maxScrollTop = Math.max(
+          0,
+          scroller.scrollHeight - scroller.clientHeight,
+        )
+        const boundedTarget = Math.max(0, Math.min(target, maxScrollTop))
+        const targetMoved =
+          initialized && Math.abs(boundedTarget - previousTarget) > 2
+        const geometryDrift =
+          initialized && Math.abs(scroller.scrollTop - boundedTarget) > 5
+        const shouldWrite = !initialized || targetMoved || geometryDrift
+        if (shouldWrite) {
+          if (virtualizer) virtualizer.scrollToOffset(boundedTarget)
+          else scroller.scrollTop = boundedTarget
+        }
+        previousTarget = boundedTarget
+        initialized = true
+
+        this.options.log?.('DIRECTIONAL HISTORY POSITION', {
+          generation: request.generation,
+          usedMethod,
+          target: boundedTarget,
+          targetMoved,
+          geometryDrift,
+          wrote: shouldWrite,
+        })
+        return {
+          kind: 'positioned',
+          scrollTop: scroller.scrollTop,
+          wrote: shouldWrite,
+          reassert: Boolean(virtualizer && !usedFallback),
+        }
+      },
+      complete,
+    }
+  }
+
+  scheduleSettlement(callback: () => void): void {
+    if (this.disposed) return
+    let frame: number | null = null
+    let pending = true
+    frame = this.options.requestFrame(() => {
+      pending = false
+      if (frame !== null) this.settlementFrames.delete(frame)
+      if (!this.disposed) callback()
+    })
+    if (pending) this.settlementFrames.add(frame)
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    for (const frame of this.settlementFrames) {
+      this.options.cancelFrame(frame)
+    }
+    this.settlementFrames.clear()
+  }
+}
+
+function cancelKineticScroll(scroller: HTMLElement): void {
+  scroller.style.overflowY = 'hidden'
+  void scroller.offsetHeight
+  scroller.style.overflowY = ''
+}

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -46,6 +46,13 @@ const directionalWindowCoordinatorSource = readFileSync(
   ),
   'utf8',
 )
+const directionalBrowserAdapterPath = resolve(
+  process.cwd(),
+  'src/components/conversation/directionalHistoryBrowserAdapter.ts',
+)
+const directionalBrowserAdapterSource = existsSync(directionalBrowserAdapterPath)
+  ? readFileSync(directionalBrowserAdapterPath, 'utf8')
+  : ''
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -160,6 +167,17 @@ describe('live message-list scroll ownership', () => {
       }
     `
     expect(competingOwner).toMatch(browserOrPixelAuthority)
+  })
+
+  it('keeps directional DOM, virtualizer, and frame mechanics behind a browser adapter', () => {
+    expect(existsSync(directionalBrowserAdapterPath)).toBe(true)
+    expect(directionalBrowserAdapterSource).toMatch(browserOrPixelAuthority)
+    expect(directionalBrowserAdapterSource).not.toMatch(
+      /\b(?:DirectionalHistoryWindowCoordinator|PositioningController)\b/,
+    )
+    expect(hookSource).not.toMatch(
+      /\b(?:cancelKineticScroll|findAnchorElement|createDirectionalHistoryExecutor|directionalReleaseFramesRef|scheduleDirectionalHistorySettlement)\b/,
+    )
   })
 
   it('persists the outgoing viewport before resetting the session for entry', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -5,7 +5,7 @@
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
  * 2. PositioningController owns every live-list positioning generation. Directional window-load
  *    eligibility/lifetime lives in a value-only coordinator; browser writes stay imperative in
- *    leased hook executors
+ *    leased browser adapters
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -50,6 +50,10 @@ import {
   type DirectionalHistorySnapshot,
 } from './directionalHistoryWindowCoordinator'
 import {
+  DirectionalHistoryBrowserAdapter,
+  type DirectionalHistoryBrowserCapture,
+} from './directionalHistoryBrowserAdapter'
+import {
   PositioningController,
   type DirectionalHistoryExecutor,
   type ExplicitTargetExecutor,
@@ -73,7 +77,6 @@ import {
   messageFraction,
   pixelOffset,
   type AnchorPreservationRequest,
-  type DirectionalHistoryRequest,
   type DesiredPosition,
   type ExplicitTargetRequest,
   type LiveEdgeRequest,
@@ -181,26 +184,6 @@ function useStableCallback<Args extends unknown[]>(
   const latest = useRef(callback)
   latest.current = callback
   return useCallback((...args: Args) => latest.current(...args), [])
-}
-
-// ============================================================================
-// KINETIC SCROLL
-// ============================================================================
-
-/**
- * Cancel an in-flight or boundary-parked kinetic (momentum) scroll on `el`.
- *
- * Toggling overflow to hidden and forcing a reflow cancels WebKit's momentum animation; the
- * caller restores the scroll position immediately after. Used by the MAM-prepend restore so a
- * fast scroll-up fling's residual velocity can't resume into the freshly prepended content and
- * overshoot the anchor (blank window / jump to bottom on Tauri WebKitGTK). `overflowY = ''`
- * yields the property back to the element's CSS class (overflow-y-auto). No-op for programmatic
- * scrolls, which carry no momentum — so it cannot be exercised by the Playwright/preview harness.
- */
-export function cancelKineticScroll(el: HTMLElement): void {
-  el.style.overflowY = 'hidden'
-  void el.offsetHeight // force reflow so the overflow change (and momentum cancel) takes effect
-  el.style.overflowY = ''
 }
 
 // ============================================================================
@@ -486,6 +469,8 @@ export function useMessageListScroll({
   if (directionalWindowRef.current === null) {
     directionalWindowRef.current = new DirectionalHistoryWindowCoordinator()
   }
+  const directionalHistoryBrowserRef =
+    useRef<DirectionalHistoryBrowserAdapter | null>(null)
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
   // by `setMeasuredAtBottom` below (never closed over directly, so a caller passing a
@@ -560,8 +545,9 @@ export function useMessageListScroll({
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
   // Generation-aware semantic controller. All live-conversation positioning slices, including
-  // directional history, are authoritative. Pixel writes stay in hook executors, while the
-  // module-private generation allocator survives StrictMode remounts.
+  // directional history, are authoritative. Pixel writes stay in leased imperative executors;
+  // directional-history mechanics live behind their browser adapter. The module-private generation
+  // allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -604,17 +590,6 @@ export function useMessageListScroll({
       },
     })
   }
-  // Browser frames on which the value-only directional coordinator is told to adjudicate a load
-  // that settled without shifting the resident window. The coordinator owns request identity and
-  // cancellation policy; this hook retains only the browser scheduling mechanism until the browser
-  // adapter extraction in the next architecture slice.
-  // A set, not a single slot: two loads can be in flight across a fast re-trigger and settle in
-  // either order, so one request's frame must never displace another's. Cancelled on unmount.
-  // Same lazy-ref idiom as pinBottomClaim below — stable identity, no per-render allocation.
-  const directionalReleaseFramesRef = useRef<Set<number> | null>(null)
-  const directionalReleaseFrames = () =>
-    (directionalReleaseFramesRef.current ??= new Set<number>())
-
   // Media load batching (for images, videos, link previews)
   // When multiple media elements load in quick succession, we batch them and apply
   // a single scroll correction at the end to avoid jitter.
@@ -1021,6 +996,22 @@ export function useMessageListScroll({
       lifecycle,
     })
   }, [])
+
+  const getDirectionalHistoryBrowser = useCallback(() => {
+    if (directionalHistoryBrowserRef.current === null) {
+      directionalHistoryBrowserRef.current =
+        new DirectionalHistoryBrowserAdapter({
+          getScroller: () => scrollerRef.current,
+          getVirtualizer: () => virtualizerRef.current,
+          getActiveConversationId: () => activeConversationIdRef.current,
+          beginLoop: (lease) => beginControllerFrameLoop('prepend', lease),
+          requestFrame: (callback) => requestAnimationFrame(callback),
+          cancelFrame: (id) => cancelAnimationFrame(id),
+          log: debugLog,
+        })
+    }
+    return directionalHistoryBrowserRef.current
+  }, [beginControllerFrameLoop])
 
   const createLiveEdgeExecutor = useCallback((
     trigger: string,
@@ -1590,169 +1581,44 @@ export function useMessageListScroll({
     messageCount,
   ])
 
-  const createDirectionalHistoryExecutor = useCallback(
-    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor => {
-      let initialized = false
-      let previousTarget = 0
-      let usedFallback = false
-
-      return {
-        reachability: (desired) => {
-          const scroller = scrollerRef.current
-          const virtualizer = virtualizerRef.current
-          return deriveReachabilityForDesired({
-            desired,
-            hasRows: Boolean(
-              (virtualizer && virtualizer.itemCount > 0) ||
-              scroller?.querySelector('[data-message-id]'),
-            ),
-            windowAtLiveEdge: true,
-            virtualizer,
-            scroller,
-            loadAround: 'unavailable',
-            canRecenter: false,
-          })
-        },
-        beginLoop: (lease) => beginControllerFrameLoop('prepend', lease),
-        positionFrame: (
-          request: DirectionalHistoryRequest,
-          lease: PositionExecutionLease,
-        ) => {
-          if (
-            !lease.isCurrent() ||
-            activeConversationIdRef.current !== request.conversationId
-          ) {
-            return { kind: 'unavailable' }
-          }
-          const scroller = scrollerRef.current
-          if (!scroller) return { kind: 'unavailable' }
-          const virtualizer = virtualizerRef.current
-
-          if (!initialized) {
-            // Preserve the pre-paint WebKit momentum cancellation from the former layout effect.
-            void scroller.offsetHeight
-            cancelKineticScroll(scroller)
-          }
-
-          let target: number | null = null
-          let usedMethod = 'none'
-          if (request.desired.messageId) {
-            const virtualOffset =
-              virtualizer?.getOffsetForMessageId(
-                request.desired.messageId,
-              ) ?? null
-            if (virtualOffset !== null) {
-              target =
-                virtualOffset - request.desired.placement.offsetPx
-              usedMethod = 'virtualizer-offset'
-            } else {
-              const anchorElement = scroller.querySelector(
-                `[data-message-id="${CSS.escape(request.desired.messageId)}"]`,
-              ) as HTMLElement | null
-              if (anchorElement) {
-                target =
-                  anchorElement.offsetTop -
-                  request.desired.placement.offsetPx
-                usedMethod = 'element-based'
-              }
-            }
-          }
-
-          if (target === null) {
-            if (initialized) {
-              // The former loop kept its full late-measurement budget if an already-applied anchor
-              // temporarily disappeared. Do not switch fallback policy after the initial landing.
-              return {
-                kind: 'positioned',
-                scrollTop: scroller.scrollTop,
-                wrote: false,
-                reassert: Boolean(virtualizer && !usedFallback),
-              }
-            }
-            target =
-              scroller.scrollHeight -
-              scroller.clientHeight -
-              request.onUnavailable.distancePx
-            usedMethod = 'distance-from-bottom'
-            usedFallback = true
-          }
-
-          const maxScrollTop = Math.max(
-            0,
-            scroller.scrollHeight - scroller.clientHeight,
+  const createDirectionalHistoryCompletion = useCallback(
+    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor['complete'] =>
+      (request, outcome) => {
+        if (activeConversationIdRef.current !== request.conversationId) return
+        if (outcome === 'applied') {
+          const restored = directionalWindowRef.current?.markRestored(
+            saved.requestId,
+            Date.now(),
           )
-          const boundedTarget = Math.max(
-            0,
-            Math.min(target, maxScrollTop),
+          const restoredAt = restored?.restoredAt
+          if (restoredAt === undefined) return
+          prevMessageCountRef.current = messageCountRef.current
+          viewportSessionRef.current?.recordProgrammaticWrite(
+            request.conversationId,
+            restoredAt,
           )
-          const targetMoved =
-            initialized && Math.abs(boundedTarget - previousTarget) > 2
-          const geometryDrift =
-            initialized && Math.abs(scroller.scrollTop - boundedTarget) > 5
-          const shouldWrite = !initialized || targetMoved || geometryDrift
-          if (shouldWrite) {
-            if (virtualizer) {
-              virtualizer.scrollToOffset(boundedTarget)
-            } else {
-              scroller.scrollTop = boundedTarget
-            }
-          }
-          previousTarget = boundedTarget
-          initialized = true
-
-          debugLog('DIRECTIONAL HISTORY POSITION', {
-            generation: request.generation,
-            usedMethod,
-            target: boundedTarget,
-            targetMoved,
-            geometryDrift,
-            wrote: shouldWrite,
-          })
-          return {
-            kind: 'positioned',
-            scrollTop: scroller.scrollTop,
-            wrote: shouldWrite,
-            reassert: Boolean(virtualizer && !usedFallback),
-          }
-        },
-        complete: (request, outcome) => {
-          if (activeConversationIdRef.current !== request.conversationId) return
-          if (outcome === 'applied') {
-            const restored = directionalWindowRef.current?.markRestored(
+          setTimeout(() => {
+            directionalWindowRef.current?.expireRestored(
               saved.requestId,
-              Date.now(),
-            )
-            const restoredAt = restored?.restoredAt
-            if (restoredAt === undefined) return
-            prevMessageCountRef.current = messageCountRef.current
-            viewportSessionRef.current?.recordProgrammaticWrite(
-              request.conversationId,
               restoredAt,
             )
-            setTimeout(() => {
-              directionalWindowRef.current?.expireRestored(
-                saved.requestId,
-                restoredAt,
-              )
-            }, DIRECTIONAL_HISTORY_COOLDOWN_MS)
-          } else {
-            directionalWindowRef.current?.finishPosition(saved.requestId)
-          }
-          if (outcome !== 'applied') {
-            viewportSessionRef.current?.recordProgrammaticWrite(
-              request.conversationId,
-              Date.now(),
-            )
-          }
-          debugLog('DIRECTIONAL HISTORY COMPLETE', {
-            generation: request.generation,
-            outcome,
-            restored: Boolean(saved.restored),
-          })
-        },
-      }
-    },
-    [beginControllerFrameLoop],
+          }, DIRECTIONAL_HISTORY_COOLDOWN_MS)
+        } else {
+          directionalWindowRef.current?.finishPosition(saved.requestId)
+        }
+        if (outcome !== 'applied') {
+          viewportSessionRef.current?.recordProgrammaticWrite(
+            request.conversationId,
+            Date.now(),
+          )
+        }
+        debugLog('DIRECTIONAL HISTORY COMPLETE', {
+          generation: request.generation,
+          outcome,
+          restored: Boolean(saved.restored),
+        })
+      },
+    [],
   )
 
   const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
@@ -2361,107 +2227,6 @@ export function useMessageListScroll({
   // LOAD OLDER MESSAGES
   // ==========================================================================
 
-  // Find the first visible message element and its offset from the viewport top
-  const findAnchorElement = () => {
-    const scroller = scrollerRef.current
-    if (!scroller) return null
-
-    const scrollTop = scroller.scrollTop
-    const virt = virtualizerRef.current
-
-    // Virtualized path: DOM order ≠ visual order (items are absolutely positioned and
-    // the DOM retains the previous render's window until React re-renders). Instead,
-    // find the topmost visible message using the virtualizer's sorted item list.
-    //
-    // Special case: at scrollTop=0, the anchor is always firstMessageId (the topmost
-    // message in the list). This is reliable even when the old virtualizer window
-    // (from the previous scrollTop) hasn't been replaced yet.
-    if (virt) {
-      if (scrollTop === 0 && firstMessageId) {
-        const virtOffset = virt.getOffsetForMessageId(firstMessageId) ?? 0
-        const result = { id: firstMessageId, offsetFromTop: virtOffset }
-        debugLog('FIND ANCHOR: scrollTop=0, using firstMessageId', result)
-        return result
-      }
-
-      // For non-zero scrollTop, use getVirtualItems() (current window in visual order)
-      // to find the first item at or near the viewport top.
-      const virtualItems = virt.getVirtualItems()
-      for (const vi of virtualItems) {
-        const viewportOffset = vi.start - scrollTop
-        if (viewportOffset >= -vi.size / 2) {
-          // Find the [data-message-id] inside this virtualizer row wrapper
-          const wrapper = scroller.querySelector(`[data-index="${vi.index}"]`)
-          const messageEl = wrapper?.querySelector('[data-message-id]') as HTMLElement | null
-          if (!messageEl) continue  // skip non-message items (header, separator, footer)
-          const result = { id: messageEl.dataset.messageId!, offsetFromTop: viewportOffset }
-          debugLog('FIND ANCHOR: virtualizer item', { ...result, viIndex: vi.index, viStart: vi.start, scrollTop })
-          return result
-        }
-      }
-
-      // Nothing found in current window (edge case: window hasn't settled yet)
-      if (firstMessageId) {
-        const virtOffset = virt.getOffsetForMessageId(firstMessageId) ?? 0
-        const result = { id: firstMessageId, offsetFromTop: virtOffset - scrollTop }
-        debugLog('FIND ANCHOR: fallback to firstMessageId', result)
-        return result
-      }
-      return null
-    }
-
-    // Non-virtualized path: iterate DOM elements in order (they ARE in visual order)
-    const messages = scroller.querySelectorAll('[data-message-id]')
-
-    if (messages.length === 0) {
-      debugLog('FIND ANCHOR: no messages found')
-      return null
-    }
-
-    const scrollerRect = scroller.getBoundingClientRect()
-
-    for (const msg of messages) {
-      const element = msg as HTMLElement
-      const rect = element.getBoundingClientRect()
-      const offsetFromViewportTop = rect.top - scrollerRect.top
-
-      // First message whose top is at or below the viewport top (with half-height tolerance)
-      if (offsetFromViewportTop >= -rect.height / 2) {
-        const result = {
-          id: element.dataset.messageId!,
-          offsetFromTop: element.offsetTop - scrollTop,
-        }
-        debugLog('FIND ANCHOR: found', {
-          id: result.id,
-          offsetFromTop: result.offsetFromTop,
-          offsetFromViewportTop,
-          scrollTop,
-          elementOffsetTop: element.offsetTop,
-        })
-        return result
-      }
-    }
-
-    // Fallback: use the first message
-    const firstMsg = messages[0] as HTMLElement
-    if (firstMsg) {
-      const result = {
-        id: firstMsg.dataset.messageId!,
-        offsetFromTop: firstMsg.offsetTop - scrollTop,
-      }
-      debugLog('FIND ANCHOR: using first message as fallback', {
-        id: result.id,
-        offsetFromTop: result.offsetFromTop,
-        scrollTop,
-        elementOffsetTop: firstMsg.offsetTop,
-      })
-      return result
-    }
-
-    debugLog('FIND ANCHOR: no anchor found')
-    return null
-  }
-
   const applyDirectionalReleaseDecision = useCallback(
     (decision: DirectionalHistoryReleaseDecision) => {
       if (decision.kind !== 'cancel') return
@@ -2480,36 +2245,32 @@ export function useMessageListScroll({
     [],
   )
 
-  const scheduleDirectionalHistorySettlement = (requestId: number) => {
-    const frames = directionalReleaseFrames()
-    // The handle is only known AFTER requestAnimationFrame returns, but the callback can run
-    // BEFORE it does — jsdom suites stub rAF synchronously. Track it only while genuinely pending.
-    let frame: number | null = null
-    let pending = true
-    frame = requestAnimationFrame(() => {
-      pending = false
-      if (frame !== null) frames.delete(frame)
-      const activeConversationId = activeConversationIdRef.current
-      applyDirectionalReleaseDecision(
-        directionalWindowRef.current?.releaseSettledWithoutShift({
-          requestId,
-          conversationId: activeConversationId,
-          firstMessageId: liveWindowRef.current.firstMessageId ?? '',
-        }) ?? { kind: 'none' },
-      )
-    })
-    if (pending) frames.add(frame)
-  }
+  const settleDirectionalHistoryAfterFrame = useCallback(
+    (browser: DirectionalHistoryBrowserAdapter, requestId: number) => {
+      browser.scheduleSettlement(() => {
+        const activeConversationId = activeConversationIdRef.current
+        applyDirectionalReleaseDecision(
+          directionalWindowRef.current?.releaseSettledWithoutShift({
+            requestId,
+            conversationId: activeConversationId,
+            firstMessageId: liveWindowRef.current.firstMessageId ?? '',
+          }) ?? { kind: 'none' },
+        )
+      })
+    },
+    [applyDirectionalReleaseDecision],
+  )
 
   const beginDirectionalHistoryLoad = (
-    scroller: HTMLDivElement,
     direction: 'older' | 'newer',
     mode: 'automatic' | 'explicit',
   ): {
     saved: DirectionalHistorySnapshot
-    anchor: { id: string; offsetFromTop: number } | null
+    capture: DirectionalHistoryBrowserCapture | null
   } | null => {
-    let anchor: { id: string; offsetFromTop: number } | null = null
+    const browser = getDirectionalHistoryBrowser()
+    if (!browser.isAvailable()) return null
+    let capture: DirectionalHistoryBrowserCapture | null = null
     const result = directionalWindowRef.current?.begin({
       conversationId,
       direction,
@@ -2527,11 +2288,11 @@ export function useMessageListScroll({
           direction === 'older' ? 'top' : 'bottom',
         ) ?? false,
       capture: () => {
-        anchor = findAnchorElement()
-        return {
-          anchorMessageId: anchor?.id ?? '',
-          anchorOffsetFromTop: anchor?.offsetFromTop ?? 0,
-          distanceFromBottom: getDistanceFromBottom(scroller),
+        capture = browser.capture(firstMessageId ?? '', messageCount)
+        return capture?.facts ?? {
+          anchorMessageId: '',
+          anchorOffsetFromTop: 0,
+          distanceFromBottom: 0,
           firstMessageId: firstMessageId ?? '',
           messageCount,
         }
@@ -2565,7 +2326,9 @@ export function useMessageListScroll({
           },
         },
         distanceFromBottom: pixelOffset(saved.distanceFromBottom),
-        executor: createDirectionalHistoryExecutor(saved),
+        executor: browser.createExecutor(
+          createDirectionalHistoryCompletion(saved),
+        ),
       }) ?? null,
     })
     if (request) {
@@ -2574,37 +2337,32 @@ export function useMessageListScroll({
         request.generation,
       )
     }
-    return { saved, anchor }
+    return { saved, capture }
   }
 
   const runDirectionalHistoryLoad = (
     saved: DirectionalHistorySnapshot,
     run: () => unknown,
   ): void => {
+    const browser = getDirectionalHistoryBrowser()
     directionalWindowRef.current?.invokeLoad(
       saved,
       run,
-      scheduleDirectionalHistorySettlement,
+      (requestId) => settleDirectionalHistoryAfterFrame(browser, requestId),
     )
   }
 
   const triggerLoadOlder = () => {
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const started = beginDirectionalHistoryLoad(
-      scroller,
-      'older',
-      'automatic',
-    )
+    const started = beginDirectionalHistoryLoad('older', 'automatic')
     if (!started) return
-    const { saved, anchor } = started
+    const { saved, capture } = started
 
     debugLog('PREPEND START', {
-      anchor,
+      anchor: capture?.anchor ?? null,
       distanceFromBottom: saved.distanceFromBottom,
-      scrollHeight: scroller.scrollHeight,
-      scrollTop: scroller.scrollTop,
-      clientHeight: scroller.clientHeight,
+      scrollHeight: capture?.geometry.scrollHeight,
+      scrollTop: capture?.geometry.scrollTop,
+      clientHeight: capture?.geometry.clientHeight,
       firstMessageId,
       messageCount,
     })
@@ -2619,34 +2377,22 @@ export function useMessageListScroll({
   // viewport steady. The evicted rows are the OLDEST — far above the viewport — so the top-visible
   // anchor survives, making the anchor-based restore direction-agnostic.
   const triggerLoadNewer = () => {
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const started = beginDirectionalHistoryLoad(
-      scroller,
-      'newer',
-      'automatic',
-    )
+    const started = beginDirectionalHistoryLoad('newer', 'automatic')
     if (!started) return
     runDirectionalHistoryLoad(started.saved, () => onLoadNewer?.())
   }
 
   const handleLoadEarlier = () => {
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const started = beginDirectionalHistoryLoad(
-      scroller,
-      'older',
-      'explicit',
-    )
+    const started = beginDirectionalHistoryLoad('older', 'explicit')
     if (!started) return
-    const { saved, anchor } = started
+    const { saved, capture } = started
 
     debugLog('LOAD EARLIER', {
-      anchor,
+      anchor: capture?.anchor ?? null,
       distanceFromBottom: saved.distanceFromBottom,
-      scrollHeight: scroller.scrollHeight,
-      scrollTop: scroller.scrollTop,
-      clientHeight: scroller.clientHeight,
+      scrollHeight: capture?.geometry.scrollHeight,
+      scrollTop: capture?.geometry.scrollTop,
+      clientHeight: capture?.geometry.clientHeight,
       firstMessageId,
       messageCount,
     })
@@ -3555,10 +3301,10 @@ export function useMessageListScroll({
         cancelAnimationFrame(correctionRafRef.current)
         correctionRafRef.current = null
       }
-      const pendingReleaseFrames = directionalReleaseFramesRef.current
-      if (pendingReleaseFrames) {
-        for (const frame of pendingReleaseFrames) cancelAnimationFrame(frame)
-        pendingReleaseFrames.clear()
+      const directionalBrowser = directionalHistoryBrowserRef.current
+      directionalBrowser?.dispose()
+      if (directionalHistoryBrowserRef.current === directionalBrowser) {
+        directionalHistoryBrowserRef.current = null
       }
     }
   }, [])
@@ -3630,13 +3376,16 @@ export function useMessageListScroll({
     positioningControllerRef.current?.reconcileDirectionalHistory({
       conversationId,
       generation: decision.generation,
-      executor: createDirectionalHistoryExecutor(saved),
+      executor: getDirectionalHistoryBrowser().createExecutor(
+        createDirectionalHistoryCompletion(saved),
+      ),
     })
 
   }, [
     conversationId,
-    createDirectionalHistoryExecutor,
+    createDirectionalHistoryCompletion,
     firstMessageId,
+    getDirectionalHistoryBrowser,
     messageCount,
     staticMode,
   ])

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -39,7 +39,7 @@ budget, and user cancellation. Media growth, unread-divider movement, and delaye
 insertions while reading history share one fixed-anchor execution machine with the former
 90-frame/8-stable-frame/8px contract. Divider movement and delayed insertion have distinct
 `layout-preservation` reasons and are ambient: they are rejected rather than superseding an
-unsettled entry restore, explicit target, or user navigation. Hook executors
+unsettled entry restore, explicit target, or user navigation. Leased imperative executors
 translate accepted requests into browser/virtualizer writes, and every frame must hold the current
 controller lease before it can write. Directional history is accepted before a load begins, remains
 pending until the first resident ID changes or the load settles without a window shift, then either
@@ -77,9 +77,11 @@ and false-to-true live-window cleanup. A loader promise bounds only the snapshot
 settlement from an older superseded load cannot release the current request, while an in-flight
 load keeps its snapshot until its own first-id shift can reconcile. Conversation entry drops the
 departed conversation's snapshot, and delayed settlement or window observation from that snapshot
-cannot mutate the active conversation. The hook currently supplies the DOM measurements and
-one-frame browser settlement callback; the coordinator imports no DOM, virtualizer, frame
-scheduler, positioning controller, or pixel-write capability.
+cannot mutate the active conversation. A dedicated `DirectionalHistoryBrowserAdapter` owns visual
+anchor capture, the one-frame settlement scheduler, reachability probes, WebKit kinetic-scroll
+cancellation, and anchor/fallback pixel writes under the controller lease. The hook constructs and
+invokes the adapter and supplies lifecycle completion callbacks. The coordinator imports no DOM,
+virtualizer, frame scheduler, positioning controller, or pixel-write capability.
 
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while
@@ -299,7 +301,9 @@ measurement, or MDS completion cannot revive cancelled work.
 ## Reconciler responsibilities
 
 The controller-owned reconcilers own the difficult runtime work below. None belongs in the pure
-model; browser-specific geometry remains in leased hook executors:
+model; browser-specific geometry remains in leased imperative executors. Directional-history
+mechanics now live behind a dedicated browser adapter, while the remaining executors are still in
+the hook:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -495,6 +499,10 @@ kinetic scrolling and stale-paint behavior.
    - [x] Extract directional history load eligibility, invocation, and completion into a window
      coordinator that owns no positioning.
    - [ ] Move DOM/virtualizer reconciliation mechanics behind explicit browser adapters.
+     - [x] Extract directional-history capture, settlement scheduling, reachability, kinetic
+       cancellation, and anchor/fallback writes behind its leased browser adapter.
+     - [ ] Extract the remaining saved, marker/target, live-edge, fixed-anchor, and resident-top
+       browser executors.
    - [ ] Leave the React hook as thin lifecycle orchestration.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove


### PR DESCRIPTION
Moves directional-history DOM and virtualizer reconciliation into a dedicated leased browser adapter.

This keeps the React scroll hook focused on lifecycle orchestration while preserving anchor capture, distance fallback, WebKit momentum cancellation, convergence thresholds, and stale-generation safeguards.
