### PR TITLE
refactor(scroll): extract saved-position browser adapter

### DIFF
--- a/apps/fluux/src/components/conversation/bottomFractionAnchorBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/bottomFractionAnchorBrowserAdapter.ts
@@ -1,0 +1,75 @@
+import type { ScrollAnchor } from '@/utils/scrollStateManager'
+import type { MessageVirtualizer } from './messageVirtualizer'
+
+export type BottomFractionAnchorFrameResult =
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      reassert: boolean
+    }
+
+export interface BottomFractionAnchorBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+}
+
+export class BottomFractionAnchorBrowserAdapter {
+  constructor(private readonly options: BottomFractionAnchorBrowserAdapterOptions) {}
+
+  position(anchor: ScrollAnchor): BottomFractionAnchorFrameResult {
+    const scroller = this.options.getScroller()
+    if (!scroller) return { kind: 'unavailable' }
+    const virtualizer = this.options.getVirtualizer()
+
+    if (virtualizer) {
+      const index = virtualizer.getIndexForMessageId(anchor.messageId)
+      if (index === null) return { kind: 'unavailable' }
+
+      // A bottom-edge anchor first mounts at `end`. Once the row has measured, later controller
+      // frames can apply the exact fractional target without racing two virtualizer positions.
+      const item = anchor.fraction < 1
+        ? virtualizer.getVirtualItems().find((candidate) => candidate.index === index)
+        : undefined
+      const size = item?.size
+      const start = size
+        ? virtualizer.getOffsetForMessageId(anchor.messageId)
+        : null
+      if (size && start !== null) {
+        const row = scroller.querySelector(
+          `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`,
+        ) as HTMLElement | null
+        const rect = row && row.offsetHeight > 0
+          ? row.getBoundingClientRect()
+          : null
+        const target = rect
+          ? rect.top - scroller.getBoundingClientRect().top + scroller.scrollTop +
+            anchor.fraction * rect.height - scroller.clientHeight
+          : start + anchor.fraction * size - scroller.clientHeight
+        virtualizer.scrollToOffset(Math.max(0, target))
+      } else {
+        virtualizer.scrollToIndex(index, { align: 'end' })
+      }
+      return {
+        kind: 'positioned',
+        scrollTop: scroller.scrollTop,
+        reassert: true,
+      }
+    }
+
+    const row = scroller.querySelector(
+      `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`,
+    ) as HTMLElement | null
+    if (!row || row.offsetHeight <= 0) return { kind: 'unavailable' }
+    const rect = row.getBoundingClientRect()
+    const contentTop =
+      rect.top - scroller.getBoundingClientRect().top + scroller.scrollTop
+    scroller.scrollTop =
+      contentTop + anchor.fraction * rect.height - scroller.clientHeight
+    return {
+      kind: 'positioned',
+      scrollTop: scroller.scrollTop,
+      reassert: false,
+    }
+  }
+}

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -53,6 +53,20 @@ const directionalBrowserAdapterPath = resolve(
 const directionalBrowserAdapterSource = existsSync(directionalBrowserAdapterPath)
   ? readFileSync(directionalBrowserAdapterPath, 'utf8')
   : ''
+const bottomFractionBrowserAdapterPath = resolve(
+  process.cwd(),
+  'src/components/conversation/bottomFractionAnchorBrowserAdapter.ts',
+)
+const bottomFractionBrowserAdapterSource = existsSync(bottomFractionBrowserAdapterPath)
+  ? readFileSync(bottomFractionBrowserAdapterPath, 'utf8')
+  : ''
+const savedPositionBrowserAdapterPath = resolve(
+  process.cwd(),
+  'src/components/conversation/savedPositionBrowserAdapter.ts',
+)
+const savedPositionBrowserAdapterSource = existsSync(savedPositionBrowserAdapterPath)
+  ? readFileSync(savedPositionBrowserAdapterPath, 'utf8')
+  : ''
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -177,6 +191,18 @@ describe('live message-list scroll ownership', () => {
     )
     expect(hookSource).not.toMatch(
       /\b(?:cancelKineticScroll|findAnchorElement|createDirectionalHistoryExecutor|directionalReleaseFramesRef|scheduleDirectionalHistorySettlement)\b/,
+    )
+  })
+
+  it('keeps saved-position DOM and virtualizer mechanics behind browser adapters', () => {
+    expect(existsSync(bottomFractionBrowserAdapterPath)).toBe(true)
+    expect(existsSync(savedPositionBrowserAdapterPath)).toBe(true)
+    expect(bottomFractionBrowserAdapterSource).toMatch(browserOrPixelAuthority)
+    expect(savedPositionBrowserAdapterSource).toMatch(browserOrPixelAuthority)
+    expect(bottomFractionBrowserAdapterSource).not.toMatch(/\bPositioningController\b/)
+    expect(savedPositionBrowserAdapterSource).not.toMatch(/\bPositioningController\b/)
+    expect(hookSource).not.toMatch(
+      /\b(?:restoreToAnchor|applyVirtualizedAnchorFrame|createSavedPositionExecutor)\b/,
     )
   })
 

--- a/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ScrollAnchor } from '@/utils/scrollStateManager'
+import { messageFraction, pixelOffset, type SavedPositionRequest } from './scrollPositionModel'
+import type { MessageVirtualizer, VirtualWindowItem } from './messageVirtualizer'
+import type {
+  LiveEdgeExecutor,
+  PositionFrameLoop,
+  SavedPositionExecutionLease,
+} from './positioningController'
+import { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import { SavedPositionBrowserAdapter } from './savedPositionBrowserAdapter'
+
+function scrollerHarness(input: {
+  scrollTop?: number
+  scrollHeight?: number
+  clientHeight?: number
+  top?: number
+} = {}) {
+  let scrollTop = input.scrollTop ?? 500
+  const scrollHeight = input.scrollHeight ?? 2_000
+  const clientHeight = input.clientHeight ?? 400
+  const top = input.top ?? 100
+  const scroller = document.createElement('div')
+  Object.defineProperties(scroller, {
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value },
+    },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    clientHeight: { configurable: true, get: () => clientHeight },
+  })
+  scroller.getBoundingClientRect = () => ({
+    top,
+    bottom: top + clientHeight,
+    left: 0,
+    right: 600,
+    width: 600,
+    height: clientHeight,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  })
+  return {
+    scroller,
+    get scrollTop() { return scrollTop },
+  }
+}
+
+function appendMessageRow(
+  scroller: HTMLElement,
+  input: { id?: string; top?: number; height?: number; offsetHeight?: number } = {},
+) {
+  const row = document.createElement('div')
+  row.className = 'message-row'
+  row.dataset.messageId = input.id ?? 'anchor'
+  const top = input.top ?? 250
+  const height = input.height ?? 200
+  Object.defineProperty(row, 'offsetHeight', {
+    configurable: true,
+    get: () => input.offsetHeight ?? height,
+  })
+  row.getBoundingClientRect = () => ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 600,
+    width: 600,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  })
+  scroller.append(row)
+  return row
+}
+
+function virtualizerHarness(
+  scroller: HTMLElement,
+  input: {
+    index?: number | null
+    offset?: number | null
+    items?: VirtualWindowItem[]
+  } = {},
+) {
+  const scrollToOffset = vi.fn((offset: number) => {
+    scroller.scrollTop = offset
+  })
+  const scrollToIndex = vi.fn(() => {
+    scroller.scrollTop = 900
+  })
+  const virtualizer: MessageVirtualizer = {
+    getVirtualItems: () => input.items ?? [
+      { index: 4, start: 600, size: 200, key: 'anchor' },
+    ],
+    getTotalSize: () => 2_000,
+    itemCount: 10,
+    getOffsetForMessageId: vi.fn(() =>
+      input.offset === undefined ? 600 : input.offset),
+    getIndexForMessageId: vi.fn(() =>
+      input.index === undefined ? 4 : input.index),
+    ensureMessageMounted: vi.fn(async () => {}),
+    measureElement: vi.fn(),
+    scrollToOffset,
+    scrollToIndex,
+    beginAnimatedScrollToOffset: vi.fn(),
+  }
+  return { virtualizer, scrollToOffset, scrollToIndex }
+}
+
+function anchor(fraction = 0.5): ScrollAnchor {
+  return { messageId: 'anchor', fraction }
+}
+
+function savedRequest(
+  desired: SavedPositionRequest['desired'] = {
+    kind: 'anchor',
+    messageId: 'anchor',
+    placement: {
+      kind: 'bottom-fraction',
+      fraction: messageFraction(0.5),
+    },
+  },
+): SavedPositionRequest {
+  return {
+    generation: 7,
+    conversationId: 'room-a',
+    source: { kind: 'entry', reason: 'saved-position' },
+    desired,
+    onUnavailable: { kind: 'live-edge' },
+  } as SavedPositionRequest
+}
+
+function lease(isCurrent: () => boolean = () => true): SavedPositionExecutionLease {
+  const controller = new AbortController()
+  return {
+    conversationId: 'room-a',
+    generation: 7,
+    operation: 1,
+    signal: controller.signal,
+    isCurrent,
+    markApplied: () => true,
+    settle: () => true,
+  }
+}
+
+function adapterHarness(input: {
+  scroller: HTMLElement | null
+  virtualizer?: MessageVirtualizer
+  hasRows?: boolean
+  windowAtLiveEdge?: boolean
+  canRecenter?: boolean
+}) {
+  const anchorAdapter = new BottomFractionAnchorBrowserAdapter({
+    getScroller: () => input.scroller,
+    getVirtualizer: () => input.virtualizer,
+  })
+  const loop = {
+    schedule: vi.fn(),
+    recordFrame: vi.fn(),
+    finish: vi.fn(),
+  } satisfies PositionFrameLoop
+  const beginLoop = vi.fn(() => loop)
+  const adapter = new SavedPositionBrowserAdapter({
+    getScroller: () => input.scroller,
+    getVirtualizer: () => input.virtualizer,
+    getWindowFacts: () => ({
+      hasRows: input.hasRows ?? true,
+      windowAtLiveEdge: input.windowAtLiveEdge ?? true,
+      canRecenter: input.canRecenter ?? false,
+    }),
+    beginLoop,
+    anchorAdapter,
+  })
+  return { adapter, anchorAdapter, beginLoop, loop }
+}
+
+function executorFor(adapter: SavedPositionBrowserAdapter) {
+  const complete = vi.fn()
+  const liveEdge = {} as LiveEdgeExecutor
+  const executor = adapter.createExecutor({ liveEdge, complete })
+  return { executor, complete, liveEdge }
+}
+
+describe('BottomFractionAnchorBrowserAdapter', () => {
+  it('uses the mounted row rect as the exact inverse of anchor capture', () => {
+    const viewport = scrollerHarness()
+    appendMessageRow(viewport.scroller)
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller)
+    const browser = new BottomFractionAnchorBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+    })
+
+    expect(browser.position(anchor())).toEqual({
+      kind: 'positioned',
+      scrollTop: 350,
+      reassert: true,
+    })
+    expect(scrollToOffset).toHaveBeenCalledWith(350)
+  })
+
+  it('falls back to virtualizer measurements until the row is mounted', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller)
+    const browser = new BottomFractionAnchorBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+    })
+
+    expect(browser.position(anchor())).toEqual({
+      kind: 'positioned',
+      scrollTop: 300,
+      reassert: true,
+    })
+    expect(scrollToOffset).toHaveBeenCalledWith(300)
+  })
+
+  it('mounts a bottom-edge anchor before fractional refinement', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToOffset, scrollToIndex } = virtualizerHarness(
+      viewport.scroller,
+    )
+    const browser = new BottomFractionAnchorBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+    })
+
+    expect(browser.position(anchor(1))).toEqual({
+      kind: 'positioned',
+      scrollTop: 900,
+      reassert: true,
+    })
+    expect(scrollToIndex).toHaveBeenCalledWith(4, { align: 'end' })
+    expect(scrollToOffset).not.toHaveBeenCalled()
+  })
+
+  it('uses current DOM geometry without a virtualizer and rejects hidden anchors', () => {
+    const viewport = scrollerHarness()
+    const row = appendMessageRow(viewport.scroller)
+    const browser = new BottomFractionAnchorBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => undefined,
+    })
+
+    expect(browser.position(anchor())).toEqual({
+      kind: 'positioned',
+      scrollTop: 350,
+      reassert: false,
+    })
+
+    Object.defineProperty(row, 'offsetHeight', {
+      configurable: true,
+      get: () => 0,
+    })
+    expect(browser.position(anchor())).toEqual({ kind: 'unavailable' })
+  })
+})
+
+describe('SavedPositionBrowserAdapter', () => {
+  it('owns reachability, loop creation, and lifecycle ports without changing them', () => {
+    const viewport = scrollerHarness({ scrollHeight: 800, clientHeight: 400 })
+    const { adapter, beginLoop, loop } = adapterHarness({
+      scroller: viewport.scroller,
+    })
+    const { executor, complete, liveEdge } = executorFor(adapter)
+    const currentLease = lease()
+
+    expect(executor.liveEdge).toBe(liveEdge)
+    expect(executor.beginLoop(currentLease)).toBe(loop)
+    expect(beginLoop).toHaveBeenCalledWith(currentLease)
+    expect(executor.reachability(
+      { kind: 'legacy-offset', offsetPx: pixelOffset(500) },
+      'unavailable',
+    )).toMatchObject({
+      kind: 'available',
+      placement: 'use-unavailable-policy',
+    })
+
+    executor.complete(savedRequest(), 'settled')
+    expect(complete).toHaveBeenCalledWith(savedRequest(), 'settled')
+  })
+
+  it('restores legacy offsets through the virtualizer or bounded DOM writes', () => {
+    const viewport = scrollerHarness({ scrollHeight: 1_000, clientHeight: 400 })
+    const { virtualizer, scrollToOffset } = virtualizerHarness(viewport.scroller)
+    const virtual = executorFor(adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    }).adapter).executor
+    const request = savedRequest({
+      kind: 'legacy-offset',
+      offsetPx: pixelOffset(550),
+    })
+
+    expect(virtual.positionFrame(request, lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 550,
+      reassert: false,
+    })
+    expect(scrollToOffset).toHaveBeenCalledWith(550)
+
+    const dom = executorFor(adapterHarness({
+      scroller: viewport.scroller,
+    }).adapter).executor
+    expect(dom.positionFrame(request, lease())).toMatchObject({
+      kind: 'positioned',
+      scrollTop: 550,
+    })
+    expect(dom.positionFrame(savedRequest({
+      kind: 'legacy-offset',
+      offsetPx: pixelOffset(601),
+    }), lease())).toEqual({ kind: 'unavailable' })
+  })
+
+  it('delegates fractional anchors and rejects stale or live-edge calls', () => {
+    const viewport = scrollerHarness()
+    const { adapter, anchorAdapter } = adapterHarness({
+      scroller: viewport.scroller,
+    })
+    const position = vi.spyOn(anchorAdapter, 'position').mockReturnValue({
+      kind: 'positioned',
+      scrollTop: 350,
+      reassert: false,
+    })
+    const executor = executorFor(adapter).executor
+
+    expect(executor.positionFrame(savedRequest(), lease())).toMatchObject({
+      kind: 'positioned',
+      scrollTop: 350,
+    })
+    expect(position).toHaveBeenCalledWith(anchor())
+
+    position.mockClear()
+    expect(executor.positionFrame(savedRequest(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    expect(position).not.toHaveBeenCalled()
+    expect(executor.positionFrame(savedRequest({
+      kind: 'live-edge',
+      follow: true,
+    }), lease())).toEqual({ kind: 'unavailable' })
+  })
+
+  it('rechecks the lease after a browser write before reporting success', () => {
+    const viewport = scrollerHarness()
+    let current = true
+    const { virtualizer } = virtualizerHarness(viewport.scroller)
+    virtualizer.scrollToOffset = vi.fn(() => {
+      current = false
+    })
+    const executor = executorFor(adapterHarness({
+      scroller: viewport.scroller,
+      virtualizer,
+    }).adapter).executor
+
+    expect(executor.positionFrame(savedRequest({
+      kind: 'legacy-offset',
+      offsetPx: pixelOffset(550),
+    }), lease(() => current))).toEqual({ kind: 'unavailable' })
+  })
+})

--- a/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.ts
@@ -1,0 +1,124 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  LiveEdgeExecutor,
+  PositionFrameLoop,
+  SavedPositionExecutor,
+  SavedPositionExecutionLease,
+} from './positioningController'
+import type { SavedPositionRequest } from './scrollPositionModel'
+import type { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+
+export interface SavedPositionWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+  canRecenter: boolean
+}
+
+export interface SavedPositionBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getWindowFacts: () => SavedPositionWindowFacts
+  beginLoop: (lease: SavedPositionExecutionLease) => PositionFrameLoop | null
+  anchorAdapter: BottomFractionAnchorBrowserAdapter
+}
+
+export interface SavedPositionBrowserPorts {
+  liveEdge: LiveEdgeExecutor
+  loadAround?: SavedPositionExecutor['loadAround']
+  recenterVersion?: string
+  recenterLiveEdge?: SavedPositionExecutor['recenterLiveEdge']
+  complete: SavedPositionExecutor['complete']
+}
+
+export class SavedPositionBrowserAdapter {
+  constructor(private readonly options: SavedPositionBrowserAdapterOptions) {}
+
+  createExecutor(ports: SavedPositionBrowserPorts): SavedPositionExecutor {
+    return {
+      liveEdge: ports.liveEdge,
+      reachability: (desired, loadAround) => {
+        const scroller = this.options.getScroller()
+        const virtualizer = this.options.getVirtualizer()
+        const facts = this.options.getWindowFacts()
+        const legacyOffsetViable =
+          desired.kind !== 'legacy-offset' ||
+          Boolean(
+            virtualizer ||
+            (
+              scroller &&
+              scroller.scrollHeight - scroller.clientHeight > 0 &&
+              desired.offsetPx >= 0 &&
+              desired.offsetPx <= scroller.scrollHeight - scroller.clientHeight
+            ),
+          )
+        return deriveReachabilityForDesired({
+          desired,
+          hasRows: facts.hasRows,
+          windowAtLiveEdge: facts.windowAtLiveEdge,
+          virtualizer,
+          scroller,
+          loadAround,
+          canRecenter: facts.canRecenter,
+          legacyOffsetViable,
+        })
+      },
+      loadAround: ports.loadAround,
+      recenterVersion: ports.recenterVersion,
+      recenterLiveEdge: ports.recenterLiveEdge,
+      beginLoop: (lease) => this.options.beginLoop(lease),
+      positionFrame: (request, lease) => this.positionFrame(request, lease),
+      complete: ports.complete,
+    }
+  }
+
+  positionFrame(
+    request: SavedPositionRequest,
+    lease: SavedPositionExecutionLease,
+  ): ReturnType<SavedPositionExecutor['positionFrame']> {
+    if (!lease.isCurrent()) return { kind: 'unavailable' }
+    const scroller = this.options.getScroller()
+    if (!scroller) return { kind: 'unavailable' }
+
+    let result: ReturnType<SavedPositionExecutor['positionFrame']>
+    if (request.desired.kind === 'anchor') {
+      result = this.options.anchorAdapter.position({
+        messageId: request.desired.messageId,
+        fraction: request.desired.placement.fraction,
+      })
+    } else if (request.desired.kind === 'legacy-offset') {
+      const virtualizer = this.options.getVirtualizer()
+      if (virtualizer) {
+        virtualizer.scrollToOffset(request.desired.offsetPx)
+        result = {
+          kind: 'positioned',
+          scrollTop: scroller.scrollTop,
+          reassert: false,
+        }
+      } else {
+        const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
+        if (
+          maxScrollTop <= 0 ||
+          request.desired.offsetPx < 0 ||
+          request.desired.offsetPx > maxScrollTop
+        ) {
+          return { kind: 'unavailable' }
+        }
+        scroller.scrollTop = request.desired.offsetPx
+        result = {
+          kind: 'positioned',
+          scrollTop: scroller.scrollTop,
+          reassert: false,
+        }
+      }
+    } else {
+      // Live-edge fallbacks transfer to their dedicated controller execution before this executor
+      // is driven. Treat a stale call as unavailable rather than creating another scroll owner.
+      return { kind: 'unavailable' }
+    }
+
+    return result.kind === 'positioned' && lease.isCurrent()
+      ? result
+      : { kind: 'unavailable' }
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -53,6 +53,8 @@ import {
   DirectionalHistoryBrowserAdapter,
   type DirectionalHistoryBrowserCapture,
 } from './directionalHistoryBrowserAdapter'
+import { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import { SavedPositionBrowserAdapter } from './savedPositionBrowserAdapter'
 import {
   PositioningController,
   type DirectionalHistoryExecutor,
@@ -62,7 +64,6 @@ import {
   type LiveEdgeCompletion,
   type PositionExecutionLease,
   type ResidentTopExecutor,
-  type SavedPositionExecutionLease,
   type SavedPositionExecutor,
   type UnreadMarkerExecutor,
 } from './positioningController'
@@ -81,7 +82,6 @@ import {
   type ExplicitTargetRequest,
   type LiveEdgeRequest,
   type ReachabilityFacts,
-  type SavedPositionRequest,
   type UnreadMarkerRequest,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
@@ -237,32 +237,6 @@ function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
   const topRel = rect.top - sTop
   return { messageId, fraction: clamp01((viewportH - topRel) / height) }
 }
-
-/**
- * Restore scroll so the viewport bottom sits at the saved FRACTION through the anchor message,
- * using the message's CURRENT measured height. Returns false if the anchor message isn't currently
- * mounted (scrolled up beyond the re-hydrated/virtualized window) so the caller can fall back.
- *
- * Measured with getBoundingClientRect, NOT offsetTop — the exact inverse of the basis
- * {@link findBottomAnchor} captures on, and for the same reason it documents. `offsetTop` is
- * relative to the element's offsetParent, which under virtualization is the row's own
- * `position:absolute` `[data-index]` wrapper (so it reads ~0 for EVERY row) and in normal flow is
- * whichever positioned ancestor happens to be nearest — not necessarily the scroller. A rect-based
- * capture paired with an offsetTop-based restore was therefore never a true inverse. Deriving both
- * sides from rects makes an unchanged capture→restore an exact no-op, so repeated restorations
- * cannot accumulate error.
- */
-function restoreToAnchor(scroller: HTMLElement, anchor: ScrollAnchor): boolean {
-  const el = scroller.querySelector(
-    `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`
-  ) as HTMLElement | null
-  if (!el || el.offsetHeight <= 0) return false
-  const rect = el.getBoundingClientRect()
-  const contentTop = rect.top - scroller.getBoundingClientRect().top + scroller.scrollTop
-  scroller.scrollTop = contentTop + anchor.fraction * rect.height - scroller.clientHeight
-  return true
-}
-
 
 // ============================================================================
 // TYPES
@@ -471,6 +445,8 @@ export function useMessageListScroll({
   }
   const directionalHistoryBrowserRef =
     useRef<DirectionalHistoryBrowserAdapter | null>(null)
+  const bottomFractionAnchorBrowserRef =
+    useRef<BottomFractionAnchorBrowserAdapter | null>(null)
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
   // by `setMeasuredAtBottom` below (never closed over directly, so a caller passing a
@@ -546,8 +522,8 @@ export function useMessageListScroll({
   const unmountDeactivationTokenRef = useRef<object | null>(null)
   // Generation-aware semantic controller. All live-conversation positioning slices, including
   // directional history, are authoritative. Pixel writes stay in leased imperative executors;
-  // directional-history mechanics live behind their browser adapter. The module-private generation
-  // allocator survives StrictMode remounts.
+  // directional-history and saved-position mechanics live behind their browser adapters. The
+  // module-private generation allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -924,51 +900,6 @@ export function useMessageListScroll({
 
   const { setScrollContainerRef, setContentRef } = stableSettersRef.current
 
-  // Apply one virtualized bottom-fraction anchor write from CURRENT measurements. Saved-position
-  // restoration and fixed-anchor media/layout preservation share this browser geometry while the
-  // positioning controller owns every frame-loop lifecycle.
-  const applyVirtualizedAnchorFrame = useCallback((anchor: ScrollAnchor): number | null => {
-    const v = virtualizerRef.current
-    const s = scrollerRef.current
-    if (!v || !s) return null
-    const idx = v.getIndexForMessageId(anchor.messageId)
-    if (idx === null) return null
-    // Issue the fractional target as the ONLY scroll write per frame. The old code ALSO called
-    // scrollToIndex(idx,'end') every frame; the two targets differ by (1-fraction)*rowHeight, and
-    // for a tall anchor at a mid fraction that per-frame kick knocks the row across the
-    // virtualization window boundary — its height flips between estimate and measured, the offsets
-    // shift, and the loop never converges ([ScrollReassertLoop] 'restore-anchor', observed as a
-    // ~253px scrollTop ping-pong). scrollToOffset re-windows just like scrollToIndex, so the
-    // fractional write alone both positions the anchor AND keeps it mounted, so it settles.
-    const item =
-      anchor.fraction < 1 ? v.getVirtualItems().find((vi) => vi.index === idx) : undefined
-    const size = item?.size
-    const start = size ? v.getOffsetForMessageId(anchor.messageId) : null
-    if (size && start !== null) {
-      // Measure the ROW when it is mounted, not the virtualizer's item. `findBottomAnchor` captures
-      // the fraction against the `.message-row` rect, while `start`/`size` describe the enclosing
-      // `[data-index]` wrapper — they differ by the inter-row gap, so capture and restore are not
-      // inverses and each preservation leaves a small residual behind. Invisible once; across a
-      // burst of arrivals it compounds into a visible drift. Deriving the target from the row's own
-      // rect makes an unchanged capture→restore an exact no-op. The WRITE still goes through the
-      // virtualizer (never a raw scrollTop), so it re-windows and cannot fight @tanstack's pending
-      // scroll reconciler.
-      const row = s.querySelector(
-        `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`
-      ) as HTMLElement | null
-      const rect = row && row.offsetHeight > 0 ? row.getBoundingClientRect() : null
-      const target = rect
-        ? rect.top - s.getBoundingClientRect().top + s.scrollTop + anchor.fraction * rect.height - s.clientHeight
-        : start + anchor.fraction * size - s.clientHeight
-      v.scrollToOffset(Math.max(0, target))
-    } else {
-      // Anchor not yet in the measured window (or fraction===1): mount it / pin its bottom to the
-      // viewport bottom. Once it measures in, later frames take the fractional branch above.
-      v.scrollToIndex(idx, { align: 'end' })
-    }
-    return s.scrollTop
-  }, [])
-
   const beginControllerFrameLoop = useCallback((
     label: ReassertLoopLabel,
     lease: PositionExecutionLease,
@@ -995,6 +926,17 @@ export function useMessageListScroll({
       },
       lifecycle,
     })
+  }, [])
+
+  const getBottomFractionAnchorBrowser = useCallback(() => {
+    if (bottomFractionAnchorBrowserRef.current === null) {
+      bottomFractionAnchorBrowserRef.current =
+        new BottomFractionAnchorBrowserAdapter({
+          getScroller: () => scrollerRef.current,
+          getVirtualizer: () => virtualizerRef.current,
+        })
+    }
+    return bottomFractionAnchorBrowserRef.current
   }, [])
 
   const getDirectionalHistoryBrowser = useCallback(() => {
@@ -1316,25 +1258,11 @@ export function useMessageListScroll({
         ) {
           return { kind: 'unavailable' }
         }
-        const scroller = scrollerRef.current
-        if (!scroller) return { kind: 'unavailable' }
         const anchor: ScrollAnchor = {
           messageId: request.desired.messageId,
           fraction: request.desired.placement.fraction,
         }
-        if (virtualizerRef.current) {
-          const scrollTop = applyVirtualizedAnchorFrame(anchor)
-          return scrollTop === null
-            ? { kind: 'unavailable' }
-            : { kind: 'positioned', scrollTop, reassert: true }
-        }
-        return restoreToAnchor(scroller, anchor)
-          ? {
-              kind: 'positioned',
-              scrollTop: scroller.scrollTop,
-              reassert: false,
-            }
-          : { kind: 'unavailable' }
+        return getBottomFractionAnchorBrowser().position(anchor)
       },
       complete: (request, outcome) => {
         if (activeConversationIdRef.current !== request.conversationId) return
@@ -1357,9 +1285,9 @@ export function useMessageListScroll({
       },
     }),
     [
-      applyVirtualizedAnchorFrame,
       beginControllerFrameLoop,
       firstMessageId,
+      getBottomFractionAnchorBrowser,
       isAtBottomRef,
       messageCount,
       rememberCurrentScrollSnapshot,
@@ -1621,128 +1549,68 @@ export function useMessageListScroll({
     [],
   )
 
-  const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
-    liveEdge: createLiveEdgeExecutor('restore-fallback'),
-    reachability: (desired, loadAround) => {
-      const scroller = scrollerRef.current
-      const virtualizer = virtualizerRef.current
-      const legacyOffsetViable =
-        desired.kind !== 'legacy-offset' ||
-        Boolean(
-          virtualizer ||
-          (
-            scroller &&
-            scroller.scrollHeight - scroller.clientHeight > 0 &&
-            desired.offsetPx >= 0 &&
-            desired.offsetPx <= scroller.scrollHeight - scroller.clientHeight
-          )
-        )
-      return deriveReachabilityForDesired({
-        desired,
+  const buildSavedPositionExecutor = useCallback((): SavedPositionExecutor => {
+    const browser = new SavedPositionBrowserAdapter({
+      getScroller: () => scrollerRef.current,
+      getVirtualizer: () => virtualizerRef.current,
+      getWindowFacts: () => ({
         hasRows: messageCount > 0 && firstMessageId !== undefined,
         windowAtLiveEdge: windowAtLiveEdge !== false,
-        virtualizer,
-        scroller,
-        loadAround,
         canRecenter: Boolean(onLoadNewer),
-        legacyOffsetViable,
-      })
-    },
-    loadAround: onLoadAroundRef.current
-      ? (messageId, signal) => {
-          if (signal.aborted) return
-          isAtBottomRef.current = false
-          debugLog('RESTORE: anchor not loaded, requesting cache slice around it', {
-            messageId,
-            conversationId,
-          })
-          return onLoadAroundRef.current?.(messageId)
-        }
-      : undefined,
-    recenterVersion: [
-      windowAtLiveEdge === false ? 'slid' : 'live',
-      isLoadingNewer ? 'loading' : 'idle',
-      messageCount,
-      lastMessageId ?? '',
-    ].join(':'),
-    recenterLiveEdge: onLoadNewer
-      ? (signal) => {
-          if (signal.aborted) return 'unavailable'
-          if (isLoadingNewer) return 'waiting'
-          onLoadNewer()
-          return 'requested'
-        }
-      : undefined,
-    beginLoop: (lease) => beginControllerFrameLoop('restore-anchor', lease),
-    positionFrame: (request: SavedPositionRequest, lease: SavedPositionExecutionLease) => {
-      if (!lease.isCurrent()) return { kind: 'unavailable' }
-      const scroller = scrollerRef.current
-      if (!scroller) return { kind: 'unavailable' }
-
-      let restored = false
-      let reassert = false
-      if (request.desired.kind === 'anchor') {
-        const anchor: ScrollAnchor = {
-          messageId: request.desired.messageId,
-          fraction: request.desired.placement.fraction,
-        }
-        if (virtualizerRef.current) {
-          restored = applyVirtualizedAnchorFrame(anchor) !== null
-          reassert = restored
-        } else {
-          restored = restoreToAnchor(scroller, anchor)
-        }
-      } else if (request.desired.kind === 'legacy-offset') {
-        const virtualizer = virtualizerRef.current
-        if (virtualizer) {
-          virtualizer.scrollToOffset(request.desired.offsetPx)
-          restored = true
-        } else {
-          const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
-          if (
-            maxScrollTop > 0 &&
-            request.desired.offsetPx >= 0 &&
-            request.desired.offsetPx <= maxScrollTop
-          ) {
-            scroller.scrollTop = request.desired.offsetPx
-            restored = true
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('restore-anchor', lease),
+      anchorAdapter: getBottomFractionAnchorBrowser(),
+    })
+    return browser.createExecutor({
+      liveEdge: createLiveEdgeExecutor('restore-fallback'),
+      loadAround: onLoadAroundRef.current
+        ? (messageId, signal) => {
+            if (signal.aborted) return
+            isAtBottomRef.current = false
+            debugLog('RESTORE: anchor not loaded, requesting cache slice around it', {
+              messageId,
+              conversationId,
+            })
+            return onLoadAroundRef.current?.(messageId)
           }
-        }
-      } else if (request.desired.kind === 'live-edge') {
-        // Live-edge fallbacks transfer to the dedicated controller execution before this executor
-        // is driven. Treat a stale call as unavailable rather than creating a second scroll owner.
-        return { kind: 'unavailable' }
-      }
-
-      if (!restored || !lease.isCurrent()) return { kind: 'unavailable' }
-      return {
-        kind: 'positioned',
-        scrollTop: scroller.scrollTop,
-        reassert,
-      }
-    },
-    complete: (request, outcome) => {
-      const scroller = scrollerRef.current
-      if (!scroller) return
-      setMeasuredAtBottom(getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD)
-      rememberCurrentScrollSnapshot()
-      viewportSessionRef.current?.recordProgrammaticWrite(
-        request.conversationId,
-        Date.now(),
-      )
-      debugLog('RESTORE: controller completed position', {
-        conversationId,
-        generation: request.generation,
-        desired: request.desired,
-        outcome,
-      })
-    },
-  }), [
-    applyVirtualizedAnchorFrame,
+        : undefined,
+      recenterVersion: [
+        windowAtLiveEdge === false ? 'slid' : 'live',
+        isLoadingNewer ? 'loading' : 'idle',
+        messageCount,
+        lastMessageId ?? '',
+      ].join(':'),
+      recenterLiveEdge: onLoadNewer
+        ? (signal) => {
+            if (signal.aborted) return 'unavailable'
+            if (isLoadingNewer) return 'waiting'
+            onLoadNewer()
+            return 'requested'
+          }
+        : undefined,
+      complete: (request, outcome) => {
+        const scroller = scrollerRef.current
+        if (!scroller) return
+        setMeasuredAtBottom(getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD)
+        rememberCurrentScrollSnapshot()
+        viewportSessionRef.current?.recordProgrammaticWrite(
+          request.conversationId,
+          Date.now(),
+        )
+        debugLog('RESTORE: controller completed position', {
+          conversationId,
+          generation: request.generation,
+          desired: request.desired,
+          outcome,
+        })
+      },
+    })
+  }, [
     beginControllerFrameLoop,
     conversationId,
     createLiveEdgeExecutor,
     firstMessageId,
+    getBottomFractionAnchorBrowser,
     isAtBottomRef,
     isLoadingNewer,
     lastMessageId,
@@ -2931,7 +2799,7 @@ export function useMessageListScroll({
           ? positioningControllerRef.current?.beginSavedPositionEntry({
               conversationId,
               entryFacts: entryExecutionFacts,
-              executor: createSavedPositionExecutor(),
+              executor: buildSavedPositionExecutor(),
             })
           : null
         if (!request) {
@@ -3014,7 +2882,7 @@ export function useMessageListScroll({
   }, [
     conversationId,
     createLiveEdgeExecutor,
-    createSavedPositionExecutor,
+    buildSavedPositionExecutor,
     createUnreadMarkerExecutor,
     emergencyLiveEdgeWrite,
     firstNewMessageId,
@@ -3138,14 +3006,14 @@ export function useMessageListScroll({
     if (controller.refreshSavedPosition({
       conversationId,
       generation: status.request.generation,
-      executor: createSavedPositionExecutor(),
+      executor: buildSavedPositionExecutor(),
     })) {
       prevMessageCountRef.current = messageCount
       prevLastMessageIdRef.current = lastMessageId
     }
   }, [
     conversationId,
-    createSavedPositionExecutor,
+    buildSavedPositionExecutor,
     firstMessageId,
     lastMessageId,
     messageCount,

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -83,6 +83,13 @@ cancellation, and anchor/fallback pixel writes under the controller lease. The h
 invokes the adapter and supplies lifecycle completion callbacks. The coordinator imports no DOM,
 virtualizer, frame scheduler, positioning controller, or pixel-write capability.
 
+Saved-position reconciliation likewise runs through a dedicated browser adapter. It owns
+reachability probes, bounded legacy-offset writes, bottom-fraction anchor positioning, and the
+restore frame-loop port, while the hook supplies cache loading, live-window recentering, live-edge
+fallback, and completion callbacks. The shared bottom-fraction adapter keeps saved restoration and
+fixed-anchor preservation on the same row-rect/virtualizer geometry without giving either a second
+positioning lifecycle.
+
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while
 remeasurement moves the target makes convergence samples unreliable and recreates scroll fighting.
@@ -301,9 +308,9 @@ measurement, or MDS completion cannot revive cancelled work.
 ## Reconciler responsibilities
 
 The controller-owned reconcilers own the difficult runtime work below. None belongs in the pure
-model; browser-specific geometry remains in leased imperative executors. Directional-history
-mechanics now live behind a dedicated browser adapter, while the remaining executors are still in
-the hook:
+model; browser-specific geometry remains in leased imperative executors. Directional-history and
+saved-position mechanics now live behind dedicated browser adapters, while the remaining executors
+are still in the hook:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -501,8 +508,10 @@ kinetic scrolling and stale-paint behavior.
    - [ ] Move DOM/virtualizer reconciliation mechanics behind explicit browser adapters.
      - [x] Extract directional-history capture, settlement scheduling, reachability, kinetic
        cancellation, and anchor/fallback writes behind its leased browser adapter.
-     - [ ] Extract the remaining saved, marker/target, live-edge, fixed-anchor, and resident-top
-       browser executors.
+     - [x] Extract saved-position reachability, legacy-offset and bottom-fraction writes behind its
+       leased browser adapter, with shared bottom-fraction geometry for fixed anchors.
+     - [ ] Extract the remaining marker/target, live-edge, fixed-anchor, and resident-top browser
+       executors.
    - [ ] Leave the React hook as thin lifecycle orchestration.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove


### PR DESCRIPTION
Moves saved-position browser reconciliation behind leased adapters, including shared bottom-fraction anchor geometry. This keeps `useMessageListScroll` focused on lifecycle orchestration while preserving deep-history loading, refresh, and live-edge fallback semantics.

Adds focused adapter and ownership coverage, and documents the saved-position takeover contract.
