### PR TITLE
refactor(scroll): extract target browser adapters

### DIFF
--- a/apps/fluux/src/components/conversation/explicitTargetBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/explicitTargetBrowserAdapter.ts
@@ -1,0 +1,201 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  ExplicitTargetExecutor,
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type { ExplicitTargetRequest } from './scrollPositionModel'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+import { findMessageTargetElement } from './messageTargetElement'
+import { evaluateJumpTarget } from './jumpTargetVisibility'
+import { signalAnomaly } from '@/utils/anomalySignal'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+
+/** Keep live-controller and isolated static-preview target flashes visually identical. */
+export const TARGET_HIGHLIGHT_MS = 1500
+
+export interface ExplicitTargetWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+}
+
+export interface ExplicitTargetPassiveContext {
+  conversationId: string
+  virtualizer: MessageVirtualizer | undefined
+}
+
+export interface ExplicitTargetBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getWindowFacts: () => ExplicitTargetWindowFacts
+  getPassiveContext: () => ExplicitTargetPassiveContext
+  getActiveConversationId: () => string
+  getStoreTargetMessageId: () => string | null | undefined
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  setMeasuredAtBottom: (atLiveEdge: boolean) => void
+  markNotAtBottom: () => void
+  consumeStoreTarget: () => void
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+export interface ExplicitTargetBrowserPorts {
+  conversationId: string
+  messageReference: string
+  consumeStoreTarget: boolean
+  loadAround?: ExplicitTargetExecutor['loadAround']
+}
+
+export class ExplicitTargetBrowserAdapter {
+  constructor(private readonly options: ExplicitTargetBrowserAdapterOptions) {}
+
+  createExecutor(ports: ExplicitTargetBrowserPorts): ExplicitTargetExecutor {
+    return {
+      reachability: (desired, loadAround) => {
+        const scroller = this.options.getScroller()
+        const virtualizer = this.options.getVirtualizer()
+        const element = scroller
+          ? findMessageTargetElement(scroller, desired.messageId)
+          : null
+        if (element) {
+          return {
+            kind: 'available',
+            index: virtualizer?.getIndexForMessageId(desired.messageId) ?? 0,
+            mounted: true,
+            placement: 'viable',
+          }
+        }
+        const window = this.options.getWindowFacts()
+        const facts = deriveReachabilityForDesired({
+          desired,
+          hasRows: window.hasRows,
+          windowAtLiveEdge: window.windowAtLiveEdge,
+          virtualizer,
+          scroller,
+          loadAround,
+          canRecenter: false,
+        })
+        // An explicit target can name the cache slice to load even before the resident window has
+        // hydrated, unlike ordinary conversation-entry positioning.
+        return facts.kind === 'empty-window'
+          ? { kind: 'target-absent', loadAround }
+          : facts
+      },
+      loadAround: ports.loadAround
+        ? (messageId, signal) => {
+            if (
+              signal.aborted ||
+              this.options.getActiveConversationId() !== ports.conversationId
+            ) {
+              return
+            }
+            this.options.markNotAtBottom()
+            this.options.log?.(
+              'TARGET MESSAGE: requesting cache slice around target',
+              { conversationId: ports.conversationId, messageId },
+            )
+            return ports.loadAround?.(messageId, signal)
+          }
+        : undefined,
+      beginLoop: (lease) => this.options.beginLoop(lease),
+      readScrollTop: () => this.options.getScroller()?.scrollTop ?? null,
+      positionFrame: (request, lease) => this.positionFrame(request, lease),
+      complete: (request, outcome, applied) => {
+        if (
+          this.options.getActiveConversationId() !== request.conversationId ||
+          request.desired.messageId !== ports.messageReference
+        ) {
+          return
+        }
+        if (
+          ports.consumeStoreTarget &&
+          this.options.getStoreTargetMessageId() !== request.desired.messageId
+        ) {
+          return
+        }
+
+        const scroller = this.options.getScroller()
+        const element = scroller
+          ? findMessageTargetElement(scroller, request.desired.messageId)
+          : null
+        if (element && applied) {
+          element.classList.add('message-highlight')
+          setTimeout(
+            () => element.classList.remove('message-highlight'),
+            TARGET_HIGHLIGHT_MS,
+          )
+        }
+        this.options.log?.('TARGET MESSAGE: controller completed', {
+          conversationId: request.conversationId,
+          generation: request.generation,
+          targetId: request.desired.messageId,
+          outcome,
+          highlighted: Boolean(element && applied),
+        })
+
+        if (__FLUUX_ANOMALY__ && scroller) {
+          const viewport = scroller.getBoundingClientRect()
+          const target = element?.getBoundingClientRect() ?? null
+          const miss = evaluateJumpTarget({
+            outcome,
+            applied,
+            target: target ? { top: target.top, bottom: target.bottom } : null,
+            viewport: { top: viewport.top, bottom: viewport.bottom },
+          })
+          if (miss) {
+            signalAnomaly({
+              name: 'scroll/jump-target-miss',
+              offBy: Math.round(miss.offBy),
+              messageId: request.desired.messageId,
+            })
+          }
+        }
+
+        if (ports.consumeStoreTarget) this.options.consumeStoreTarget()
+      },
+    }
+  }
+
+  private positionFrame(
+    request: ExplicitTargetRequest,
+    lease: PositionExecutionLease,
+  ): ReturnType<ExplicitTargetExecutor['positionFrame']> {
+    if (!lease.isCurrent()) return { kind: 'unavailable' }
+    const scroller = this.options.getScroller()
+    if (!scroller) return { kind: 'unavailable' }
+
+    // Requests can be submitted during entry. Wait for the passive handoff so the virtualizer from
+    // the conversation being left cannot receive the first center write.
+    const passive = this.options.getPassiveContext()
+    if (passive.conversationId !== request.conversationId) {
+      return { kind: 'waiting' }
+    }
+
+    const targetId = request.desired.messageId
+    const virtualizer = passive.virtualizer
+    const index = virtualizer?.getIndexForMessageId(targetId) ?? null
+    const element = findMessageTargetElement(scroller, targetId)
+    if (index === null && !element) return { kind: 'waiting' }
+    if (!lease.isCurrent()) return { kind: 'unavailable' }
+
+    if (index !== null && virtualizer) {
+      virtualizer.scrollToIndex(index, { align: 'center' })
+    } else {
+      element?.scrollIntoView({ block: 'center' })
+    }
+    const scrollTop = scroller.scrollTop
+    const distanceFromBottom =
+      scroller.scrollHeight - scrollTop - scroller.clientHeight
+    this.options.setMeasuredAtBottom(
+      distanceFromBottom < AT_BOTTOM_THRESHOLD,
+    )
+    this.options.log?.('TARGET MESSAGE: controller positioned frame', {
+      conversationId: request.conversationId,
+      generation: request.generation,
+      targetId,
+      index,
+      scrollTop,
+      distanceFromBottom,
+    })
+    return { kind: 'positioned', scrollTop, wrote: true }
+  }
+}

--- a/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
+++ b/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
@@ -3,8 +3,8 @@
  *
  * Lives with the scroll code rather than under `src/anomaly/`, for two reasons. It is
  * a scroll invariant — the same kind of pure decision as `fabVisibility.ts` — and its
- * only caller is `useMessageListScroll`, which ships in release builds and therefore
- * must not import the anomaly tree at all. A static import there would pull the
+ * only caller is `ExplicitTargetBrowserAdapter`, which ships in release builds and
+ * therefore must not import the anomaly tree at all. A static import there would pull the
  * recorder and serializer into the production bundle even behind a dead branch.
  *
  * The check is not timed: the explicit-target executor has an exact settle point

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -67,6 +67,20 @@ const savedPositionBrowserAdapterPath = resolve(
 const savedPositionBrowserAdapterSource = existsSync(savedPositionBrowserAdapterPath)
   ? readFileSync(savedPositionBrowserAdapterPath, 'utf8')
   : ''
+const unreadMarkerBrowserAdapterPath = resolve(
+  process.cwd(),
+  'src/components/conversation/unreadMarkerBrowserAdapter.ts',
+)
+const unreadMarkerBrowserAdapterSource = existsSync(unreadMarkerBrowserAdapterPath)
+  ? readFileSync(unreadMarkerBrowserAdapterPath, 'utf8')
+  : ''
+const explicitTargetBrowserAdapterPath = resolve(
+  process.cwd(),
+  'src/components/conversation/explicitTargetBrowserAdapter.ts',
+)
+const explicitTargetBrowserAdapterSource = existsSync(explicitTargetBrowserAdapterPath)
+  ? readFileSync(explicitTargetBrowserAdapterPath, 'utf8')
+  : ''
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -203,6 +217,18 @@ describe('live message-list scroll ownership', () => {
     expect(savedPositionBrowserAdapterSource).not.toMatch(/\bPositioningController\b/)
     expect(hookSource).not.toMatch(
       /\b(?:restoreToAnchor|applyVirtualizedAnchorFrame|createSavedPositionExecutor)\b/,
+    )
+  })
+
+  it('keeps unread-marker and explicit-target browser mechanics behind leased adapters', () => {
+    expect(existsSync(unreadMarkerBrowserAdapterPath)).toBe(true)
+    expect(existsSync(explicitTargetBrowserAdapterPath)).toBe(true)
+    expect(unreadMarkerBrowserAdapterSource).toMatch(browserOrPixelAuthority)
+    expect(explicitTargetBrowserAdapterSource).toMatch(browserOrPixelAuthority)
+    expect(unreadMarkerBrowserAdapterSource).not.toMatch(/\bPositioningController\b/)
+    expect(explicitTargetBrowserAdapterSource).not.toMatch(/\bPositioningController\b/)
+    expect(hookSource).not.toMatch(
+      /\b(?:createUnreadMarkerExecutor|createExplicitTargetExecutor)\b/,
     )
   })
 

--- a/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
@@ -1,0 +1,467 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  LiveEdgeExecutor,
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type {
+  ExplicitTargetRequest,
+  UnreadMarkerRequest,
+} from './scrollPositionModel'
+import { ExplicitTargetBrowserAdapter } from './explicitTargetBrowserAdapter'
+import { UnreadMarkerBrowserAdapter } from './unreadMarkerBrowserAdapter'
+
+function scrollerHarness(input: {
+  scrollTop?: number
+  scrollHeight?: number
+  clientHeight?: number
+} = {}) {
+  let scrollTop = input.scrollTop ?? 400
+  const scrollHeight = input.scrollHeight ?? 2_000
+  const clientHeight = input.clientHeight ?? 600
+  const scroller = document.createElement('div')
+  Object.defineProperties(scroller, {
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value },
+    },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    clientHeight: { configurable: true, get: () => clientHeight },
+  })
+  scroller.getBoundingClientRect = () => ({
+    top: 100,
+    bottom: 100 + clientHeight,
+    left: 0,
+    right: 600,
+    width: 600,
+    height: clientHeight,
+    x: 0,
+    y: 100,
+    toJSON: () => ({}),
+  })
+  return {
+    scroller,
+    get scrollTop() { return scrollTop },
+  }
+}
+
+function appendMessage(
+  scroller: HTMLElement,
+  input: { id?: string; offsetTop?: number; rectTop?: number } = {},
+) {
+  const element = document.createElement('div')
+  element.dataset.messageId = input.id ?? 'message-5'
+  Object.defineProperty(element, 'offsetTop', {
+    configurable: true,
+    get: () => input.offsetTop ?? 500,
+  })
+  element.getBoundingClientRect = () => ({
+    top: input.rectTop ?? 300,
+    bottom: (input.rectTop ?? 300) + 80,
+    left: 0,
+    right: 600,
+    width: 600,
+    height: 80,
+    x: 0,
+    y: input.rectTop ?? 300,
+    toJSON: () => ({}),
+  })
+  element.scrollIntoView = vi.fn(() => { scroller.scrollTop = 700 })
+  scroller.append(element)
+  return element
+}
+
+function virtualizerHarness(
+  scroller: HTMLElement,
+  input: {
+    index?: number | null
+    offset?: number | null
+    itemCount?: number
+    landedTop?: number
+  } = {},
+) {
+  const scrollToIndex = vi.fn(() => {
+    scroller.scrollTop = input.landedTop ?? 900
+  })
+  const virtualizer: MessageVirtualizer = {
+    getVirtualItems: () => [],
+    getTotalSize: () => 2_000,
+    itemCount: input.itemCount ?? 20,
+    getOffsetForMessageId: vi.fn(() =>
+      input.offset === undefined ? 900 : input.offset),
+    getIndexForMessageId: vi.fn(() =>
+      input.index === undefined ? 5 : input.index),
+    ensureMessageMounted: vi.fn(async () => {}),
+    measureElement: vi.fn(),
+    scrollToOffset: vi.fn((offset: number) => { scroller.scrollTop = offset }),
+    scrollToIndex,
+    beginAnimatedScrollToOffset: vi.fn(),
+  }
+  return { virtualizer, scrollToIndex }
+}
+
+function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
+  const controller = new AbortController()
+  return {
+    conversationId: 'room-a',
+    generation: 7,
+    operation: 1,
+    signal: controller.signal,
+    isCurrent,
+    markApplied: () => true,
+    settle: () => true,
+  }
+}
+
+function unreadRequest(
+  align: 'start' | 'top-third' = 'top-third',
+): UnreadMarkerRequest {
+  return {
+    generation: 7,
+    conversationId: 'room-a',
+    source: { kind: 'entry', reason: 'unread-marker' },
+    desired: { kind: 'message', messageId: 'message-5', align },
+    onUnavailable: { kind: 'live-edge' },
+  }
+}
+
+function explicitRequest(): ExplicitTargetRequest {
+  return {
+    generation: 7,
+    conversationId: 'room-a',
+    source: { kind: 'user-navigation', reason: 'message-target' },
+    desired: { kind: 'message', messageId: 'message-5', align: 'center' },
+    onUnavailable: { kind: 'wait' },
+  }
+}
+
+function loopHarness() {
+  const loop = {
+    schedule: vi.fn(),
+    recordFrame: vi.fn(),
+    finish: vi.fn(),
+  } satisfies PositionFrameLoop
+  return { loop, beginLoop: vi.fn(() => loop) }
+}
+
+describe('UnreadMarkerBrowserAdapter', () => {
+  it('owns reachability and loop creation while preserving the live-edge fallback port', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer } = virtualizerHarness(viewport.scroller)
+    const { loop, beginLoop } = loopHarness()
+    const liveEdge = {} as LiveEdgeExecutor
+    const executor = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+      getWindowFacts: () => ({ hasRows: true, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
+      beginLoop,
+      setMeasuredAtBottom: vi.fn(),
+    }).createExecutor(liveEdge)
+
+    expect(executor.liveEdge).toBe(liveEdge)
+    expect(executor.reachability(unreadRequest().desired)).toMatchObject({
+      kind: 'available',
+      index: 5,
+    })
+    expect(executor.beginLoop(lease())).toBe(loop)
+    expect(executor.readScrollTop()).toBe(400)
+  })
+
+  it('re-reads current window facts instead of freezing the render that built the executor', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer } = virtualizerHarness(viewport.scroller)
+    let hasRows = false
+    const executor = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+      getWindowFacts: () => ({ hasRows, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
+      beginLoop: loopHarness().beginLoop,
+      setMeasuredAtBottom: vi.fn(),
+    }).createExecutor({} as LiveEdgeExecutor)
+
+    expect(executor.reachability(unreadRequest().desired)).toEqual({
+      kind: 'empty-window',
+    })
+    hasRows = true
+    expect(executor.reachability(unreadRequest().desired)).toMatchObject({
+      kind: 'available',
+      index: 5,
+    })
+  })
+
+  it('waits for the passive conversation handoff and distinguishes hydration from absence', () => {
+    const viewport = scrollerHarness()
+    const hydrating = virtualizerHarness(viewport.scroller, {
+      index: null,
+      itemCount: 0,
+    }).virtualizer
+    let passiveConversation = 'room-old'
+    const adapter = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => hydrating,
+      getWindowFacts: () => ({ hasRows: true, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({
+        conversationId: passiveConversation,
+        virtualizer: hydrating,
+      }),
+      beginLoop: loopHarness().beginLoop,
+      setMeasuredAtBottom: vi.fn(),
+    })
+    const executor = adapter.createExecutor({} as LiveEdgeExecutor)
+
+    expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'waiting' })
+    passiveConversation = 'room-a'
+    expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'waiting' })
+    Object.defineProperty(hydrating, 'itemCount', { value: 20 })
+    expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'unavailable' })
+  })
+
+  it('rejects near-top markers and positions virtual markers from current measurements', () => {
+    const viewport = scrollerHarness({ clientHeight: 600 })
+    const nearTop = virtualizerHarness(viewport.scroller, { offset: 200 }).virtualizer
+    let virtualizer = nearTop
+    const measured = vi.fn()
+    const executor = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+      getWindowFacts: () => ({ hasRows: true, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
+      beginLoop: loopHarness().beginLoop,
+      setMeasuredAtBottom: measured,
+    }).createExecutor({} as LiveEdgeExecutor)
+
+    expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'unavailable' })
+    const mounted = virtualizerHarness(viewport.scroller, {
+      offset: 900,
+      landedTop: 1_395,
+    })
+    virtualizer = mounted.virtualizer
+    expect(executor.positionFrame(unreadRequest('start'), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 1_395,
+      atLiveEdge: true,
+    })
+    expect(mounted.scrollToIndex).toHaveBeenCalledWith(5, { align: 'start' })
+    expect(measured).toHaveBeenLastCalledWith(true)
+  })
+
+  it('applies top-third placement without a virtualizer and never writes under a stale lease', () => {
+    const viewport = scrollerHarness({ clientHeight: 600 })
+    appendMessage(viewport.scroller, { offsetTop: 800 })
+    const executor = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => undefined,
+      getWindowFacts: () => ({ hasRows: true, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({ conversationId: 'room-a', virtualizer: undefined }),
+      beginLoop: loopHarness().beginLoop,
+      setMeasuredAtBottom: vi.fn(),
+    }).createExecutor({} as LiveEdgeExecutor)
+
+    expect(executor.positionFrame(unreadRequest(), lease())).toMatchObject({
+      kind: 'positioned',
+      scrollTop: 600,
+    })
+    viewport.scroller.scrollTop = 111
+    expect(executor.positionFrame(unreadRequest(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    expect(viewport.scrollTop).toBe(111)
+  })
+})
+
+describe('ExplicitTargetBrowserAdapter', () => {
+  function harness(input: {
+    scroller?: HTMLElement | null
+    virtualizer?: MessageVirtualizer
+    passiveConversation?: () => string
+    activeConversation?: () => string
+    storeTarget?: () => string | undefined
+    hasRows?: boolean
+  } = {}) {
+    const viewport = scrollerHarness()
+    const scroller = input.scroller === undefined ? viewport.scroller : input.scroller
+    const { loop, beginLoop } = loopHarness()
+    const measured = vi.fn()
+    const markNotAtBottom = vi.fn()
+    const consumeStoreTarget = vi.fn()
+    const adapter = new ExplicitTargetBrowserAdapter({
+      getScroller: () => scroller,
+      getVirtualizer: () => input.virtualizer,
+      getWindowFacts: () => ({
+        hasRows: input.hasRows ?? true,
+        windowAtLiveEdge: true,
+      }),
+      getPassiveContext: () => ({
+        conversationId: input.passiveConversation?.() ?? 'room-a',
+        virtualizer: input.virtualizer,
+      }),
+      getActiveConversationId: () => input.activeConversation?.() ?? 'room-a',
+      getStoreTargetMessageId: () => input.storeTarget?.() ?? 'message-5',
+      beginLoop,
+      setMeasuredAtBottom: measured,
+      markNotAtBottom,
+      consumeStoreTarget,
+    })
+    return {
+      adapter,
+      viewport,
+      scroller,
+      loop,
+      beginLoop,
+      measured,
+      markNotAtBottom,
+      consumeStoreTarget,
+    }
+  }
+
+  it('resolves mounted aliases and promotes an empty window to an around-load target', () => {
+    const mounted = harness()
+    const element = appendMessage(mounted.viewport.scroller)
+    element.dataset.messageId = 'row-local'
+    element.dataset.stanzaId = 'message-5'
+    const mountedExecutor = mounted.adapter.createExecutor({
+      conversationId: 'room-a',
+      messageReference: 'message-5',
+      consumeStoreTarget: false,
+    })
+
+    expect(mountedExecutor.reachability(explicitRequest().desired, 'unavailable')).toEqual({
+      kind: 'available',
+      index: 0,
+      mounted: true,
+      placement: 'viable',
+    })
+    expect(mountedExecutor.beginLoop(lease())).toBe(mounted.loop)
+    expect(mountedExecutor.readScrollTop()).toBe(400)
+
+    const empty = harness({ hasRows: false })
+    const emptyExecutor = empty.adapter.createExecutor({
+      conversationId: 'room-a',
+      messageReference: 'message-5',
+      consumeStoreTarget: false,
+      loadAround: vi.fn(),
+    })
+    expect(emptyExecutor.reachability(explicitRequest().desired, 'available')).toEqual({
+      kind: 'target-absent',
+      loadAround: 'available',
+    })
+  })
+
+  it('guards around loading by abort and active conversation before changing bottom intent', () => {
+    let activeConversation = 'room-a'
+    const loadAround = vi.fn()
+    const result = harness({ activeConversation: () => activeConversation })
+    const executor = result.adapter.createExecutor({
+      conversationId: 'room-a',
+      messageReference: 'message-5',
+      consumeStoreTarget: false,
+      loadAround,
+    })
+    const aborted = new AbortController()
+    aborted.abort()
+
+    executor.loadAround?.('message-5', aborted.signal)
+    activeConversation = 'room-b'
+    executor.loadAround?.('message-5', new AbortController().signal)
+    expect(loadAround).not.toHaveBeenCalled()
+    expect(result.markNotAtBottom).not.toHaveBeenCalled()
+
+    activeConversation = 'room-a'
+    executor.loadAround?.('message-5', new AbortController().signal)
+    expect(result.markNotAtBottom).toHaveBeenCalledOnce()
+    expect(loadAround).toHaveBeenCalledOnce()
+  })
+
+  it('waits for passive handoff then centers through the virtualizer under the lease', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToIndex } = virtualizerHarness(viewport.scroller, {
+      landedTop: 700,
+    })
+    let passiveConversation = 'room-old'
+    const result = harness({
+      scroller: viewport.scroller,
+      virtualizer,
+      passiveConversation: () => passiveConversation,
+    })
+    const executor = result.adapter.createExecutor({
+      conversationId: 'room-a',
+      messageReference: 'message-5',
+      consumeStoreTarget: false,
+    })
+
+    expect(executor.positionFrame(explicitRequest(), lease())).toEqual({ kind: 'waiting' })
+    passiveConversation = 'room-a'
+    expect(executor.positionFrame(explicitRequest(), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 700,
+      wrote: true,
+    })
+    expect(scrollToIndex).toHaveBeenCalledWith(5, { align: 'center' })
+    expect(result.measured).toHaveBeenCalledWith(false)
+
+    viewport.scroller.scrollTop = 123
+    expect(executor.positionFrame(explicitRequest(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    expect(viewport.scrollTop).toBe(123)
+  })
+
+  it('falls back to the scoped mounted element when no virtual index exists', () => {
+    const viewport = scrollerHarness()
+    const element = appendMessage(viewport.scroller)
+    const result = harness({ scroller: viewport.scroller })
+    const executor = result.adapter.createExecutor({
+      conversationId: 'room-a',
+      messageReference: 'message-5',
+      consumeStoreTarget: false,
+    })
+
+    expect(executor.positionFrame(explicitRequest(), lease())).toMatchObject({
+      kind: 'positioned',
+      scrollTop: 700,
+    })
+    expect(element.scrollIntoView).toHaveBeenCalledWith({ block: 'center' })
+  })
+
+  it('highlights only applied current targets and consumes only the matching store target', () => {
+    vi.useFakeTimers()
+    try {
+      let activeConversation = 'room-a'
+      let storeTarget = 'message-5'
+      const result = harness({
+        activeConversation: () => activeConversation,
+        storeTarget: () => storeTarget,
+      })
+      const element = appendMessage(result.viewport.scroller)
+      const executor = result.adapter.createExecutor({
+        conversationId: 'room-a',
+        messageReference: 'message-5',
+        consumeStoreTarget: true,
+      })
+
+      executor.complete(explicitRequest(), 'settled', false)
+      expect(element).not.toHaveClass('message-highlight')
+      expect(result.consumeStoreTarget).toHaveBeenCalledOnce()
+
+      result.consumeStoreTarget.mockClear()
+      executor.complete(explicitRequest(), 'settled', true)
+      expect(element).toHaveClass('message-highlight')
+      expect(result.consumeStoreTarget).toHaveBeenCalledOnce()
+      vi.runAllTimers()
+      expect(element).not.toHaveClass('message-highlight')
+
+      result.consumeStoreTarget.mockClear()
+      storeTarget = 'message-newer'
+      executor.complete(explicitRequest(), 'settled', true)
+      activeConversation = 'room-b'
+      executor.complete(explicitRequest(), 'settled', true)
+      expect(result.consumeStoreTarget).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/fluux/src/components/conversation/unreadMarkerBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/unreadMarkerBrowserAdapter.ts
@@ -1,0 +1,128 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  PositionExecutionLease,
+  PositionFrameLoop,
+  UnreadMarkerExecutor,
+} from './positioningController'
+import type { UnreadMarkerRequest } from './scrollPositionModel'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+
+export interface UnreadMarkerWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+}
+
+export interface UnreadMarkerPassiveContext {
+  conversationId: string
+  virtualizer: MessageVirtualizer | undefined
+}
+
+export interface UnreadMarkerBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getWindowFacts: () => UnreadMarkerWindowFacts
+  getPassiveContext: () => UnreadMarkerPassiveContext
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  setMeasuredAtBottom: (atLiveEdge: boolean) => void
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+export class UnreadMarkerBrowserAdapter {
+  constructor(private readonly options: UnreadMarkerBrowserAdapterOptions) {}
+
+  createExecutor(
+    liveEdge: UnreadMarkerExecutor['liveEdge'],
+  ): UnreadMarkerExecutor {
+    return {
+      liveEdge,
+      reachability: (desired) => {
+        const facts = this.options.getWindowFacts()
+        return deriveReachabilityForDesired({
+          desired,
+          hasRows: facts.hasRows,
+          windowAtLiveEdge: facts.windowAtLiveEdge,
+          virtualizer: this.options.getVirtualizer(),
+          scroller: this.options.getScroller(),
+          loadAround: 'unavailable',
+          canRecenter: false,
+        })
+      },
+      beginLoop: (lease) => this.options.beginLoop(lease),
+      readScrollTop: () => this.options.getScroller()?.scrollTop ?? null,
+      positionFrame: (request, lease) => this.positionFrame(request, lease),
+    }
+  }
+
+  private positionFrame(
+    request: UnreadMarkerRequest,
+    lease: PositionExecutionLease,
+  ): ReturnType<UnreadMarkerExecutor['positionFrame']> {
+    if (!lease.isCurrent()) return { kind: 'unavailable' }
+    const scroller = this.options.getScroller()
+    if (!scroller) return { kind: 'unavailable' }
+
+    // Entry waits until the passive latest-value handoff has installed the new conversation's
+    // virtualizer. The synchronous render ref can still describe a transient pre-paint window.
+    const passive = this.options.getPassiveContext()
+    if (passive.conversationId !== request.conversationId) {
+      return { kind: 'waiting' }
+    }
+
+    const virtualizer = passive.virtualizer
+    const markerId = request.desired.messageId
+    const markerIndex = virtualizer
+      ? virtualizer.getIndexForMessageId(markerId)
+      : null
+    let offset: number | null = null
+    if (virtualizer) {
+      if (markerIndex === null) {
+        // An empty virtualizer is still hydrating. Once it has rows, an unindexed divider names a
+        // message outside the resident slice and must transfer to the live-edge fallback.
+        return virtualizer.itemCount === 0
+          ? { kind: 'waiting' }
+          : { kind: 'unavailable' }
+      }
+      offset = virtualizer.getOffsetForMessageId(markerId)
+    } else {
+      const element = scroller.querySelector(
+        `[data-message-id="${CSS.escape(markerId)}"]`,
+      ) as HTMLElement | null
+      if (element) offset = element.offsetTop
+    }
+    if (offset === null) return { kind: 'waiting' }
+
+    // Avoid scrollTop=0, which is the explicit load-older threshold. An unread divider near the
+    // resident start retains the established live-edge fallback instead.
+    if (offset <= scroller.clientHeight / 3) {
+      return { kind: 'unavailable' }
+    }
+    if (!lease.isCurrent()) return { kind: 'unavailable' }
+
+    if (virtualizer && markerIndex !== null) {
+      virtualizer.scrollToIndex(markerIndex, { align: 'start' })
+    } else {
+      const top = request.desired.align === 'top-third'
+        ? Math.max(0, offset - scroller.clientHeight / 3)
+        : offset
+      scroller.scrollTop = top
+    }
+
+    const scrollTop = scroller.scrollTop
+    const distanceFromBottom =
+      scroller.scrollHeight - scrollTop - scroller.clientHeight
+    const atLiveEdge = distanceFromBottom < AT_BOTTOM_THRESHOLD
+    this.options.setMeasuredAtBottom(atLiveEdge)
+    this.options.log?.('UNREAD MARKER: controller positioned frame', {
+      conversationId: request.conversationId,
+      generation: request.generation,
+      markerId,
+      markerIndex,
+      offset,
+      scrollTop,
+      distanceFromBottom,
+      atLiveEdge,
+    })
+    return { kind: 'positioned', scrollTop, atLiveEdge }
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -37,7 +37,6 @@ import { decideRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { signalAnomaly } from '@/utils/anomalySignal'
-import { evaluateJumpTarget } from './jumpTargetVisibility'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
@@ -55,17 +54,20 @@ import {
 } from './directionalHistoryBrowserAdapter'
 import { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
 import { SavedPositionBrowserAdapter } from './savedPositionBrowserAdapter'
+import { UnreadMarkerBrowserAdapter } from './unreadMarkerBrowserAdapter'
+import {
+  ExplicitTargetBrowserAdapter,
+  TARGET_HIGHLIGHT_MS,
+} from './explicitTargetBrowserAdapter'
 import {
   PositioningController,
   type DirectionalHistoryExecutor,
-  type ExplicitTargetExecutor,
   type AnchorPreservationExecutor,
   type LiveEdgeExecutor,
   type LiveEdgeCompletion,
   type PositionExecutionLease,
   type ResidentTopExecutor,
   type SavedPositionExecutor,
-  type UnreadMarkerExecutor,
 } from './positioningController'
 import {
   deriveAtLiveEdge,
@@ -82,7 +84,6 @@ import {
   type ExplicitTargetRequest,
   type LiveEdgeRequest,
   type ReachabilityFacts,
-  type UnreadMarkerRequest,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
 import { findMessageTargetElement } from './messageTargetElement'
@@ -139,9 +140,6 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
-// How long a jumped-to message keeps its highlight tint, for both the controller-owned live path
-// and the scoped static-preview path (they must flash identically).
-const TARGET_HIGHLIGHT_MS = 1500
 // While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
 // above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
 // the frame where the last row's measurement settles — coalesced height deltas, or a height delta
@@ -522,8 +520,8 @@ export function useMessageListScroll({
   const unmountDeactivationTokenRef = useRef<object | null>(null)
   // Generation-aware semantic controller. All live-conversation positioning slices, including
   // directional history, are authoritative. Pixel writes stay in leased imperative executors;
-  // directional-history and saved-position mechanics live behind their browser adapters. The
-  // module-private generation allocator survives StrictMode remounts.
+  // directional-history, saved-position, unread-marker, and explicit-target mechanics live behind
+  // their browser adapters. The module-private generation allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -1621,266 +1619,67 @@ export function useMessageListScroll({
     windowAtLiveEdge,
   ])
 
-  const createUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => ({
-    liveEdge: createLiveEdgeExecutor('marker-fallback'),
-    reachability: (desired) => deriveReachabilityForDesired({
-      desired,
-      hasRows: messageCount > 0 && firstMessageId !== undefined,
-      windowAtLiveEdge: windowAtLiveEdge !== false,
-      virtualizer: virtualizerRef.current,
-      scroller: scrollerRef.current,
-      loadAround: 'unavailable',
-      canRecenter: false,
-    }),
-    beginLoop: (lease: PositionExecutionLease) =>
-      beginControllerFrameLoop('marker', lease),
-    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
-    positionFrame: (
-      request: UnreadMarkerRequest,
-      lease: PositionExecutionLease,
-    ) => {
-      if (!lease.isCurrent()) return { kind: 'unavailable' }
-      const scroller = scrollerRef.current
-      if (!scroller) return { kind: 'unavailable' }
-
-      // Entry waits until the passive latest-value handoff has installed the new conversation's
-      // virtualizer. Reading the synchronous render ref here can act on a transient pre-paint
-      // window and advance viewport-derived read state before the new list is settled.
-      const latest = latestRef.current
-      if (latest.conversationId !== request.conversationId) {
-        return { kind: 'waiting' }
-      }
-      const virtualizer = latest.virtualizer
-      const markerId = request.desired.messageId
-      const markerIndex = virtualizer
-        ? virtualizer.getIndexForMessageId(markerId)
-        : null
-      let offset: number | null = null
-      if (virtualizer) {
-        if (markerIndex === null) {
-          // An unindexed marker is transient only while the item set is still being
-          // built — then the next frame can resolve it. Once the window HAS rows and
-          // the divider is still absent, it names a message outside the resident
-          // slice (rooms load 100 messages on activation; a read pointer synced from
-          // another device can predate that). No retry can succeed, so `waiting`
-          // would park the list at scrollTop 0 — the oldest loaded message — for the
-          // rest of the visit, with entry's `isAtBottom = false` freezing the read
-          // pointer and counting every later message unread. Terminal instead, so the
-          // controller's live-edge fallback takes over.
-          return virtualizer.itemCount === 0
-            ? { kind: 'waiting' }
-            : { kind: 'unavailable' }
-        }
-        offset = virtualizer.getOffsetForMessageId(markerId)
-      } else {
-        const element = scroller.querySelector(
-          `[data-message-id="${CSS.escape(markerId)}"]`,
-        ) as HTMLElement | null
-        if (element) offset = element.offsetTop
-      }
-      if (offset === null) return { kind: 'waiting' }
-
-      // Avoid a target at scrollTop=0: handleScroll treats that as an explicit request for older
-      // history. For all/mostly-unread windows, preserve the established live-edge fallback.
-      if (offset <= scroller.clientHeight / 3) {
-        return { kind: 'unavailable' }
-      }
-      if (!lease.isCurrent()) return { kind: 'unavailable' }
-
-      if (virtualizer && markerIndex !== null) {
-        virtualizer.scrollToIndex(markerIndex, { align: 'start' })
-      } else {
-        const top =
-          request.desired.align === 'top-third'
-            ? Math.max(0, offset - scroller.clientHeight / 3)
-            : offset
-        scroller.scrollTop = top
-      }
-
-      const scrollTop = scroller.scrollTop
-      const distanceFromBottom =
-        scroller.scrollHeight - scrollTop - scroller.clientHeight
-      const atLiveEdge = distanceFromBottom < AT_BOTTOM_THRESHOLD
-      setMeasuredAtBottom(atLiveEdge)
-      debugLog('UNREAD MARKER: controller positioned frame', {
-        conversationId: request.conversationId,
-        generation: request.generation,
-        markerId,
-        markerIndex,
-        offset,
-        scrollTop,
-        distanceFromBottom,
-        atLiveEdge,
-      })
-      return { kind: 'positioned', scrollTop, atLiveEdge }
-    },
-  }), [
-    firstMessageId,
+  const buildUnreadMarkerExecutor = useCallback(() => {
+    const browser = new UnreadMarkerBrowserAdapter({
+      getScroller: () => scrollerRef.current,
+      getVirtualizer: () => virtualizerRef.current,
+      getWindowFacts: () => ({
+        hasRows:
+          liveWindowRef.current.messageCount > 0 &&
+          liveWindowRef.current.firstMessageId !== undefined,
+        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
+      }),
+      getPassiveContext: () => ({
+        conversationId: latestRef.current.conversationId,
+        virtualizer: latestRef.current.virtualizer,
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('marker', lease),
+      setMeasuredAtBottom,
+      log: debugLog,
+    })
+    return browser.createExecutor(createLiveEdgeExecutor('marker-fallback'))
+  }, [
     beginControllerFrameLoop,
     createLiveEdgeExecutor,
-    messageCount,
     setMeasuredAtBottom,
-    windowAtLiveEdge,
   ])
 
-  const createExplicitTargetExecutor = useCallback((
+  const buildExplicitTargetExecutor = useCallback((
     messageReference: string,
     consumeStoreTarget: boolean,
-  ): ExplicitTargetExecutor => ({
-    reachability: (desired, loadAround) => {
-      const scroller = scrollerRef.current
-      const virtualizer = virtualizerRef.current
-      const element = scroller
-        ? findMessageTargetElement(scroller, desired.messageId)
-        : null
-      if (element) {
-        return {
-          kind: 'available',
-          index: virtualizer?.getIndexForMessageId(desired.messageId) ?? 0,
-          mounted: true,
-          placement: 'viable',
-        }
-      }
-      const facts = deriveReachabilityForDesired({
-        desired,
-        hasRows: messageCount > 0 && firstMessageId !== undefined,
-        windowAtLiveEdge: windowAtLiveEdge !== false,
-        virtualizer,
-        scroller,
-        loadAround,
-        canRecenter: false,
-      })
-      // Unlike ordinary entry hydration, an explicit target is meaningful even when the resident
-      // window is empty: it can name the cache slice that must be loaded.
-      return facts.kind === 'empty-window'
-        ? { kind: 'target-absent', loadAround }
-        : facts
-    },
-    loadAround: onLoadAroundRef.current
-      ? (messageId, signal) => {
-          if (
-            signal.aborted ||
-            activeConversationIdRef.current !== conversationId
-          ) {
-            return
-          }
-          isAtBottomRef.current = false
-          debugLog('TARGET MESSAGE: requesting cache slice around target', {
-            conversationId,
-            messageId,
-          })
-          return onLoadAroundRef.current?.(messageId)
-        }
-      : undefined,
-    beginLoop: (lease) => beginControllerFrameLoop('target', lease),
-    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
-    positionFrame: (
-      request: ExplicitTargetRequest,
-      lease: PositionExecutionLease,
-    ) => {
-      if (!lease.isCurrent()) return { kind: 'unavailable' }
-      const scroller = scrollerRef.current
-      if (!scroller) return { kind: 'unavailable' }
-
-      // The request may be submitted during entry. Wait for the passive handoff so a stale
-      // virtualizer from the room we left cannot receive the first center write.
-      const latest = latestRef.current
-      if (latest.conversationId !== request.conversationId) {
-        return { kind: 'waiting' }
-      }
-
-      const targetId = request.desired.messageId
-      const virtualizer = latest.virtualizer
-      const index = virtualizer?.getIndexForMessageId(targetId) ?? null
-      const element = findMessageTargetElement(scroller, targetId)
-      if (index === null && !element) return { kind: 'waiting' }
-      if (!lease.isCurrent()) return { kind: 'unavailable' }
-
-      if (index !== null && virtualizer) {
-        virtualizer.scrollToIndex(index, { align: 'center' })
-      } else {
-        element?.scrollIntoView({ block: 'center' })
-      }
-      const scrollTop = scroller.scrollTop
-      const distanceFromBottom =
-        scroller.scrollHeight - scrollTop - scroller.clientHeight
-      setMeasuredAtBottom(distanceFromBottom < AT_BOTTOM_THRESHOLD)
-      debugLog('TARGET MESSAGE: controller positioned frame', {
-        conversationId: request.conversationId,
-        generation: request.generation,
-        targetId,
-        index,
-        scrollTop,
-        distanceFromBottom,
-      })
-      return { kind: 'positioned', scrollTop, wrote: true }
-    },
-    complete: (request, outcome, applied) => {
-      if (
-        activeConversationIdRef.current !== request.conversationId ||
-        request.desired.messageId !== messageReference
-      ) {
-        return
-      }
-      if (
-        consumeStoreTarget &&
-        targetMessageIdRef.current !== request.desired.messageId
-      ) {
-        return
-      }
-
-      const element = scrollerRef.current
-        ? findMessageTargetElement(
-            scrollerRef.current,
-            request.desired.messageId,
-          )
-        : null
-      if (element && applied) {
-        element.classList.add('message-highlight')
-        setTimeout(() => element.classList.remove('message-highlight'), TARGET_HIGHLIGHT_MS)
-      }
-      debugLog('TARGET MESSAGE: controller completed', {
-        conversationId: request.conversationId,
-        generation: request.generation,
-        targetId: request.desired.messageId,
-        outcome,
-        highlighted: Boolean(element && applied),
-      })
-
-      // The jump has settled, which makes this the one moment the claim "the target
-      // is on screen" can be checked. Measured from the live rects rather than from
-      // any scroll bookkeeping, so a wrong offset cannot hide behind agreeing state.
-      if (__FLUUX_ANOMALY__) {
-        const settledScroller = scrollerRef.current
-        if (settledScroller) {
-          const viewport = settledScroller.getBoundingClientRect()
-          const target = element?.getBoundingClientRect() ?? null
-          const miss = evaluateJumpTarget({
-            outcome,
-            applied,
-            target: target ? { top: target.top, bottom: target.bottom } : null,
-            viewport: { top: viewport.top, bottom: viewport.bottom },
-          })
-          if (miss) {
-            signalAnomaly({
-              name: 'scroll/jump-target-miss',
-              offBy: Math.round(miss.offBy),
-              messageId: request.desired.messageId,
-            })
-          }
-        }
-      }
-
-      if (consumeStoreTarget) onTargetMessageConsumedRef.current?.()
-    },
-  }), [
+  ) => {
+    const browser = new ExplicitTargetBrowserAdapter({
+      getScroller: () => scrollerRef.current,
+      getVirtualizer: () => virtualizerRef.current,
+      getWindowFacts: () => ({
+        hasRows:
+          liveWindowRef.current.messageCount > 0 &&
+          liveWindowRef.current.firstMessageId !== undefined,
+        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
+      }),
+      getPassiveContext: () => ({
+        conversationId: latestRef.current.conversationId,
+        virtualizer: latestRef.current.virtualizer,
+      }),
+      getActiveConversationId: () => activeConversationIdRef.current,
+      getStoreTargetMessageId: () => targetMessageIdRef.current,
+      beginLoop: (lease) => beginControllerFrameLoop('target', lease),
+      setMeasuredAtBottom,
+      markNotAtBottom: () => { isAtBottomRef.current = false },
+      consumeStoreTarget: () => onTargetMessageConsumedRef.current?.(),
+      log: debugLog,
+    })
+    return browser.createExecutor({
+      conversationId,
+      messageReference,
+      consumeStoreTarget,
+      loadAround: onLoadAroundRef.current,
+    })
+  }, [
     beginControllerFrameLoop,
     conversationId,
-    firstMessageId,
     isAtBottomRef,
-    messageCount,
     setMeasuredAtBottom,
-    windowAtLiveEdge,
   ])
 
   const requestMessageTargetImpl = useCallback((messageReference: string) => {
@@ -1904,11 +1703,11 @@ export function useMessageListScroll({
     positioningControllerRef.current?.beginExplicitTarget({
       conversationId,
       messageId: messageReference,
-      executor: createExplicitTargetExecutor(messageReference, false),
+      executor: buildExplicitTargetExecutor(messageReference, false),
     })
   }, [
     conversationId,
-    createExplicitTargetExecutor,
+    buildExplicitTargetExecutor,
     isAtBottomRef,
     staticMode,
   ])
@@ -1975,7 +1774,7 @@ export function useMessageListScroll({
       const request = positioningControllerRef.current?.beginUnreadMarkerNavigation({
         conversationId,
         navigationFacts,
-        executor: createUnreadMarkerExecutor(),
+        executor: buildUnreadMarkerExecutor(),
       })
       if (request) {
         return
@@ -1991,7 +1790,7 @@ export function useMessageListScroll({
   }, [
     conversationId,
     createLiveEdgeExecutor,
-    createUnreadMarkerExecutor,
+    buildUnreadMarkerExecutor,
     emergencyLiveEdgeWrite,
     firstNewMessageId,
   ])
@@ -2821,7 +2620,7 @@ export function useMessageListScroll({
           ? positioningControllerRef.current?.beginUnreadMarkerEntry({
             conversationId,
             entryFacts: entryExecutionFacts,
-            executor: createUnreadMarkerExecutor(),
+            executor: buildUnreadMarkerExecutor(),
           })
           : null
         if (!request) {
@@ -2883,7 +2682,7 @@ export function useMessageListScroll({
     conversationId,
     createLiveEdgeExecutor,
     buildSavedPositionExecutor,
-    createUnreadMarkerExecutor,
+    buildUnreadMarkerExecutor,
     emergencyLiveEdgeWrite,
     firstNewMessageId,
     isAtBottomRef,
@@ -3121,7 +2920,7 @@ export function useMessageListScroll({
     }
 
     isAtBottomRef.current = false
-    const executor = createExplicitTargetExecutor(targetMessageId, true)
+    const executor = buildExplicitTargetExecutor(targetMessageId, true)
     if (
       previous &&
       previous.conversationId === conversationId &&
@@ -3145,7 +2944,7 @@ export function useMessageListScroll({
     targetMessageId,
     messageCount,
     conversationId,
-    createExplicitTargetExecutor,
+    buildExplicitTargetExecutor,
     isAtBottomRef,
     staticMode,
   ])
@@ -3664,9 +3463,9 @@ export function useMessageListScroll({
         unreadMarkerNeedsVisit: true,
         unreadMarkerAlign: virtualizerRef.current ? 'start' : 'top-third',
       },
-      executor: createUnreadMarkerExecutor(),
+      executor: buildUnreadMarkerExecutor(),
     })
-  }, [firstNewMessageId, conversationId, createUnreadMarkerExecutor])
+  }, [firstNewMessageId, conversationId, buildUnreadMarkerExecutor])
 
   // ==========================================================================
   // RETURN

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -308,9 +308,9 @@ measurement, or MDS completion cannot revive cancelled work.
 ## Reconciler responsibilities
 
 The controller-owned reconcilers own the difficult runtime work below. None belongs in the pure
-model; browser-specific geometry remains in leased imperative executors. Directional-history and
-saved-position mechanics now live behind dedicated browser adapters, while the remaining executors
-are still in the hook:
+model; browser-specific geometry remains in leased imperative executors. Directional-history,
+saved-position, unread-marker, and explicit-target mechanics now live behind dedicated browser
+adapters, while the remaining executors are still in the hook:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -510,8 +510,9 @@ kinetic scrolling and stale-paint behavior.
        cancellation, and anchor/fallback writes behind its leased browser adapter.
      - [x] Extract saved-position reachability, legacy-offset and bottom-fraction writes behind its
        leased browser adapter, with shared bottom-fraction geometry for fixed anchors.
-     - [ ] Extract the remaining marker/target, live-edge, fixed-anchor, and resident-top browser
-       executors.
+     - [x] Extract unread-marker and explicit-target reachability, passive conversation handoff,
+       leased positioning, around loading, and target completion behind dedicated browser adapters.
+     - [ ] Extract the remaining live-edge, fixed-anchor, and resident-top browser executors.
    - [ ] Leave the React hook as thin lifecycle orchestration.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove


### PR DESCRIPTION
Moves unread-marker and explicit-message target reconciliation out of `useMessageListScroll` and into dedicated leased browser adapters. The adapters retain passive hydration handoff, live-edge fallback, around loading, scoped target resolution, and target completion while the hook remains lifecycle wiring.

Adds falsifiable adapter and ownership coverage and updates the positioning contract for the completed migration slice.
