### PR TITLE
refactor(scroll): extract live-edge, fixed-anchor and resident-top adapters

### DIFF
--- a/apps/fluux/src/components/conversation/anchorPreservationBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/anchorPreservationBrowserAdapter.ts
@@ -1,0 +1,111 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  AnchorPreservationExecutor,
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type { AnchorPreservationRequest } from './scrollPositionModel'
+import type { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+
+/** Distinguishes the three fixed-anchor stimuli in frame-loop diagnostics. */
+export type AnchorPreservationLoopLabel =
+  | 'media-anchor'
+  | 'divider-anchor'
+  | 'insertion-anchor'
+
+export interface AnchorPreservationWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+}
+
+export interface AnchorPreservationBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getActiveConversationId: () => string
+  getWindowFacts: () => AnchorPreservationWindowFacts
+  beginLoop: (
+    label: AnchorPreservationLoopLabel,
+    lease: PositionExecutionLease,
+  ) => PositionFrameLoop | null
+  anchorAdapter: BottomFractionAnchorBrowserAdapter
+  /**
+   * Raw bottom-intent bookkeeping, deliberately NOT the measured-live-edge evidence channel:
+   * preserving a reading point must not report a live-edge observation to the SDK.
+   */
+  setAtBottom: (atBottom: boolean) => void
+  rememberScrollSnapshot: () => void
+  recordProgrammaticWrite: (conversationId: string) => void
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+/**
+ * Owns the browser half of fixed-anchor layout preservation: media remeasurement, unread-divider
+ * movement, and delayed live-path insertion inside the resident window. All three share the
+ * bottom-fraction geometry adapter, so saved restoration and preservation converge on identical
+ * row-rect/virtualizer measurements without a second positioning lifecycle.
+ */
+export class AnchorPreservationBrowserAdapter {
+  constructor(private readonly options: AnchorPreservationBrowserAdapterOptions) {}
+
+  createExecutor(
+    label: AnchorPreservationLoopLabel,
+  ): AnchorPreservationExecutor {
+    return {
+      reachability: (desired) => {
+        const facts = this.options.getWindowFacts()
+        return deriveReachabilityForDesired({
+          desired,
+          hasRows: facts.hasRows,
+          windowAtLiveEdge: facts.windowAtLiveEdge,
+          virtualizer: this.options.getVirtualizer(),
+          scroller: this.options.getScroller(),
+          loadAround: 'unavailable',
+          canRecenter: false,
+        })
+      },
+      beginLoop: (lease) => this.options.beginLoop(label, lease),
+      positionFrame: (request, lease) => this.positionFrame(request, lease),
+      complete: (request, outcome) => {
+        if (
+          this.options.getActiveConversationId() !== request.conversationId
+        ) {
+          return
+        }
+        const scroller = this.options.getScroller()
+        if (scroller) {
+          this.options.setAtBottom(
+            scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <
+              AT_BOTTOM_THRESHOLD,
+          )
+          this.options.rememberScrollSnapshot()
+        }
+        this.options.recordProgrammaticWrite(request.conversationId)
+        this.options.log?.('ANCHOR: controller completed preservation', {
+          conversationId: request.conversationId,
+          generation: request.generation,
+          source: request.source.kind,
+          outcome,
+        })
+      },
+    }
+  }
+
+  private positionFrame(
+    request: AnchorPreservationRequest,
+    lease: PositionExecutionLease,
+  ): ReturnType<AnchorPreservationExecutor['positionFrame']> {
+    if (
+      !lease.isCurrent() ||
+      this.options.getActiveConversationId() !== request.conversationId
+    ) {
+      return { kind: 'unavailable' }
+    }
+    const anchor: ScrollAnchor = {
+      messageId: request.desired.messageId,
+      fraction: request.desired.placement.fraction,
+    }
+    return this.options.anchorAdapter.position(anchor)
+  }
+}

--- a/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type { AnchorPreservationRequest } from './scrollPositionModel'
+import { messageFraction } from './scrollPositionModel'
+import type { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import {
+  AnchorPreservationBrowserAdapter,
+  type AnchorPreservationLoopLabel,
+} from './anchorPreservationBrowserAdapter'
+import { ResidentTopBrowserAdapter } from './residentTopBrowserAdapter'
+
+function scrollerHarness(input: {
+  scrollTop?: number
+  scrollHeight?: number
+  clientHeight?: number
+} = {}) {
+  let scrollTop = input.scrollTop ?? 400
+  const scrollHeight = input.scrollHeight ?? 2_000
+  const clientHeight = input.clientHeight ?? 600
+  const scroller = document.createElement('div')
+  Object.defineProperties(scroller, {
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value },
+    },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    clientHeight: { configurable: true, get: () => clientHeight },
+  })
+  scroller.scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+    if (typeof options === 'object' && typeof options?.top === 'number') {
+      scrollTop = options.top
+    }
+  }) as HTMLElement['scrollTo']
+  return {
+    scroller,
+    get scrollTop() { return scrollTop },
+    setScrollTop: (value: number) => { scrollTop = value },
+  }
+}
+
+function virtualizerHarness(input: { itemCount?: number } = {}) {
+  const beginAnimatedScrollToOffset = vi.fn()
+  const virtualizer: MessageVirtualizer = {
+    getVirtualItems: () => [],
+    getTotalSize: () => 2_000,
+    itemCount: input.itemCount ?? 20,
+    getOffsetForMessageId: vi.fn(() => 900),
+    getIndexForMessageId: vi.fn(() => 5),
+    ensureMessageMounted: vi.fn(async () => {}),
+    measureElement: vi.fn(),
+    scrollToOffset: vi.fn(),
+    scrollToIndex: vi.fn(),
+    beginAnimatedScrollToOffset,
+  }
+  return { virtualizer, beginAnimatedScrollToOffset }
+}
+
+function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
+  return {
+    conversationId: 'room-a',
+    generation: 7,
+    operation: 1,
+    signal: new AbortController().signal,
+    isCurrent,
+    markApplied: () => true,
+    settle: () => true,
+  }
+}
+
+function loopHarness() {
+  const loop = {
+    schedule: vi.fn(),
+    recordFrame: vi.fn(),
+    finish: vi.fn(),
+  } satisfies PositionFrameLoop
+  return { loop, beginLoop: vi.fn(() => loop) }
+}
+
+function anchorRequest(
+  fraction = 0.5,
+  conversationId = 'room-a',
+): AnchorPreservationRequest {
+  return {
+    generation: 7,
+    conversationId,
+    source: { kind: 'media-preservation', reason: 'remeasure' },
+    desired: {
+      kind: 'anchor',
+      messageId: 'message-5',
+      placement: {
+        kind: 'bottom-fraction',
+        fraction: messageFraction(fraction),
+      },
+    },
+    onUnavailable: { kind: 'warn-and-stop' },
+  }
+}
+
+describe('AnchorPreservationBrowserAdapter', () => {
+  function harness(input: {
+    scroller?: HTMLElement | null
+    virtualizer?: MessageVirtualizer
+    hasRows?: boolean
+    activeConversation?: () => string
+  } = {}) {
+    const viewport = scrollerHarness()
+    const scroller = input.scroller === undefined ? viewport.scroller : input.scroller
+    const loop = {
+      schedule: vi.fn(),
+      recordFrame: vi.fn(),
+      finish: vi.fn(),
+    } satisfies PositionFrameLoop
+    const beginLoop = vi.fn(
+      (_label: AnchorPreservationLoopLabel, _lease: PositionExecutionLease) => loop,
+    )
+    const position = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 1_234,
+      reassert: true,
+    }))
+    const setAtBottom = vi.fn()
+    const rememberScrollSnapshot = vi.fn()
+    const recordProgrammaticWrite = vi.fn()
+    const adapter = new AnchorPreservationBrowserAdapter({
+      getScroller: () => scroller,
+      getVirtualizer: () => input.virtualizer,
+      getActiveConversationId: () => input.activeConversation?.() ?? 'room-a',
+      getWindowFacts: () => ({
+        hasRows: input.hasRows ?? true,
+        windowAtLiveEdge: true,
+      }),
+      beginLoop,
+      anchorAdapter: { position } as unknown as BottomFractionAnchorBrowserAdapter,
+      setAtBottom,
+      rememberScrollSnapshot,
+      recordProgrammaticWrite,
+    })
+    return {
+      adapter,
+      viewport,
+      loop,
+      beginLoop,
+      position,
+      setAtBottom,
+      rememberScrollSnapshot,
+      recordProgrammaticWrite,
+    }
+  }
+
+  it('labels its frame loop per stimulus so three ambient owners stay distinguishable', () => {
+    const scope = harness()
+
+    scope.adapter.createExecutor('media-anchor').beginLoop(lease())
+    scope.adapter.createExecutor('divider-anchor').beginLoop(lease())
+    scope.adapter.createExecutor('insertion-anchor').beginLoop(lease())
+
+    expect(scope.beginLoop.mock.calls.map(([label]) => label)).toEqual([
+      'media-anchor',
+      'divider-anchor',
+      'insertion-anchor',
+    ])
+  })
+
+  it('reports an empty hydrating window rather than treating the anchor as missing', () => {
+    const hydrating = harness({ hasRows: false })
+    expect(
+      hydrating.adapter.createExecutor('media-anchor')
+        .reachability(anchorRequest().desired),
+    ).toEqual({ kind: 'empty-window' })
+
+    const populated = harness()
+    expect(
+      populated.adapter.createExecutor('media-anchor')
+        .reachability(anchorRequest().desired),
+    ).not.toEqual({ kind: 'empty-window' })
+  })
+
+  it('delegates the write to the shared bottom-fraction geometry with the request placement', () => {
+    const scope = harness()
+    const executor = scope.adapter.createExecutor('media-anchor')
+
+    expect(executor.positionFrame(anchorRequest(0.25), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 1_234,
+      reassert: true,
+    })
+    expect(scope.position).toHaveBeenCalledWith({
+      messageId: 'message-5',
+      fraction: 0.25,
+    })
+  })
+
+  it('writes for neither a stale lease nor a conversation that has been left', () => {
+    let activeConversation = 'room-a'
+    const scope = harness({ activeConversation: () => activeConversation })
+    const executor = scope.adapter.createExecutor('divider-anchor')
+
+    expect(executor.positionFrame(anchorRequest(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    activeConversation = 'room-b'
+    expect(executor.positionFrame(anchorRequest(), lease())).toEqual({
+      kind: 'unavailable',
+    })
+    expect(scope.position).not.toHaveBeenCalled()
+
+    activeConversation = 'room-a'
+    executor.positionFrame(anchorRequest(), lease())
+    expect(scope.position).toHaveBeenCalledOnce()
+  })
+
+  it('records the landed reading point only for the conversation still displayed', () => {
+    let activeConversation = 'room-b'
+    const scope = harness({ activeConversation: () => activeConversation })
+    const executor = scope.adapter.createExecutor('insertion-anchor')
+
+    executor.complete(anchorRequest(), 'settled')
+    expect(scope.setAtBottom).not.toHaveBeenCalled()
+    expect(scope.rememberScrollSnapshot).not.toHaveBeenCalled()
+    expect(scope.recordProgrammaticWrite).not.toHaveBeenCalled()
+
+    activeConversation = 'room-a'
+    executor.complete(anchorRequest(), 'settled')
+    // 2000 - 400 - 600 = 1000px from the bottom: preservation must not claim the live edge.
+    expect(scope.setAtBottom).toHaveBeenCalledWith(false)
+    expect(scope.rememberScrollSnapshot).toHaveBeenCalledOnce()
+    expect(scope.recordProgrammaticWrite).toHaveBeenCalledWith('room-a')
+
+    scope.viewport.setScrollTop(1_399)
+    executor.complete(anchorRequest(), 'settled')
+    expect(scope.setAtBottom).toHaveBeenLastCalledWith(true)
+  })
+})
+
+describe('ResidentTopBrowserAdapter', () => {
+  function harness(input: {
+    scroller?: HTMLElement | null
+    virtualizer?: MessageVirtualizer
+    hasRows?: boolean
+  } = {}) {
+    const viewport = scrollerHarness()
+    const scroller = input.scroller === undefined ? viewport.scroller : input.scroller
+    const { loop, beginLoop } = loopHarness()
+    const executor = new ResidentTopBrowserAdapter({
+      getScroller: () => scroller,
+      getVirtualizer: () => input.virtualizer,
+      getWindowFacts: () => ({
+        hasRows: input.hasRows ?? true,
+        windowAtLiveEdge: true,
+      }),
+      beginLoop,
+    }).createExecutor()
+    return { executor, viewport, loop, beginLoop }
+  }
+
+  function residentTopRequest() {
+    return {
+      generation: 7,
+      conversationId: 'room-a',
+      source: { kind: 'user-navigation', reason: 'resident-top' },
+      desired: { kind: 'resident-top' },
+    } as Parameters<ReturnType<typeof harness>['executor']['start']>[0]
+  }
+
+  it('issues the animated write THROUGH the virtualizer so its reconciler is retargeted', () => {
+    const { virtualizer, beginAnimatedScrollToOffset } = virtualizerHarness()
+    const scope = harness({ virtualizer })
+
+    expect(scope.executor.start(residentTopRequest(), lease())).toEqual({
+      kind: 'started',
+    })
+    expect(beginAnimatedScrollToOffset).toHaveBeenCalledWith(0)
+    // A raw smooth write here loses to @tanstack's still-armed pending-scroll reconciler.
+    expect(scope.viewport.scroller.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('falls back to one native smooth write when no virtualizer owns the window', () => {
+    const scope = harness()
+
+    expect(scope.executor.start(residentTopRequest(), lease())).toEqual({
+      kind: 'started',
+    })
+    expect(scope.viewport.scroller.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    })
+  })
+
+  it('starts nothing under a stale lease or without a scroller', () => {
+    const { virtualizer, beginAnimatedScrollToOffset } = virtualizerHarness()
+    const stale = harness({ virtualizer })
+    expect(stale.executor.start(residentTopRequest(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    expect(beginAnimatedScrollToOffset).not.toHaveBeenCalled()
+
+    const detached = harness({ scroller: null, virtualizer })
+    expect(detached.executor.start(residentTopRequest(), lease())).toEqual({
+      kind: 'unavailable',
+    })
+  })
+
+  it('only observes scrollTop afterwards, never reissuing the target', () => {
+    const { virtualizer, beginAnimatedScrollToOffset } = virtualizerHarness()
+    const scope = harness({ virtualizer })
+    scope.executor.start(residentTopRequest(), lease())
+
+    scope.viewport.setScrollTop(120)
+    expect(scope.executor.readScrollTop()).toBe(120)
+    scope.viewport.setScrollTop(0)
+    expect(scope.executor.readScrollTop()).toBe(0)
+    expect(beginAnimatedScrollToOffset).toHaveBeenCalledOnce()
+  })
+
+  it('distinguishes an empty window from a resident one before any write', () => {
+    expect(harness({ hasRows: false }).executor.reachability()).toEqual({
+      kind: 'empty-window',
+    })
+    expect(harness().executor.reachability()).not.toEqual({ kind: 'empty-window' })
+  })
+})

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
@@ -1,0 +1,430 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type { LiveEdgeRequest } from './scrollPositionModel'
+import {
+  BOTTOM_PIN_TOLERANCE,
+  LiveEdgeBrowserAdapter,
+  type LiveEdgeBrowserAdapterOptions,
+  type LiveEdgeBrowserPorts,
+} from './liveEdgeBrowserAdapter'
+
+function scrollerHarness(input: {
+  scrollTop?: number
+  scrollHeight?: number
+  clientHeight?: number
+} = {}) {
+  let scrollTop = input.scrollTop ?? 0
+  let scrollHeight = input.scrollHeight ?? 2_000
+  const clientHeight = input.clientHeight ?? 600
+  let repaints = 0
+  const scroller = document.createElement('div')
+  Object.defineProperties(scroller, {
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value },
+    },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    clientHeight: { configurable: true, get: () => clientHeight },
+    // The stale-paint repair is the ONLY code reading offsetHeight (it forces the layout between
+    // the two overflowY writes), so counting reads counts forced repaints. Asserting on the
+    // inline style cannot work: the repair restores it to '' before returning.
+    offsetHeight: {
+      configurable: true,
+      get: () => {
+        repaints += 1
+        return clientHeight
+      },
+    },
+  })
+  scroller.scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+    if (typeof options === 'object' && typeof options?.top === 'number') {
+      scrollTop = options.top
+    }
+  }) as HTMLElement['scrollTo']
+  return {
+    scroller,
+    get scrollTop() { return scrollTop },
+    get repaints() { return repaints },
+    setScrollTop: (value: number) => { scrollTop = value },
+    setScrollHeight: (value: number) => { scrollHeight = value },
+  }
+}
+
+function virtualizerHarness(
+  land: (scrollTop: number) => void,
+  input: {
+    itemCount?: number
+    landedTop?: number
+    /** Indexes currently in the measured window; the tail is unmounted by default. */
+    mountedIndexes?: number[]
+  } = {},
+) {
+  const scrollToIndex = vi.fn(() => land(input.landedTop ?? 1_400))
+  const virtualizer: MessageVirtualizer = {
+    getVirtualItems: () => (input.mountedIndexes ?? []).map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: index * 100 + 100,
+      size: 100,
+      lane: 0,
+    })),
+    getTotalSize: () => 2_000,
+    itemCount: input.itemCount ?? 20,
+    getOffsetForMessageId: vi.fn(() => 900),
+    getIndexForMessageId: vi.fn(() => 5),
+    ensureMessageMounted: vi.fn(async () => {}),
+    measureElement: vi.fn(),
+    scrollToOffset: vi.fn(),
+    scrollToIndex,
+    beginAnimatedScrollToOffset: vi.fn(),
+  }
+  return { virtualizer, scrollToIndex }
+}
+
+function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
+  return {
+    conversationId: 'room-a',
+    generation: 7,
+    operation: 1,
+    signal: new AbortController().signal,
+    isCurrent,
+    markApplied: () => true,
+    settle: () => true,
+  }
+}
+
+function request(): LiveEdgeRequest {
+  return {
+    generation: 7,
+    conversationId: 'room-a',
+    source: { kind: 'entry', reason: 'live-edge' },
+    desired: { kind: 'live-edge', follow: true },
+  }
+}
+
+function loopHarness() {
+  const loop = {
+    schedule: vi.fn(),
+    recordFrame: vi.fn(),
+    finish: vi.fn(),
+  } satisfies PositionFrameLoop
+  return { loop, beginLoop: vi.fn(() => loop) }
+}
+
+function harness(input: {
+  scroller?: HTMLElement | null
+  virtualizer?: MessageVirtualizer
+  hasRows?: boolean
+  windowAtLiveEdge?: boolean
+  activeConversation?: () => string
+  isLoadingOlder?: () => boolean
+  options?: Partial<LiveEdgeBrowserAdapterOptions>
+} = {}) {
+  const { beginLoop, loop } = loopHarness()
+  const rememberBottomIntent = vi.fn()
+  const setMeasuredAtBottom = vi.fn()
+  const recordProgrammaticWrite = vi.fn()
+  let clock = 0
+  const adapter = new LiveEdgeBrowserAdapter({
+    getScroller: () => input.scroller ?? null,
+    getVirtualizer: () => input.virtualizer,
+    getActiveConversationId: () => input.activeConversation?.() ?? 'room-a',
+    getWindowFacts: () => ({
+      hasRows: input.hasRows ?? true,
+      windowAtLiveEdge: input.windowAtLiveEdge ?? true,
+    }),
+    isLoadingOlder: () => input.isLoadingOlder?.() ?? false,
+    beginLoop,
+    setMeasuredAtBottom,
+    recordProgrammaticWrite,
+    readRepaintMode: () => 'on-write',
+    now: () => (clock += 1),
+    ...input.options,
+  })
+  const create = (ports: Partial<LiveEdgeBrowserPorts> = {}) =>
+    adapter.createExecutor({
+      trigger: 'new-message',
+      rememberBottomIntent,
+      canRecenter: false,
+      ...ports,
+    })
+  return {
+    adapter,
+    create,
+    beginLoop,
+    loop,
+    rememberBottomIntent,
+    setMeasuredAtBottom,
+    recordProgrammaticWrite,
+  }
+}
+
+describe('LiveEdgeBrowserAdapter', () => {
+  it('re-reads window facts per call while keeping recenter provenance per execution', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer } = virtualizerHarness(viewport.setScrollTop)
+    let hasRows = false
+    const recenter = vi.fn(() => 'requested' as const)
+    const scope = harness({
+      scroller: viewport.scroller,
+      virtualizer,
+      // Read through a getter so the assertion below proves the executor is not frozen to the
+      // window that existed when it was built.
+      get hasRows() { return hasRows },
+    })
+    const executor = scope.create({
+      canRecenter: true,
+      recenterVersion: 'slid:idle:20:m-9',
+      recenter,
+    })
+
+    expect(executor.reachability()).toEqual({ kind: 'empty-window' })
+    hasRows = true
+    // The tail is resident but outside the measured window, so it must mount before reconciling.
+    expect(executor.reachability()).toEqual({
+      kind: 'global-live-edge',
+      state: { kind: 'resident-tail', index: 19, mounted: false },
+    })
+    expect(executor.recenterVersion).toBe('slid:idle:20:m-9')
+    expect(executor.recenter?.(new AbortController().signal)).toBe('requested')
+    expect(executor.beginLoop(lease())).toBe(scope.loop)
+  })
+
+  it('reports the tail as mounted once it enters the measured window', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer } = virtualizerHarness(viewport.setScrollTop, {
+      mountedIndexes: [17, 18, 19],
+    })
+    const executor = harness({ scroller: viewport.scroller, virtualizer }).create()
+
+    expect(executor.reachability()).toEqual({
+      kind: 'global-live-edge',
+      state: { kind: 'resident-tail', index: 19, mounted: true },
+    })
+  })
+
+  it('carries per-execution forward-window availability into a slid-up window verdict', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer } = virtualizerHarness(viewport.setScrollTop)
+    const scope = harness({
+      scroller: viewport.scroller,
+      virtualizer,
+      windowAtLiveEdge: false,
+    })
+
+    // Resident rows are not proof the global tail is resident: a slid-up window must recenter
+    // first, and whether it can is a fact of the request, not of live geometry.
+    expect(scope.create({ canRecenter: false }).reachability()).toEqual({
+      kind: 'global-live-edge',
+      state: { kind: 'unavailable' },
+    })
+    expect(scope.create({ canRecenter: true }).reachability()).toEqual({
+      kind: 'global-live-edge',
+      state: { kind: 'recenter-available' },
+    })
+  })
+
+  it('pins through the virtualizer on the first frame and records bottom intent once', () => {
+    const viewport = scrollerHarness({ scrollHeight: 2_000, clientHeight: 600 })
+    const { virtualizer, scrollToIndex } = virtualizerHarness(
+      viewport.setScrollTop,
+      { landedTop: 1_400 },
+    )
+    const scope = harness({ scroller: viewport.scroller, virtualizer })
+    const executor = scope.create()
+
+    expect(executor.positionFrame(request(), lease())).toEqual({
+      kind: 'positioned',
+      scrollTop: 1_400,
+      atLiveEdge: true,
+      wrote: true,
+      reassert: true,
+    })
+    expect(scrollToIndex).toHaveBeenCalledWith(19, { align: 'end' })
+    expect(scope.rememberBottomIntent).toHaveBeenCalledOnce()
+  })
+
+  it('re-asserts only on height change or drift past the sub-row tolerance', () => {
+    const viewport = scrollerHarness({ scrollHeight: 2_000, clientHeight: 600 })
+    const { virtualizer, scrollToIndex } = virtualizerHarness(
+      viewport.setScrollTop,
+      { landedTop: 1_400 },
+    )
+    const scope = harness({ scroller: viewport.scroller, virtualizer })
+    const executor = scope.create()
+    executor.positionFrame(request(), lease())
+    scrollToIndex.mockClear()
+
+    // Settled: same height, distance 0.
+    expect(executor.positionFrame(request(), lease())).toMatchObject({ wrote: false })
+    expect(scrollToIndex).not.toHaveBeenCalled()
+
+    // Drift inside the tolerance is still treated as pinned.
+    viewport.setScrollTop(1_400 - BOTTOM_PIN_TOLERANCE)
+    expect(executor.positionFrame(request(), lease())).toMatchObject({ wrote: false })
+    expect(scrollToIndex).not.toHaveBeenCalled()
+
+    // One pixel past it is the missed-frame correction the WebKit coalescing bug needs.
+    viewport.setScrollTop(1_400 - BOTTOM_PIN_TOLERANCE - 1)
+    expect(executor.positionFrame(request(), lease())).toMatchObject({ wrote: true })
+    expect(scrollToIndex).toHaveBeenCalledOnce()
+  })
+
+  it('never writes for a stale lease or a conversation that has already been left', () => {
+    const viewport = scrollerHarness({ scrollTop: 42 })
+    const { virtualizer, scrollToIndex } = virtualizerHarness(viewport.setScrollTop)
+    let activeConversation = 'room-a'
+    const scope = harness({
+      scroller: viewport.scroller,
+      virtualizer,
+      activeConversation: () => activeConversation,
+    })
+    const executor = scope.create()
+
+    expect(executor.positionFrame(request(), lease(() => false))).toEqual({
+      kind: 'unavailable',
+    })
+    activeConversation = 'room-b'
+    expect(executor.positionFrame(request(), lease())).toEqual({ kind: 'unavailable' })
+    expect(scrollToIndex).not.toHaveBeenCalled()
+    expect(viewport.scrollTop).toBe(42)
+  })
+
+  it('animates the non-virtualized first frame only for a smooth entry request', () => {
+    const smoothViewport = scrollerHarness()
+    const smooth = harness({ scroller: smoothViewport.scroller })
+      .create({ trigger: 'switch', smoothNonVirtualized: true })
+
+    expect(smooth.positionFrame(request(), lease())).toMatchObject({
+      kind: 'positioned',
+      // Entry keeps its historical deferred second write; every other stimulus is one-shot.
+      reassert: true,
+    })
+    expect(smoothViewport.scroller.scrollTo).toHaveBeenCalledWith({
+      top: 2_000,
+      behavior: 'smooth',
+    })
+    // The follow-up frame is a raw write, not a second animation.
+    smooth.positionFrame(request(), lease())
+    expect(smoothViewport.scroller.scrollTo).toHaveBeenCalledOnce()
+
+    const rawViewport = scrollerHarness()
+    const raw = harness({ scroller: rawViewport.scroller }).create({ trigger: 'new-message' })
+    expect(raw.positionFrame(request(), lease())).toMatchObject({ reassert: false })
+    expect(rawViewport.scroller.scrollTo).not.toHaveBeenCalled()
+    expect(rawViewport.scrollTop).toBe(2_000)
+  })
+})
+
+describe('LiveEdgeBrowserAdapter repaint debt', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  function pinScope(isLoadingOlder = () => false) {
+    const viewport = scrollerHarness({ scrollHeight: 2_000, clientHeight: 600 })
+    const { virtualizer } = virtualizerHarness(viewport.setScrollTop, {
+      landedTop: 1_400,
+    })
+    const scope = harness({
+      scroller: viewport.scroller,
+      virtualizer,
+      isLoadingOlder,
+    })
+    return { ...scope, viewport }
+  }
+
+  /** Drive one content-arrival pin whose write actually moves scrollTop. */
+  function arrive(scope: ReturnType<typeof pinScope>, trigger = 'new-message') {
+    scope.viewport.setScrollTop(0)
+    const executor = scope.create({ trigger })
+    executor.positionFrame(request(), lease())
+    return executor
+  }
+
+  it('coalesces a burst of content-arrival pins into one trailing repaint', () => {
+    const scope = pinScope()
+    // An isolated first arrival still paints promptly.
+    arrive(scope)
+    expect(scope.viewport.repaints).toBe(1)
+
+    // Every later arrival inside the burst window supersedes the last and must NOT repaint —
+    // each overflow toggle is ~50-150ms of WebKitGTK main-thread freeze.
+    const second = arrive(scope)
+    arrive(scope)
+    expect(scope.viewport.repaints).toBe(1)
+
+    second.complete(request(), 'settled')
+    expect(scope.viewport.repaints).toBe(2)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('PinBurstProbe'))
+  })
+
+  it('discards owed repaint on takeover and after a conversation leaves', () => {
+    const scope = pinScope()
+    const executor = arrive(scope)
+    arrive(scope)
+    const beforeTakeover = scope.viewport.repaints
+
+    executor.complete(request(), 'user-takeover')
+    expect(scope.viewport.repaints).toBe(beforeTakeover)
+    expect(warn).not.toHaveBeenCalled()
+
+    const left = pinScope()
+    const leftExecutor = arrive(left)
+    arrive(left)
+    const beforeLeaving = left.viewport.repaints
+    left.adapter.resetRepaintDebt()
+    leftExecutor.complete(request(), 'settled')
+    expect(left.viewport.repaints).toBe(beforeLeaving)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the forced repaint while background history paging is in flight', () => {
+    let loadingOlder = true
+    const paging = pinScope(() => loadingOlder)
+    const pagingExecutor = paging.create({ trigger: 'switch' })
+    pagingExecutor.positionFrame(request(), lease())
+    pagingExecutor.complete(request(), 'best-effort')
+    // A catch-up pages in merges every ~50-300ms; repainting per merge is the freeze.
+    expect(paging.viewport.repaints).toBe(0)
+
+    loadingOlder = false
+    const idle = pinScope(() => loadingOlder)
+    const idleExecutor = idle.create({ trigger: 'switch' })
+    idleExecutor.positionFrame(request(), lease())
+    expect(idle.viewport.repaints).toBe(1)
+    idleExecutor.complete(request(), 'best-effort')
+    expect(idle.viewport.repaints).toBe(2)
+    expect(idle.setMeasuredAtBottom).toHaveBeenLastCalledWith(true)
+    expect(idle.recordProgrammaticWrite).toHaveBeenCalledWith('room-a')
+  })
+
+  it('drops completion bookkeeping for a conversation that is no longer displayed', () => {
+    let activeConversation = 'room-b'
+    const viewport = scrollerHarness()
+    const scope = harness({
+      scroller: viewport.scroller,
+      activeConversation: () => activeConversation,
+    })
+    const executor = scope.create()
+
+    executor.complete(request(), 'settled')
+    expect(scope.setMeasuredAtBottom).not.toHaveBeenCalled()
+    expect(scope.recordProgrammaticWrite).not.toHaveBeenCalled()
+
+    activeConversation = 'room-a'
+    executor.complete(request(), 'settled')
+    expect(scope.recordProgrammaticWrite).toHaveBeenCalledWith('room-a')
+  })
+})

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
@@ -1,0 +1,321 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  LiveEdgeExecutor,
+  PositionExecutionLease,
+  PositionFrameLoop,
+} from './positioningController'
+import type { LiveEdgeRequest } from './scrollPositionModel'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+import {
+  createPinRunTracker,
+  readPinRepaintMode,
+  shouldForceRepaint,
+  type PinRepaintMode,
+} from './pinBottomRun'
+import {
+  createPinRepaintBurst,
+  pinBurstProbeLine,
+  type PinRepaintBurst,
+} from './pinRepaintBurst'
+import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+
+// While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
+// above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
+// the frame where the last row's measurement settles — coalesced height deltas, or a height delta
+// captured into the previous frame's baseline — leaving the view a row short with no further change
+// to react to. WebKit (the desktop WKWebView) hits this intermittently; Chromium masks it via
+// overflow-anchor. Re-asserting on measured distance self-heals it: scrollToIndex(last,'end') is a
+// no-op once truly pinned, so this converges and cannot oscillate. Sub-row tolerance keeps it from
+// firing on harmless subpixel rounding.
+export const BOTTOM_PIN_TOLERANCE = 4
+// A pin run whose cumulative forced work (layout flushes + scroll writes + repaints) reaches this
+// is worth one rate-limited [PinLoopProbe] line in fluux.log — it attributes the layoutPaint cost
+// RenderCostProbe can only measure in aggregate. ~3 frame budgets; healthy runs stay far below.
+const PIN_PROBE_THRESHOLD_MS = 50
+// Pin triggers that represent NEW CONTENT landing at the bottom (as opposed to a user/layout event
+// like a conversation switch, FAB tap, or viewport resize). Only these feed the repaint-burst
+// coalescer: a rapid run of them — live chatter, a reaction storm, images decoding, or a reconnect
+// flushing queued messages — is exactly the burst whose per-arrival forced repaints freeze WebKitGTK.
+const CONTENT_ARRIVAL_TRIGGERS: ReadonlySet<string> = new Set([
+  'new-message',
+  'content-growth',
+  'media-load',
+  'row-growth',
+  'mam-catchup-complete',
+])
+
+const distanceFromBottom = (el: HTMLElement) =>
+  el.scrollHeight - el.scrollTop - el.clientHeight
+
+export interface LiveEdgeWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+}
+
+export interface LiveEdgeBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getActiveConversationId: () => string
+  /**
+   * Window facts must come from a ref, not the render that built an executor. A live-edge executor
+   * can outlive that render: the unread-marker fallback carries one from entry and promotes it from
+   * inside a rAF frame, long after the cached slice landed. Describing the entry window there
+   * reports `empty-window` for a window that has since filled, which parks the promoted execution in
+   * `pending` with no frame loop — and no later stimulus revives it.
+   */
+  getWindowFacts: () => LiveEdgeWindowFacts
+  /** Background MAM paging suppresses forced repaints; `undefined` means "not loading". */
+  isLoadingOlder: () => boolean | undefined
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  setMeasuredAtBottom: (atLiveEdge: boolean) => void
+  recordProgrammaticWrite: (conversationId: string) => void
+  /** Injectable for tests; production reads `localStorage`. */
+  readRepaintMode?: () => PinRepaintMode
+  now?: () => number
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+/**
+ * Per-execution ports. Unlike the window facts above, these deliberately belong to the render that
+ * built the executor: forward-window availability and the conversation whose bottom intent is being
+ * recorded are structural facts of that request, not live geometry to re-read mid-run.
+ */
+export interface LiveEdgeBrowserPorts {
+  /** Names the stimulus in diagnostics and selects burst/first-frame behaviour. */
+  trigger: string
+  /** Conversation entry historically animated the non-virtualized FAB/End write. */
+  smoothNonVirtualized?: boolean
+  rememberBottomIntent: () => void
+  canRecenter: boolean
+  recenterVersion?: string
+  recenter?: LiveEdgeExecutor['recenter']
+}
+
+/**
+ * Owns every bottom-specific browser mechanic: tail-layout flushes for late WebKit measurement, the
+ * missed-frame distance correction, repaint-burst coalescing, background-MAM repaint suppression,
+ * and the `overflowY` stale-paint repair. These are executor mechanics under the controller lease,
+ * not a second positioning authority.
+ *
+ * The repaint burst and the run-cost probe are adapter-scoped, so a rapid run of superseding
+ * content-arrival pins coalesces into one trailing repaint across executors.
+ */
+export class LiveEdgeBrowserAdapter {
+  private burst: PinRepaintBurst | null = null
+  private runProbe: RenderCostProbe | null = null
+
+  constructor(private readonly options: LiveEdgeBrowserAdapterOptions) {}
+
+  /** Drop repaint debt from a conversation being left so it cannot flush into the next one. */
+  resetRepaintDebt(): void {
+    this.burst?.reset()
+  }
+
+  createExecutor(ports: LiveEdgeBrowserPorts): LiveEdgeExecutor {
+    const options = this.options
+    const now = options.now ?? (() => performance.now())
+    const burst = (this.burst ??= createPinRepaintBurst())
+    const run = createPinRunTracker()
+    const repaintMode = options.readRepaintMode
+      ? options.readRepaintMode()
+      : readPinRepaintMode(
+          typeof window === 'undefined' ? undefined : window.localStorage,
+        )
+    let initialized = false
+    let lastHeight = 0
+    let wroteAny = false
+
+    const flushTailLayout = () => {
+      const scroller = options.getScroller()
+      if (!scroller) return
+      const started = now()
+      scroller.getBoundingClientRect()
+      const rows = scroller.querySelectorAll('[data-message-id]')
+      for (let i = Math.max(0, rows.length - 3); i < rows.length; i++) {
+        rows[i].getBoundingClientRect()
+      }
+      run.addMs('flush', now() - started)
+    }
+
+    const forceRepaint = () => {
+      const scroller = options.getScroller()
+      if (!scroller) return
+      const started = now()
+      scroller.style.overflowY = 'hidden'
+      void scroller.offsetHeight
+      scroller.style.overflowY = ''
+      run.addMs('repaint', now() - started)
+    }
+
+    const repaintCoalesced = (moved: boolean) => {
+      if (!shouldForceRepaint(moved, repaintMode, options.isLoadingOlder())) return
+      if (repaintMode === 'on-write' && burst.suppress(now())) {
+        burst.markSuppressed()
+        return
+      }
+      forceRepaint()
+    }
+
+    const writeVirtualizedPin = (): boolean => {
+      const scroller = options.getScroller()
+      const virtualizer = options.getVirtualizer()
+      if (!scroller || !virtualizer || virtualizer.itemCount === 0) return false
+      const before = scroller.scrollTop
+      const started = now()
+      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
+      run.addMs('scroll', now() - started)
+      const moved = scroller.scrollTop !== before
+      wroteAny ||= moved
+      repaintCoalesced(moved)
+      return moved
+    }
+
+    const flushOwedRepaint = () => {
+      if (!burst.owed()) return
+      forceRepaint()
+      console.warn(pinBurstProbeLine(ports.trigger, burst.settle()))
+    }
+
+    return {
+      reachability: () => {
+        const facts = options.getWindowFacts()
+        return deriveReachabilityForDesired({
+          desired: { kind: 'live-edge', follow: true },
+          hasRows: facts.hasRows,
+          windowAtLiveEdge: facts.windowAtLiveEdge,
+          virtualizer: options.getVirtualizer(),
+          scroller: options.getScroller(),
+          loadAround: 'unavailable',
+          canRecenter: ports.canRecenter,
+        })
+      },
+      recenterVersion: ports.recenterVersion,
+      recenter: ports.recenter,
+      beginLoop: (lease) => options.beginLoop(lease),
+      positionFrame: (
+        request: LiveEdgeRequest,
+        lease: PositionExecutionLease,
+      ) => {
+        if (
+          !lease.isCurrent() ||
+          options.getActiveConversationId() !== request.conversationId
+        ) {
+          return { kind: 'unavailable' }
+        }
+        const scroller = options.getScroller()
+        if (!scroller) return { kind: 'unavailable' }
+        const virtualizer = options.getVirtualizer()
+
+        if (!virtualizer) {
+          const firstFrame = !initialized
+          const before = scroller.scrollTop
+          if (ports.smoothNonVirtualized && firstFrame) {
+            scroller.scrollTo({
+              top: scroller.scrollHeight,
+              behavior: 'smooth',
+            })
+          } else {
+            scroller.scrollTop = scroller.scrollHeight
+          }
+          initialized = true
+          ports.rememberBottomIntent()
+          return {
+            kind: 'positioned',
+            scrollTop: scroller.scrollTop,
+            atLiveEdge: true,
+            wrote: scroller.scrollTop !== before,
+            // Conversation entry historically issued one deferred raw write after the immediate
+            // layout-effect write. Keep that exact two-write edge-case repair under controller
+            // scheduling; all other non-virtualized stimuli remain one-shot.
+            reassert: firstFrame && ports.trigger === 'switch',
+          }
+        }
+        if (virtualizer.itemCount === 0) return { kind: 'unavailable' }
+
+        if (!initialized) {
+          initialized = true
+          if (CONTENT_ARRIVAL_TRIGGERS.has(ports.trigger)) {
+            burst.note(now())
+          }
+          flushTailLayout()
+          writeVirtualizedPin()
+          lastHeight = scroller.scrollHeight
+          ports.rememberBottomIntent()
+          options.log?.('PIN start', {
+            trigger: ports.trigger,
+            itemCount: virtualizer.itemCount,
+            distFromBottom: distanceFromBottom(scroller),
+          })
+          return {
+            kind: 'positioned',
+            scrollTop: scroller.scrollTop,
+            atLiveEdge: distanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
+            wrote: true,
+            reassert: true,
+          }
+        }
+
+        flushTailLayout()
+        const height = scroller.scrollHeight
+        const distance = distanceFromBottom(scroller)
+        const needsWrite =
+          height !== lastHeight || distance > BOTTOM_PIN_TOLERANCE
+        if (needsWrite) {
+          options.log?.('PIN re-assert', {
+            distFromBottom: distance,
+            heightChanged: height !== lastHeight,
+          })
+          lastHeight = height
+          writeVirtualizedPin()
+        }
+        run.frame(needsWrite)
+        return {
+          kind: 'positioned',
+          scrollTop: scroller.scrollTop,
+          atLiveEdge: distanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
+          wrote: needsWrite,
+          reassert: true,
+        }
+      },
+      complete: (request, outcome) => {
+        if (options.getActiveConversationId() !== request.conversationId) return
+        const scroller = options.getScroller()
+        if (outcome === 'user-takeover' || outcome === 'superseded') {
+          // Cancellation abandons this executor's paint obligation. Carrying the debt into a newer
+          // generation could repaint after genuine user takeover or charge unrelated content.
+          burst.reset()
+        } else if (outcome === 'best-effort' && scroller) {
+          flushTailLayout()
+          if (burst.owed()) {
+            flushOwedRepaint()
+          } else if (
+            shouldForceRepaint(wroteAny, repaintMode, options.isLoadingOlder())
+          ) {
+            forceRepaint()
+          }
+        } else if (outcome === 'settled') {
+          flushOwedRepaint()
+        }
+
+        if (scroller) {
+          options.setMeasuredAtBottom(
+            distanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
+          )
+          options.recordProgrammaticWrite(request.conversationId)
+        }
+        const probe = (this.runProbe ??= createRenderCostProbe({
+          thresholdMs: PIN_PROBE_THRESHOLD_MS,
+        }))
+        if (probe.record(run.totalForcedMs(), now())) {
+          console.warn(run.summaryLine(ports.trigger))
+        }
+        options.log?.('PIN completed', {
+          trigger: ports.trigger,
+          outcome,
+          distFromBottom: scroller ? distanceFromBottom(scroller) : null,
+        })
+      },
+    }
+  }
+}

--- a/apps/fluux/src/components/conversation/residentTopBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/residentTopBrowserAdapter.ts
@@ -1,0 +1,68 @@
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type {
+  PositionExecutionLease,
+  PositionFrameLoop,
+  ResidentTopExecutor,
+} from './positioningController'
+import { deriveReachabilityForDesired } from './scrollPositionFacts'
+
+export interface ResidentTopWindowFacts {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+}
+
+export interface ResidentTopBrowserAdapterOptions {
+  getScroller: () => HTMLElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getWindowFacts: () => ResidentTopWindowFacts
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  log?: (action: string, data?: Record<string, unknown>) => void
+}
+
+/**
+ * Owns the Home/resident-top browser write. One animated command is issued and then only observed:
+ * the controller settles it from `readScrollTop`, so the executor never reissues the target.
+ */
+export class ResidentTopBrowserAdapter {
+  constructor(private readonly options: ResidentTopBrowserAdapterOptions) {}
+
+  createExecutor(): ResidentTopExecutor {
+    return {
+      reachability: () => {
+        const facts = this.options.getWindowFacts()
+        return deriveReachabilityForDesired({
+          desired: { kind: 'resident-top' },
+          hasRows: facts.hasRows,
+          windowAtLiveEdge: facts.windowAtLiveEdge,
+          virtualizer: this.options.getVirtualizer(),
+          scroller: this.options.getScroller(),
+          loadAround: 'unavailable',
+          canRecenter: false,
+        })
+      },
+      beginLoop: (lease) => this.options.beginLoop(lease),
+      start: (_request, lease) => {
+        const scroller = this.options.getScroller()
+        if (!lease.isCurrent() || !scroller) return { kind: 'unavailable' }
+        const virtualizer = this.options.getVirtualizer()
+        // One smooth write either way — but on the virtualized path it must be issued THROUGH the
+        // virtualizer. Cancelling the superseded live-edge execution only retires our own lease and
+        // frame loop; @tanstack's pending-scroll reconciler stays armed on the live edge for
+        // several more seconds and re-applies it whenever late row measurement moves its target,
+        // overriding this animation with no controller event to observe. Issuing the write through
+        // the virtualizer retargets that reconciler onto resident top instead of racing it.
+        if (virtualizer) virtualizer.beginAnimatedScrollToOffset(0)
+        else scroller.scrollTo({ top: 0, behavior: 'smooth' })
+        return { kind: 'started' }
+      },
+      readScrollTop: () => this.options.getScroller()?.scrollTop ?? null,
+      complete: (request, outcome) => {
+        this.options.log?.('RESIDENT TOP: controller completed', {
+          conversationId: request.conversationId,
+          generation: request.generation,
+          outcome,
+        })
+      },
+    }
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -31,11 +31,8 @@ import {
   type ControllerFrameLoopLifecycle,
   type ControllerFrameLoopRegistration,
 } from './controllerFrameLoop'
-import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
-import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
-import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { signalAnomaly } from '@/utils/anomalySignal'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
@@ -60,11 +57,19 @@ import {
   TARGET_HIGHLIGHT_MS,
 } from './explicitTargetBrowserAdapter'
 import {
+  BOTTOM_PIN_TOLERANCE,
+  LiveEdgeBrowserAdapter,
+} from './liveEdgeBrowserAdapter'
+import {
+  AnchorPreservationBrowserAdapter,
+  type AnchorPreservationLoopLabel,
+} from './anchorPreservationBrowserAdapter'
+import { ResidentTopBrowserAdapter } from './residentTopBrowserAdapter'
+import {
   PositioningController,
   type DirectionalHistoryExecutor,
   type AnchorPreservationExecutor,
   type LiveEdgeExecutor,
-  type LiveEdgeCompletion,
   type PositionExecutionLease,
   type ResidentTopExecutor,
   type SavedPositionExecutor,
@@ -82,7 +87,6 @@ import {
   type AnchorPreservationRequest,
   type DesiredPosition,
   type ExplicitTargetRequest,
-  type LiveEdgeRequest,
   type ReachabilityFacts,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
@@ -140,30 +144,7 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
-// While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
-// above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
-// the frame where the last row's measurement settles — coalesced height deltas, or a height delta
-// captured into the previous frame's baseline — leaving the view a row short with no further change
-// to react to. WebKit (the desktop WKWebView) hits this intermittently; Chromium masks it via
-// overflow-anchor. Re-asserting on measured distance self-heals it: scrollToIndex(last,'end') is a
-// no-op once truly pinned, so this converges and cannot oscillate. Sub-row tolerance keeps it from
-// firing on harmless subpixel rounding.
-const BOTTOM_PIN_TOLERANCE = 4
-// A pin run whose cumulative forced work (layout flushes + scroll writes + repaints) reaches this
-// is worth one rate-limited [PinLoopProbe] line in fluux.log — it attributes the layoutPaint cost
-// RenderCostProbe can only measure in aggregate. ~3 frame budgets; healthy runs stay far below.
-const PIN_PROBE_THRESHOLD_MS = 50
-// Pin triggers that represent NEW CONTENT landing at the bottom (as opposed to a user/layout event
-// like a conversation switch, FAB tap, or viewport resize). Only these feed the repaint-burst
-// coalescer: a rapid run of them — live chatter, a reaction storm, images decoding, or a reconnect
-// flushing queued messages — is exactly the burst whose per-arrival forced repaints freeze WebKitGTK.
-const CONTENT_ARRIVAL_TRIGGERS: ReadonlySet<string> = new Set([
-  'new-message',
-  'content-growth',
-  'media-load',
-  'row-growth',
-  'mam-catchup-complete',
-])
+// BOTTOM_PIN_TOLERANCE is imported from liveEdgeBrowserAdapter, which owns bottom-pin geometry.
 
 /**
  * Freeze a callback's identity while always invoking its latest version.
@@ -408,17 +389,9 @@ export function useMessageListScroll({
   // lifecycle releases this claim on every terminal path; its deadline remains browser/scheduler
   // defense in depth. See pinLoopClaim.ts.
   const pinBottomClaimRef = useRef<PinLoopClaim | null>(null)
-  // Same lazy-ref idiom as pinRunProbeRef / pinRepaintBurstRef below: a ref is stable, so reading it
-  // at the use sites keeps the exhaustive-deps rule satisfied without a dependency.
+  // Lazy-ref idiom shared with the browser adapters below: a ref is stable, so reading it at the use
+  // sites keeps the exhaustive-deps rule satisfied without a dependency.
   const pinBottomClaim = () => (pinBottomClaimRef.current ??= createPinLoopClaim())
-  // Rate-limits the [PinLoopProbe] fluux.log line to one per cooldown (like RenderCostProbe).
-  const pinRunProbeRef = useRef<RenderCostProbe | null>(null)
-  // Coalesces forced repaints across a BURST of content-arrival pins (each superseding the last).
-  // On WebKitGTK the overflow-toggle repaint is ~50–150ms; without this, a burst of new messages /
-  // reactions / images fires one per arrival and freezes the main thread. Suppresses the
-  // intermediate repaints (scroll position still written, layout stays correct) and forces exactly
-  // one trailing repaint once arrival quiesces — see pinRepaintBurst.ts.
-  const pinRepaintBurstRef = useRef<PinRepaintBurst | null>(null)
   // Supersede any in-flight re-assert loop. Held in a ref (read as `.current()`) so callers in
   // useCallback / useLayoutEffect don't need it as a dependency — react-hooks treats refs as stable.
   const supersedeReassertLoopRef = useRef(() => {
@@ -445,6 +418,10 @@ export function useMessageListScroll({
     useRef<DirectionalHistoryBrowserAdapter | null>(null)
   const bottomFractionAnchorBrowserRef =
     useRef<BottomFractionAnchorBrowserAdapter | null>(null)
+  // Held once, unlike the per-request browser adapters built inside their executor factories: the
+  // repaint-burst coalescer and pin-cost probe must span a burst of superseding content-arrival
+  // pins, so one instance has to outlive any single executor.
+  const liveEdgeBrowserRef = useRef<LiveEdgeBrowserAdapter | null>(null)
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
   // by `setMeasuredAtBottom` below (never closed over directly, so a caller passing a
@@ -953,255 +930,69 @@ export function useMessageListScroll({
     return directionalHistoryBrowserRef.current
   }, [beginControllerFrameLoop])
 
+  const getLiveEdgeBrowser = useCallback(() => {
+    if (liveEdgeBrowserRef.current === null) {
+      liveEdgeBrowserRef.current = new LiveEdgeBrowserAdapter({
+        getScroller: () => scrollerRef.current,
+        getVirtualizer: () => virtualizerRef.current,
+        getActiveConversationId: () => activeConversationIdRef.current,
+        // Window facts come from the ref, not the render that built the executor. A live-edge
+        // executor can outlive that render: the unread-marker fallback carries one from entry and
+        // promotes it from inside a rAF frame, long after the cached slice landed. See the ref's
+        // declaration and the adapter's `getWindowFacts` contract.
+        getWindowFacts: () => ({
+          hasRows:
+            liveWindowRef.current.messageCount > 0 &&
+            liveWindowRef.current.firstMessageId !== undefined,
+          windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
+        }),
+        isLoadingOlder: () => isLoadingOlderRef.current,
+        beginLoop: (lease) => {
+          const claim = pinBottomClaim()
+          return beginControllerFrameLoop('pin-bottom', lease, {
+            onStart: claim.renew,
+            onFrame: claim.renew,
+            onFinish: claim.release,
+          })
+        },
+        setMeasuredAtBottom,
+        recordProgrammaticWrite: (id) =>
+          viewportSessionRef.current?.recordProgrammaticWrite(id, Date.now()),
+        log: debugLog,
+      })
+    }
+    return liveEdgeBrowserRef.current
+  }, [beginControllerFrameLoop, setMeasuredAtBottom])
+
   const createLiveEdgeExecutor = useCallback((
     trigger: string,
     smoothNonVirtualized = false,
-  ): LiveEdgeExecutor => {
-    const burst = (pinRepaintBurstRef.current ??= createPinRepaintBurst())
-    const run = createPinRunTracker()
-    const repaintMode = readPinRepaintMode(
-      typeof window === 'undefined' ? undefined : window.localStorage,
-    )
-    let initialized = false
-    let lastHeight = 0
-    let wroteAny = false
-
-    const flushTailLayout = () => {
-      const scroller = scrollerRef.current
-      if (!scroller) return
-      const started = performance.now()
-      scroller.getBoundingClientRect()
-      const rows = scroller.querySelectorAll('[data-message-id]')
-      for (let i = Math.max(0, rows.length - 3); i < rows.length; i++) {
-        rows[i].getBoundingClientRect()
-      }
-      run.addMs('flush', performance.now() - started)
-    }
-
-    const forceRepaint = () => {
-      const scroller = scrollerRef.current
-      if (!scroller) return
-      const started = performance.now()
-      scroller.style.overflowY = 'hidden'
-      void scroller.offsetHeight
-      scroller.style.overflowY = ''
-      run.addMs('repaint', performance.now() - started)
-    }
-
-    const repaintCoalesced = (moved: boolean) => {
-      if (!shouldForceRepaint(moved, repaintMode, isLoadingOlderRef.current)) return
-      if (repaintMode === 'on-write' && burst.suppress(performance.now())) {
-        burst.markSuppressed()
-        return
-      }
-      forceRepaint()
-    }
-
-    const writeVirtualizedPin = (): boolean => {
-      const scroller = scrollerRef.current
-      const virtualizer = virtualizerRef.current
-      if (!scroller || !virtualizer || virtualizer.itemCount === 0) return false
-      const before = scroller.scrollTop
-      const started = performance.now()
-      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
-      run.addMs('scroll', performance.now() - started)
-      const moved = scroller.scrollTop !== before
-      wroteAny ||= moved
-      repaintCoalesced(moved)
-      return moved
-    }
-
-    const flushOwedRepaint = () => {
-      if (!burst.owed()) return
-      forceRepaint()
-      console.warn(pinBurstProbeLine(trigger, burst.settle()))
-    }
-
-    return {
-      // Window facts come from the ref, not this render's props. A live-edge executor can outlive
-      // the render that built it: the unread-marker fallback carries one from entry and promotes it
-      // from inside a rAF frame, long after the cached slice landed. Describing the entry window
-      // there reports `empty-window` for a window that has since filled, which parks the promoted
-      // execution in `pending` with no frame loop — and no later stimulus revives it, because the
-      // refresh effect already ran before the fallback existed. See the ref's declaration.
-      reachability: () => deriveReachabilityForDesired({
-        desired: { kind: 'live-edge', follow: true },
-        hasRows:
-          liveWindowRef.current.messageCount > 0 &&
-          liveWindowRef.current.firstMessageId !== undefined,
-        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
-        virtualizer: virtualizerRef.current,
-        scroller: scrollerRef.current,
-        loadAround: 'unavailable',
-        canRecenter: Boolean(onLoadNewer),
-      }),
-      recenterVersion: [
-        windowAtLiveEdge === false ? 'slid' : 'live',
-        isLoadingNewer ? 'loading' : 'idle',
-        messageCount,
-        lastMessageId ?? '',
-      ].join(':'),
-      recenter: onLoadNewer
-        ? (signal) => {
-            if (signal.aborted) return 'unavailable'
-            if (isLoadingNewer) return 'waiting'
-            onLoadNewer()
-            return 'requested'
-          }
-        : undefined,
-      beginLoop: (lease) => {
-        const claim = pinBottomClaim()
-        return beginControllerFrameLoop('pin-bottom', lease, {
-          onStart: claim.renew,
-          onFrame: claim.renew,
-          onFinish: claim.release,
-        })
-      },
-      positionFrame: (
-        request: LiveEdgeRequest,
-        lease: PositionExecutionLease,
-      ) => {
-        if (
-          !lease.isCurrent() ||
-          activeConversationIdRef.current !== request.conversationId
-        ) {
-          return { kind: 'unavailable' }
+  ): LiveEdgeExecutor => getLiveEdgeBrowser().createExecutor({
+    trigger,
+    smoothNonVirtualized,
+    rememberBottomIntent,
+    canRecenter: Boolean(onLoadNewer),
+    recenterVersion: [
+      windowAtLiveEdge === false ? 'slid' : 'live',
+      isLoadingNewer ? 'loading' : 'idle',
+      messageCount,
+      lastMessageId ?? '',
+    ].join(':'),
+    recenter: onLoadNewer
+      ? (signal) => {
+          if (signal.aborted) return 'unavailable'
+          if (isLoadingNewer) return 'waiting'
+          onLoadNewer()
+          return 'requested'
         }
-        const scroller = scrollerRef.current
-        if (!scroller) return { kind: 'unavailable' }
-        const virtualizer = virtualizerRef.current
-
-        if (!virtualizer) {
-          const firstFrame = !initialized
-          const before = scroller.scrollTop
-          if (smoothNonVirtualized && firstFrame) {
-            scroller.scrollTo({
-              top: scroller.scrollHeight,
-              behavior: 'smooth',
-            })
-          } else {
-            scroller.scrollTop = scroller.scrollHeight
-          }
-          initialized = true
-          rememberBottomIntent()
-          return {
-            kind: 'positioned',
-            scrollTop: scroller.scrollTop,
-            atLiveEdge: true,
-            wrote: scroller.scrollTop !== before,
-            // Conversation entry historically issued one deferred raw write after the immediate
-            // layout-effect write. Keep that exact two-write edge-case repair under controller
-            // scheduling; all other non-virtualized stimuli remain one-shot.
-            reassert: firstFrame && trigger === 'switch',
-          }
-        }
-        if (virtualizer.itemCount === 0) return { kind: 'unavailable' }
-
-        if (!initialized) {
-          initialized = true
-          if (CONTENT_ARRIVAL_TRIGGERS.has(trigger)) {
-            burst.note(performance.now())
-          }
-          flushTailLayout()
-          writeVirtualizedPin()
-          lastHeight = scroller.scrollHeight
-          rememberBottomIntent()
-          debugLog('PIN start', {
-            trigger,
-            itemCount: virtualizer.itemCount,
-            distFromBottom: getDistanceFromBottom(scroller),
-          })
-          return {
-            kind: 'positioned',
-            scrollTop: scroller.scrollTop,
-            atLiveEdge:
-              getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
-            wrote: true,
-            reassert: true,
-          }
-        }
-
-        flushTailLayout()
-        const height = scroller.scrollHeight
-        const distance = getDistanceFromBottom(scroller)
-        const needsWrite =
-          height !== lastHeight || distance > BOTTOM_PIN_TOLERANCE
-        if (needsWrite) {
-          debugLog('PIN re-assert', {
-            distFromBottom: distance,
-            heightChanged: height !== lastHeight,
-          })
-          lastHeight = height
-          writeVirtualizedPin()
-        }
-        run.frame(needsWrite)
-        return {
-          kind: 'positioned',
-          scrollTop: scroller.scrollTop,
-          atLiveEdge:
-            getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
-          wrote: needsWrite,
-          reassert: true,
-        }
-      },
-      complete: (
-        request: LiveEdgeRequest,
-        outcome: LiveEdgeCompletion,
-      ) => {
-        if (activeConversationIdRef.current !== request.conversationId) return
-        const scroller = scrollerRef.current
-        if (
-          outcome === 'user-takeover' ||
-          outcome === 'superseded'
-        ) {
-          // Cancellation abandons this executor's paint obligation. Carrying the debt into a newer
-          // generation could repaint after genuine user takeover or charge unrelated content.
-          burst.reset()
-        } else if (outcome === 'best-effort' && scroller) {
-          flushTailLayout()
-          if (burst.owed()) {
-            flushOwedRepaint()
-          } else if (
-            shouldForceRepaint(
-              wroteAny,
-              repaintMode,
-              isLoadingOlderRef.current,
-            )
-          ) {
-            forceRepaint()
-          }
-        } else if (outcome === 'settled') {
-          flushOwedRepaint()
-        }
-
-        if (scroller) {
-          setMeasuredAtBottom(getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD)
-          viewportSessionRef.current?.recordProgrammaticWrite(
-            request.conversationId,
-            Date.now(),
-          )
-        }
-        const probe = (pinRunProbeRef.current ??= createRenderCostProbe({
-          thresholdMs: PIN_PROBE_THRESHOLD_MS,
-        }))
-        if (probe.record(run.totalForcedMs(), performance.now())) {
-          console.warn(run.summaryLine(trigger))
-        }
-        debugLog('PIN completed', {
-          trigger,
-          outcome,
-          distFromBottom: scroller ? getDistanceFromBottom(scroller) : null,
-        })
-      },
-    }
-  }, [
-    beginControllerFrameLoop,
+      : undefined,
+  }), [
+    getLiveEdgeBrowser,
     isLoadingNewer,
     lastMessageId,
     messageCount,
     onLoadNewer,
     rememberBottomIntent,
-    setMeasuredAtBottom,
     windowAtLiveEdge,
   ])
 
@@ -1235,53 +1026,23 @@ export function useMessageListScroll({
   }, [rememberBottomIntent])
 
   const createAnchorPreservationExecutor = useCallback(
-    (loopLabel: 'media-anchor' | 'divider-anchor' | 'insertion-anchor'): AnchorPreservationExecutor => ({
-      reachability: (desired) => deriveReachabilityForDesired({
-        desired,
-        hasRows: messageCount > 0 && firstMessageId !== undefined,
-        windowAtLiveEdge: windowAtLiveEdge !== false,
-        virtualizer: virtualizerRef.current,
-        scroller: scrollerRef.current,
-        loadAround: 'unavailable',
-        canRecenter: false,
-      }),
-      beginLoop: (lease) => beginControllerFrameLoop(loopLabel, lease),
-      positionFrame: (
-        request: AnchorPreservationRequest,
-        lease: PositionExecutionLease,
-      ) => {
-        if (
-          !lease.isCurrent() ||
-          activeConversationIdRef.current !== request.conversationId
-        ) {
-          return { kind: 'unavailable' }
-        }
-        const anchor: ScrollAnchor = {
-          messageId: request.desired.messageId,
-          fraction: request.desired.placement.fraction,
-        }
-        return getBottomFractionAnchorBrowser().position(anchor)
-      },
-      complete: (request, outcome) => {
-        if (activeConversationIdRef.current !== request.conversationId) return
-        const scroller = scrollerRef.current
-        if (scroller) {
-          isAtBottomRef.current =
-            getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD
-          rememberCurrentScrollSnapshot()
-        }
-        viewportSessionRef.current?.recordProgrammaticWrite(
-          request.conversationId,
-          Date.now(),
-        )
-        debugLog('ANCHOR: controller completed preservation', {
-          conversationId: request.conversationId,
-          generation: request.generation,
-          source: request.source.kind,
-          outcome,
-        })
-      },
-    }),
+    (loopLabel: AnchorPreservationLoopLabel): AnchorPreservationExecutor =>
+      new AnchorPreservationBrowserAdapter({
+        getScroller: () => scrollerRef.current,
+        getVirtualizer: () => virtualizerRef.current,
+        getActiveConversationId: () => activeConversationIdRef.current,
+        getWindowFacts: () => ({
+          hasRows: messageCount > 0 && firstMessageId !== undefined,
+          windowAtLiveEdge: windowAtLiveEdge !== false,
+        }),
+        beginLoop: (label, lease) => beginControllerFrameLoop(label, lease),
+        anchorAdapter: getBottomFractionAnchorBrowser(),
+        setAtBottom: (atBottom) => { isAtBottomRef.current = atBottom },
+        rememberScrollSnapshot: rememberCurrentScrollSnapshot,
+        recordProgrammaticWrite: (id) =>
+          viewportSessionRef.current?.recordProgrammaticWrite(id, Date.now()),
+        log: debugLog,
+      }).createExecutor(loopLabel),
     [
       beginControllerFrameLoop,
       firstMessageId,
@@ -1799,40 +1560,17 @@ export function useMessageListScroll({
   // list — and re-binds the ⌘/Ctrl+↓ listener — on every append.
   const scrollToBottom = useStableCallback(scrollToBottomImpl)
 
-  const createResidentTopExecutor = useCallback((): ResidentTopExecutor => ({
-    reachability: () => deriveReachabilityForDesired({
-      desired: { kind: 'resident-top' },
-      hasRows: messageCount > 0 && firstMessageId !== undefined,
-      windowAtLiveEdge: windowAtLiveEdge !== false,
-      virtualizer: virtualizerRef.current,
-      scroller: scrollerRef.current,
-      loadAround: 'unavailable',
-      canRecenter: false,
-    }),
-    beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
-    start: (_request, lease) => {
-      const scroller = scrollerRef.current
-      if (!lease.isCurrent() || !scroller) return { kind: 'unavailable' }
-      const virtualizer = virtualizerRef.current
-      // One smooth write either way — but on the virtualized path it must be issued THROUGH the
-      // virtualizer. Cancelling the superseded live-edge execution only retires our own lease and
-      // frame loop; @tanstack's pending-scroll reconciler stays armed on the live edge for
-      // several more seconds and re-applies it whenever late row measurement moves its target,
-      // overriding this animation with no controller event to observe. Issuing the write through
-      // the virtualizer retargets that reconciler onto resident top instead of racing it.
-      if (virtualizer) virtualizer.beginAnimatedScrollToOffset(0)
-      else scroller.scrollTo({ top: 0, behavior: 'smooth' })
-      return { kind: 'started' }
-    },
-    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
-    complete: (request, outcome) => {
-      debugLog('RESIDENT TOP: controller completed', {
-        conversationId: request.conversationId,
-        generation: request.generation,
-        outcome,
-      })
-    },
-  }), [
+  const createResidentTopExecutor = useCallback((): ResidentTopExecutor =>
+    new ResidentTopBrowserAdapter({
+      getScroller: () => scrollerRef.current,
+      getVirtualizer: () => virtualizerRef.current,
+      getWindowFacts: () => ({
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
+      log: debugLog,
+    }).createExecutor(), [
     beginControllerFrameLoop,
     firstMessageId,
     messageCount,
@@ -2511,7 +2249,9 @@ export function useMessageListScroll({
     }
     mediaLoadSnapshotRef.current = null
     // Drop any repaint-burst debt from the room we're leaving so it can't flush into the new one.
-    pinRepaintBurstRef.current?.reset()
+    // Read through the ref, not the lazy getter: a list that never pinned owes nothing, and building
+    // the adapter here just to reset it would also add a dependency to this entry effect.
+    liveEdgeBrowserRef.current?.resetRepaintDebt()
 
     // In static mode (read-only previews), skip all scroll positioning.
     // The parent component handles its own scroll-to-target.

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -101,6 +101,19 @@ than competing lifecycle owners. A settled or best-effort generation flushes any
 repaint; user takeover or supersession deliberately discards that debt so it cannot repaint after
 the reader takes control or leak into unrelated content.
 
+They live in a `LiveEdgeBrowserAdapter` whose repaint-burst coalescer and pin-cost probe are
+adapter-scoped rather than per-executor: a burst is precisely a run of arrivals each superseding the
+last, so state that ended with one executor could never coalesce. Window facts are re-read per call
+because a live-edge executor outlives the render that built it, while forward-window availability
+and the conversation whose bottom intent is recorded stay per-execution — they are facts of the
+request, not live geometry. Conversation entry drops any owed repaint debt so it cannot flush into
+the room being opened.
+
+Fixed-anchor preservation and resident-top navigation likewise reconcile through
+`AnchorPreservationBrowserAdapter` and `ResidentTopBrowserAdapter`. The first routes all three
+ambient stimuli through the shared bottom-fraction geometry under distinct frame-loop labels; the
+second issues one animated write and thereafter only observes `scrollTop`.
+
 Resident-top navigation starts one native smooth write from its leased executor, then observes
 `scrollTop` without reissuing the target. It settles after two frames within 1px of the resident
 top, or releases best-effort after 120 observation frames without snapping. Home resets the prior
@@ -308,9 +321,9 @@ measurement, or MDS completion cannot revive cancelled work.
 ## Reconciler responsibilities
 
 The controller-owned reconcilers own the difficult runtime work below. None belongs in the pure
-model; browser-specific geometry remains in leased imperative executors. Directional-history,
-saved-position, unread-marker, and explicit-target mechanics now live behind dedicated browser
-adapters, while the remaining executors are still in the hook:
+model; browser-specific geometry remains in leased imperative executors. Every slice now reconciles
+behind a dedicated browser adapter — directional history, saved position, unread marker, explicit
+target, live edge, fixed anchor, and resident top:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -365,7 +378,11 @@ The controller-owned mechanisms retain leased browser reconcilers for saved anch
 explicit center-aligned targets, live edge, fixed-anchor media/layout preservation, directional
 history, and resident top. These
 reconcilers implement measurement convergence; they are not separate positioning authorities.
-There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
+There is no independent positioning frame-loop implementation left inside `useMessageListScroll`:
+the hook constructs each adapter, supplies its value ports, and passes the resulting executor to the
+controller. Exactly three pixel writes remain in the hook, and none of them is a positioning owner —
+the two isolated static-preview operations documented below, and the emergency bottom write that
+keeps the list usable when the controller itself cannot be constructed.
 
 Ambient layout preservation is entirely inside the scroll owner. `MessageList` receives only the
 store-owned interior-placement version; it receives no raw anchor capture/restore callbacks. The
@@ -505,14 +522,14 @@ kinetic scrolling and stale-paint behavior.
      viewport-session snapshots.
    - [x] Extract directional history load eligibility, invocation, and completion into a window
      coordinator that owns no positioning.
-   - [ ] Move DOM/virtualizer reconciliation mechanics behind explicit browser adapters.
+   - [x] Move DOM/virtualizer reconciliation mechanics behind explicit browser adapters.
      - [x] Extract directional-history capture, settlement scheduling, reachability, kinetic
        cancellation, and anchor/fallback writes behind its leased browser adapter.
      - [x] Extract saved-position reachability, legacy-offset and bottom-fraction writes behind its
        leased browser adapter, with shared bottom-fraction geometry for fixed anchors.
      - [x] Extract unread-marker and explicit-target reachability, passive conversation handoff,
        leased positioning, around loading, and target completion behind dedicated browser adapters.
-     - [ ] Extract the remaining live-edge, fixed-anchor, and resident-top browser executors.
+     - [x] Extract the remaining live-edge, fixed-anchor, and resident-top browser executors.
    - [ ] Leave the React hook as thin lifecycle orchestration.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove


### PR DESCRIPTION
Moves the last three positioning executors out of `useMessageListScroll` and behind leased browser adapters, completing the browser-adapter boundary for message-list scroll positioning.

The live-edge adapter keeps every bottom-specific safeguard: tail-layout flushes for late WebKit measurement, the 4px missed-frame correction, repaint-burst coalescing, background-paging repaint suppression, and the `overflowY` stale-paint repair. Its burst coalescer and cost probe are adapter-scoped rather than per-executor, since a burst is by definition a run of arrivals each superseding the last, so state ending with one executor could never coalesce. Forward-window availability and bottom-intent bookkeeping stay per-execution, matching what the building render captured before, while window facts are still re-read per call so a promoted fallback cannot describe a window that has since filled.

Fixed-anchor preservation routes its three ambient stimuli through the shared bottom-fraction geometry under distinct frame-loop labels. Resident-top keeps issuing its single animated write through the virtualizer so TanStack's pending-scroll reconciler is retargeted rather than raced.

Behaviour is unchanged. The hook drops 367 lines and retains no positioning frame loop; the only pixel writes left in it are the two isolated static-preview operations and the emergency bottom write used when the controller cannot be constructed.