### PR TITLE
refactor(scroll): reduce the message-list hook toward orchestration

### DIFF
--- a/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.ts
+++ b/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.ts
@@ -52,8 +52,8 @@ export interface FabSample {
  * hook-internal ref — and hardcoding `false` at the only real call site would ship a
  * tested branch that nothing exercises, which is hollow by a different route.
  *
- * Two guards cover it instead. The hook clears the FAB EAGERLY when a pin loop lands
- * at the bottom (`useMessageListScroll.ts:693`), and the hold window below outlasts
+ * Two guards cover it instead. The hook's `rememberBottomIntent` callback clears the FAB EAGERLY
+ * when a pin loop lands at the bottom, and the hold window below outlasts
  * the few frames a loop spends approaching from beyond the FAB threshold to inside the
  * at-bottom one. And on reflection the suppression was never quite right: a FAB still
  * shown a full second after the viewport reached the bottom IS the staleness this

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -243,8 +243,8 @@ export function install(): () => void {
   if (attachRefs === 1) {
     attachments++
 
-    // The sentinels in `useMessageListScroll` and `stallSentinel` cannot import
-    // this tree — they ship in release builds. They signal into a neutral seam
+    // The message-list scroll sentinels and `stallSentinel` cannot import this
+    // tree — they ship in release builds. They signal into a neutral seam
     // instead, and this is where the seam is connected. Registration is idempotent
     // (the handler is a fresh closure over the same runtime), so a StrictMode
     // remount replaces it rather than stacking a second one.

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -187,8 +187,8 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
   // The target row and the rows above it size asynchronously (avatars, media, link previews),
   // so a single scroll computed from the first, unsettled layout lands the target off-position
   // — often well above the fold once the content grows. We therefore re-assert the position
-  // across frames until the landing point stops moving (mirrors the live path's marker/pin
-  // re-assert loops in useMessageListScroll), bailing the moment the user takes over.
+  // across frames until the landing point stops moving (mirrors the live message-list path's
+  // marker/pin re-assert loops), bailing the moment the user takes over.
   // Keyed on the TARGET (previewResult) + the initial load flag — NOT on messages.length.
   // loadMessages sets `messages` and clears `isLoading` in one batched update, so this fires
   // exactly once when the target's context is ready. Loading OLDER context on scroll-to-top

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -2,11 +2,11 @@
  * Diagnostic-only monitor for the message list's rAF-driven scroll re-assert
  * loops.
  *
- * Background: useMessageListScroll keeps the virtualized list pinned to the
- * right place by RE-ASSERTING a scroll target across several frames as rows
- * measure asynchronously — the live-edge executor (stick to bottom), the
- * controller-owned unread-marker reconciliation, and the directional-history
- * executor (anchor restore). Each is a `requestAnimationFrame` loop
+ * Background: the message-list positioning executors keep the virtualized list
+ * pinned to the right place by RE-ASSERTING a scroll target across several
+ * frames as rows measure asynchronously — the live-edge executor (stick to
+ * bottom), the controller-owned unread-marker reconciliation, and the
+ * directional-history executor (anchor restore). Each is a `requestAnimationFrame` loop
  * that calls the virtualizer's `scrollToOffset`/`scrollToIndex`, which re-windows
  * and re-renders.
  *

--- a/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
@@ -103,8 +103,8 @@ export function createResizeLoopMonitor(opts: ResizeLoopMonitorOptions = {}): Re
  * Lives here rather than at the call site because there are TWO observers using
  * this monitor — the content one and the scroller one — and a mapping written
  * twice is a mapping that can disagree with itself. It is also the only way this
- * translation gets a unit test at all: the call sites are buried inside a rAF
- * loop in `useMessageListScroll`.
+ * translation gets a unit test at all: the call sites are buried inside rAF
+ * loops in `useScrollContainerBinding` and `useMessageListScroll`.
  */
 export function resizeLoopSignal(warning: ResizeLoopWarning): AnomalySignal {
   return {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1,5 +1,5 @@
 /**
- * useMessageListScroll - Simple, imperative scroll management
+ * useMessageListScroll - Message-list scroll lifecycle orchestration
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
@@ -19,18 +19,11 @@
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
-import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
-import { createSlowCorrectionMonitor, slowCorrectionSignal } from './slowCorrectionMonitor'
-import {
-  createReassertLoopMonitor,
-  reassertLoopSignal,
-  type ReassertLoopLabel,
-} from './reassertLoopMonitor'
-import {
-  createControllerFrameLoop,
-  type ControllerFrameLoopLifecycle,
-  type ControllerFrameLoopRegistration,
-} from './controllerFrameLoop'
+// Still used by the composer/container resize observer below, a separate owner from the content
+// observer that moved into useScrollContainerBinding.
+import { createResizeLoopMonitor } from './resizeLoopMonitor'
+import type { ControllerFrameLoopRegistration } from './controllerFrameLoop'
+import { useScrollContainerBinding } from './useScrollContainerBinding'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
 import { signalAnomaly } from '@/utils/anomalySignal'
@@ -40,40 +33,18 @@ import { notifyUserInput } from '@/utils/renderLoopDetector'
 import { ViewportSession } from './viewportSession'
 import { ScrollPersistenceAdapter } from './scrollPersistenceAdapter'
 import {
-  DIRECTIONAL_HISTORY_COOLDOWN_MS,
   DirectionalHistoryWindowCoordinator,
   type DirectionalHistoryReleaseDecision,
   type DirectionalHistorySnapshot,
 } from './directionalHistoryWindowCoordinator'
-import {
+import type {
   DirectionalHistoryBrowserAdapter,
-  type DirectionalHistoryBrowserCapture,
+  DirectionalHistoryBrowserCapture,
 } from './directionalHistoryBrowserAdapter'
-import { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
-import { SavedPositionBrowserAdapter } from './savedPositionBrowserAdapter'
-import { UnreadMarkerBrowserAdapter } from './unreadMarkerBrowserAdapter'
-import {
-  ExplicitTargetBrowserAdapter,
-  TARGET_HIGHLIGHT_MS,
-} from './explicitTargetBrowserAdapter'
-import {
-  BOTTOM_PIN_TOLERANCE,
-  LiveEdgeBrowserAdapter,
-} from './liveEdgeBrowserAdapter'
-import {
-  AnchorPreservationBrowserAdapter,
-  type AnchorPreservationLoopLabel,
-} from './anchorPreservationBrowserAdapter'
-import { ResidentTopBrowserAdapter } from './residentTopBrowserAdapter'
-import {
-  PositioningController,
-  type DirectionalHistoryExecutor,
-  type AnchorPreservationExecutor,
-  type LiveEdgeExecutor,
-  type PositionExecutionLease,
-  type ResidentTopExecutor,
-  type SavedPositionExecutor,
-} from './positioningController'
+import { TARGET_HIGHLIGHT_MS } from './explicitTargetBrowserAdapter'
+import { BOTTOM_PIN_TOLERANCE } from './liveEdgeBrowserAdapter'
+import { useScrollExecutors } from './useScrollExecutors'
+import { PositioningController } from './positioningController'
 import {
   deriveAtLiveEdge,
   deriveEntryPositionFacts,
@@ -366,22 +337,14 @@ export function useMessageListScroll({
   // REFS - All scroll state lives here, NOT in React state
   // ==========================================================================
 
+  // The content wrapper, its ResizeObserver, the correction frame and their diagnostic monitors are
+  // owned by useScrollContainerBinding; only the scroller itself is read across this hook.
   const scrollerRef = useRef<HTMLDivElement | null>(null)
-  const contentRef = useRef<HTMLDivElement | null>(null)
-  const contentObserverRef = useRef<ResizeObserver | null>(null)
-  // Pending rAF id for the coalesced scroll correction (content ResizeObserver).
-  const correctionRafRef = useRef<number | null>(null)
-  // Diagnostic-only monitor for runaway ResizeObserver fire rates (WebKitGTK).
-  const resizeMonitorRef = useRef<ReturnType<typeof createResizeLoopMonitor> | null>(null)
-  // Diagnostic-only monitor for SLOW corrections (reflow cost, not fire rate).
-  const slowCorrectionMonitorRef = useRef<ReturnType<typeof createSlowCorrectionMonitor> | null>(null)
-  // Diagnostic-only monitor for the controller-owned rAF scroll re-assert loops:
-  // surfaces a non-converging loop or two overlapping loops fighting over scrollTop on WebKit
-  // (frame-coupled, so invisible to the headless harness and the other monitors). Never cancels.
-  const reassertMonitorRef = useRef<ReturnType<typeof createReassertLoopMonitor> | null>(null)
   // In-flight controller-owned scroll re-assert loop (rAF id + idempotent terminal cleanup). Starting any loop
   // supersedes whatever is in flight so bottom, message, restore, media, and history targets cannot
   // fight over scrollTop. Single-flight: latest accepted generation wins with a fresh budget.
+  // Owned here rather than in useScrollExecutors because the scroll handler reads it to tell a
+  // controller-owned scroll from genuine user input.
   const reassertLoopRef = useRef<ControllerFrameLoopRegistration | null>(null)
   // Whether a pin-bottom re-assert loop is in flight. The row-growth re-pin defers to an active loop
   // (it re-checks scrollHeight every frame and picks the change up itself) instead of restarting it
@@ -389,14 +352,9 @@ export function useMessageListScroll({
   // lifecycle releases this claim on every terminal path; its deadline remains browser/scheduler
   // defense in depth. See pinLoopClaim.ts.
   const pinBottomClaimRef = useRef<PinLoopClaim | null>(null)
-  // Lazy-ref idiom shared with the browser adapters below: a ref is stable, so reading it at the use
-  // sites keeps the exhaustive-deps rule satisfied without a dependency.
+  // Lazy-ref idiom shared with the extracted browser-adapter hook: a ref is stable, so reading it
+  // at the use sites keeps the exhaustive-deps rule satisfied without a dependency.
   const pinBottomClaim = () => (pinBottomClaimRef.current ??= createPinLoopClaim())
-  // Supersede any in-flight re-assert loop. Held in a ref (read as `.current()`) so callers in
-  // useCallback / useLayoutEffect don't need it as a dependency — react-hooks treats refs as stable.
-  const supersedeReassertLoopRef = useRef(() => {
-    reassertLoopRef.current?.finish()
-  })
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -414,14 +372,6 @@ export function useMessageListScroll({
   if (directionalWindowRef.current === null) {
     directionalWindowRef.current = new DirectionalHistoryWindowCoordinator()
   }
-  const directionalHistoryBrowserRef =
-    useRef<DirectionalHistoryBrowserAdapter | null>(null)
-  const bottomFractionAnchorBrowserRef =
-    useRef<BottomFractionAnchorBrowserAdapter | null>(null)
-  // Held once, unlike the per-request browser adapters built inside their executor factories: the
-  // repaint-burst coalescer and pin-cost probe must span a burst of superseding content-arrival
-  // pins, so one instance has to outlive any single executor.
-  const liveEdgeBrowserRef = useRef<LiveEdgeBrowserAdapter | null>(null)
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
   // by `setMeasuredAtBottom` below (never closed over directly, so a caller passing a
@@ -467,8 +417,8 @@ export function useMessageListScroll({
 
   // Latest MAM-loading state (forward catch-up on entry, or backward "load older" pagination) for
   // the active conversation, read imperatively inside the live-edge executor —
-  // see the repaint-suppression note in writePin below. Updated synchronously in the render body
-  // (same pattern as virtualizerRef) so it is never stale when the pin loop reads it mid-run.
+  // see the repaint-suppression note in LiveEdgeBrowserAdapter. Updated synchronously in the render
+  // body (same pattern as virtualizerRef) so it is never stale when the pin loop reads it mid-run.
   const isLoadingOlderRef = useRef(isLoadingOlder)
   isLoadingOlderRef.current = isLoadingOlder
 
@@ -489,9 +439,6 @@ export function useMessageListScroll({
   useEffect(() => {
     previousReadPositionRef.current = readPointerId
   }, [conversationId, readPointerId])
-  // Teardown for the native user-input listeners attached to the scroller (set them via addEventListener
-  // so touch/keyboard scrolls — which don't go through the React onWheel handler — also count).
-  const userInputCleanupRef = useRef<(() => void) | null>(null)
   // React StrictMode replays layout-effect cleanup/setup without unmounting the DOM. Defer controller
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
@@ -641,360 +588,95 @@ export function useMessageListScroll({
   // CALLBACK REFS: scroll container + content wrapper
   // ==========================================================================
   //
-  // Using a callback ref for the content wrapper ensures the ResizeObserver is
-  // connected as soon as the wrapper mounts, even if it mounts after initial
-  // render (e.g., MUC rooms that show a loading state before revealing
-  // messages).
-  //
-  // Two constraints shape the implementation:
-  //
-  // 1. ATTACH ORDER: React attaches refs child-first within a commit. When the
-  //    list mounts WITH messages already present, the content-wrapper ref runs
-  //    before the scroller ref is set. Observer setup is therefore late-bound:
-  //    both setters call trySetupContentObserver(), and whichever attaches
-  //    last completes the setup.
-  //
-  // 2. IDENTITY STABILITY: both setters are created once (lazy useRef), NOT
-  //    re-created per render. An unstable callback ref makes React detach
-  //    (null) + reattach it on EVERY render, tearing down and recreating the
-  //    observer each time — a forced-reflow amplifier in busy rooms. Per-render
-  //    values they need are read through latestRef (updated each render via
-  //    effect), never closed over.
+  // The dedicated binding owns ref identity, attach-order handling, native input listeners, and
+  // the non-virtualized content observer. Its module comment documents those local invariants.
 
   const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround })
   useEffect(() => {
     latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround }
   })
 
-  const stableSettersRef = useRef<{
-    setScrollContainerRef: (el: HTMLDivElement | null) => void
-    setContentRef: (el: HTMLDivElement | null) => void
-  } | null>(null)
-
-  if (stableSettersRef.current === null) {
-    const teardownContentObserver = () => {
-      if (contentObserverRef.current) {
-        contentObserverRef.current.disconnect()
-        contentObserverRef.current = null
+  const {
+    setScrollContainerRef,
+    setContentRef,
+    teardownContentObserver,
+    detachUserInputListeners,
+  } = useScrollContainerBinding({
+    setScroller: (el) => {
+      scrollerRef.current = el
+      const external = latestRef.current.externalScrollerRef
+      if (external) {
+        (external as React.MutableRefObject<HTMLElement | null>).current = el
       }
-      if (correctionRafRef.current !== null) {
-        cancelAnimationFrame(correctionRafRef.current)
-        correctionRafRef.current = null
-      }
-    }
+    },
+    getScroller: () => scrollerRef.current,
+    getVirtualizer: () => latestRef.current.virtualizer,
+    isStaticMode: () => latestRef.current.staticMode,
+    isAtBottom: () => latestRef.current.isAtBottomRef.current,
+    getActiveConversationId: () => activeConversationIdRef.current,
+    getLoggedConversationId: () => latestRef.current.conversationId,
+    isDirectionalHistoryPending: (id) =>
+      positioningControllerRef.current?.isDirectionalHistoryPending(id) ?? false,
+    isMediaLoadBatchActive: () => mediaLoadSnapshotRef.current !== null,
+    reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
+    recordUserInput: (id, at) =>
+      viewportSessionRef.current?.recordUserInput(id, at),
+    observeUserInput: (id) =>
+      positioningControllerRef.current?.observeUserInput(id),
+    log: debugLog,
+  })
 
-    const trySetupContentObserver = () => {
-      const scroller = scrollerRef.current
-      const element = contentRef.current
-      if (!scroller || !element || contentObserverRef.current) return
-
-      // Conversation entry owns initial bottom placement through the controller's live-edge
-      // executor. In particular, its non-virtualized switch path retains the historical immediate
-      // plus deferred repair, so this observer must not issue a second pair of mount-time writes.
-
-      // Set up content ResizeObserver
-      let lastHeight = scroller.scrollHeight
-
-      // The actual measure + scroll-correction. Run at most once per frame via
-      // the rAF-coalescing in the observer callback below.
-      const runCorrection = () => {
-        correctionRafRef.current = null
-        const currentScroller = scrollerRef.current
-        if (!currentScroller) return
-
-        // Time the whole correction (including the skip paths — the
-        // scrollHeight read below is the reflow that costs, whatever branch
-        // follows). The frequency monitor in the observer callback cannot see
-        // this failure mode: slow corrections fire only a few times a second.
-        const correctionStart = performance.now()
-        try {
-          runCorrectionBody(currentScroller)
-        } finally {
-          const correctionEnd = performance.now()
-          if (!slowCorrectionMonitorRef.current) {
-            slowCorrectionMonitorRef.current = createSlowCorrectionMonitor()
-          }
-          const slow = slowCorrectionMonitorRef.current.record(
-            correctionEnd - correctionStart,
-            correctionEnd,
-          )
-          if (slow) {
-            // Context reads are warn-path only (rate-limited): querySelectorAll
-            // over the backlog is not free.
-            const rows = currentScroller.querySelectorAll('.message-row').length
-            console.warn(
-              `[SlowScrollCorrection] scroll correction took ${Math.round(correctionEnd - correctionStart)}ms ` +
-              `(rows=${rows}, scrollHeight=${currentScroller.scrollHeight}, ` +
-              `conversation=${latestRef.current.conversationId}) — ` +
-              `reflow cost scales with the rendered backlog.`
-            )
-            if (__FLUUX_ANOMALY__) {
-              signalAnomaly(
-                slowCorrectionSignal(slow, Math.round(correctionEnd - correctionStart), rows),
-              )
-            }
-          }
-        }
-      }
-
-      const runCorrectionBody = (currentScroller: HTMLDivElement) => {
-        const newHeight = currentScroller.scrollHeight
-
-        // When virtualized, the content wrapper IS the @tanstack spacer, whose height
-        // churns on every row measurement; a stick-to-bottom correction here feeds back
-        // into the virtualizer and loops. Stick-to-bottom is handled by the new-message /
-        // typing / reactions effects + the virtualizer instead.
-        if (latestRef.current.virtualizer) {
-          lastHeight = newHeight
-          return
-        }
-
-        const currentScrollTop = currentScroller.scrollTop
-
-        // Skip during prepend that's actively in progress (not yet restored)
-        if (
-          positioningControllerRef.current?.isDirectionalHistoryPending(
-            activeConversationIdRef.current,
-          )
-        ) {
-          debugLog('RESIZE SKIP (prepend in progress)', {
-            newHeight,
-            lastHeight,
-            currentScrollTop,
-          })
-          lastHeight = newHeight
-          return
-        }
-
-        // Skip during media load batch - let the debounced handler manage it
-        if (mediaLoadSnapshotRef.current) {
-          debugLog('RESIZE SKIP (media load batch in progress)', {
-            newHeight,
-            lastHeight,
-            currentScrollTop,
-          })
-          lastHeight = newHeight
-          return
-        }
-
-        const { staticMode, isAtBottomRef } = latestRef.current
-
-        // Content grew and we were at bottom -> stay at bottom. Re-open the current live-edge
-        // generation so the controller remains the only owner even on the non-virtualized path.
-        if (newHeight > lastHeight && isAtBottomRef.current && !staticMode) {
-          debugLog('RESIZE SCROLL TO BOTTOM', {
-            newHeight,
-            lastHeight,
-            isAtBottom: isAtBottomRef.current,
-            scrollTopBefore: currentScrollTop,
-          })
-          reconcileLiveEdgeRef.current('content-growth')
-        } else if (newHeight !== lastHeight) {
-          debugLog('RESIZE NO SCROLL', {
-            newHeight,
-            lastHeight,
-            isAtBottom: isAtBottomRef.current,
-            currentScrollTop,
-          })
-        }
-
-        lastHeight = newHeight
-      }
-
-      const observer = new ResizeObserver(() => {
-        // When virtualized, skip entirely: the wrapper is the @tanstack spacer whose
-        // height churns on every row measurement, and correcting scroll here loops back
-        // into the virtualizer (re-measure → spacer change → RO → scroll → re-render).
-        if (latestRef.current.virtualizer) return
-        // Diagnostic only: surface a runaway fire rate. WebKitGTK can oscillate
-        // a <video controls> height continuously, firing this hundreds of times
-        // a second — a pure main-thread loop the React render-loop detector
-        // can't see. Log-rate-limited; never disconnects.
-        if (!resizeMonitorRef.current) resizeMonitorRef.current = createResizeLoopMonitor()
-        const warning = resizeMonitorRef.current.record(performance.now())
-        if (warning) {
-          console.warn(warning.message)
-          if (__FLUUX_ANOMALY__) signalAnomaly(resizeLoopSignal(warning))
-        }
-
-        // Coalesce the measure + correction into a single rAF no matter how many
-        // times the observer fires this frame. This breaks the read-scrollHeight
-        // -> write-scrollTop -> reflow -> re-fire feedback and caps the expensive
-        // work to once per frame.
-        if (correctionRafRef.current === null) {
-          correctionRafRef.current = requestAnimationFrame(runCorrection)
-        }
-      })
-
-      observer.observe(element)
-      contentObserverRef.current = observer
-    }
-
-    stableSettersRef.current = {
-      setScrollContainerRef: (el: HTMLDivElement | null) => {
-        scrollerRef.current = el
-        const externalScrollerRef = latestRef.current.externalScrollerRef
-        if (externalScrollerRef) {
-          (externalScrollerRef as React.MutableRefObject<HTMLElement | null>).current = el
-        }
-        // Native user-input listeners: mark a GENUINE user scroll so the viewport session's save
-        // gate opens. wheel covers mouse/trackpad, touchstart covers
-        // mobile, keydown covers PageUp/Down/arrows/Space when the list is focused. These are
-        // distinct from media/measurement-driven scroll events, which must NOT open the gate.
-        userInputCleanupRef.current?.()
-        userInputCleanupRef.current = null
-        if (el) {
-          const markUserScrolled = () => {
-            viewportSessionRef.current?.recordUserInput(
-              activeConversationIdRef.current,
-              Date.now(),
-            )
-            positioningControllerRef.current?.observeUserInput(
-              activeConversationIdRef.current,
-            )
-          }
-          el.addEventListener('wheel', markUserScrolled, { passive: true })
-          el.addEventListener('touchstart', markUserScrolled, { passive: true })
-          el.addEventListener('keydown', markUserScrolled)
-          userInputCleanupRef.current = () => {
-            el.removeEventListener('wheel', markUserScrolled)
-            el.removeEventListener('touchstart', markUserScrolled)
-            el.removeEventListener('keydown', markUserScrolled)
-          }
-          trySetupContentObserver()
-        }
+  // Executor construction is delegated to useScrollExecutors. Its factory identities intentionally
+  // churn with the live window so dependent effects below re-run when the window moves.
+  const {
+    createLiveEdgeExecutor,
+    createAnchorPreservationExecutor,
+    buildDirectionalHistoryExecutor,
+    buildSavedPositionExecutor,
+    buildUnreadMarkerExecutor,
+    buildExplicitTargetExecutor,
+    createResidentTopExecutor,
+    // Not construction: an availability probe and the one-frame settlement scheduler, both of which
+    // the directional load flow drives directly.
+    getDirectionalHistoryBrowser,
+    resetLiveEdgeRepaintDebt,
+    disposeDirectionalHistoryBrowser,
+  } = useScrollExecutors({
+    ports: {
+      getScroller: () => scrollerRef.current,
+      getVirtualizer: () => virtualizerRef.current,
+      getActiveConversationId: () => activeConversationIdRef.current,
+      getLiveWindow: () => liveWindowRef.current,
+      getPassiveContext: () => ({
+        conversationId: latestRef.current.conversationId,
+        virtualizer: latestRef.current.virtualizer,
+      }),
+      isLoadingOlder: () => isLoadingOlderRef.current,
+      getLoadAround: () => onLoadAroundRef.current,
+      getStoreTargetMessageId: () => targetMessageIdRef.current,
+      consumeStoreTarget: () => onTargetMessageConsumedRef.current?.(),
+      recordProgrammaticWrite: (id, at) =>
+        viewportSessionRef.current?.recordProgrammaticWrite(id, at),
+      getDirectionalWindow: () => directionalWindowRef.current,
+      syncPrevMessageCount: () => {
+        prevMessageCountRef.current = messageCountRef.current
       },
-      setContentRef: (element: HTMLDivElement | null) => {
-        if (element === contentRef.current) return
-        teardownContentObserver()
-        contentRef.current = element
-        if (element) trySetupContentObserver()
-      },
-    }
-  }
-
-  const { setScrollContainerRef, setContentRef } = stableSettersRef.current
-
-  const beginControllerFrameLoop = useCallback((
-    label: ReassertLoopLabel,
-    lease: PositionExecutionLease,
-    lifecycle?: ControllerFrameLoopLifecycle,
-  ) => {
-    if (!lease.isCurrent()) return null
-    return createControllerFrameLoop({
-      lease,
-      supersede: supersedeReassertLoopRef.current,
-      beginHandle: () => (reassertMonitorRef.current ??=
-        createReassertLoopMonitor()).begin(label, performance.now()),
-      registry: reassertLoopRef,
-      // Native WebKit/Chromium scheduler methods require Window as their receiver. Keep them behind
-      // closures when passing into the extracted adapter; an unbound method throws before the first
-      // convergence frame and strands the requested position.
-      requestFrame: (callback) => requestAnimationFrame(callback),
-      cancelFrame: (id) => cancelAnimationFrame(id),
-      now: () => performance.now(),
-      // The adapter forwards whatever the monitor produced; deciding what to do with it
-      // belongs here. Fan-out, not re-pointing: the prose is untouched.
-      warn: (warning) => {
-        console.warn(warning.message)
-        if (__FLUUX_ANOMALY__) signalAnomaly(reassertLoopSignal(warning))
-      },
-      lifecycle,
-    })
-  }, [])
-
-  const getBottomFractionAnchorBrowser = useCallback(() => {
-    if (bottomFractionAnchorBrowserRef.current === null) {
-      bottomFractionAnchorBrowserRef.current =
-        new BottomFractionAnchorBrowserAdapter({
-          getScroller: () => scrollerRef.current,
-          getVirtualizer: () => virtualizerRef.current,
-        })
-    }
-    return bottomFractionAnchorBrowserRef.current
-  }, [])
-
-  const getDirectionalHistoryBrowser = useCallback(() => {
-    if (directionalHistoryBrowserRef.current === null) {
-      directionalHistoryBrowserRef.current =
-        new DirectionalHistoryBrowserAdapter({
-          getScroller: () => scrollerRef.current,
-          getVirtualizer: () => virtualizerRef.current,
-          getActiveConversationId: () => activeConversationIdRef.current,
-          beginLoop: (lease) => beginControllerFrameLoop('prepend', lease),
-          requestFrame: (callback) => requestAnimationFrame(callback),
-          cancelFrame: (id) => cancelAnimationFrame(id),
-          log: debugLog,
-        })
-    }
-    return directionalHistoryBrowserRef.current
-  }, [beginControllerFrameLoop])
-
-  const getLiveEdgeBrowser = useCallback(() => {
-    if (liveEdgeBrowserRef.current === null) {
-      liveEdgeBrowserRef.current = new LiveEdgeBrowserAdapter({
-        getScroller: () => scrollerRef.current,
-        getVirtualizer: () => virtualizerRef.current,
-        getActiveConversationId: () => activeConversationIdRef.current,
-        // Window facts come from the ref, not the render that built the executor. A live-edge
-        // executor can outlive that render: the unread-marker fallback carries one from entry and
-        // promotes it from inside a rAF frame, long after the cached slice landed. See the ref's
-        // declaration and the adapter's `getWindowFacts` contract.
-        getWindowFacts: () => ({
-          hasRows:
-            liveWindowRef.current.messageCount > 0 &&
-            liveWindowRef.current.firstMessageId !== undefined,
-          windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
-        }),
-        isLoadingOlder: () => isLoadingOlderRef.current,
-        beginLoop: (lease) => {
-          const claim = pinBottomClaim()
-          return beginControllerFrameLoop('pin-bottom', lease, {
-            onStart: claim.renew,
-            onFrame: claim.renew,
-            onFinish: claim.release,
-          })
-        },
-        setMeasuredAtBottom,
-        recordProgrammaticWrite: (id) =>
-          viewportSessionRef.current?.recordProgrammaticWrite(id, Date.now()),
-        log: debugLog,
-      })
-    }
-    return liveEdgeBrowserRef.current
-  }, [beginControllerFrameLoop, setMeasuredAtBottom])
-
-  const createLiveEdgeExecutor = useCallback((
-    trigger: string,
-    smoothNonVirtualized = false,
-  ): LiveEdgeExecutor => getLiveEdgeBrowser().createExecutor({
-    trigger,
-    smoothNonVirtualized,
-    rememberBottomIntent,
-    canRecenter: Boolean(onLoadNewer),
-    recenterVersion: [
-      windowAtLiveEdge === false ? 'slid' : 'live',
-      isLoadingNewer ? 'loading' : 'idle',
-      messageCount,
-      lastMessageId ?? '',
-    ].join(':'),
-    recenter: onLoadNewer
-      ? (signal) => {
-          if (signal.aborted) return 'unavailable'
-          if (isLoadingNewer) return 'waiting'
-          onLoadNewer()
-          return 'requested'
-        }
-      : undefined,
-  }), [
-    getLiveEdgeBrowser,
-    isLoadingNewer,
-    lastMessageId,
+      pinBottomClaim,
+      reassertLoopRegistry: reassertLoopRef,
+      log: debugLog,
+    },
+    conversationId,
     messageCount,
-    onLoadNewer,
-    rememberBottomIntent,
+    firstMessageId,
+    lastMessageId,
     windowAtLiveEdge,
-  ])
+    isLoadingNewer,
+    onLoadNewer,
+    isAtBottomRef,
+    setMeasuredAtBottom,
+    rememberBottomIntent,
+    rememberCurrentScrollSnapshot,
+  })
 
   const reconcileLiveEdge = useCallback((trigger: string): boolean => {
     const controller = positioningControllerRef.current
@@ -1024,35 +706,6 @@ export function useMessageListScroll({
     }
     rememberBottomIntent()
   }, [rememberBottomIntent])
-
-  const createAnchorPreservationExecutor = useCallback(
-    (loopLabel: AnchorPreservationLoopLabel): AnchorPreservationExecutor =>
-      new AnchorPreservationBrowserAdapter({
-        getScroller: () => scrollerRef.current,
-        getVirtualizer: () => virtualizerRef.current,
-        getActiveConversationId: () => activeConversationIdRef.current,
-        getWindowFacts: () => ({
-          hasRows: messageCount > 0 && firstMessageId !== undefined,
-          windowAtLiveEdge: windowAtLiveEdge !== false,
-        }),
-        beginLoop: (label, lease) => beginControllerFrameLoop(label, lease),
-        anchorAdapter: getBottomFractionAnchorBrowser(),
-        setAtBottom: (atBottom) => { isAtBottomRef.current = atBottom },
-        rememberScrollSnapshot: rememberCurrentScrollSnapshot,
-        recordProgrammaticWrite: (id) =>
-          viewportSessionRef.current?.recordProgrammaticWrite(id, Date.now()),
-        log: debugLog,
-      }).createExecutor(loopLabel),
-    [
-      beginControllerFrameLoop,
-      firstMessageId,
-      getBottomFractionAnchorBrowser,
-      isAtBottomRef,
-      messageCount,
-      rememberCurrentScrollSnapshot,
-      windowAtLiveEdge,
-    ],
-  )
 
   // Keep a pre-mutation divider anchor while the reader is scrolled up. On the render where the
   // divider moves, the id mismatch deliberately prevents this effect from replacing the old
@@ -1268,181 +921,6 @@ export function useMessageListScroll({
     messageCount,
   ])
 
-  const createDirectionalHistoryCompletion = useCallback(
-    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor['complete'] =>
-      (request, outcome) => {
-        if (activeConversationIdRef.current !== request.conversationId) return
-        if (outcome === 'applied') {
-          const restored = directionalWindowRef.current?.markRestored(
-            saved.requestId,
-            Date.now(),
-          )
-          const restoredAt = restored?.restoredAt
-          if (restoredAt === undefined) return
-          prevMessageCountRef.current = messageCountRef.current
-          viewportSessionRef.current?.recordProgrammaticWrite(
-            request.conversationId,
-            restoredAt,
-          )
-          setTimeout(() => {
-            directionalWindowRef.current?.expireRestored(
-              saved.requestId,
-              restoredAt,
-            )
-          }, DIRECTIONAL_HISTORY_COOLDOWN_MS)
-        } else {
-          directionalWindowRef.current?.finishPosition(saved.requestId)
-        }
-        if (outcome !== 'applied') {
-          viewportSessionRef.current?.recordProgrammaticWrite(
-            request.conversationId,
-            Date.now(),
-          )
-        }
-        debugLog('DIRECTIONAL HISTORY COMPLETE', {
-          generation: request.generation,
-          outcome,
-          restored: Boolean(saved.restored),
-        })
-      },
-    [],
-  )
-
-  const buildSavedPositionExecutor = useCallback((): SavedPositionExecutor => {
-    const browser = new SavedPositionBrowserAdapter({
-      getScroller: () => scrollerRef.current,
-      getVirtualizer: () => virtualizerRef.current,
-      getWindowFacts: () => ({
-        hasRows: messageCount > 0 && firstMessageId !== undefined,
-        windowAtLiveEdge: windowAtLiveEdge !== false,
-        canRecenter: Boolean(onLoadNewer),
-      }),
-      beginLoop: (lease) => beginControllerFrameLoop('restore-anchor', lease),
-      anchorAdapter: getBottomFractionAnchorBrowser(),
-    })
-    return browser.createExecutor({
-      liveEdge: createLiveEdgeExecutor('restore-fallback'),
-      loadAround: onLoadAroundRef.current
-        ? (messageId, signal) => {
-            if (signal.aborted) return
-            isAtBottomRef.current = false
-            debugLog('RESTORE: anchor not loaded, requesting cache slice around it', {
-              messageId,
-              conversationId,
-            })
-            return onLoadAroundRef.current?.(messageId)
-          }
-        : undefined,
-      recenterVersion: [
-        windowAtLiveEdge === false ? 'slid' : 'live',
-        isLoadingNewer ? 'loading' : 'idle',
-        messageCount,
-        lastMessageId ?? '',
-      ].join(':'),
-      recenterLiveEdge: onLoadNewer
-        ? (signal) => {
-            if (signal.aborted) return 'unavailable'
-            if (isLoadingNewer) return 'waiting'
-            onLoadNewer()
-            return 'requested'
-          }
-        : undefined,
-      complete: (request, outcome) => {
-        const scroller = scrollerRef.current
-        if (!scroller) return
-        setMeasuredAtBottom(getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD)
-        rememberCurrentScrollSnapshot()
-        viewportSessionRef.current?.recordProgrammaticWrite(
-          request.conversationId,
-          Date.now(),
-        )
-        debugLog('RESTORE: controller completed position', {
-          conversationId,
-          generation: request.generation,
-          desired: request.desired,
-          outcome,
-        })
-      },
-    })
-  }, [
-    beginControllerFrameLoop,
-    conversationId,
-    createLiveEdgeExecutor,
-    firstMessageId,
-    getBottomFractionAnchorBrowser,
-    isAtBottomRef,
-    isLoadingNewer,
-    lastMessageId,
-    messageCount,
-    onLoadNewer,
-    rememberCurrentScrollSnapshot,
-    setMeasuredAtBottom,
-    windowAtLiveEdge,
-  ])
-
-  const buildUnreadMarkerExecutor = useCallback(() => {
-    const browser = new UnreadMarkerBrowserAdapter({
-      getScroller: () => scrollerRef.current,
-      getVirtualizer: () => virtualizerRef.current,
-      getWindowFacts: () => ({
-        hasRows:
-          liveWindowRef.current.messageCount > 0 &&
-          liveWindowRef.current.firstMessageId !== undefined,
-        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
-      }),
-      getPassiveContext: () => ({
-        conversationId: latestRef.current.conversationId,
-        virtualizer: latestRef.current.virtualizer,
-      }),
-      beginLoop: (lease) => beginControllerFrameLoop('marker', lease),
-      setMeasuredAtBottom,
-      log: debugLog,
-    })
-    return browser.createExecutor(createLiveEdgeExecutor('marker-fallback'))
-  }, [
-    beginControllerFrameLoop,
-    createLiveEdgeExecutor,
-    setMeasuredAtBottom,
-  ])
-
-  const buildExplicitTargetExecutor = useCallback((
-    messageReference: string,
-    consumeStoreTarget: boolean,
-  ) => {
-    const browser = new ExplicitTargetBrowserAdapter({
-      getScroller: () => scrollerRef.current,
-      getVirtualizer: () => virtualizerRef.current,
-      getWindowFacts: () => ({
-        hasRows:
-          liveWindowRef.current.messageCount > 0 &&
-          liveWindowRef.current.firstMessageId !== undefined,
-        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
-      }),
-      getPassiveContext: () => ({
-        conversationId: latestRef.current.conversationId,
-        virtualizer: latestRef.current.virtualizer,
-      }),
-      getActiveConversationId: () => activeConversationIdRef.current,
-      getStoreTargetMessageId: () => targetMessageIdRef.current,
-      beginLoop: (lease) => beginControllerFrameLoop('target', lease),
-      setMeasuredAtBottom,
-      markNotAtBottom: () => { isAtBottomRef.current = false },
-      consumeStoreTarget: () => onTargetMessageConsumedRef.current?.(),
-      log: debugLog,
-    })
-    return browser.createExecutor({
-      conversationId,
-      messageReference,
-      consumeStoreTarget,
-      loadAround: onLoadAroundRef.current,
-    })
-  }, [
-    beginControllerFrameLoop,
-    conversationId,
-    isAtBottomRef,
-    setMeasuredAtBottom,
-  ])
-
   const requestMessageTargetImpl = useCallback((messageReference: string) => {
     if (staticMode) {
       // Search/activity previews mount their own non-virtualized list beside the live conversation.
@@ -1560,23 +1038,6 @@ export function useMessageListScroll({
   // list — and re-binds the ⌘/Ctrl+↓ listener — on every append.
   const scrollToBottom = useStableCallback(scrollToBottomImpl)
 
-  const createResidentTopExecutor = useCallback((): ResidentTopExecutor =>
-    new ResidentTopBrowserAdapter({
-      getScroller: () => scrollerRef.current,
-      getVirtualizer: () => virtualizerRef.current,
-      getWindowFacts: () => ({
-        hasRows: messageCount > 0 && firstMessageId !== undefined,
-        windowAtLiveEdge: windowAtLiveEdge !== false,
-      }),
-      beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
-      log: debugLog,
-    }).createExecutor(), [
-    beginControllerFrameLoop,
-    firstMessageId,
-    messageCount,
-    windowAtLiveEdge,
-  ])
-
   const scrollToTopImpl = useCallback(() => {
     directionalWindowRef.current?.suppressAutomaticLoads(Date.now())
     if (staticMode) {
@@ -1604,7 +1065,7 @@ export function useMessageListScroll({
   // Re-pin to the bottom when the VIEWPORT itself shrinks (or grows) under a list
   // that is following along — most importantly when the mobile on-screen keyboard
   // deploys. The keyboard shrinks the scroller's clientHeight WITHOUT changing the
-  // content height, so the content ResizeObserver above never fires and the latest
+  // content height, so the content ResizeObserver binding never fires and the latest
   // message slides out of view behind the composer/keyboard. window 'resize' fires
   // when the layout viewport resizes (Android, resizing webviews); visualViewport
   // 'resize' covers the overlay-keyboard case (iOS). Reasserts directly (no rAF
@@ -1731,9 +1192,7 @@ export function useMessageListScroll({
           },
         },
         distanceFromBottom: pixelOffset(saved.distanceFromBottom),
-        executor: browser.createExecutor(
-          createDirectionalHistoryCompletion(saved),
-        ),
+        executor: buildDirectionalHistoryExecutor(saved),
       }) ?? null,
     })
     if (request) {
@@ -2249,9 +1708,8 @@ export function useMessageListScroll({
     }
     mediaLoadSnapshotRef.current = null
     // Drop any repaint-burst debt from the room we're leaving so it can't flush into the new one.
-    // Read through the ref, not the lazy getter: a list that never pinned owes nothing, and building
-    // the adapter here just to reset it would also add a dependency to this entry effect.
-    liveEdgeBrowserRef.current?.resetRepaintDebt()
+    // The executor hook performs this without constructing an adapter for a list that never pinned.
+    resetLiveEdgeRepaintDebt()
 
     // In static mode (read-only previews), skip all scroll positioning.
     // The parent component handles its own scroll-to-target.
@@ -2429,6 +1887,7 @@ export function useMessageListScroll({
     lastMessageId,
     messageCount,
     readPointerId,
+    resetLiveEdgeRepaintDebt,
     staticMode,
     targetMessageId,
     windowAtLiveEdge,
@@ -2638,10 +2097,9 @@ export function useMessageListScroll({
           previousReadPositionRef.current,
         )
       }
-      userInputCleanupRef.current?.()
-      userInputCleanupRef.current = null
+      detachUserInputListeners()
     }
-  }, [])
+  }, [detachUserInputListeners])
 
   // Store-driven search/activity/reaction targets use the same controller execution as reply,
   // poll, and find-on-page requests. Re-renders refresh the executor for the existing generation;
@@ -2701,20 +2159,10 @@ export function useMessageListScroll({
       if (mediaLoadDebounceRef.current) {
         clearTimeout(mediaLoadDebounceRef.current)
       }
-      if (contentObserverRef.current) {
-        contentObserverRef.current.disconnect()
-      }
-      if (correctionRafRef.current !== null) {
-        cancelAnimationFrame(correctionRafRef.current)
-        correctionRafRef.current = null
-      }
-      const directionalBrowser = directionalHistoryBrowserRef.current
-      directionalBrowser?.dispose()
-      if (directionalHistoryBrowserRef.current === directionalBrowser) {
-        directionalHistoryBrowserRef.current = null
-      }
+      teardownContentObserver()
+      disposeDirectionalHistoryBrowser()
     }
-  }, [])
+  }, [disposeDirectionalHistoryBrowser, teardownContentObserver])
 
   // ==========================================================================
   // EFFECT: Returned to the live edge → drop any stale directional-load anchor.
@@ -2783,16 +2231,13 @@ export function useMessageListScroll({
     positioningControllerRef.current?.reconcileDirectionalHistory({
       conversationId,
       generation: decision.generation,
-      executor: getDirectionalHistoryBrowser().createExecutor(
-        createDirectionalHistoryCompletion(saved),
-      ),
+      executor: buildDirectionalHistoryExecutor(saved),
     })
 
   }, [
+    buildDirectionalHistoryExecutor,
     conversationId,
-    createDirectionalHistoryCompletion,
     firstMessageId,
-    getDirectionalHistoryBrowser,
     messageCount,
     staticMode,
   ])
@@ -3085,7 +2530,7 @@ export function useMessageListScroll({
     // never happens synchronously inside the ResizeObserver delivery cycle —
     // that synchronous write is the literal trigger for WebKitGTK's
     // "ResizeObserver loop completed with undelivered notifications". Parity with
-    // the content observer's rAF coalescing (see setContentRef above).
+    // the content observer's rAF coalescing in useScrollContainerBinding.
     const runCorrection = () => {
       scheduled = false
       rafId = null

--- a/apps/fluux/src/components/conversation/useScrollContainerBinding.test.ts
+++ b/apps/fluux/src/components/conversation/useScrollContainerBinding.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import {
+  useScrollContainerBinding,
+  type ScrollContainerBindingPorts,
+} from './useScrollContainerBinding'
+
+interface FakeObserver {
+  target: Element | null
+  fire: () => void
+  disconnected: boolean
+}
+
+let observers: FakeObserver[] = []
+let rafQueue: Array<{ id: number; cb: () => void; cancelled: boolean }> = []
+let nextRafId = 1
+
+function flushFrames() {
+  const due = rafQueue
+  rafQueue = []
+  for (const frame of due) if (!frame.cancelled) frame.cb()
+}
+
+beforeEach(() => {
+  observers = []
+  rafQueue = []
+  nextRafId = 1
+  vi.stubGlobal('ResizeObserver', class {
+    private readonly record: FakeObserver
+    constructor(callback: () => void) {
+      this.record = { target: null, fire: callback, disconnected: false }
+    }
+    observe(target: Element) {
+      this.record.target = target
+      observers.push(this.record)
+    }
+    disconnect() { this.record.disconnected = true }
+    unobserve() {}
+  })
+  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+    const id = nextRafId++
+    rafQueue.push({ id, cb, cancelled: false })
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    const frame = rafQueue.find((f) => f.id === id)
+    if (frame) frame.cancelled = true
+  })
+})
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+function scrollerElement(scrollHeight = 1_000) {
+  const el = document.createElement('div')
+  let height = scrollHeight
+  Object.defineProperties(el, {
+    scrollHeight: { configurable: true, get: () => height },
+    scrollTop: { configurable: true, get: () => 0, set: () => {} },
+    clientHeight: { configurable: true, get: () => 600 },
+  })
+  return { el, grow: (to: number) => { height = to } }
+}
+
+function portsHarness(overrides: Partial<ScrollContainerBindingPorts> = {}) {
+  let attached: HTMLDivElement | null = null
+  const state = {
+    virtualizer: undefined as MessageVirtualizer | undefined,
+    staticMode: false,
+    atBottom: true,
+    directionalPending: false,
+    mediaBatch: false,
+  }
+  const reconcileLiveEdge = vi.fn()
+  const recordUserInput = vi.fn()
+  const observeUserInput = vi.fn()
+  const ports: ScrollContainerBindingPorts = {
+    setScroller: (el) => { attached = el },
+    getScroller: () => attached,
+    getVirtualizer: () => state.virtualizer,
+    isStaticMode: () => state.staticMode,
+    isAtBottom: () => state.atBottom,
+    getActiveConversationId: () => 'room-a',
+    getLoggedConversationId: () => 'room-a',
+    isDirectionalHistoryPending: () => state.directionalPending,
+    isMediaLoadBatchActive: () => state.mediaBatch,
+    reconcileLiveEdge,
+    recordUserInput,
+    observeUserInput,
+    log: vi.fn(),
+    ...overrides,
+  }
+  return { ports, state, reconcileLiveEdge, recordUserInput, observeUserInput }
+}
+
+function mount(overrides: Partial<ScrollContainerBindingPorts> = {}) {
+  const harness = portsHarness(overrides)
+  const rendered = renderHook(
+    (p: ScrollContainerBindingPorts) => useScrollContainerBinding(p),
+    { initialProps: harness.ports },
+  )
+  return { ...harness, ...rendered }
+}
+
+describe('useScrollContainerBinding attachment', () => {
+  it('keeps both setters identical across renders', () => {
+    const { result, rerender, ports } = mount()
+    const first = { ...result.current }
+
+    // A fresh ports object every render is the expected calling convention.
+    rerender({ ...ports })
+    rerender({ ...ports })
+
+    // An unstable callback ref makes React detach+reattach on EVERY render, tearing down and
+    // rebuilding the observer each time — a forced-reflow amplifier in busy rooms.
+    expect(result.current.setScrollContainerRef).toBe(first.setScrollContainerRef)
+    expect(result.current.setContentRef).toBe(first.setContentRef)
+    expect(result.current.teardownContentObserver).toBe(first.teardownContentObserver)
+    expect(result.current.detachUserInputListeners).toBe(first.detachUserInputListeners)
+  })
+
+  it('completes late-bound setup whichever node attaches last', () => {
+    // React attaches refs child-first: with messages already present the content wrapper lands
+    // BEFORE the scroller, so setup must not be tied to one particular arrival order.
+    const contentFirst = mount()
+    const content = document.createElement('div')
+    contentFirst.result.current.setContentRef(content)
+    expect(observers).toHaveLength(0)
+    contentFirst.result.current.setScrollContainerRef(scrollerElement().el)
+    expect(observers).toHaveLength(1)
+    expect(observers[0].target).toBe(content)
+
+    observers = []
+    const scrollerFirst = mount()
+    scrollerFirst.result.current.setScrollContainerRef(scrollerElement().el)
+    expect(observers).toHaveLength(0)
+    const otherContent = document.createElement('div')
+    scrollerFirst.result.current.setContentRef(otherContent)
+    expect(observers).toHaveLength(1)
+    expect(observers[0].target).toBe(otherContent)
+  })
+
+  it('rebuilds the observer only when the content node actually changes', () => {
+    const { result } = mount()
+    result.current.setScrollContainerRef(scrollerElement().el)
+    const content = document.createElement('div')
+    result.current.setContentRef(content)
+    expect(observers).toHaveLength(1)
+
+    result.current.setContentRef(content)
+    expect(observers).toHaveLength(1)
+    expect(observers[0].disconnected).toBe(false)
+
+    result.current.setContentRef(document.createElement('div'))
+    expect(observers).toHaveLength(2)
+    expect(observers[0].disconnected).toBe(true)
+  })
+
+  it('moves the user-input listeners with the scroller and releases them on teardown', () => {
+    const { result, recordUserInput, observeUserInput } = mount()
+    const first = scrollerElement().el
+    result.current.setScrollContainerRef(first)
+    first.dispatchEvent(new Event('wheel'))
+    expect(recordUserInput).toHaveBeenCalledTimes(1)
+    expect(observeUserInput).toHaveBeenCalledTimes(1)
+
+    const second = scrollerElement().el
+    result.current.setScrollContainerRef(second)
+    // The old node must be silent, or a detached scroller keeps opening the persistence gate.
+    first.dispatchEvent(new Event('wheel'))
+    expect(recordUserInput).toHaveBeenCalledTimes(1)
+    second.dispatchEvent(new Event('touchstart'))
+    second.dispatchEvent(new Event('keydown'))
+    expect(recordUserInput).toHaveBeenCalledTimes(3)
+
+    result.current.detachUserInputListeners()
+    second.dispatchEvent(new Event('wheel'))
+    expect(recordUserInput).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('useScrollContainerBinding growth correction', () => {
+  function attached(overrides: Partial<ScrollContainerBindingPorts> = {}) {
+    const scope = mount(overrides)
+    const scroller = scrollerElement()
+    scope.result.current.setScrollContainerRef(scroller.el)
+    scope.result.current.setContentRef(document.createElement('div'))
+    return { ...scope, scroller }
+  }
+
+  it('re-opens the live-edge generation when content grows at the bottom', () => {
+    const scope = attached()
+    scope.scroller.grow(1_400)
+    observers[0].fire()
+    flushFrames()
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('content-growth')
+  })
+
+  it('coalesces a burst of observer fires into a single correction frame', () => {
+    const scope = attached()
+    scope.scroller.grow(1_400)
+    observers[0].fire()
+    observers[0].fire()
+    observers[0].fire()
+    // The read-scrollHeight -> write-scrollTop -> reflow -> re-fire feedback is what this caps.
+    expect(rafQueue).toHaveLength(1)
+    flushFrames()
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledTimes(1)
+  })
+
+  it('never corrects while reading history, mid-prepend, mid-media-batch, or in a preview', () => {
+    for (const mutate of [
+      (s: ReturnType<typeof attached>) => { s.state.atBottom = false },
+      (s: ReturnType<typeof attached>) => { s.state.directionalPending = true },
+      (s: ReturnType<typeof attached>) => { s.state.mediaBatch = true },
+      (s: ReturnType<typeof attached>) => { s.state.staticMode = true },
+    ]) {
+      observers = []
+      rafQueue = []
+      const scope = attached()
+      mutate(scope)
+      scope.scroller.grow(1_400)
+      observers[0].fire()
+      flushFrames()
+      expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+    }
+  })
+
+  it('does not correct when the content merely shrinks', () => {
+    const scope = attached()
+    scope.scroller.grow(600)
+    observers[0].fire()
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('skips the observer entirely while virtualized', () => {
+    const scope = attached()
+    scope.state.virtualizer = {} as MessageVirtualizer
+    scope.scroller.grow(1_400)
+    observers[0].fire()
+    // The wrapper IS the @tanstack spacer: scheduling a frame here loops back into the virtualizer
+    // (re-measure -> spacer change -> RO -> scroll -> re-render).
+    expect(rafQueue).toHaveLength(0)
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('abandons an already-queued correction when virtualization flips on before the frame runs', () => {
+    const scope = attached()
+    scope.scroller.grow(1_400)
+    observers[0].fire()
+    expect(rafQueue).toHaveLength(1)
+
+    // The observer callback's early return cannot cover this: the frame was queued while the list
+    // was still non-virtualized. Correcting now writes scrollTop against the @tanstack spacer.
+    scope.state.virtualizer = {} as MessageVirtualizer
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('drops a pending correction frame when the observer is torn down', () => {
+    const scope = attached()
+    scope.scroller.grow(1_400)
+    observers[0].fire()
+    expect(rafQueue).toHaveLength(1)
+
+    scope.result.current.teardownContentObserver()
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+    expect(observers[0].disconnected).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/useScrollContainerBinding.ts
+++ b/apps/fluux/src/components/conversation/useScrollContainerBinding.ts
@@ -1,0 +1,281 @@
+/**
+ * useScrollContainerBinding - callback refs for the scroller and content wrapper
+ *
+ * Owns everything that must be wired to those two DOM nodes: the genuine-user-input listeners on
+ * the scroller, and the content ResizeObserver that keeps a NON-virtualized list pinned while its
+ * content grows.
+ *
+ * It owns no positioning generation. Content growth re-opens the caller's current live-edge
+ * generation through `reconcileLiveEdge`, so the controller stays the only position owner even on
+ * the non-virtualized path.
+ *
+ * Two constraints shape the implementation:
+ *
+ * 1. ATTACH ORDER: React attaches refs child-first within a commit. When the list mounts WITH
+ *    messages already present, the content-wrapper ref runs before the scroller ref is set.
+ *    Observer setup is therefore late-bound: both setters call `trySetupContentObserver()`, and
+ *    whichever attaches last completes the setup.
+ *
+ * 2. IDENTITY STABILITY: both setters are created once (lazy ref), NOT re-created per render. An
+ *    unstable callback ref makes React detach (null) + reattach it on EVERY render, tearing down
+ *    and recreating the observer each time — a forced-reflow amplifier in busy rooms. Per-render
+ *    values are read through `ports`, never closed over.
+ */
+
+import { useRef } from 'react'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
+import {
+  createSlowCorrectionMonitor,
+  slowCorrectionSignal,
+} from './slowCorrectionMonitor'
+import { signalAnomaly } from '@/utils/anomalySignal'
+
+export interface ScrollContainerBindingPorts {
+  /** Publish the attached scroller: the caller's own ref plus any external one it mirrors. */
+  setScroller: (el: HTMLDivElement | null) => void
+  getScroller: () => HTMLDivElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  isStaticMode: () => boolean
+  isAtBottom: () => boolean
+  getActiveConversationId: () => string
+  /** Conversation shown in the slow-correction warning; the passive latest-value one. */
+  getLoggedConversationId: () => string
+  isDirectionalHistoryPending: (conversationId: string) => boolean
+  isMediaLoadBatchActive: () => boolean
+  reconcileLiveEdge: (trigger: string) => void
+  recordUserInput: (conversationId: string, at: number) => void
+  observeUserInput: (conversationId: string) => void
+  log: (action: string, data?: Record<string, unknown>) => void
+}
+
+export interface ScrollContainerBinding {
+  setScrollContainerRef: (el: HTMLDivElement | null) => void
+  setContentRef: (el: HTMLDivElement | null) => void
+  /** Unmount: stop observing and drop any coalesced correction frame. */
+  teardownContentObserver: () => void
+  /** Unmount: release the genuine-user-input listeners from the attached scroller. */
+  detachUserInputListeners: () => void
+}
+
+export function useScrollContainerBinding(
+  ports: ScrollContainerBindingPorts,
+): ScrollContainerBinding {
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const contentObserverRef = useRef<ResizeObserver | null>(null)
+  const correctionRafRef = useRef<number | null>(null)
+  // Diagnostic-only monitor for a runaway observer fire rate.
+  const resizeMonitorRef = useRef<ReturnType<typeof createResizeLoopMonitor> | null>(null)
+  // Diagnostic-only monitor for SLOW corrections (reflow cost, not fire rate).
+  const slowCorrectionMonitorRef =
+    useRef<ReturnType<typeof createSlowCorrectionMonitor> | null>(null)
+  const userInputCleanupRef = useRef<(() => void) | null>(null)
+
+  const bindingRef = useRef<ScrollContainerBinding | null>(null)
+
+  if (bindingRef.current === null) {
+    const teardownContentObserver = () => {
+      if (contentObserverRef.current) {
+        contentObserverRef.current.disconnect()
+        contentObserverRef.current = null
+      }
+      if (correctionRafRef.current !== null) {
+        cancelAnimationFrame(correctionRafRef.current)
+        correctionRafRef.current = null
+      }
+    }
+
+    const detachUserInputListeners = () => {
+      userInputCleanupRef.current?.()
+      userInputCleanupRef.current = null
+    }
+
+    const trySetupContentObserver = () => {
+      const scroller = portsRef.current.getScroller()
+      const element = contentRef.current
+      if (!scroller || !element || contentObserverRef.current) return
+
+      // Conversation entry owns initial bottom placement through the controller's live-edge
+      // executor. In particular, its non-virtualized switch path retains the historical immediate
+      // plus deferred repair, so this observer must not issue a second pair of mount-time writes.
+
+      // Set up content ResizeObserver
+      let lastHeight = scroller.scrollHeight
+
+      // The actual measure + scroll-correction. Run at most once per frame via
+      // the rAF-coalescing in the observer callback below.
+      const runCorrection = () => {
+        correctionRafRef.current = null
+        const currentScroller = portsRef.current.getScroller()
+        if (!currentScroller) return
+
+        // Time the whole correction (including the skip paths — the
+        // scrollHeight read below is the reflow that costs, whatever branch
+        // follows). The frequency monitor in the observer callback cannot see
+        // this failure mode: slow corrections fire only a few times a second.
+        const correctionStart = performance.now()
+        try {
+          runCorrectionBody(currentScroller)
+        } finally {
+          const correctionEnd = performance.now()
+          if (!slowCorrectionMonitorRef.current) {
+            slowCorrectionMonitorRef.current = createSlowCorrectionMonitor()
+          }
+          const slow = slowCorrectionMonitorRef.current.record(
+            correctionEnd - correctionStart,
+            correctionEnd,
+          )
+          if (slow) {
+            // Context reads are warn-path only (rate-limited): querySelectorAll
+            // over the backlog is not free.
+            const rows = currentScroller.querySelectorAll('.message-row').length
+            console.warn(
+              `[SlowScrollCorrection] scroll correction took ${Math.round(correctionEnd - correctionStart)}ms ` +
+              `(rows=${rows}, scrollHeight=${currentScroller.scrollHeight}, ` +
+              `conversation=${portsRef.current.getLoggedConversationId()}) — ` +
+              `reflow cost scales with the rendered backlog.`
+            )
+            if (__FLUUX_ANOMALY__) {
+              signalAnomaly(
+                slowCorrectionSignal(slow, Math.round(correctionEnd - correctionStart), rows),
+              )
+            }
+          }
+        }
+      }
+
+      const runCorrectionBody = (currentScroller: HTMLDivElement) => {
+        const newHeight = currentScroller.scrollHeight
+
+        // When virtualized, the content wrapper IS the @tanstack spacer, whose height
+        // churns on every row measurement; a stick-to-bottom correction here feeds back
+        // into the virtualizer and loops. Stick-to-bottom is handled by the new-message /
+        // typing / reactions effects + the virtualizer instead.
+        if (portsRef.current.getVirtualizer()) {
+          lastHeight = newHeight
+          return
+        }
+
+        const currentScrollTop = currentScroller.scrollTop
+
+        // Skip during prepend that's actively in progress (not yet restored)
+        if (
+          portsRef.current.isDirectionalHistoryPending(
+            portsRef.current.getActiveConversationId(),
+          )
+        ) {
+          portsRef.current.log('RESIZE SKIP (prepend in progress)', {
+            newHeight,
+            lastHeight,
+            currentScrollTop,
+          })
+          lastHeight = newHeight
+          return
+        }
+
+        // Skip during media load batch - let the debounced handler manage it
+        if (portsRef.current.isMediaLoadBatchActive()) {
+          portsRef.current.log('RESIZE SKIP (media load batch in progress)', {
+            newHeight,
+            lastHeight,
+            currentScrollTop,
+          })
+          lastHeight = newHeight
+          return
+        }
+
+        const staticMode = portsRef.current.isStaticMode()
+        const atBottom = portsRef.current.isAtBottom()
+
+        // Content grew and we were at bottom -> stay at bottom. Re-open the current live-edge
+        // generation so the controller remains the only owner even on the non-virtualized path.
+        if (newHeight > lastHeight && atBottom && !staticMode) {
+          portsRef.current.log('RESIZE SCROLL TO BOTTOM', {
+            newHeight,
+            lastHeight,
+            isAtBottom: atBottom,
+            scrollTopBefore: currentScrollTop,
+          })
+          portsRef.current.reconcileLiveEdge('content-growth')
+        } else if (newHeight !== lastHeight) {
+          portsRef.current.log('RESIZE NO SCROLL', {
+            newHeight,
+            lastHeight,
+            isAtBottom: atBottom,
+            currentScrollTop,
+          })
+        }
+
+        lastHeight = newHeight
+      }
+
+      const observer = new ResizeObserver(() => {
+        // When virtualized, skip entirely: the wrapper is the @tanstack spacer whose
+        // height churns on every row measurement, and correcting scroll here loops back
+        // into the virtualizer (re-measure → spacer change → RO → scroll → re-render).
+        if (portsRef.current.getVirtualizer()) return
+        // Diagnostic only: surface a runaway fire rate. WebKitGTK can oscillate
+        // a <video controls> height continuously, firing this hundreds of times
+        // a second — a pure main-thread loop the React render-loop detector
+        // can't see. Log-rate-limited; never disconnects.
+        if (!resizeMonitorRef.current) resizeMonitorRef.current = createResizeLoopMonitor()
+        const warning = resizeMonitorRef.current.record(performance.now())
+        if (warning) {
+          console.warn(warning.message)
+          if (__FLUUX_ANOMALY__) signalAnomaly(resizeLoopSignal(warning))
+        }
+
+        // Coalesce the measure + correction into a single rAF no matter how many
+        // times the observer fires this frame. This breaks the read-scrollHeight
+        // -> write-scrollTop -> reflow -> re-fire feedback and caps the expensive
+        // work to once per frame.
+        if (correctionRafRef.current === null) {
+          correctionRafRef.current = requestAnimationFrame(runCorrection)
+        }
+      })
+
+      observer.observe(element)
+      contentObserverRef.current = observer
+    }
+
+    bindingRef.current = {
+      setScrollContainerRef: (el: HTMLDivElement | null) => {
+        portsRef.current.setScroller(el)
+        // Native user-input listeners: mark a GENUINE user scroll so the viewport session's save
+        // gate opens. wheel covers mouse/trackpad, touchstart covers
+        // mobile, keydown covers PageUp/Down/arrows/Space when the list is focused. These are
+        // distinct from media/measurement-driven scroll events, which must NOT open the gate.
+        detachUserInputListeners()
+        if (el) {
+          const markUserScrolled = () => {
+            const active = portsRef.current
+            active.recordUserInput(active.getActiveConversationId(), Date.now())
+            active.observeUserInput(active.getActiveConversationId())
+          }
+          el.addEventListener('wheel', markUserScrolled, { passive: true })
+          el.addEventListener('touchstart', markUserScrolled, { passive: true })
+          el.addEventListener('keydown', markUserScrolled)
+          userInputCleanupRef.current = () => {
+            el.removeEventListener('wheel', markUserScrolled)
+            el.removeEventListener('touchstart', markUserScrolled)
+            el.removeEventListener('keydown', markUserScrolled)
+          }
+          trySetupContentObserver()
+        }
+      },
+      setContentRef: (element: HTMLDivElement | null) => {
+        if (element === contentRef.current) return
+        teardownContentObserver()
+        contentRef.current = element
+        if (element) trySetupContentObserver()
+      },
+      teardownContentObserver,
+      detachUserInputListeners,
+    }
+  }
+
+  return bindingRef.current
+}

--- a/apps/fluux/src/components/conversation/useScrollExecutors.test.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { ControllerFrameLoopRegistration } from './controllerFrameLoop'
+import type { PinLoopClaim } from './pinLoopClaim'
+import type { DirectionalHistoryWindowCoordinator } from './directionalHistoryWindowCoordinator'
+import {
+  useScrollExecutors,
+  type ScrollExecutorPorts,
+  type UseScrollExecutorsInput,
+} from './useScrollExecutors'
+
+function portsHarness(overrides: Partial<ScrollExecutorPorts> = {}) {
+  const scroller = document.createElement('div')
+  const recordProgrammaticWrite = vi.fn()
+  const log = vi.fn()
+  const liveWindow = {
+    messageCount: 20,
+    firstMessageId: 'm-0' as string | undefined,
+    windowAtLiveEdge: true as boolean | undefined,
+  }
+  const ports: ScrollExecutorPorts = {
+    getScroller: () => scroller,
+    getVirtualizer: () => undefined,
+    getActiveConversationId: () => 'room-a',
+    getLiveWindow: () => liveWindow,
+    getPassiveContext: () => ({ conversationId: 'room-a', virtualizer: undefined }),
+    isLoadingOlder: () => false,
+    getLoadAround: () => undefined,
+    getStoreTargetMessageId: () => null,
+    consumeStoreTarget: vi.fn(),
+    recordProgrammaticWrite,
+    getDirectionalWindow: () => null as DirectionalHistoryWindowCoordinator | null,
+    syncPrevMessageCount: vi.fn(),
+    pinBottomClaim: () => ({
+      renew: vi.fn(),
+      release: vi.fn(),
+      isHeld: () => false,
+    }) as unknown as PinLoopClaim,
+    reassertLoopRegistry: {
+      current: null as ControllerFrameLoopRegistration | null,
+    },
+    log,
+    ...overrides,
+  }
+  return { ports, scroller, liveWindow, recordProgrammaticWrite, log }
+}
+
+/**
+ * Model the caller's identity contract faithfully, because these controls are ABOUT identity.
+ *
+ * In `useMessageListScroll` these are `useCallback`s: `setMeasuredAtBottom` and
+ * `rememberCurrentScrollSnapshot` are stable, `isAtBottomRef` is a ref, and `rememberBottomIntent`
+ * changes only with the conversation. A harness that allocates a fresh `vi.fn()` per render makes
+ * every factory churn for the wrong reason and silently passes even when the window facts have been
+ * dropped from a dependency array.
+ */
+function baseInput(
+  ports: ScrollExecutorPorts,
+  overrides: Partial<UseScrollExecutorsInput> = {},
+): UseScrollExecutorsInput {
+  const conversationId = overrides.conversationId ?? 'room-a'
+  return {
+    ports,
+    conversationId,
+    messageCount: 20,
+    firstMessageId: 'm-0',
+    lastMessageId: 'm-19',
+    windowAtLiveEdge: true,
+    isLoadingNewer: false,
+    onLoadNewer: undefined,
+    isAtBottomRef: STABLE_AT_BOTTOM_REF,
+    setMeasuredAtBottom: STABLE_SET_MEASURED_AT_BOTTOM,
+    rememberBottomIntent: rememberBottomIntentFor(conversationId),
+    rememberCurrentScrollSnapshot: STABLE_REMEMBER_SNAPSHOT,
+    ...overrides,
+  }
+}
+
+const STABLE_AT_BOTTOM_REF = { current: true }
+const STABLE_SET_MEASURED_AT_BOTTOM = vi.fn()
+const STABLE_REMEMBER_SNAPSHOT = vi.fn()
+const rememberBottomIntentByConversation = new Map<string, () => void>()
+function rememberBottomIntentFor(conversationId: string) {
+  const existing = rememberBottomIntentByConversation.get(conversationId)
+  if (existing) return existing
+  const created = vi.fn()
+  rememberBottomIntentByConversation.set(conversationId, created)
+  return created
+}
+
+describe('useScrollExecutors identity churn', () => {
+  // The factories below are dependencies of effects in useMessageListScroll that MUST re-run when
+  // the live window moves — the `refresh` live-edge effect exists for exactly that. Holding the
+  // factories in a ref, or memoising them on [] , silently stops those effects from re-firing. These
+  // controls fail against that "simplification".
+  const churnCases: Array<{
+    what: string
+    change: Partial<UseScrollExecutorsInput>
+    churns: Array<keyof ReturnType<typeof useScrollExecutors>>
+  }> = [
+    {
+      what: 'a new message lands (messageCount)',
+      change: { messageCount: 21 },
+      churns: [
+        'createLiveEdgeExecutor',
+        'createAnchorPreservationExecutor',
+        'buildSavedPositionExecutor',
+        'createResidentTopExecutor',
+      ],
+    },
+    {
+      what: 'the window slides off the live edge',
+      change: { windowAtLiveEdge: false },
+      churns: [
+        'createLiveEdgeExecutor',
+        'createAnchorPreservationExecutor',
+        'buildSavedPositionExecutor',
+        'createResidentTopExecutor',
+      ],
+    },
+    {
+      what: 'the newest message id changes',
+      change: { lastMessageId: 'm-20' },
+      churns: ['createLiveEdgeExecutor', 'buildSavedPositionExecutor'],
+    },
+    {
+      what: 'a forward-window load starts',
+      change: { isLoadingNewer: true },
+      churns: ['createLiveEdgeExecutor', 'buildSavedPositionExecutor'],
+    },
+    {
+      what: 'the conversation changes',
+      change: { conversationId: 'room-b' },
+      churns: ['buildSavedPositionExecutor', 'buildExplicitTargetExecutor'],
+    },
+  ]
+
+  it.each(churnCases)('re-creates its factories when $what', ({ change, churns }) => {
+    const { ports } = portsHarness()
+    const { result, rerender } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+    const before = { ...result.current }
+
+    rerender(baseInput(ports, change))
+
+    for (const key of churns) {
+      expect(
+        result.current[key],
+        `${String(key)} must not be frozen across a window change`,
+      ).not.toBe(before[key])
+    }
+  })
+
+  it('keeps a stable identity for the two lifecycle escape hatches', () => {
+    const { ports } = portsHarness()
+    const { result, rerender } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+    const before = { ...result.current }
+
+    // Both are consumed by effects that must NOT re-run on ordinary appends.
+    rerender(baseInput(ports, { messageCount: 21, lastMessageId: 'm-20' }))
+    expect(result.current.resetLiveEdgeRepaintDebt).toBe(before.resetLiveEdgeRepaintDebt)
+    expect(result.current.disposeDirectionalHistoryBrowser).toBe(
+      before.disposeDirectionalHistoryBrowser,
+    )
+    expect(result.current.getDirectionalHistoryBrowser).toBe(
+      before.getDirectionalHistoryBrowser,
+    )
+  })
+})
+
+describe('useScrollExecutors adapter ownership', () => {
+  it('shares one live-edge adapter across executors so a repaint burst can coalesce', () => {
+    let scrollTop = 0
+    let repaints = 0
+    const scroller = document.createElement('div')
+    Object.defineProperties(scroller, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (v: number) => { scrollTop = v },
+      },
+      scrollHeight: { configurable: true, get: () => 2_000 },
+      clientHeight: { configurable: true, get: () => 600 },
+      // Only the stale-paint repair forces layout between its two overflowY writes.
+      offsetHeight: { configurable: true, get: () => { repaints += 1; return 600 } },
+    })
+    const virtualizer = {
+      getVirtualItems: () => [],
+      getTotalSize: () => 2_000,
+      itemCount: 20,
+      getOffsetForMessageId: vi.fn(() => 0),
+      getIndexForMessageId: vi.fn(() => 0),
+      ensureMessageMounted: vi.fn(async () => {}),
+      measureElement: vi.fn(),
+      scrollToOffset: vi.fn(),
+      scrollToIndex: vi.fn(() => { scrollTop = 1_400 }),
+      beginAnimatedScrollToOffset: vi.fn(),
+    }
+    const { ports } = portsHarness({
+      getScroller: () => scroller,
+      getVirtualizer: () => virtualizer,
+    })
+    const { result, rerender } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+    const lease = {
+      conversationId: 'room-a',
+      generation: 1,
+      operation: 1,
+      signal: new AbortController().signal,
+      isCurrent: () => true,
+      markApplied: () => true,
+      settle: () => true,
+    }
+    const request = {
+      generation: 1,
+      conversationId: 'room-a',
+      source: { kind: 'entry', reason: 'live-edge' },
+      desired: { kind: 'live-edge', follow: true },
+    } as Parameters<
+      ReturnType<typeof useScrollExecutors>['createLiveEdgeExecutor'] extends
+        (...a: never[]) => infer E ? E extends { positionFrame: infer P } ? P : never : never
+    >[0]
+
+    // An isolated first arrival paints promptly.
+    result.current.createLiveEdgeExecutor('new-message').positionFrame(request, lease)
+    expect(repaints).toBe(1)
+
+    // A second arrival built from a LATER render must join the first one's burst and be suppressed.
+    // Giving each executor its own adapter resets the burst, so this would repaint again.
+    scrollTop = 0
+    rerender(baseInput(ports, { messageCount: 21 }))
+    result.current.createLiveEdgeExecutor('new-message').positionFrame(request, lease)
+    expect(repaints).toBe(1)
+  })
+
+  it('reads ports through a ref rather than freezing the first render', () => {
+    const harness = portsHarness()
+    const { result, rerender } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(harness.ports) },
+    )
+    const executor = result.current.createLiveEdgeExecutor('marker-fallback')
+    expect(executor.reachability()).not.toEqual({ kind: 'empty-window' })
+
+    // A later render supplies a fresh ports object describing an empty window. The executor built
+    // earlier must observe it: a live-edge executor outlives the render that built it.
+    const emptied = portsHarness({
+      getLiveWindow: () => ({
+        messageCount: 0,
+        firstMessageId: undefined,
+        windowAtLiveEdge: true,
+      }),
+    })
+    rerender(baseInput(emptied.ports))
+    expect(executor.reachability()).toEqual({ kind: 'empty-window' })
+  })
+
+  it('builds the directional-history executor here, not at the call site', () => {
+    const { ports } = portsHarness()
+    const { result } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+    const saved = { requestId: 1, restored: false } as Parameters<
+      typeof result.current.buildDirectionalHistoryExecutor
+    >[0]
+
+    // The hook must hand back a whole executor. Exposing only the completion callback pushes
+    // createExecutor back into useMessageListScroll and reopens the construction boundary.
+    const executor = result.current.buildDirectionalHistoryExecutor(saved)
+    expect(typeof executor.reachability).toBe('function')
+    expect(typeof executor.positionFrame).toBe('function')
+    expect(typeof executor.beginLoop).toBe('function')
+    expect(typeof executor.complete).toBe('function')
+
+    // Each load gets its own executor: the completion closes over that load's snapshot.
+    expect(result.current.buildDirectionalHistoryExecutor(saved)).not.toBe(executor)
+  })
+
+  it('disposes the directional adapter only when it is still the current one', () => {
+    const { ports } = portsHarness()
+    const { result } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+
+    const browser = result.current.getDirectionalHistoryBrowser()
+    expect(result.current.getDirectionalHistoryBrowser()).toBe(browser)
+
+    result.current.disposeDirectionalHistoryBrowser()
+    // A rebuild after disposal must hand out a fresh adapter, not the disposed one.
+    expect(result.current.getDirectionalHistoryBrowser()).not.toBe(browser)
+  })
+})

--- a/apps/fluux/src/components/conversation/useScrollExecutors.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.ts
@@ -1,0 +1,559 @@
+/**
+ * useScrollExecutors - construction of every leased positioning executor
+ *
+ * Each positioning slice reconciles behind its own browser adapter. This hook owns the wiring
+ * between those adapters and the controller: it builds each executor, holds the adapters that must
+ * outlive a single execution, and keeps the frame-loop factory the adapters lease.
+ *
+ * It deliberately owns no positioning decision, no effect, and no lifecycle. `useMessageListScroll`
+ * decides WHEN a request is submitted; this hook only decides HOW its executor is assembled.
+ *
+ * ## Why the callback identities still churn
+ *
+ * The factories below are `useCallback`s whose dependency arrays intentionally track render-scoped
+ * window facts. That churn is load-bearing, not an oversight: several effects in the scroll hook
+ * list a factory as their dependency precisely so they re-run when the live window moves — the
+ * `refresh` live-edge effect exists for exactly that reason. Freezing these identities (for example
+ * by holding one factory object in a ref) silently stops those effects from re-firing.
+ *
+ * Values that appear in a dependency array are therefore passed as explicit arguments. Everything
+ * else — pure ref readers with stable identity — travels in `ports`, which is read through a ref so
+ * it never widens a dependency array.
+ */
+
+import { useCallback, useRef, type RefObject } from 'react'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import type { PinLoopClaim } from './pinLoopClaim'
+import {
+  createControllerFrameLoop,
+  type ControllerFrameLoopLifecycle,
+  type ControllerFrameLoopRegistration,
+} from './controllerFrameLoop'
+import {
+  createReassertLoopMonitor,
+  reassertLoopSignal,
+  type ReassertLoopLabel,
+} from './reassertLoopMonitor'
+import { BottomFractionAnchorBrowserAdapter } from './bottomFractionAnchorBrowserAdapter'
+import { DirectionalHistoryBrowserAdapter } from './directionalHistoryBrowserAdapter'
+import { SavedPositionBrowserAdapter } from './savedPositionBrowserAdapter'
+import { UnreadMarkerBrowserAdapter } from './unreadMarkerBrowserAdapter'
+import { ExplicitTargetBrowserAdapter } from './explicitTargetBrowserAdapter'
+import { LiveEdgeBrowserAdapter } from './liveEdgeBrowserAdapter'
+import {
+  AnchorPreservationBrowserAdapter,
+  type AnchorPreservationLoopLabel,
+} from './anchorPreservationBrowserAdapter'
+import { ResidentTopBrowserAdapter } from './residentTopBrowserAdapter'
+import {
+  DIRECTIONAL_HISTORY_COOLDOWN_MS,
+  type DirectionalHistorySnapshot,
+  type DirectionalHistoryWindowCoordinator,
+} from './directionalHistoryWindowCoordinator'
+import type {
+  AnchorPreservationExecutor,
+  DirectionalHistoryExecutor,
+  ExplicitTargetExecutor,
+  LiveEdgeExecutor,
+  PositionExecutionLease,
+  ResidentTopExecutor,
+  SavedPositionExecutor,
+  UnreadMarkerExecutor,
+} from './positioningController'
+import { signalAnomaly } from '@/utils/anomalySignal'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+
+/** Live-window facts as the executors describe them, read fresh on every call. */
+export interface ScrollExecutorLiveWindow {
+  messageCount: number
+  firstMessageId: string | undefined
+  windowAtLiveEdge: boolean | undefined
+}
+
+/**
+ * Stable ref readers and side-effect sinks. None of these may appear in a dependency array, so the
+ * hook reads them through a ref; supplying a fresh object literal each render is expected.
+ */
+export interface ScrollExecutorPorts {
+  getScroller: () => HTMLDivElement | null
+  getVirtualizer: () => MessageVirtualizer | undefined
+  getActiveConversationId: () => string
+  /**
+   * The live window as of NOW, not as of the render that built an executor. A live-edge executor
+   * outlives that render: the unread-marker fallback carries one from entry and promotes it from
+   * inside a rAF frame, long after the cached slice landed. Describing the entry window there
+   * reports `empty-window` for a window that has since filled, parking the promoted execution in
+   * `pending` with no frame loop.
+   */
+  getLiveWindow: () => ScrollExecutorLiveWindow
+  /**
+   * Latest-value conversation handoff. Entry positioning must wait for it so the virtualizer from
+   * the conversation being left cannot receive the first write.
+   */
+  getPassiveContext: () => {
+    conversationId: string
+    virtualizer: MessageVirtualizer | undefined
+  }
+  isLoadingOlder: () => boolean | undefined
+  getLoadAround: () =>
+    | ((anchorMessageId: string) => Promise<unknown> | void)
+    | undefined
+  getStoreTargetMessageId: () => string | null | undefined
+  consumeStoreTarget: () => void
+  recordProgrammaticWrite: (conversationId: string, at: number) => void
+  getDirectionalWindow: () => DirectionalHistoryWindowCoordinator | null
+  /** Adopt the current message count as the directional-load baseline after a landed restore. */
+  syncPrevMessageCount: () => void
+  pinBottomClaim: () => PinLoopClaim
+  /** Shared with the scroll handler, which reads it to tell programmatic scroll from genuine input. */
+  reassertLoopRegistry: RefObject<ControllerFrameLoopRegistration | null>
+  log: (action: string, data?: Record<string, unknown>) => void
+}
+
+export interface UseScrollExecutorsInput {
+  ports: ScrollExecutorPorts
+  // Everything below participates in a dependency array. See the note at the top of this file.
+  conversationId: string
+  messageCount: number
+  firstMessageId: string | undefined
+  lastMessageId: string | undefined
+  windowAtLiveEdge: boolean | undefined
+  isLoadingNewer: boolean | undefined
+  onLoadNewer: (() => unknown) | undefined
+  isAtBottomRef: RefObject<boolean>
+  setMeasuredAtBottom: (atEdge: boolean) => void
+  rememberBottomIntent: () => void
+  rememberCurrentScrollSnapshot: () => void
+}
+
+export interface ScrollExecutors {
+  createLiveEdgeExecutor: (
+    trigger: string,
+    smoothNonVirtualized?: boolean,
+  ) => LiveEdgeExecutor
+  createAnchorPreservationExecutor: (
+    loopLabel: AnchorPreservationLoopLabel,
+  ) => AnchorPreservationExecutor
+  buildDirectionalHistoryExecutor: (
+    saved: DirectionalHistorySnapshot,
+  ) => DirectionalHistoryExecutor
+  buildSavedPositionExecutor: () => SavedPositionExecutor
+  buildUnreadMarkerExecutor: () => UnreadMarkerExecutor
+  buildExplicitTargetExecutor: (
+    messageReference: string,
+    consumeStoreTarget: boolean,
+  ) => ExplicitTargetExecutor
+  createResidentTopExecutor: () => ResidentTopExecutor
+  getDirectionalHistoryBrowser: () => DirectionalHistoryBrowserAdapter
+  /** Conversation entry: drop repaint debt owed by the room being left. */
+  resetLiveEdgeRepaintDebt: () => void
+  /** Unmount: release the directional adapter's scheduler without racing a rebuild. */
+  disposeDirectionalHistoryBrowser: () => void
+}
+
+const distanceFromBottom = (el: HTMLElement) =>
+  el.scrollHeight - el.scrollTop - el.clientHeight
+
+export function useScrollExecutors({
+  ports,
+  conversationId,
+  messageCount,
+  firstMessageId,
+  lastMessageId,
+  windowAtLiveEdge,
+  isLoadingNewer,
+  onLoadNewer,
+  isAtBottomRef,
+  setMeasuredAtBottom,
+  rememberBottomIntent,
+  rememberCurrentScrollSnapshot,
+}: UseScrollExecutorsInput): ScrollExecutors {
+  // Plain value assignment in the render body, matching the scroll hook's other latest-value refs.
+  // Reading ports through this ref is what keeps them out of every dependency array below.
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  const reassertMonitorRef = useRef<ReturnType<typeof createReassertLoopMonitor> | null>(null)
+  const supersedeReassertLoopRef = useRef(() => {
+    portsRef.current.reassertLoopRegistry.current?.finish()
+  })
+
+  // Adapters that must outlive a single executor. The live-edge adapter is the load-bearing case:
+  // its repaint-burst coalescer spans a run of arrivals that each supersede the last, so
+  // per-executor state could never coalesce.
+  const bottomFractionAnchorBrowserRef =
+    useRef<BottomFractionAnchorBrowserAdapter | null>(null)
+  const directionalHistoryBrowserRef =
+    useRef<DirectionalHistoryBrowserAdapter | null>(null)
+  const liveEdgeBrowserRef = useRef<LiveEdgeBrowserAdapter | null>(null)
+
+  const beginControllerFrameLoop = useCallback((
+    label: ReassertLoopLabel,
+    lease: PositionExecutionLease,
+    lifecycle?: ControllerFrameLoopLifecycle,
+  ) => {
+    if (!lease.isCurrent()) return null
+    return createControllerFrameLoop({
+      lease,
+      supersede: supersedeReassertLoopRef.current,
+      beginHandle: () => (reassertMonitorRef.current ??=
+        createReassertLoopMonitor()).begin(label, performance.now()),
+      registry: portsRef.current.reassertLoopRegistry,
+      // Native WebKit/Chromium scheduler methods require Window as their receiver. Keep them behind
+      // closures when passing into the extracted adapter; an unbound method throws before the first
+      // convergence frame and strands the requested position.
+      requestFrame: (callback) => requestAnimationFrame(callback),
+      cancelFrame: (id) => cancelAnimationFrame(id),
+      now: () => performance.now(),
+      // The adapter forwards whatever the monitor produced; deciding what to do with it
+      // belongs here. Fan-out, not re-pointing: the prose is untouched.
+      warn: (warning) => {
+        console.warn(warning.message)
+        if (__FLUUX_ANOMALY__) signalAnomaly(reassertLoopSignal(warning))
+      },
+      lifecycle,
+    })
+  }, [])
+
+  const getBottomFractionAnchorBrowser = useCallback(() => {
+    if (bottomFractionAnchorBrowserRef.current === null) {
+      bottomFractionAnchorBrowserRef.current =
+        new BottomFractionAnchorBrowserAdapter({
+          getScroller: () => portsRef.current.getScroller(),
+          getVirtualizer: () => portsRef.current.getVirtualizer(),
+        })
+    }
+    return bottomFractionAnchorBrowserRef.current
+  }, [])
+
+  const getDirectionalHistoryBrowser = useCallback(() => {
+    if (directionalHistoryBrowserRef.current === null) {
+      directionalHistoryBrowserRef.current =
+        new DirectionalHistoryBrowserAdapter({
+          getScroller: () => portsRef.current.getScroller(),
+          getVirtualizer: () => portsRef.current.getVirtualizer(),
+          getActiveConversationId: () =>
+            portsRef.current.getActiveConversationId(),
+          beginLoop: (lease) => beginControllerFrameLoop('prepend', lease),
+          requestFrame: (callback) => requestAnimationFrame(callback),
+          cancelFrame: (id) => cancelAnimationFrame(id),
+          log: (action, data) => portsRef.current.log(action, data),
+        })
+    }
+    return directionalHistoryBrowserRef.current
+  }, [beginControllerFrameLoop])
+
+  const getLiveEdgeBrowser = useCallback(() => {
+    if (liveEdgeBrowserRef.current === null) {
+      liveEdgeBrowserRef.current = new LiveEdgeBrowserAdapter({
+        getScroller: () => portsRef.current.getScroller(),
+        getVirtualizer: () => portsRef.current.getVirtualizer(),
+        getActiveConversationId: () =>
+          portsRef.current.getActiveConversationId(),
+        getWindowFacts: () => {
+          const live = portsRef.current.getLiveWindow()
+          return {
+            hasRows: live.messageCount > 0 && live.firstMessageId !== undefined,
+            windowAtLiveEdge: live.windowAtLiveEdge !== false,
+          }
+        },
+        isLoadingOlder: () => portsRef.current.isLoadingOlder(),
+        beginLoop: (lease) => {
+          const claim = portsRef.current.pinBottomClaim()
+          return beginControllerFrameLoop('pin-bottom', lease, {
+            onStart: claim.renew,
+            onFrame: claim.renew,
+            onFinish: claim.release,
+          })
+        },
+        setMeasuredAtBottom,
+        recordProgrammaticWrite: (id) =>
+          portsRef.current.recordProgrammaticWrite(id, Date.now()),
+        log: (action, data) => portsRef.current.log(action, data),
+      })
+    }
+    return liveEdgeBrowserRef.current
+  }, [beginControllerFrameLoop, setMeasuredAtBottom])
+
+  const createLiveEdgeExecutor = useCallback((
+    trigger: string,
+    smoothNonVirtualized = false,
+  ): LiveEdgeExecutor => getLiveEdgeBrowser().createExecutor({
+    trigger,
+    smoothNonVirtualized,
+    rememberBottomIntent,
+    canRecenter: Boolean(onLoadNewer),
+    recenterVersion: [
+      windowAtLiveEdge === false ? 'slid' : 'live',
+      isLoadingNewer ? 'loading' : 'idle',
+      messageCount,
+      lastMessageId ?? '',
+    ].join(':'),
+    recenter: onLoadNewer
+      ? (signal) => {
+          if (signal.aborted) return 'unavailable'
+          if (isLoadingNewer) return 'waiting'
+          onLoadNewer()
+          return 'requested'
+        }
+      : undefined,
+  }), [
+    getLiveEdgeBrowser,
+    isLoadingNewer,
+    lastMessageId,
+    messageCount,
+    onLoadNewer,
+    rememberBottomIntent,
+    windowAtLiveEdge,
+  ])
+
+  const createAnchorPreservationExecutor = useCallback(
+    (loopLabel: AnchorPreservationLoopLabel): AnchorPreservationExecutor =>
+      new AnchorPreservationBrowserAdapter({
+        getScroller: () => portsRef.current.getScroller(),
+        getVirtualizer: () => portsRef.current.getVirtualizer(),
+        getActiveConversationId: () =>
+          portsRef.current.getActiveConversationId(),
+        getWindowFacts: () => ({
+          hasRows: messageCount > 0 && firstMessageId !== undefined,
+          windowAtLiveEdge: windowAtLiveEdge !== false,
+        }),
+        beginLoop: (label, lease) => beginControllerFrameLoop(label, lease),
+        anchorAdapter: getBottomFractionAnchorBrowser(),
+        setAtBottom: (atBottom) => { isAtBottomRef.current = atBottom },
+        rememberScrollSnapshot: rememberCurrentScrollSnapshot,
+        recordProgrammaticWrite: (id) =>
+          portsRef.current.recordProgrammaticWrite(id, Date.now()),
+        log: (action, data) => portsRef.current.log(action, data),
+      }).createExecutor(loopLabel),
+    [
+      beginControllerFrameLoop,
+      firstMessageId,
+      getBottomFractionAnchorBrowser,
+      isAtBottomRef,
+      messageCount,
+      rememberCurrentScrollSnapshot,
+      windowAtLiveEdge,
+    ],
+  )
+
+  const createDirectionalHistoryCompletion = useCallback(
+    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor['complete'] =>
+      (request, outcome) => {
+        const active = portsRef.current
+        if (active.getActiveConversationId() !== request.conversationId) return
+        if (outcome === 'applied') {
+          const restored = active.getDirectionalWindow()?.markRestored(
+            saved.requestId,
+            Date.now(),
+          )
+          const restoredAt = restored?.restoredAt
+          if (restoredAt === undefined) return
+          active.syncPrevMessageCount()
+          active.recordProgrammaticWrite(request.conversationId, restoredAt)
+          setTimeout(() => {
+            portsRef.current.getDirectionalWindow()?.expireRestored(
+              saved.requestId,
+              restoredAt,
+            )
+          }, DIRECTIONAL_HISTORY_COOLDOWN_MS)
+        } else {
+          active.getDirectionalWindow()?.finishPosition(saved.requestId)
+        }
+        if (outcome !== 'applied') {
+          active.recordProgrammaticWrite(request.conversationId, Date.now())
+        }
+        active.log('DIRECTIONAL HISTORY COMPLETE', {
+          generation: request.generation,
+          outcome,
+          restored: Boolean(saved.restored),
+        })
+      },
+    [],
+  )
+
+  const buildDirectionalHistoryExecutor = useCallback(
+    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor =>
+      getDirectionalHistoryBrowser().createExecutor(
+        createDirectionalHistoryCompletion(saved),
+      ),
+    [createDirectionalHistoryCompletion, getDirectionalHistoryBrowser],
+  )
+
+  const buildSavedPositionExecutor = useCallback((): SavedPositionExecutor => {
+    const browser = new SavedPositionBrowserAdapter({
+      getScroller: () => portsRef.current.getScroller(),
+      getVirtualizer: () => portsRef.current.getVirtualizer(),
+      getWindowFacts: () => ({
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+        canRecenter: Boolean(onLoadNewer),
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('restore-anchor', lease),
+      anchorAdapter: getBottomFractionAnchorBrowser(),
+    })
+    return browser.createExecutor({
+      liveEdge: createLiveEdgeExecutor('restore-fallback'),
+      loadAround: portsRef.current.getLoadAround()
+        ? (messageId, signal) => {
+            if (signal.aborted) return
+            isAtBottomRef.current = false
+            portsRef.current.log(
+              'RESTORE: anchor not loaded, requesting cache slice around it',
+              { messageId, conversationId },
+            )
+            return portsRef.current.getLoadAround()?.(messageId)
+          }
+        : undefined,
+      recenterVersion: [
+        windowAtLiveEdge === false ? 'slid' : 'live',
+        isLoadingNewer ? 'loading' : 'idle',
+        messageCount,
+        lastMessageId ?? '',
+      ].join(':'),
+      recenterLiveEdge: onLoadNewer
+        ? (signal) => {
+            if (signal.aborted) return 'unavailable'
+            if (isLoadingNewer) return 'waiting'
+            onLoadNewer()
+            return 'requested'
+          }
+        : undefined,
+      complete: (request, outcome) => {
+        const scroller = portsRef.current.getScroller()
+        if (!scroller) return
+        setMeasuredAtBottom(distanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD)
+        rememberCurrentScrollSnapshot()
+        portsRef.current.recordProgrammaticWrite(
+          request.conversationId,
+          Date.now(),
+        )
+        portsRef.current.log('RESTORE: controller completed position', {
+          conversationId,
+          generation: request.generation,
+          desired: request.desired,
+          outcome,
+        })
+      },
+    })
+  }, [
+    beginControllerFrameLoop,
+    conversationId,
+    createLiveEdgeExecutor,
+    firstMessageId,
+    getBottomFractionAnchorBrowser,
+    isAtBottomRef,
+    isLoadingNewer,
+    lastMessageId,
+    messageCount,
+    onLoadNewer,
+    rememberCurrentScrollSnapshot,
+    setMeasuredAtBottom,
+    windowAtLiveEdge,
+  ])
+
+  const buildUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => {
+    const browser = new UnreadMarkerBrowserAdapter({
+      getScroller: () => portsRef.current.getScroller(),
+      getVirtualizer: () => portsRef.current.getVirtualizer(),
+      getWindowFacts: () => {
+        const live = portsRef.current.getLiveWindow()
+        return {
+          hasRows: live.messageCount > 0 && live.firstMessageId !== undefined,
+          windowAtLiveEdge: live.windowAtLiveEdge !== false,
+        }
+      },
+      getPassiveContext: () => portsRef.current.getPassiveContext(),
+      beginLoop: (lease) => beginControllerFrameLoop('marker', lease),
+      setMeasuredAtBottom,
+      log: (action, data) => portsRef.current.log(action, data),
+    })
+    return browser.createExecutor(createLiveEdgeExecutor('marker-fallback'))
+  }, [
+    beginControllerFrameLoop,
+    createLiveEdgeExecutor,
+    setMeasuredAtBottom,
+  ])
+
+  const buildExplicitTargetExecutor = useCallback((
+    messageReference: string,
+    consumeStoreTarget: boolean,
+  ): ExplicitTargetExecutor => {
+    const browser = new ExplicitTargetBrowserAdapter({
+      getScroller: () => portsRef.current.getScroller(),
+      getVirtualizer: () => portsRef.current.getVirtualizer(),
+      getWindowFacts: () => {
+        const live = portsRef.current.getLiveWindow()
+        return {
+          hasRows: live.messageCount > 0 && live.firstMessageId !== undefined,
+          windowAtLiveEdge: live.windowAtLiveEdge !== false,
+        }
+      },
+      getPassiveContext: () => portsRef.current.getPassiveContext(),
+      getActiveConversationId: () =>
+        portsRef.current.getActiveConversationId(),
+      getStoreTargetMessageId: () =>
+        portsRef.current.getStoreTargetMessageId(),
+      beginLoop: (lease) => beginControllerFrameLoop('target', lease),
+      setMeasuredAtBottom,
+      markNotAtBottom: () => { isAtBottomRef.current = false },
+      consumeStoreTarget: () => portsRef.current.consumeStoreTarget(),
+      log: (action, data) => portsRef.current.log(action, data),
+    })
+    return browser.createExecutor({
+      conversationId,
+      messageReference,
+      consumeStoreTarget,
+      loadAround: portsRef.current.getLoadAround(),
+    })
+  }, [
+    beginControllerFrameLoop,
+    conversationId,
+    isAtBottomRef,
+    setMeasuredAtBottom,
+  ])
+
+  const createResidentTopExecutor = useCallback((): ResidentTopExecutor =>
+    new ResidentTopBrowserAdapter({
+      getScroller: () => portsRef.current.getScroller(),
+      getVirtualizer: () => portsRef.current.getVirtualizer(),
+      getWindowFacts: () => ({
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
+      log: (action, data) => portsRef.current.log(action, data),
+    }).createExecutor(), [
+    beginControllerFrameLoop,
+    firstMessageId,
+    messageCount,
+    windowAtLiveEdge,
+  ])
+
+  const resetLiveEdgeRepaintDebt = useCallback(() => {
+    // Read through the ref, not the lazy getter: a list that never pinned owes nothing, and building
+    // the adapter here just to reset it would also add a dependency to the caller's entry effect.
+    liveEdgeBrowserRef.current?.resetRepaintDebt()
+  }, [])
+
+  const disposeDirectionalHistoryBrowser = useCallback(() => {
+    const directionalBrowser = directionalHistoryBrowserRef.current
+    directionalBrowser?.dispose()
+    if (directionalHistoryBrowserRef.current === directionalBrowser) {
+      directionalHistoryBrowserRef.current = null
+    }
+  }, [])
+
+  return {
+    createLiveEdgeExecutor,
+    createAnchorPreservationExecutor,
+    buildDirectionalHistoryExecutor,
+    buildSavedPositionExecutor,
+    buildUnreadMarkerExecutor,
+    buildExplicitTargetExecutor,
+    createResidentTopExecutor,
+    getDirectionalHistoryBrowser,
+    resetLiveEdgeRepaintDebt,
+    disposeDirectionalHistoryBrowser,
+  }
+}

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -1,7 +1,7 @@
 /**
  * The neutral observation seam into the dev-only anomaly runtime.
  *
- * The sentinels live in production code — `useMessageListScroll` and
+ * The sentinels live in production code — the message-list scroll subsystem and
  * `stallSentinel` ship in every build, because their `console.warn` prose is the
  * troubleshooting path in `fluux.log`. They must therefore never import anything
  * under `src/anomaly/`: a static import would put the recorder, the serializer and

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -378,11 +378,19 @@ The controller-owned mechanisms retain leased browser reconcilers for saved anch
 explicit center-aligned targets, live edge, fixed-anchor media/layout preservation, directional
 history, and resident top. These
 reconcilers implement measurement convergence; they are not separate positioning authorities.
-There is no independent positioning frame-loop implementation left inside `useMessageListScroll`:
-the hook constructs each adapter, supplies its value ports, and passes the resulting executor to the
-controller. Exactly three pixel writes remain in the hook, and none of them is a positioning owner —
+There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
+Executor construction lives in `useScrollExecutors` without exception: it supplies each adapter's
+value ports and hands the finished executor back for the hook to submit, so no `createExecutor` call
+appears in `useMessageListScroll`. The hook still reaches the directional-history adapter directly
+for its availability probe and its one-frame settlement scheduler, neither of which builds an
+executor. Exactly three pixel writes remain in the hook, and none of them is a positioning owner —
 the two isolated static-preview operations documented below, and the emergency bottom write that
 keeps the list usable when the controller itself cannot be constructed.
+
+The executor factories' changing callback identities are part of that integration contract because
+dependent effects use them to follow render-scoped window facts. The authoritative explanation and
+dependency rules live with the implementation in
+`apps/fluux/src/components/conversation/useScrollExecutors.ts`.
 
 Ambient layout preservation is entirely inside the scroll owner. `MessageList` receives only the
 store-owned interior-placement version; it receives no raw anchor capture/restore callbacks. The
@@ -530,7 +538,18 @@ kinetic scrolling and stale-paint behavior.
      - [x] Extract unread-marker and explicit-target reachability, passive conversation handoff,
        leased positioning, around loading, and target completion behind dedicated browser adapters.
      - [x] Extract the remaining live-edge, fixed-anchor, and resident-top browser executors.
-   - [ ] Leave the React hook as thin lifecycle orchestration.
+   - [ ] Leave the React hook as thin lifecycle orchestration. Taken one cohesive unit at a time so
+     each step keeps the scroll invariants as its gate:
+     - [x] Move executor construction — the frame-loop factory, the adapters that outlive one
+       execution, and every `create*`/`build*Executor` — into `useScrollExecutors`.
+     - [x] Extract the scroller/content callback refs, their genuine-input listeners, and the
+       non-virtualized content-growth observer into `useScrollContainerBinding`.
+     - [ ] Extract ambient divider/insertion anchor tracking.
+     - [ ] Extract media-growth snapshotting and debouncing.
+     - [ ] Extract directional-history release and post-frame settling.
+     - [ ] Reduce the scroll event handler to a value-only interpretation of geometry.
+     - [ ] Express conversation-entry arbitration as a pure model over facts, leaving a thin effect
+       that applies its verdict.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove
 one previous source of scroll authority.


### PR DESCRIPTION
Moves two cohesive units out of `useMessageListScroll` so it keeps deciding *when* a position is requested rather than how the request is assembled. The hook drops 533 lines; behaviour is unchanged.

`useScrollExecutors` owns executor construction — the controller frame-loop factory, the adapters that outlive a single execution, and every executor factory. No `createExecutor` call remains in the scroll hook.

One constraint shaped that seam. The factory identities intentionally keep churning with the live window, because several effects list a factory as their dependency precisely so they re-run when the window moves (the `refresh` live-edge effect exists for that alone). Freezing them — for instance by holding one factory object in a ref — silently stops those effects firing. Every dependency array is therefore carried over unchanged, and only stable ref readers travel in the `ports` bag, which is read through a ref so it cannot widen one. The live-edge adapter stays a single instance because its repaint-burst coalescer spans a run of arrivals that each supersede the last.

`useScrollContainerBinding` owns the scroller and content-wrapper callback refs together with everything wired to those nodes: the genuine-input listeners, and the `ResizeObserver` that keeps a non-virtualized list pinned as its content grows. Both setters keep their once-created identity, since an unstable callback ref makes React detach and reattach on every render and rebuild the observer each time. Setup stays late-bound because React attaches refs child-first.

This is the first half of reducing the hook to lifecycle orchestration; the remaining units are tracked in the contract document.