### PR TITLE
test(e2ee): raise timeouts for the real-key-generation suites

### DIFF
--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -25,6 +25,12 @@ import {
   type XMPPPrimitives,
 } from '@fluux/sdk'
 
+// The cross-device verification-sync tests drive real openpgp.js work, so they
+// are CPU-bound and inflate several-fold under the contention of a full
+// `npm test`. Timing is not what they assert, and the 5s default left too
+// little headroom on a loaded runner. See WebOpenPGPPlugin.test.ts.
+vi.setConfig({ testTimeout: 30_000 })
+
 /**
  * Wrap a body string in the `<payload xmlns='jabber:client'><body>…</body></payload>`
  * envelope the plugin now expects as its plaintext input. Matches what Chat.ts

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -27,6 +27,24 @@ import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
 import { clearSessionPassphrase, setSessionPassphrase } from './webPassphraseStore'
 import type { KeyBundle } from './OpenPGPPluginBase'
 
+// Every test here generates real OpenPGP keys, so each one is CPU-bound and
+// contends with the rest of the suite for cores. Isolated, the slowest is
+// ~130ms; under a full `npm test` the same test measured 1477ms — the slowest
+// in the whole app suite — and a smaller or busier CI runner inflates it
+// further. The 5s default left too little headroom and the key-expiration
+// tests (which generate a key, then re-sign it) flaked. Timing is not what
+// any of these assert, so give the file room rather than trading correctness
+// signal for a deadline.
+vi.setConfig({ testTimeout: 30_000 })
+
+// Budget for the `vi.waitFor` polls in the pending-signature-buffer tests,
+// whose drain runs a fire-and-forget openpgp.js verify. `waitFor` carries its
+// own deadline, so `testTimeout` above does not cover it — at the previous
+// 5000ms a loaded run gave up on a drain that was still progressing. Keep this
+// comfortably below `testTimeout` so a genuine stall still surfaces as the
+// failing assertion inside `waitFor` rather than an opaque test timeout.
+const DRAIN_POLL_TIMEOUT_MS = 20_000
+
 const FIXTURES_DIR = resolve(__dirname, 'fixtures')
 
 // Expose the crypto-layer protected methods so we can round-trip
@@ -2341,7 +2359,7 @@ describe('WebOpenPGPPlugin', () => {
         // poll for the resulting update rather than guessing a fixed number of
         // event-loop turns — `flushAsync`'s fixed tick budget flakes under the
         // CPU contention of a full parallel test run.
-        await vi.waitFor(() => expect(bob.securityUpdates).toHaveLength(1), { timeout: 5000 })
+        await vi.waitFor(() => expect(bob.securityUpdates).toHaveLength(1), { timeout: DRAIN_POLL_TIMEOUT_MS })
         expect(bob.securityUpdates[0].securityContext.trust).toBe('tofu')
         expect(bob.securityUpdates[0].messageId).toBe('m-drain')
       })
@@ -2396,7 +2414,7 @@ describe('WebOpenPGPPlugin', () => {
         setSessionPassphrase('bob-strong-pp')
         bob.plugin.onPeerKeysChanged('alice@example.com')
 
-        await vi.waitFor(() => expect(bob.securityUpdates).toHaveLength(1), { timeout: 5000 })
+        await vi.waitFor(() => expect(bob.securityUpdates).toHaveLength(1), { timeout: DRAIN_POLL_TIMEOUT_MS })
         expect(bob.securityUpdates[0].securityContext.trust).toBe('rejected')
         expect(bob.securityUpdates[0].body).toBe('[Message rejected: invalid signature]')
       })
@@ -2429,7 +2447,7 @@ describe('WebOpenPGPPlugin', () => {
         // Wait until the re-verify decrypt was actually attempted (and rejected)
         // before restoring the mock — that ordering is the real dependency, not a
         // fixed number of ticks. Then let the rejection's catch handler settle.
-        await vi.waitFor(() => expect(spy).toHaveBeenCalled(), { timeout: 5000 })
+        await vi.waitFor(() => expect(spy).toHaveBeenCalled(), { timeout: DRAIN_POLL_TIMEOUT_MS })
         await flushAsync()
         spy.mockRestore()
 
@@ -2442,7 +2460,7 @@ describe('WebOpenPGPPlugin', () => {
         bob.plugin.onPeerKeysChanged('alice@example.com')
         await vi.waitFor(
           () => expect(bob.securityUpdates.filter((u) => u.securityContext.trust === 'tofu')).toHaveLength(1),
-          { timeout: 5000 },
+          { timeout: DRAIN_POLL_TIMEOUT_MS },
         )
         const upgrades = bob.securityUpdates.filter((u) => u.securityContext.trust === 'tofu')
         expect(upgrades[0].messageId).toBe('m-transient')

--- a/apps/fluux/src/e2ee/backupInterop.test.ts
+++ b/apps/fluux/src/e2ee/backupInterop.test.ts
@@ -15,7 +15,7 @@
  * would break Rust↔Web interop, even if the web→web round-trip still
  * passes.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   InMemoryStorageBackend,
   createPluginStorage,
@@ -25,6 +25,12 @@ import {
 } from '@fluux/sdk'
 import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
 import { clearSessionPassphrase, setSessionPassphrase } from './webPassphraseStore'
+
+// These round-trips generate and re-wrap real OpenPGP keys, so the tests are
+// CPU-bound and inflate several-fold under the contention of a full
+// `npm test`. Timing is not what they assert, and the 5s default left too
+// little headroom on a loaded runner. See WebOpenPGPPlugin.test.ts.
+vi.setConfig({ testTimeout: 30_000 })
 
 class TestableWebOpenPGPPlugin extends WebOpenPGPPlugin {
   callBackupEncrypt(jid: string, pp: string) {

--- a/apps/fluux/src/e2ee/backupKeyMaterial.test.ts
+++ b/apps/fluux/src/e2ee/backupKeyMaterial.test.ts
@@ -4,13 +4,20 @@
  * because openpgp.js performs realm-sensitive Uint8Array checks that fail
  * under jsdom.
  */
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import type { PrivateKey } from 'openpgp'
 import {
   isArmoredKeyText,
   splitArmorBlocks,
   parseSecretKeysFromBackupPayload,
 } from './backupKeyMaterial'
+
+// The shared fixture key below is generated once in `beforeAll`, so the real
+// openpgp.js cost lands on the hook rather than on any single test — it is
+// `hookTimeout` (10s by default), not `testTimeout`, that bounds it. Key
+// generation is CPU-bound and inflates several-fold under the contention of a
+// full `npm test`. See WebOpenPGPPlugin.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 
 const enc = (s: string) => new TextEncoder().encode(s)
 

--- a/apps/fluux/src/e2ee/consumeMigrationVectors.test.ts
+++ b/apps/fluux/src/e2ee/consumeMigrationVectors.test.ts
@@ -23,7 +23,7 @@
  */
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   InMemoryStorageBackend,
   createPluginStorage,
@@ -33,6 +33,12 @@ import {
 } from '@fluux/sdk'
 import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
 import { clearSessionPassphrase } from './webPassphraseStore'
+
+// Importing these fixtures runs real openpgp.js key work, so the tests are
+// CPU-bound and inflate several-fold under the contention of a full
+// `npm test`. Timing is not what they assert, and the 5s default left too
+// little headroom on a loaded runner. See WebOpenPGPPlugin.test.ts.
+vi.setConfig({ testTimeout: 30_000 })
 
 const FIXTURES_DIR = resolve(__dirname, 'fixtures')
 const readFixture = (name: string) => readFileSync(resolve(FIXTURES_DIR, name), 'utf-8')

--- a/apps/fluux/src/e2ee/consumeSequoiaVectors.test.ts
+++ b/apps/fluux/src/e2ee/consumeSequoiaVectors.test.ts
@@ -15,7 +15,7 @@
  */
 import { readFileSync, existsSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   InMemoryStorageBackend,
   createPluginStorage,
@@ -25,6 +25,12 @@ import {
 } from '@fluux/sdk'
 import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
 import { clearSessionPassphrase, setSessionPassphrase } from './webPassphraseStore'
+
+// Decrypting and verifying the Sequoia fixtures is real openpgp.js work, so
+// the tests are CPU-bound and inflate several-fold under the contention of a
+// full `npm test`. Timing is not what they assert, and the 5s default left too
+// little headroom on a loaded runner. See WebOpenPGPPlugin.test.ts.
+vi.setConfig({ testTimeout: 30_000 })
 
 const FIXTURES_DIR = resolve(__dirname, 'fixtures')
 const META_PATH = resolve(FIXTURES_DIR, 'sequoia_meta.json')


### PR DESCRIPTION
Tests that generate real OpenPGP keys are CPU-bound, so they inflate several-fold under the contention of a full `npm test`. `WebOpenPGPPlugin`'s "clears the expiration on subkeys too" runs in ~130ms on its own but measured 1477ms in a full run, the slowest test in the app suite. That left too little headroom under vitest's 5s default and flaked on loaded CI runners.

Six suites do real crypto and now set a file-level `testTimeout`; timing is not what any of them assert. The rest of `src/e2ee` stays on the 5s default, so hang detection is unchanged for the other ~5,800 tests.

Two cases needed more than the test timeout:

- `backupKeyMaterial` generates its fixture key in `beforeAll`, so the cost lands on the hook. That is bounded by `hookTimeout` (10s default), which `testTimeout` does not cover. Its slowest test is 8ms, so a durations-only scan misses it, and the failure mode is a skipped test rather than a red one.
- The pending-signature-buffer tests poll with `vi.waitFor`, which carries its own hard-coded 5s budget that `testTimeout` does not govern either. Those now share a named constant.

Targets were chosen by measurement rather than by which files import `openpgp`. Slowest test per file, run as a directory so they contend with each other: `consumeMigrationVectors` 1051ms, `WebOpenPGPPlugin` 1034ms, `backupInterop` 999ms, `consumeSequoiaVectors` 801ms, `SequoiaPgpPlugin` 557ms. The next file down is 131ms and not crypto.
