### PR TITLE
fix(chat): clear the send-animation timer on unmount

### DIFF
--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -815,6 +815,35 @@ describe('ChatView', () => {
 
       expect(mockProcessMessageForLinkPreview).not.toHaveBeenCalled()
     })
+
+    it('clears the send-animation timer on unmount', async () => {
+      // The send animation arms a 400 ms timer that resets React state. Left
+      // armed past unmount it fires into a torn-down environment, which surfaces
+      // as an intermittent "window is not defined" unhandled error whenever the
+      // suite finishes within that window.
+      mockEncryptionState = { kind: 'disabled' }
+      const setSpy = vi.spyOn(globalThis, 'setTimeout')
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+      try {
+        const { unmount } = render(<ChatView />)
+        fireEvent.click(screen.getByTestId('send-button'))
+
+        await waitFor(() => {
+          expect(setSpy.mock.calls.some(([, delay]) => delay === 400)).toBe(true)
+        })
+
+        const animationTimerIndex = setSpy.mock.calls.findIndex(([, delay]) => delay === 400)
+        const animationTimerId = setSpy.mock.results[animationTimerIndex].value
+
+        unmount()
+
+        expect(clearSpy).toHaveBeenCalledWith(animationTimerId)
+      } finally {
+        setSpy.mockRestore()
+        clearSpy.mockRestore()
+      }
+    })
   })
 
   describe('Loading state', () => {

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -190,6 +190,15 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     lastSentTimerRef.current = setTimeout(() => setLastSentMessageId(null), 400)
   }, [])
 
+  // Drop the pending send-animation timer on unmount: it is the only timer here
+  // that sets React state, so left armed it fires into a torn-down tree.
+  useEffect(() => () => {
+    if (lastSentTimerRef.current) {
+      clearTimeout(lastSentTimerRef.current)
+      lastSentTimerRef.current = null
+    }
+  }, [])
+
   // Note: Media load scroll handling is now managed by useMessageListScroll hook
   // via the handleMediaLoad callback passed through renderMessage. This provides
   // batched scroll correction to avoid jitter when multiple images load.


### PR DESCRIPTION
Sending a message arms a 400 ms timer that clears the send-animation highlight by
setting React state. Nothing cancelled it on unmount, so it could outlive both the
component and the surrounding environment.

In CI this showed up as an intermittent `ReferenceError: window is not defined`
raised from `resolveUpdatePriority`, reported as an unhandled error attributed to
`ChatView.test.tsx`. The race is between the timer and teardown: the tests that
click send resolve in well under 400 ms, so whenever the test file finished inside
that window the callback fired into a torn-down tree. That is why it only appeared
in some full-suite runs, and why a focused run never reproduces it.

Clearing the timer in an unmount cleanup closes the window. It is the only timer in
this component that dispatches React state.
