### PR TITLE
refactor(scroll): finish reducing the message-list hook to orchestration

### DIFF
--- a/apps/fluux/src/components/conversation/ambientAnchorDecisions.test.ts
+++ b/apps/fluux/src/components/conversation/ambientAnchorDecisions.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decideDividerMutation,
+  decideInsertionMutation,
+  insertionAnchorApplies,
+  residentArrayUnchanged,
+  shouldCaptureDividerAnchor,
+  shouldRecaptureInsertionAnchor,
+  type ResidentTrackingState,
+} from './ambientAnchorDecisions'
+
+const resident = (
+  overrides: Partial<ResidentTrackingState> = {},
+): ResidentTrackingState => ({
+  conversationId: 'room-a',
+  messageCount: 200,
+  firstMessageId: 'm-0',
+  lastMessageId: 'm-199',
+  interiorPlacementVersion: 7,
+  ...overrides,
+})
+
+describe('shouldCaptureDividerAnchor', () => {
+  const base = {
+    tracked: { conversationId: 'room-a', dividerId: 'd-1' },
+    conversationId: 'room-a',
+    dividerId: 'd-1',
+    readerScrolledUp: true,
+  }
+
+  it('captures while the tracked divider still describes this render', () => {
+    expect(shouldCaptureDividerAnchor(base)).toBe(true)
+  })
+
+  it('refuses on the commit where the divider moves, so the pre-mutation geometry survives', () => {
+    // The whole point: capturing here would overwrite the anchor the restore is about to use.
+    expect(shouldCaptureDividerAnchor({ ...base, dividerId: 'd-2' })).toBe(false)
+  })
+
+  it('refuses at the live edge, where there is no reading point to hold', () => {
+    expect(shouldCaptureDividerAnchor({ ...base, readerScrolledUp: false })).toBe(false)
+  })
+
+  it('refuses for a conversation the tracking does not describe', () => {
+    expect(shouldCaptureDividerAnchor({ ...base, conversationId: 'room-b' })).toBe(false)
+  })
+})
+
+describe('decideDividerMutation', () => {
+  const base = {
+    tracked: { conversationId: 'room-a', dividerId: 'd-1' },
+    conversationId: 'room-a',
+    dividerId: 'd-2',
+    readerScrolledUp: true,
+    hasAnchor: true,
+  }
+
+  it('preserves when the divider moved under a scrolled-up reader holding an anchor', () => {
+    expect(decideDividerMutation(base)).toEqual({ kind: 'preserve' })
+  })
+
+  it('reports unchanged when the divider did not move', () => {
+    // Paired with the case above: only dividerId differs.
+    expect(decideDividerMutation({ ...base, dividerId: 'd-1' })).toEqual({
+      kind: 'unchanged',
+    })
+  })
+
+  it('resets for a new conversation instead of preserving the departed reading point', () => {
+    expect(decideDividerMutation({ ...base, conversationId: 'room-b' })).toEqual({
+      kind: 'reset',
+    })
+  })
+
+  it('only retracks at the live edge or with no anchor captured', () => {
+    expect(decideDividerMutation({ ...base, readerScrolledUp: false })).toEqual({
+      kind: 'retrack',
+    })
+    expect(decideDividerMutation({ ...base, hasAnchor: false })).toEqual({
+      kind: 'retrack',
+    })
+  })
+})
+
+describe('residentArrayUnchanged', () => {
+  it('is true only when every tracked end matches', () => {
+    expect(residentArrayUnchanged(resident(), resident())).toBe(true)
+  })
+
+  it.each([
+    ['conversation', { conversationId: 'room-b' }],
+    ['count', { messageCount: 201 }],
+    ['first id', { firstMessageId: 'm-1' }],
+    ['last id', { lastMessageId: 'm-200' }],
+    ['interior placement', { interiorPlacementVersion: 8 }],
+  ])('detects a change of %s', (_label, change) => {
+    expect(residentArrayUnchanged(resident(), resident(change))).toBe(false)
+  })
+})
+
+describe('shouldRecaptureInsertionAnchor', () => {
+  const current = { scrollTop: 500, scrollHeight: 5_000, clientHeight: 600 }
+
+  it('recaptures when nothing has been captured yet', () => {
+    expect(shouldRecaptureInsertionAnchor({ captured: null, current })).toBe(true)
+  })
+
+  it('skips the per-row scan when no scalar moved', () => {
+    expect(
+      shouldRecaptureInsertionAnchor({ captured: { ...current }, current }),
+    ).toBe(false)
+  })
+
+  it.each([
+    ['the reader scrolled', { scrollTop: 501 }],
+    ['rows re-measured', { scrollHeight: 5_001 }],
+    ['the viewport resized', { clientHeight: 601 }],
+  ])('recaptures when %s', (_label, change) => {
+    // A virtualizer re-measure moves scrollHeight without touching any message id, so keying on
+    // ids alone lets the snapshot age out and the restore lands where the reader no longer is.
+    expect(
+      shouldRecaptureInsertionAnchor({
+        captured: { ...current, ...change },
+        current,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('insertionAnchorApplies', () => {
+  it('keeps no anchor at the live edge', () => {
+    // 5000 - 4400 - 600 = 0 from the bottom.
+    expect(
+      insertionAnchorApplies(
+        { scrollTop: 4_400, scrollHeight: 5_000, clientHeight: 600 },
+        300,
+      ),
+    ).toBe(false)
+  })
+
+  it('keeps an anchor once the reader is clear of the threshold', () => {
+    expect(
+      insertionAnchorApplies(
+        { scrollTop: 4_100, scrollHeight: 5_000, clientHeight: 600 },
+        300,
+      ),
+    ).toBe(true)
+  })
+
+  it('treats exactly the threshold as away from the edge', () => {
+    expect(
+      insertionAnchorApplies(
+        { scrollTop: 4_100, scrollHeight: 5_000, clientHeight: 600 },
+        300,
+      ),
+    ).toBe(true)
+    expect(
+      insertionAnchorApplies(
+        { scrollTop: 4_101, scrollHeight: 5_000, clientHeight: 600 },
+        300,
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('decideInsertionMutation', () => {
+  const call = (
+    next: Partial<ResidentTrackingState>,
+    extra: { directionalLoadLanding?: boolean; hasAnchor?: boolean } = {},
+  ) =>
+    decideInsertionMutation({
+      tracked: resident(),
+      next: resident(next),
+      directionalLoadLanding: extra.directionalLoadLanding ?? false,
+      hasAnchor: extra.hasAnchor ?? true,
+    })
+
+  it('preserves a mid-array insertion that grew the array without moving the bottom', () => {
+    expect(call({ messageCount: 201 })).toEqual({ kind: 'preserve' })
+  })
+
+  it('preserves an insertion at the resident bound, where only the first id moves', () => {
+    // `appendLive` evicts the oldest row as it inserts, so the count is identical.
+    expect(call({ firstMessageId: 'm-1' })).toEqual({ kind: 'preserve' })
+  })
+
+  it('ignores a live-edge arrival, which moves the last row', () => {
+    // Paired with the first case: same count change, but the bottom moved too.
+    expect(call({ messageCount: 201, lastMessageId: 'm-200' })).toEqual({
+      kind: 'retrack',
+    })
+  })
+
+  it('yields to a directional load landing in this commit', () => {
+    // Same array change as the preserved case; only the in-flight snapshot differs. A first-id
+    // change alone cannot distinguish these two, which is why the load flag is consulted.
+    expect(call({ firstMessageId: 'older-0', messageCount: 250 })).toEqual({
+      kind: 'preserve',
+    })
+    expect(
+      call(
+        { firstMessageId: 'older-0', messageCount: 250 },
+        { directionalLoadLanding: true },
+      ),
+    ).toEqual({ kind: 'retrack' })
+  })
+
+  it('treats an interior placement bump as authoritative even when the bottom moved', () => {
+    expect(
+      call({ interiorPlacementVersion: 8, lastMessageId: 'm-200' }),
+    ).toEqual({ kind: 'preserve' })
+  })
+
+  it('ignores a stale interior placement version that went backwards', () => {
+    expect(call({ interiorPlacementVersion: 6 })).toEqual({ kind: 'retrack' })
+  })
+
+  it('only retracks when nothing about the resident array moved', () => {
+    expect(call({})).toEqual({ kind: 'retrack' })
+  })
+
+  it('only retracks when no pre-mutation anchor was captured', () => {
+    expect(call({ messageCount: 201 }, { hasAnchor: false })).toEqual({
+      kind: 'retrack',
+    })
+  })
+
+  it('resets for a new conversation before any insertion test runs', () => {
+    expect(call({ conversationId: 'room-b', messageCount: 201 })).toEqual({
+      kind: 'reset',
+    })
+  })
+})

--- a/apps/fluux/src/components/conversation/ambientAnchorDecisions.ts
+++ b/apps/fluux/src/components/conversation/ambientAnchorDecisions.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure decisions for ambient layout preservation.
+ *
+ * Two mutations move a scrolled-up reader without them asking: the unread divider changing position,
+ * and a delayed live-path message sorting into the MIDDLE of the resident array. Both are ambient —
+ * they preserve a reading point rather than navigating — so the controller rejects them while a
+ * requested position is still unsettled.
+ *
+ * Everything here is a value-only decision over facts. No DOM, no controller, no measurement.
+ */
+
+export interface DividerTrackingState {
+  conversationId: string
+  dividerId: string | undefined
+}
+
+export interface ResidentTrackingState {
+  conversationId: string
+  messageCount: number
+  firstMessageId: string | undefined
+  lastMessageId: string | undefined
+  interiorPlacementVersion: number
+}
+
+export interface ScrollGeometrySample {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+}
+
+export type AmbientMutationDecision =
+  /** Conversation changed: adopt the new tracking and drop the departed room's anchor. */
+  | { kind: 'reset' }
+  /** Nothing this owner reacts to moved. */
+  | { kind: 'unchanged' }
+  /** Something moved, but there is no reading point worth preserving. */
+  | { kind: 'retrack' }
+  /** Preserve the captured reading point, then adopt the new tracking. */
+  | { kind: 'preserve' }
+
+/**
+ * Capture is allowed only while the tracked state still describes this render. On the very commit
+ * where the divider moves, the id mismatch deliberately blocks capture so a POST-mutation
+ * measurement cannot overwrite the pre-mutation geometry the restore needs.
+ */
+export function shouldCaptureDividerAnchor(input: {
+  tracked: DividerTrackingState
+  conversationId: string
+  dividerId: string | undefined
+  readerScrolledUp: boolean
+}): boolean {
+  return (
+    input.tracked.conversationId === input.conversationId &&
+    input.tracked.dividerId === input.dividerId &&
+    input.readerScrolledUp
+  )
+}
+
+export function decideDividerMutation(input: {
+  tracked: DividerTrackingState
+  conversationId: string
+  dividerId: string | undefined
+  readerScrolledUp: boolean
+  hasAnchor: boolean
+}): AmbientMutationDecision {
+  if (input.tracked.conversationId !== input.conversationId) return { kind: 'reset' }
+  if (input.tracked.dividerId === input.dividerId) return { kind: 'unchanged' }
+  return input.readerScrolledUp && input.hasAnchor
+    ? { kind: 'preserve' }
+    : { kind: 'retrack' }
+}
+
+/**
+ * True while the resident array is identical to what the last capture saw. Both the capture effect
+ * and the scroll handler gate on this so the commit that mutates the array still holds geometry
+ * measured BEFORE the mutation.
+ */
+export function residentArrayUnchanged(
+  tracked: ResidentTrackingState,
+  next: ResidentTrackingState,
+): boolean {
+  return (
+    tracked.conversationId === next.conversationId &&
+    tracked.messageCount === next.messageCount &&
+    tracked.firstMessageId === next.firstMessageId &&
+    tracked.lastMessageId === next.lastMessageId &&
+    tracked.interiorPlacementVersion === next.interiorPlacementVersion
+  )
+}
+
+/**
+ * Re-measuring is a per-row scan, so it is gated on the two cheap scalar reads that between them
+ * cover every way the geometry can move: `scrollTop` (the reader scrolled) and `scrollHeight` (rows
+ * re-measured, viewport resized). A virtualizer re-measure moves every row's content offset without
+ * changing any message id, `bottomVisibleMessageId`, or firing a scroll event — keyed on any of
+ * those the snapshot silently ages out and the restore lands on geometry the reader already left.
+ */
+export function shouldRecaptureInsertionAnchor(input: {
+  captured: ScrollGeometrySample | null
+  current: ScrollGeometrySample
+}): boolean {
+  const { captured, current } = input
+  if (!captured) return true
+  return (
+    captured.scrollTop !== current.scrollTop ||
+    captured.scrollHeight !== current.scrollHeight ||
+    captured.clientHeight !== current.clientHeight
+  )
+}
+
+/** At the live edge nothing above the reader can be pushed down, so no anchor is kept. */
+export function insertionAnchorApplies(
+  geometry: ScrollGeometrySample,
+  atBottomThreshold: number,
+): boolean {
+  const distanceFromBottom =
+    geometry.scrollHeight - geometry.scrollTop - geometry.clientHeight
+  return distanceFromBottom >= atBottomThreshold
+}
+
+/**
+ * Distinguish a mid-array insertion from the three other ways the resident array changes.
+ *
+ * - A live-edge arrival moves the LAST row. Content added below a scrolled-up reader cannot move
+ *   them, and the bottom-pin loop owns the at-bottom case.
+ * - A load-older/newer batch also rewrites the array without moving the bottom row and owns its own
+ *   directional restore, which must not be fought. It is identified by a snapshot landing in THIS
+ *   commit, not merely by a first-id change: at the resident bound an insertion evicts the oldest
+ *   row and so moves the first id too.
+ * - An interior placement bump is authoritative on its own, even when the ids look unchanged.
+ */
+export function decideInsertionMutation(input: {
+  tracked: ResidentTrackingState
+  next: ResidentTrackingState
+  directionalLoadLanding: boolean
+  hasAnchor: boolean
+}): AmbientMutationDecision {
+  const { tracked, next } = input
+  if (tracked.conversationId !== next.conversationId) return { kind: 'reset' }
+
+  const bottomMoved = tracked.lastMessageId !== next.lastMessageId
+  const residentChanged =
+    tracked.messageCount !== next.messageCount ||
+    tracked.firstMessageId !== next.firstMessageId
+  const interiorPlacementAdvanced =
+    next.interiorPlacementVersion > tracked.interiorPlacementVersion
+
+  const inserted =
+    !input.directionalLoadLanding &&
+    (interiorPlacementAdvanced || (residentChanged && !bottomMoved))
+
+  return inserted && input.hasAnchor ? { kind: 'preserve' } : { kind: 'retrack' }
+}

--- a/apps/fluux/src/components/conversation/bottomAnchor.ts
+++ b/apps/fluux/src/components/conversation/bottomAnchor.ts
@@ -1,0 +1,49 @@
+import type { ScrollAnchor } from '@/utils/scrollStateManager'
+
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
+
+/**
+ * Capture a CONTENT anchor: the bottom-most visible message and the FRACTION (0..1) of its
+ * height at which the viewport bottom sits. fraction=1 → the message's bottom edge is at the
+ * window bottom; 0.5 → the window bottom cuts its middle.
+ *
+ * Storing a fraction (not a pixel gap) makes the position INDEPENDENT OF RENDERING: on return we
+ * re-derive pixels from the message's CURRENT measured height, so a re-measure, a width change, or
+ * a virtualization re-window can't corrupt it. The previous implementation stored a pixel gap found
+ * via a BINARY SEARCH over `offsetTop` assuming rows were in sorted document order — false under
+ * virtualization (the DOM holds an unsorted/stale window), which produced a wildly wrong gap and
+ * flung the view to the bottom on return. This is a linear max-scan over the (small) rendered
+ * window using each row's own `offsetTop`/`offsetHeight`, so DOM order no longer matters.
+ */
+export function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
+  const rows = scroller.querySelectorAll('.message-row[data-message-id]')
+  if (rows.length === 0) return null
+  // Measure with getBoundingClientRect (relative to the scroller), NOT offsetTop. Under
+  // virtualization each `.message-row` sits inside its own `position:absolute` `[data-index]`
+  // wrapper, which is the row's offsetParent — so `offsetTop` is ~0 for EVERY row and the old
+  // "greatest offsetTop" pick always returned the top-most MOUNTED row instead of the bottom-most
+  // visible one. That wrong anchor was saved/restored (masked by consistency-only tests) and is a
+  // root cause of the conversation-switch "drifts back in time" report. Bounding rects reflect the
+  // real on-screen position for both the virtualized and the normal-flow paths.
+  const sTop = scroller.getBoundingClientRect().top
+  const viewportH = scroller.clientHeight
+  // Bottom-most row whose TOP is still within the viewport (greatest scroller-relative top < height).
+  let best: HTMLElement | null = null
+  let bestTop = -Infinity
+  for (const node of rows) {
+    const el = node as HTMLElement
+    if (el.offsetHeight <= 0) continue
+    const top = el.getBoundingClientRect().top - sTop
+    if (top < viewportH && top > bestTop) {
+      best = el
+      bestTop = top
+    }
+  }
+  if (best === null) best = rows[rows.length - 1] as HTMLElement
+  const messageId = best.dataset.messageId
+  if (!messageId) return null
+  const rect = best.getBoundingClientRect()
+  const height = rect.height || 1
+  const topRel = rect.top - sTop
+  return { messageId, fraction: clamp01((viewportH - topRel) / height) }
+}

--- a/apps/fluux/src/components/conversation/entryArbitration.test.ts
+++ b/apps/fluux/src/components/conversation/entryArbitration.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+import {
+  arbitrateEntry,
+  isSyncedLiveEdgeEntry,
+  shouldSupersedeWithLateSyncedLiveEdge,
+  type EntryArbitrationInput,
+  type LateSyncedLiveEdgeInput,
+} from './entryArbitration'
+
+/** A saved position written against an OLDER pointer, with the pointer now at the newest row. */
+const syncedEntry = (
+  overrides: Partial<EntryArbitrationInput> = {},
+): EntryArbitrationInput => ({
+  persistedAction: 'restore-position',
+  savedReadPositionId: 'm-40',
+  firstUnreadMessageId: undefined,
+  readPointerId: 'm-99',
+  lastMessageId: 'm-99',
+  targetMessageId: undefined,
+  ...overrides,
+})
+
+describe('isSyncedLiveEdgeEntry', () => {
+  it('supersedes when the synced pointer names the newest row and the save is older', () => {
+    expect(isSyncedLiveEdgeEntry(syncedEntry())).toBe(true)
+  })
+
+  it('needs a saved position to supersede in the first place', () => {
+    expect(
+      isSyncedLiveEdgeEntry(syncedEntry({ persistedAction: 'scroll-to-bottom' })),
+    ).toBe(false)
+    expect(isSyncedLiveEdgeEntry(syncedEntry({ persistedAction: 'no-action' }))).toBe(
+      false,
+    )
+  })
+
+  it('never overrides a genuine unread divider', () => {
+    // The divider is the stronger, more specific signal for where to land.
+    expect(
+      isSyncedLiveEdgeEntry(syncedEntry({ firstUnreadMessageId: 'm-70' })),
+    ).toBe(false)
+  })
+
+  it('requires a pointer that actually resolved', () => {
+    expect(isSyncedLiveEdgeEntry(syncedEntry({ readPointerId: undefined }))).toBe(false)
+    // The explicit `!== undefined` guard is what covers an EMPTY conversation: with no pointer and
+    // no newest row, a bare equality check reads `undefined === undefined` as "the pointer is at
+    // the tail" and throws away a perfectly good saved position.
+    expect(
+      isSyncedLiveEdgeEntry(
+        syncedEntry({ readPointerId: undefined, lastMessageId: undefined }),
+      ),
+    ).toBe(false)
+  })
+
+  it('requires the pointer to name the NEWEST row, not merely a newer one', () => {
+    // Paired with the passing case: the pointer moved forward but not to the tail, so the saved
+    // position is still the better answer.
+    expect(
+      isSyncedLiveEdgeEntry(syncedEntry({ readPointerId: 'm-80', lastMessageId: 'm-99' })),
+    ).toBe(false)
+  })
+
+  it('does nothing when the save already reflects this read state', () => {
+    expect(
+      isSyncedLiveEdgeEntry(syncedEntry({ savedReadPositionId: 'm-99' })),
+    ).toBe(false)
+  })
+
+  it('supersedes when the save was written against no pointer at all', () => {
+    expect(
+      isSyncedLiveEdgeEntry(syncedEntry({ savedReadPositionId: undefined })),
+    ).toBe(true)
+  })
+})
+
+describe('arbitrateEntry: priority table', () => {
+  it('prefers a saved position over an unread divider', () => {
+    const plan = arbitrateEntry(
+      syncedEntry({
+        firstUnreadMessageId: 'm-70',
+        readPointerId: 'm-40',
+        lastMessageId: 'm-99',
+      }),
+    )
+    expect(plan.branch).toBe('saved-position')
+  })
+
+  it('prefers an unread divider over the live edge when nothing was saved', () => {
+    const plan = arbitrateEntry(
+      syncedEntry({ persistedAction: 'scroll-to-bottom', firstUnreadMessageId: 'm-70' }),
+    )
+    expect(plan.branch).toBe('unread-marker')
+  })
+
+  it('steps aside for an explicit target once no saved position or divider applies', () => {
+    const plan = arbitrateEntry(
+      syncedEntry({
+        persistedAction: 'scroll-to-bottom',
+        firstUnreadMessageId: undefined,
+        targetMessageId: 'm-12',
+      }),
+    )
+    expect(plan.branch).toBe('defer-to-target')
+  })
+
+  it('does NOT let an explicit target displace a saved position or a divider', () => {
+    // The target is a separate, newer request that supersedes entry later; it must not reorder
+    // the provisional table here.
+    expect(
+      arbitrateEntry(
+        syncedEntry({
+          readPointerId: 'm-40',
+          lastMessageId: 'm-99',
+          targetMessageId: 'm-12',
+        }),
+      ).branch,
+    ).toBe('saved-position')
+    expect(
+      arbitrateEntry(
+        syncedEntry({
+          persistedAction: 'scroll-to-bottom',
+          firstUnreadMessageId: 'm-70',
+          targetMessageId: 'm-12',
+        }),
+      ).branch,
+    ).toBe('unread-marker')
+  })
+
+  it('falls back to the live edge with nothing saved, unread, or targeted', () => {
+    const plan = arbitrateEntry(
+      syncedEntry({ persistedAction: 'scroll-to-bottom', savedReadPositionId: undefined }),
+    )
+    expect(plan.branch).toBe('live-edge')
+  })
+
+  it('treats no-action exactly like scroll-to-bottom', () => {
+    expect(
+      arbitrateEntry(syncedEntry({ persistedAction: 'no-action' })).branch,
+    ).toBe('live-edge')
+    expect(
+      arbitrateEntry(
+        syncedEntry({ persistedAction: 'no-action', firstUnreadMessageId: 'm-70' }),
+      ).branch,
+    ).toBe('unread-marker')
+  })
+})
+
+describe('arbitrateEntry: synced live edge invalidating local state', () => {
+  it('sends a superseded restore to the live edge and retires the saved position', () => {
+    const plan = arbitrateEntry(syncedEntry())
+    expect(plan).toMatchObject({
+      syncedLiveEdgeSupersedes: true,
+      clearSavedPosition: true,
+      armPendingSyncedLiveEdge: false,
+      branch: 'live-edge',
+      entersAtBottom: true,
+    })
+  })
+
+  it('still steps aside for an explicit target after superseding', () => {
+    const plan = arbitrateEntry(syncedEntry({ targetMessageId: 'm-12' }))
+    expect(plan.clearSavedPosition).toBe(true)
+    expect(plan.branch).toBe('defer-to-target')
+    expect(plan.entersAtBottom).toBe(false)
+  })
+
+  it('arms the late watch for a restore that was NOT superseded', () => {
+    // Paired with the superseding case: the pointer has not reached the tail, so the restore
+    // stands and must be watched in case the pointer resolves afterwards.
+    const plan = arbitrateEntry(
+      syncedEntry({ readPointerId: 'm-40', lastMessageId: 'm-99' }),
+    )
+    expect(plan).toMatchObject({
+      syncedLiveEdgeSupersedes: false,
+      clearSavedPosition: false,
+      armPendingSyncedLiveEdge: true,
+      branch: 'saved-position',
+    })
+  })
+
+  it('never arms the watch when no position was restored', () => {
+    expect(
+      arbitrateEntry(syncedEntry({ persistedAction: 'scroll-to-bottom' }))
+        .armPendingSyncedLiveEdge,
+    ).toBe(false)
+  })
+
+  it('enters at the bottom only on the live-edge branch', () => {
+    expect(arbitrateEntry(syncedEntry()).entersAtBottom).toBe(true)
+    expect(
+      arbitrateEntry(syncedEntry({ readPointerId: 'm-40', lastMessageId: 'm-99' }))
+        .entersAtBottom,
+    ).toBe(false)
+    expect(
+      arbitrateEntry(
+        syncedEntry({ persistedAction: 'scroll-to-bottom', firstUnreadMessageId: 'm-70' }),
+      ).entersAtBottom,
+    ).toBe(false)
+  })
+})
+
+describe('shouldSupersedeWithLateSyncedLiveEdge', () => {
+  const late = (
+    overrides: Partial<LateSyncedLiveEdgeInput> = {},
+  ): LateSyncedLiveEdgeInput => ({
+    armedForConversation: 'room-a',
+    conversationId: 'room-a',
+    staticMode: false,
+    hasGenuineInput: false,
+    firstUnreadMessageId: undefined,
+    readPointerId: 'm-99',
+    lastMessageId: 'm-99',
+    armedSavedReadPositionId: 'm-40',
+    ...overrides,
+  })
+
+  it('supersedes when the pointer resolves to the tail after the restore landed', () => {
+    expect(shouldSupersedeWithLateSyncedLiveEdge(late())).toBe(true)
+  })
+
+  it('does nothing unless entry armed the watch for THIS conversation', () => {
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ armedForConversation: undefined })),
+    ).toBe(false)
+    // A delayed result from the room just left must never reposition the current one.
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ armedForConversation: 'room-b' })),
+    ).toBe(false)
+  })
+
+  it('yields to the reader once they have taken over', () => {
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ hasGenuineInput: true })),
+    ).toBe(false)
+  })
+
+  it('never fires in a static preview', () => {
+    expect(shouldSupersedeWithLateSyncedLiveEdge(late({ staticMode: true }))).toBe(false)
+  })
+
+  it('leaves a divider-bearing conversation to the divider settle path', () => {
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ firstUnreadMessageId: 'm-70' })),
+    ).toBe(false)
+  })
+
+  it('requires a resolved pointer that reached the tail and moved past the save', () => {
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ readPointerId: undefined })),
+    ).toBe(false)
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ readPointerId: 'm-80' })),
+    ).toBe(false)
+    expect(
+      shouldSupersedeWithLateSyncedLiveEdge(late({ armedSavedReadPositionId: 'm-99' })),
+    ).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/entryArbitration.ts
+++ b/apps/fluux/src/components/conversation/entryArbitration.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure arbitration of what a conversation entry positions to.
+ *
+ * Entry selects exactly ONE provisional request, in this priority order:
+ *
+ *   1. an already-resolved synced live edge, which invalidates stale local state;
+ *   2. a saved position (fixed anchor, or a transitional raw-only offset);
+ *   3. the first unread message;
+ *   4. the live edge.
+ *
+ * An explicit reply/search/activity target is deliberately NOT folded into that table. It is a
+ * separate, newer request that supersedes the provisional entry choice, so entry only steps aside
+ * for it.
+ *
+ * Value-only: no DOM, no controller, no persistence. The caller supplies what the persistence
+ * adapter and the store already decided, and applies the verdict.
+ */
+
+import type { ScrollEntryAction } from './scrollPersistenceAdapter'
+
+/**
+ * What the persistence adapter concluded from the stored state. Only `restore-position` is
+ * distinguished here: `no-action` and `scroll-to-bottom` both leave entry free to choose from the
+ * remaining priority table.
+ */
+export type PersistedEntryAction = ScrollEntryAction
+
+export type EntryBranch =
+  | 'saved-position'
+  | 'unread-marker'
+  | 'defer-to-target'
+  | 'live-edge'
+
+export interface EntryArbitrationInput {
+  persistedAction: PersistedEntryAction
+  /** Read pointer the saved position was written against. */
+  savedReadPositionId: string | undefined
+  firstUnreadMessageId: string | undefined
+  /** The read pointer as currently known, including one synced from another device. */
+  readPointerId: string | undefined
+  lastMessageId: string | undefined
+  targetMessageId: string | null | undefined
+}
+
+export interface EntryArbitration {
+  /**
+   * The remote pointer already identifies the newest downloaded row, and it is not the pointer the
+   * saved position was written against. The saved position is therefore stale and must not win
+   * merely because no unread divider exists.
+   */
+  syncedLiveEdgeSupersedes: boolean
+  /** Retire the persisted position, because the synced pointer superseded it. */
+  clearSavedPosition: boolean
+  /**
+   * Watch for a pointer that resolves AFTER this entry. With no divider, observing that transition
+   * is the only signal that the restore became obsolete.
+   */
+  armPendingSyncedLiveEdge: boolean
+  branch: EntryBranch
+  /**
+   * Entry marks the list not-at-bottom for every branch but the live edge, so the content-growth
+   * observer cannot auto-pin while entry is still aiming somewhere else.
+   */
+  entersAtBottom: boolean
+}
+
+/**
+ * Does an already-resolved synced read pointer invalidate the saved position?
+ *
+ * All five conditions matter. Dropping any one of them lets a saved position lose to a pointer that
+ * is not actually newer, or lets a genuine unread divider be skipped.
+ */
+export function isSyncedLiveEdgeEntry(input: EntryArbitrationInput): boolean {
+  return (
+    input.persistedAction === 'restore-position' &&
+    // An unread divider is a stronger, more specific signal; never override it here.
+    input.firstUnreadMessageId === undefined &&
+    input.readPointerId !== undefined &&
+    // The pointer must name the newest row we hold, not merely some newer row.
+    input.readPointerId === input.lastMessageId &&
+    // Equal pointers mean the saved position already reflects this read state.
+    input.readPointerId !== input.savedReadPositionId
+  )
+}
+
+export function arbitrateEntry(input: EntryArbitrationInput): EntryArbitration {
+  const syncedLiveEdgeSupersedes = isSyncedLiveEdgeEntry(input)
+  const restoring =
+    input.persistedAction === 'restore-position' && !syncedLiveEdgeSupersedes
+
+  const branch: EntryBranch = restoring
+    ? 'saved-position'
+    : input.firstUnreadMessageId !== undefined
+      ? 'unread-marker'
+      : input.targetMessageId
+        ? 'defer-to-target'
+        : 'live-edge'
+
+  return {
+    syncedLiveEdgeSupersedes,
+    clearSavedPosition: syncedLiveEdgeSupersedes,
+    armPendingSyncedLiveEdge: restoring,
+    branch,
+    entersAtBottom: branch === 'live-edge',
+  }
+}
+
+export interface LateSyncedLiveEdgeInput {
+  /** Entry armed the watch for this conversation. */
+  armedForConversation: string | undefined
+  conversationId: string
+  staticMode: boolean
+  /** The reader has taken over, so no automatic correction may follow. */
+  hasGenuineInput: boolean
+  firstUnreadMessageId: string | undefined
+  readPointerId: string | undefined
+  lastMessageId: string | undefined
+  /** Pointer the armed restore was written against. */
+  armedSavedReadPositionId: string | undefined
+}
+
+/**
+ * The zero-unread twin of the divider-clear settle: a restore can land BEFORE MAM resolves another
+ * device's pointer to the newest downloaded row. With no divider, that pointer transition is the
+ * only evidence the restore is obsolete.
+ */
+export function shouldSupersedeWithLateSyncedLiveEdge(
+  input: LateSyncedLiveEdgeInput,
+): boolean {
+  if (input.armedForConversation !== input.conversationId) return false
+  if (input.staticMode || input.hasGenuineInput) return false
+  if (input.firstUnreadMessageId !== undefined) return false
+  if (input.readPointerId === undefined) return false
+  if (input.readPointerId !== input.lastMessageId) return false
+  return input.readPointerId !== input.armedSavedReadPositionId
+}

--- a/apps/fluux/src/components/conversation/mediaGrowthDecisions.test.ts
+++ b/apps/fluux/src/components/conversation/mediaGrowthDecisions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decideMediaBatchOutcome,
+  isGenuineScrollDuringBatch,
+} from './mediaGrowthDecisions'
+
+describe('decideMediaBatchOutcome', () => {
+  it('follows the live edge when the reader was there and never moved', () => {
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: true,
+        userScrolled: false,
+        hasAnchor: true,
+      }),
+    ).toEqual({ kind: 'live-edge' })
+  })
+
+  it('preserves the reading anchor when the reader was up in history', () => {
+    // Paired with the case above: only wasAtBottom differs.
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: false,
+        userScrolled: false,
+        hasAnchor: true,
+      }),
+    ).toEqual({ kind: 'preserve-anchor' })
+  })
+
+  it('respects a genuine move regardless of where the batch started', () => {
+    // A reader who scrolled during decoding chose their position; neither correction may fire.
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: true,
+        userScrolled: true,
+        hasAnchor: true,
+      }),
+    ).toEqual({ kind: 'respect-user' })
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: false,
+        userScrolled: true,
+        hasAnchor: true,
+      }),
+    ).toEqual({ kind: 'respect-user' })
+  })
+
+  it('does nothing when scrolled up with no anchor captured', () => {
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: false,
+        userScrolled: false,
+        hasAnchor: false,
+      }),
+    ).toEqual({ kind: 'none' })
+  })
+
+  it('still follows the live edge without an anchor, which it does not need', () => {
+    expect(
+      decideMediaBatchOutcome({
+        wasAtBottom: true,
+        userScrolled: false,
+        hasAnchor: false,
+      }),
+    ).toEqual({ kind: 'live-edge' })
+  })
+})
+
+describe('isGenuineScrollDuringBatch', () => {
+  const base = {
+    batchActive: true,
+    controllerOwnsPixels: false,
+    previousScrollHeight: 5_000,
+    scrollHeight: 5_000,
+  }
+
+  it('counts a move that left the content height alone', () => {
+    expect(isGenuineScrollDuringBatch(base)).toBe(true)
+  })
+
+  it('ignores the scroll event media growth fires as it decodes', () => {
+    // This is the whole defect it guards: a growth event marking userScrolled made the handler
+    // "respect" a position the reader never chose, leaving the view drifted.
+    expect(
+      isGenuineScrollDuringBatch({ ...base, scrollHeight: 5_400 }),
+    ).toBe(false)
+  })
+
+  it('ignores a scroll the controller itself is driving', () => {
+    expect(
+      isGenuineScrollDuringBatch({ ...base, controllerOwnsPixels: true }),
+    ).toBe(false)
+  })
+
+  it('ignores everything when no batch is open', () => {
+    expect(isGenuineScrollDuringBatch({ ...base, batchActive: false })).toBe(false)
+  })
+
+  it('ignores the first observation, which has no previous height to compare', () => {
+    expect(
+      isGenuineScrollDuringBatch({ ...base, previousScrollHeight: undefined }),
+    ).toBe(false)
+    expect(
+      isGenuineScrollDuringBatch({ ...base, previousScrollHeight: null }),
+    ).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/mediaGrowthDecisions.ts
+++ b/apps/fluux/src/components/conversation/mediaGrowthDecisions.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure decision for what a settled media-load batch should do.
+ *
+ * Media decoding changes content height after the fact. A batch captures the reader's intent at its
+ * START — were they at the live edge, and where were they reading — then applies exactly one
+ * correction once decoding quiesces, so a run of images cannot produce a run of scroll writes.
+ *
+ * Value-only: no DOM, no controller, no timers.
+ */
+
+export interface MediaBatchSnapshotFacts {
+  /** The reader was following the live edge when the batch began. */
+  wasAtBottom: boolean
+  /** A GENUINE user scroll landed during the batch — not a growth-driven event. */
+  userScrolled: boolean
+  /** A pre-growth reading anchor was captured. */
+  hasAnchor: boolean
+}
+
+export type MediaBatchOutcome =
+  /** Follow the live edge again: growth below the fold moved the newest message out of view. */
+  | { kind: 'live-edge' }
+  /** Media above the viewport grew and pushed the reading position down; put it back. */
+  | { kind: 'preserve-anchor' }
+  /** The reader moved during the batch. Their position is theirs; leave it alone. */
+  | { kind: 'respect-user' }
+  /** Nothing to correct and nothing captured to correct toward. */
+  | { kind: 'none' }
+
+export function decideMediaBatchOutcome(
+  facts: MediaBatchSnapshotFacts,
+): MediaBatchOutcome {
+  if (facts.userScrolled) return { kind: 'respect-user' }
+  if (facts.wasAtBottom) return { kind: 'live-edge' }
+  return facts.hasAnchor ? { kind: 'preserve-anchor' } : { kind: 'none' }
+}
+
+/**
+ * Whether a scroll event during a batch counts as the reader moving.
+ *
+ * Media growth itself fires scroll events. Treating one as user intent is exactly what made the
+ * handler "respect" a position the reader never chose, leaving the view drifted — at the bottom no
+ * re-pin, scrolled up no re-anchor. A genuine move changes `scrollTop` while the content height
+ * stands still; growth changes the height.
+ */
+export function isGenuineScrollDuringBatch(input: {
+  batchActive: boolean
+  controllerOwnsPixels: boolean
+  previousScrollHeight: number | null | undefined
+  scrollHeight: number
+}): boolean {
+  return (
+    input.batchActive &&
+    !input.controllerOwnsPixels &&
+    input.previousScrollHeight === input.scrollHeight
+  )
+}

--- a/apps/fluux/src/components/conversation/scrollEventDecisions.test.ts
+++ b/apps/fluux/src/components/conversation/scrollEventDecisions.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RECENT_INTENT_WINDOW_MS,
+  TRAVEL_AWAY_THRESHOLD,
+  decideMarkerClear,
+  isMarkerAboveViewport,
+  planScrollEvent,
+  planWheelEvent,
+  type MarkerClearFacts,
+  type ScrollEventFacts,
+  type WheelEventFacts,
+} from './scrollEventDecisions'
+
+const AT_BOTTOM = 300
+const LOAD_NEWER = 4
+
+const scrollFacts = (
+  overrides: Partial<ScrollEventFacts> = {},
+): ScrollEventFacts => ({
+  scrollTop: 2_000,
+  distanceFromBottom: 1_000,
+  controllerOwnsPixels: false,
+  growthDrivenDuringControllerScroll: false,
+  genuineUserScroll: false,
+  staticMode: false,
+  hasTravelledAwayFromTop: true,
+  atBottomThreshold: AT_BOTTOM,
+  loadNewerThreshold: LOAD_NEWER,
+  ...overrides,
+})
+
+describe('planScrollEvent: measured live-edge evidence', () => {
+  it('records the measurement for an ordinary event', () => {
+    const plan = planScrollEvent(scrollFacts({ distanceFromBottom: 10 }))
+    expect(plan.recordMeasuredAtBottom).toBe(true)
+    expect(plan.atBottom).toBe(true)
+  })
+
+  it('refuses to record a growth-driven event under a running loop', () => {
+    // Believing this flips the at-bottom flag false, the pin loop bails, and a send is stranded
+    // below the fold — the WebKitGTK send-stick defect.
+    const plan = planScrollEvent(
+      scrollFacts({
+        distanceFromBottom: 900,
+        controllerOwnsPixels: true,
+        growthDrivenDuringControllerScroll: true,
+      }),
+    )
+    expect(plan.recordMeasuredAtBottom).toBe(false)
+  })
+
+  it('still records a genuine scroll-up during a loop, which leaves the height alone', () => {
+    // Paired with the case above: a loop is running, but this is not growth-driven.
+    const plan = planScrollEvent(
+      scrollFacts({
+        distanceFromBottom: 900,
+        controllerOwnsPixels: true,
+        growthDrivenDuringControllerScroll: false,
+      }),
+    )
+    expect(plan.recordMeasuredAtBottom).toBe(true)
+    expect(plan.atBottom).toBe(false)
+  })
+
+  it('reads at-bottom off the supplied threshold, exclusive', () => {
+    expect(planScrollEvent(scrollFacts({ distanceFromBottom: 299 })).atBottom).toBe(true)
+    expect(planScrollEvent(scrollFacts({ distanceFromBottom: 300 })).atBottom).toBe(false)
+  })
+})
+
+describe('planScrollEvent: reader attribution', () => {
+  it('tracks the bottom-visible message only for a reader-owned scroll', () => {
+    expect(planScrollEvent(scrollFacts()).trackBottomVisibleMessage).toBe(true)
+    expect(
+      planScrollEvent(scrollFacts({ controllerOwnsPixels: true }))
+        .trackBottomVisibleMessage,
+    ).toBe(false)
+  })
+
+  it('observes input only on the session verdict, not merely a non-programmatic event', () => {
+    // Distinct facts: a measurement-settle frame is non-programmatic yet not a genuine move.
+    expect(planScrollEvent(scrollFacts()).observeGenuineInput).toBe(false)
+    expect(
+      planScrollEvent(scrollFacts({ genuineUserScroll: true })).observeGenuineInput,
+    ).toBe(true)
+  })
+})
+
+describe('planScrollEvent: travel latches', () => {
+  it('arms the top latch past the threshold, but never for a controller-owned move', () => {
+    expect(
+      planScrollEvent(scrollFacts({ scrollTop: TRAVEL_AWAY_THRESHOLD + 1 }))
+        .markTravelAwayFromTop,
+    ).toBe(true)
+    expect(
+      planScrollEvent(scrollFacts({ scrollTop: TRAVEL_AWAY_THRESHOLD }))
+        .markTravelAwayFromTop,
+    ).toBe(false)
+    // Home's smooth trip from the bottom crosses this threshold and must not look like pagination.
+    expect(
+      planScrollEvent(
+        scrollFacts({ scrollTop: 2_000, controllerOwnsPixels: true }),
+      ).markTravelAwayFromTop,
+    ).toBe(false)
+  })
+
+  it('arms the bottom latch even under the controller, unlike the top latch', () => {
+    // Deliberate asymmetry: content growth alone moves this edge.
+    expect(
+      planScrollEvent(
+        scrollFacts({ distanceFromBottom: 1_000, controllerOwnsPixels: true }),
+      ).markTravelAwayFromBottom,
+    ).toBe(true)
+    expect(
+      planScrollEvent(
+        scrollFacts({ distanceFromBottom: TRAVEL_AWAY_THRESHOLD }),
+      ).markTravelAwayFromBottom,
+    ).toBe(false)
+  })
+})
+
+describe('planScrollEvent: boundary loads', () => {
+  it('loads older only at the very top after genuine travel', () => {
+    expect(planScrollEvent(scrollFacts({ scrollTop: 0 })).loadOlder).toBe(true)
+    expect(planScrollEvent(scrollFacts({ scrollTop: 1 })).loadOlder).toBe(false)
+  })
+
+  it('refuses the entry transient at scrollTop 0 before the reader ever travelled', () => {
+    // Loading here prepends a batch and clears bottom-stick for the next arrival.
+    expect(
+      planScrollEvent(
+        scrollFacts({ scrollTop: 0, hasTravelledAwayFromTop: false }),
+      ).loadOlder,
+    ).toBe(false)
+  })
+
+  it('loads newer at or inside the resident-bottom threshold', () => {
+    expect(
+      planScrollEvent(scrollFacts({ distanceFromBottom: LOAD_NEWER })).loadNewer,
+    ).toBe(true)
+    expect(
+      planScrollEvent(scrollFacts({ distanceFromBottom: LOAD_NEWER + 1 })).loadNewer,
+    ).toBe(false)
+  })
+
+  it('never loads in a static preview, which starts at scrollTop 0', () => {
+    const preview = planScrollEvent(
+      scrollFacts({ scrollTop: 0, distanceFromBottom: 0, staticMode: true }),
+    )
+    expect(preview.loadOlder).toBe(false)
+    expect(preview.loadNewer).toBe(false)
+  })
+})
+
+describe('planWheelEvent', () => {
+  const wheel = (overrides: Partial<WheelEventFacts> = {}): WheelEventFacts => ({
+    scrollTop: 0,
+    distanceFromBottom: 5_000,
+    deltaY: -10,
+    staticMode: false,
+    loadNewerThreshold: LOAD_NEWER,
+    ...overrides,
+  })
+
+  it('loads older on a wheel-up pinned at the top, with no travel requirement', () => {
+    // A wheel is explicit intent, unlike the passive scroll path.
+    expect(planWheelEvent(wheel()).loadOlder).toBe(true)
+  })
+
+  it('does not load older when wheeling down, or away from the top', () => {
+    expect(planWheelEvent(wheel({ deltaY: 10 })).loadOlder).toBe(false)
+    expect(planWheelEvent(wheel({ scrollTop: 5 })).loadOlder).toBe(false)
+  })
+
+  it('loads newer on a wheel-down pinned at the resident bottom, where no scroll event fires', () => {
+    expect(
+      planWheelEvent(wheel({ distanceFromBottom: 0, deltaY: 10 })).loadNewer,
+    ).toBe(true)
+    expect(
+      planWheelEvent(wheel({ distanceFromBottom: 0, deltaY: -10 })).loadNewer,
+    ).toBe(false)
+  })
+
+  it('arms each travel latch on the direction that leaves that edge', () => {
+    expect(planWheelEvent(wheel({ deltaY: 10 })).markTravelAwayFromTop).toBe(true)
+    expect(planWheelEvent(wheel({ deltaY: -10 })).markTravelAwayFromTop).toBe(false)
+    expect(
+      planWheelEvent(wheel({ distanceFromBottom: 1_000, deltaY: -10 }))
+        .markTravelAwayFromBottom,
+    ).toBe(true)
+    expect(
+      planWheelEvent(wheel({ distanceFromBottom: 1_000, deltaY: 10 }))
+        .markTravelAwayFromBottom,
+    ).toBe(false)
+  })
+
+  it('never loads in a static preview', () => {
+    expect(planWheelEvent(wheel({ staticMode: true })).loadOlder).toBe(false)
+    expect(
+      planWheelEvent(wheel({ distanceFromBottom: 0, deltaY: 10, staticMode: true }))
+        .loadNewer,
+    ).toBe(false)
+  })
+})
+
+describe('isMarkerAboveViewport', () => {
+  it('is true only for a known offset above the current scrollTop', () => {
+    expect(isMarkerAboveViewport(100, 200)).toBe(true)
+    expect(isMarkerAboveViewport(200, 200)).toBe(false)
+    expect(isMarkerAboveViewport(300, 200)).toBe(false)
+  })
+
+  it('treats an unknown offset as not above, including offset zero as a real value', () => {
+    expect(isMarkerAboveViewport(null, 200)).toBe(false)
+    expect(isMarkerAboveViewport(undefined, 200)).toBe(false)
+    // 0 is a legitimate offset: the marker is the very first row.
+    expect(isMarkerAboveViewport(0, 200)).toBe(true)
+    expect(isMarkerAboveViewport(0, 0)).toBe(false)
+  })
+})
+
+describe('decideMarkerClear', () => {
+  const facts = (overrides: Partial<MarkerClearFacts> = {}): MarkerClearFacts => ({
+    hasMarker: true,
+    canClear: true,
+    controllerOwnsPixels: false,
+    armed: false,
+    distanceFromBottom: 1_000,
+    atBottomThreshold: AT_BOTTOM,
+    lastUserIntentAt: 0,
+    now: 10_000,
+    ...overrides,
+  })
+
+  it('only arms on the first scroll, so the marker is never retired unseen', () => {
+    expect(decideMarkerClear(facts())).toBe('arm')
+  })
+
+  it('clears once armed and read through to the bottom', () => {
+    expect(decideMarkerClear(facts({ armed: true, distanceFromBottom: 10 }))).toBe(
+      'clear',
+    )
+  })
+
+  it('does not clear when armed but still up in history', () => {
+    // Scrolled-past must keep the divider: the jump-to-last-read pill needs it.
+    expect(decideMarkerClear(facts({ armed: true }))).toBe('none')
+  })
+
+  it('clears immediately on an at-bottom arrival that follows a recent intent', () => {
+    expect(
+      decideMarkerClear(
+        facts({
+          distanceFromBottom: 10,
+          lastUserIntentAt: 10_000 - (RECENT_INTENT_WINDOW_MS - 1),
+        }),
+      ),
+    ).toBe('clear')
+  })
+
+  it('only arms when the at-bottom arrival follows a stale intent', () => {
+    // Paired with the case above: identical but for the intent age.
+    expect(
+      decideMarkerClear(
+        facts({
+          distanceFromBottom: 10,
+          lastUserIntentAt: 10_000 - RECENT_INTENT_WINDOW_MS,
+        }),
+      ),
+    ).toBe('arm')
+  })
+
+  it('treats a never-recorded intent as stale rather than recent', () => {
+    expect(
+      decideMarkerClear(facts({ distanceFromBottom: 10, lastUserIntentAt: 0 })),
+    ).toBe('arm')
+    // The sentinel must be tested as "absent", not merely subtracted: with a small clock,
+    // `now - 0` falls inside the window and a bare arithmetic check would call it recent, clearing
+    // the divider on the reader's very first scroll.
+    expect(
+      decideMarkerClear(
+        facts({ distanceFromBottom: 10, lastUserIntentAt: 0, now: 100 }),
+      ),
+    ).toBe('arm')
+  })
+
+  it('does nothing without a marker, without a clear callback, or under the controller', () => {
+    expect(decideMarkerClear(facts({ hasMarker: false }))).toBe('none')
+    expect(decideMarkerClear(facts({ canClear: false }))).toBe('none')
+    // A FAB jump-to-present drives a reassert loop and must not clear the divider.
+    expect(
+      decideMarkerClear(
+        facts({ armed: true, distanceFromBottom: 10, controllerOwnsPixels: true }),
+      ),
+    ).toBe('none')
+  })
+})

--- a/apps/fluux/src/components/conversation/scrollEventDecisions.ts
+++ b/apps/fluux/src/components/conversation/scrollEventDecisions.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure interpretation of a scroll or wheel event.
+ *
+ * The handler reads geometry once and asks these functions what follows. Nothing here touches the
+ * DOM, the controller, React state or timers, so every threshold and gate below is directly
+ * testable — which the inline handler's dense boolean expressions were not.
+ *
+ * The recurring discriminator is whether a scroll event came from the READER. Three distinct facts
+ * answer that, and they are not interchangeable:
+ *
+ * - `controllerOwnsPixels`: a re-assert loop is writing scrollTop right now.
+ * - `growthDrivenDuringControllerScroll`: the engine fired an event because content grew under a
+ *   running loop, at an unchanged scrollTop.
+ * - `genuineUserScroll`: the viewport session's own verdict, which also covers scrollbar drags that
+ *   fire no wheel or touch event.
+ */
+
+/** Pixels away from an edge before the reader counts as having travelled away from it. */
+export const TRAVEL_AWAY_THRESHOLD = 50
+/** How recently a user intent must have landed for an at-bottom arrival to be theirs. */
+export const RECENT_INTENT_WINDOW_MS = 1500
+
+export interface ScrollEventFacts {
+  scrollTop: number
+  distanceFromBottom: number
+  /** A re-assert loop owns scrollTop: these events are not the reader. */
+  controllerOwnsPixels: boolean
+  /** Content grew under a running loop at an unchanged scrollTop. */
+  growthDrivenDuringControllerScroll: boolean
+  /** The viewport session's verdict, covering scrollbar drags too. */
+  genuineUserScroll: boolean
+  staticMode: boolean
+  hasTravelledAwayFromTop: boolean
+  atBottomThreshold: number
+  loadNewerThreshold: number
+}
+
+export interface ScrollEventPlan {
+  /**
+   * Whether the measured live-edge evidence may be rewritten. A growth-driven event under a loop
+   * reports a transiently large distance at an unchanged scrollTop; believing it flips the flag
+   * false and makes the pin loop bail, stranding a send below the fold.
+   */
+  recordMeasuredAtBottom: boolean
+  atBottom: boolean
+  /** Only a genuine move updates the divider-snap trigger. */
+  trackBottomVisibleMessage: boolean
+  observeGenuineInput: boolean
+  /**
+   * A controller-owned animation can cross the top threshold too — Home's smooth trip from the
+   * bottom most obviously — and that is not evidence of a pagination gesture.
+   */
+  markTravelAwayFromTop: boolean
+  /** The bottom latch is deliberately NOT gated on the controller: growth alone moves this edge. */
+  markTravelAwayFromBottom: boolean
+  /**
+   * A PASSIVE scroll reaching the top must only auto-load when the reader genuinely travelled up to
+   * it. On entry the list briefly renders at scrollTop 0 before settling; loading there prepends a
+   * batch and clears the at-bottom flag, breaking bottom-stick for the next arrival.
+   */
+  loadOlder: boolean
+  loadNewer: boolean
+}
+
+export function planScrollEvent(facts: ScrollEventFacts): ScrollEventPlan {
+  const atBottom = facts.distanceFromBottom < facts.atBottomThreshold
+  return {
+    recordMeasuredAtBottom: !facts.growthDrivenDuringControllerScroll,
+    atBottom,
+    trackBottomVisibleMessage: !facts.controllerOwnsPixels,
+    observeGenuineInput: facts.genuineUserScroll,
+    markTravelAwayFromTop:
+      !facts.controllerOwnsPixels && facts.scrollTop > TRAVEL_AWAY_THRESHOLD,
+    markTravelAwayFromBottom: facts.distanceFromBottom > TRAVEL_AWAY_THRESHOLD,
+    loadOlder:
+      facts.scrollTop === 0 && !facts.staticMode && facts.hasTravelledAwayFromTop,
+    loadNewer:
+      facts.distanceFromBottom <= facts.loadNewerThreshold && !facts.staticMode,
+  }
+}
+
+export interface WheelEventFacts {
+  scrollTop: number
+  distanceFromBottom: number
+  deltaY: number
+  staticMode: boolean
+  loadNewerThreshold: number
+}
+
+export interface WheelEventPlan {
+  loadOlder: boolean
+  loadNewer: boolean
+  markTravelAwayFromTop: boolean
+  markTravelAwayFromBottom: boolean
+}
+
+/**
+ * A wheel is explicit intent, so unlike a passive scroll it is NOT gated on having travelled away.
+ * It also covers the two positions where no scroll event fires at all: pinned at the top wheeling
+ * up, and pinned at the resident bottom wheeling down.
+ */
+export function planWheelEvent(facts: WheelEventFacts): WheelEventPlan {
+  const wheelingUp = facts.deltaY < 0
+  const wheelingDown = facts.deltaY > 0
+  return {
+    loadOlder: facts.scrollTop === 0 && wheelingUp && !facts.staticMode,
+    loadNewer:
+      facts.distanceFromBottom <= facts.loadNewerThreshold &&
+      wheelingDown &&
+      !facts.staticMode,
+    markTravelAwayFromTop: facts.scrollTop === 0 && wheelingDown,
+    markTravelAwayFromBottom:
+      facts.distanceFromBottom > TRAVEL_AWAY_THRESHOLD && wheelingUp,
+  }
+}
+
+/**
+ * Is the unread divider scrolled ABOVE the viewport?
+ *
+ * Compares the marker's content-relative offset against live scrollTop, which works whether or not
+ * the marker row is mounted. It deliberately does NOT compare virtual indexes: for a short or medium
+ * conversation the rendered window can cover the ENTIRE item list, so the first rendered index stays
+ * 0 regardless of scroll position and an index comparison would never fire.
+ */
+export function isMarkerAboveViewport(
+  markerOffset: number | null | undefined,
+  scrollTop: number,
+): boolean {
+  return markerOffset != null && markerOffset < scrollTop
+}
+
+export type MarkerClearAction = 'arm' | 'clear' | 'none'
+
+export interface MarkerClearFacts {
+  hasMarker: boolean
+  canClear: boolean
+  controllerOwnsPixels: boolean
+  /** The reader has already produced one scroll since the marker appeared. */
+  armed: boolean
+  distanceFromBottom: number
+  atBottomThreshold: number
+  lastUserIntentAt: number
+  now: number
+}
+
+/**
+ * Decide whether this scroll retires the new-message divider.
+ *
+ * The first scroll after the marker appears only ARMS the clear, so the marker is never retired
+ * before the reader can see it. The exception is an at-bottom arrival that follows a recent genuine
+ * intent: that is the reader deliberately going to the present, so it may clear immediately.
+ *
+ * Only a read-through to the bottom clears. Scrolled-past and DOM-trimmed deliberately do not:
+ * those are exactly the states where the jump-to-last-read pill must still show.
+ */
+export function decideMarkerClear(facts: MarkerClearFacts): MarkerClearAction {
+  if (!facts.hasMarker || !facts.canClear || facts.controllerOwnsPixels) {
+    return 'none'
+  }
+  const atBottom = facts.distanceFromBottom < facts.atBottomThreshold
+  const recentUserScrollIntent =
+    facts.lastUserIntentAt > 0 &&
+    facts.now - facts.lastUserIntentAt < RECENT_INTENT_WINDOW_MS
+  if (!facts.armed && !(atBottom && recentUserScrollIntent)) return 'arm'
+  return atBottom ? 'clear' : 'none'
+}

--- a/apps/fluux/src/components/conversation/useAmbientAnchorPreservation.ts
+++ b/apps/fluux/src/components/conversation/useAmbientAnchorPreservation.ts
@@ -1,0 +1,333 @@
+/**
+ * useAmbientAnchorPreservation - preserve a reading point through ambient layout mutations
+ *
+ * Two mutations move a scrolled-up reader without them asking for it:
+ *
+ * 1. The unread divider changes position.
+ * 2. A delayed arrival — offline replay, gateway/MUC history, the MAM `{ids}` fetch — reaches the
+ *    LIVE path carrying an OLD timestamp, so `appendLive` sorts it into the MIDDLE of the resident
+ *    array. Landing above the reader it pushes the reading position down by the inserted height:
+ *    the reader drifts backwards in time.
+ *
+ * Nothing else covers case 2. Media-growth compensation is reachable only from `onMediaLoad` and an
+ * insertion fires no media event; the new-message effect deliberately does nothing for an incoming
+ * message while scrolled up; and browser-native CSS scroll anchoring — which handles this in normal
+ * flow — is inert under virtualization, because the virtualizer rewrites every row's inline `top` on
+ * each commit, and WebKit does not implement it at all.
+ *
+ * Both are ambient layout preservation, NOT navigation: they go through the layout-preservation
+ * request source, so the model rejects them while an entry restore, explicit target, or Home/End
+ * command is still in flight rather than superseding what the reader asked for.
+ *
+ * Every branch decision lives in `ambientAnchorDecisions`; this hook only measures, holds the
+ * captured anchors, and submits requests.
+ */
+
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+import { findBottomAnchor } from './bottomAnchor'
+import {
+  decideDividerMutation,
+  decideInsertionMutation,
+  insertionAnchorApplies,
+  residentArrayUnchanged,
+  shouldCaptureDividerAnchor,
+  shouldRecaptureInsertionAnchor,
+  type ResidentTrackingState,
+  type ScrollGeometrySample,
+} from './ambientAnchorDecisions'
+import { runScrollShadowSafely } from './scrollPositionShadow'
+import { messageFraction, type AnchorPreservationRequest } from './scrollPositionModel'
+import type { AnchorPreservationExecutor } from './positioningController'
+
+type AmbientReason = 'divider-mutation' | 'message-insertion'
+type AmbientLoopLabel = 'divider-anchor' | 'insertion-anchor'
+
+export interface AmbientAnchorPorts {
+  getScroller: () => HTMLElement | null
+  /** The viewport session's own bottom anchor, preferred over a locally captured one. */
+  getSessionBottomAnchor: (conversationId: string) => ScrollAnchor | null | undefined
+  recordBottomAnchor: (conversationId: string, anchor: ScrollAnchor | null) => void
+  /** True while a directional load's snapshot is landing in THIS commit. */
+  isDirectionalLoadLanding: (conversationId: string, firstMessageId: string) => boolean
+  beginLayoutPreservation: (input: {
+    conversationId: string
+    desired: AnchorPreservationRequest['desired']
+    reason: AmbientReason
+    executor: AnchorPreservationExecutor
+  }) => void
+}
+
+export interface UseAmbientAnchorPreservationInput {
+  ports: AmbientAnchorPorts
+  conversationId: string
+  firstNewMessageId: string | undefined
+  /** The reader is away from the live edge, so there is a reading point worth holding. */
+  showScrollToBottom: boolean
+  bottomVisibleMessageId: string | null
+  messageCount: number
+  firstMessageId: string | undefined
+  lastMessageId: string | undefined
+  interiorPlacementVersion: number
+  /** Identity churns with the live window; kept in the effect dependency arrays deliberately. */
+  createAnchorPreservationExecutor: (
+    loopLabel: AmbientLoopLabel,
+  ) => AnchorPreservationExecutor
+}
+
+export interface AmbientAnchorPreservation {
+  /**
+   * Refresh the pre-mutation insertion anchor from a measurement the caller already took, but only
+   * while the resident array is unchanged.
+   */
+  refreshInsertionAnchorIfStable: (
+    scroller: HTMLElement,
+    measuredAnchor: ScrollAnchor | null,
+  ) => void
+}
+
+export function useAmbientAnchorPreservation({
+  ports,
+  conversationId,
+  firstNewMessageId,
+  showScrollToBottom,
+  bottomVisibleMessageId,
+  messageCount,
+  firstMessageId,
+  lastMessageId,
+  interiorPlacementVersion,
+  createAnchorPreservationExecutor,
+}: UseAmbientAnchorPreservationInput): AmbientAnchorPreservation {
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  const dividerAnchorRef = useRef<ScrollAnchor | null>(null)
+  const dividerTrackingRef = useRef({
+    conversationId,
+    dividerId: firstNewMessageId,
+  })
+
+  // Tracked by BOTH ends of the resident array, not by count: at the resident bound `appendLive`
+  // trims the oldest row as it inserts, so the count does not change and only the first id moves.
+  const insertionAnchorRef = useRef<ScrollAnchor | null>(null)
+  const insertionGeometryRef = useRef<ScrollGeometrySample | null>(null)
+  const insertionTrackingRef = useRef<ResidentTrackingState>({
+    conversationId,
+    messageCount,
+    firstMessageId,
+    lastMessageId,
+    interiorPlacementVersion,
+  })
+
+  // This render's resident facts, read by the scroll-event path, which runs outside a commit.
+  const residentRef = useRef<ResidentTrackingState>({
+    conversationId,
+    messageCount,
+    firstMessageId,
+    lastMessageId,
+    interiorPlacementVersion,
+  })
+  residentRef.current = {
+    conversationId,
+    messageCount,
+    firstMessageId,
+    lastMessageId,
+    interiorPlacementVersion,
+  }
+
+  const readGeometry = (scroller: HTMLElement): ScrollGeometrySample => ({
+    scrollTop: scroller.scrollTop,
+    scrollHeight: scroller.scrollHeight,
+    clientHeight: scroller.clientHeight,
+  })
+
+  const captureInsertionAnchor = useCallback(
+    (scroller: HTMLElement, measuredAnchor?: ScrollAnchor | null) => {
+      const geometry = readGeometry(scroller)
+      insertionGeometryRef.current = geometry
+      if (!insertionAnchorApplies(geometry, AT_BOTTOM_THRESHOLD)) {
+        insertionAnchorRef.current = null
+        return
+      }
+      insertionAnchorRef.current =
+        measuredAnchor === undefined ? findBottomAnchor(scroller) : measuredAnchor
+    },
+    [],
+  )
+
+  const submitPreservation = useCallback(
+    (
+      anchor: ScrollAnchor,
+      reason: AmbientReason,
+      activeConversationId: string,
+      executor: AnchorPreservationExecutor,
+    ) => {
+      runScrollShadowSafely({
+        event:
+          reason === 'divider-mutation'
+            ? 'divider-anchor-preservation'
+            : 'insertion-anchor-preservation',
+        conversationId: activeConversationId,
+        fallback: undefined,
+        observe: () => {
+          const desired: AnchorPreservationRequest['desired'] = {
+            kind: 'anchor',
+            messageId: anchor.messageId,
+            placement: {
+              kind: 'bottom-fraction',
+              fraction: messageFraction(anchor.fraction),
+            },
+          }
+          portsRef.current.beginLayoutPreservation({
+            conversationId: activeConversationId,
+            desired,
+            reason,
+            executor,
+          })
+        },
+      })
+    },
+    [],
+  )
+
+  // Keep a pre-mutation divider anchor while the reader is scrolled up. On the render where the
+  // divider moves, the id mismatch deliberately prevents this effect from replacing the old
+  // geometry with a post-mutation measurement.
+  useLayoutEffect(() => {
+    if (
+      !shouldCaptureDividerAnchor({
+        tracked: dividerTrackingRef.current,
+        conversationId,
+        dividerId: firstNewMessageId,
+        readerScrolledUp: showScrollToBottom,
+      })
+    ) {
+      return
+    }
+    const scroller = portsRef.current.getScroller()
+    if (!scroller) return
+    const anchor = findBottomAnchor(scroller)
+    dividerAnchorRef.current = anchor
+    portsRef.current.recordBottomAnchor(conversationId, anchor)
+  }, [
+    bottomVisibleMessageId,
+    conversationId,
+    firstNewMessageId,
+    showScrollToBottom,
+  ])
+
+  // Divider mutation may correct immediately before paint when no requested navigation owns the
+  // controller; the model rejects it while one is still in flight.
+  useLayoutEffect(() => {
+    const anchor =
+      portsRef.current.getSessionBottomAnchor(conversationId) ??
+      dividerAnchorRef.current
+    const decision = decideDividerMutation({
+      tracked: dividerTrackingRef.current,
+      conversationId,
+      dividerId: firstNewMessageId,
+      readerScrolledUp: showScrollToBottom,
+      hasAnchor: Boolean(anchor),
+    })
+    if (decision.kind === 'unchanged') return
+    if (decision.kind === 'reset') {
+      dividerTrackingRef.current = { conversationId, dividerId: firstNewMessageId }
+      dividerAnchorRef.current = null
+      return
+    }
+    if (decision.kind === 'preserve' && anchor) {
+      submitPreservation(
+        anchor,
+        'divider-mutation',
+        conversationId,
+        createAnchorPreservationExecutor('divider-anchor'),
+      )
+    }
+    dividerTrackingRef.current = { conversationId, dividerId: firstNewMessageId }
+  }, [
+    conversationId,
+    createAnchorPreservationExecutor,
+    firstNewMessageId,
+    showScrollToBottom,
+    submitPreservation,
+  ])
+
+  // No dependency array. The anchor has to survive a virtualizer RE-MEASURE, which re-renders and
+  // moves every row's content offset without changing the message identifiers,
+  // `bottomVisibleMessageId`, or firing a scroll event. See shouldRecaptureInsertionAnchor.
+  useLayoutEffect(() => {
+    if (!residentArrayUnchanged(insertionTrackingRef.current, residentRef.current)) {
+      return
+    }
+    const scroller = portsRef.current.getScroller()
+    if (!scroller) return
+    if (
+      !shouldRecaptureInsertionAnchor({
+        captured: insertionGeometryRef.current,
+        current: readGeometry(scroller),
+      })
+    ) {
+      return
+    }
+    captureInsertionAnchor(scroller)
+  })
+
+  useLayoutEffect(() => {
+    const next: ResidentTrackingState = {
+      conversationId,
+      messageCount,
+      firstMessageId,
+      lastMessageId,
+      interiorPlacementVersion,
+    }
+    // Declared before the directional restore effect, so an in-flight snapshot is still unrestored
+    // here when its load genuinely lands.
+    const decision = decideInsertionMutation({
+      tracked: insertionTrackingRef.current,
+      next,
+      directionalLoadLanding: portsRef.current.isDirectionalLoadLanding(
+        conversationId,
+        firstMessageId ?? '',
+      ),
+      hasAnchor: Boolean(insertionAnchorRef.current),
+    })
+    if (decision.kind === 'reset') {
+      insertionTrackingRef.current = next
+      insertionAnchorRef.current = null
+      insertionGeometryRef.current = null
+      return
+    }
+    const anchor = insertionAnchorRef.current
+    if (decision.kind === 'preserve' && anchor) {
+      submitPreservation(
+        anchor,
+        'message-insertion',
+        conversationId,
+        createAnchorPreservationExecutor('insertion-anchor'),
+      )
+    }
+    insertionTrackingRef.current = next
+  }, [
+    conversationId,
+    createAnchorPreservationExecutor,
+    firstMessageId,
+    interiorPlacementVersion,
+    lastMessageId,
+    messageCount,
+    submitPreservation,
+  ])
+
+  const refreshInsertionAnchorIfStable = useCallback(
+    (scroller: HTMLElement, measuredAnchor: ScrollAnchor | null) => {
+      // The tracked state is the authority here, not a captured render: this runs inside a scroll
+      // event, so it must compare against the newest resident facts.
+      if (!residentArrayUnchanged(insertionTrackingRef.current, residentRef.current)) {
+        return
+      }
+      captureInsertionAnchor(scroller, measuredAnchor)
+    },
+    [captureInsertionAnchor],
+  )
+
+  return { refreshInsertionAnchorIfStable }
+}

--- a/apps/fluux/src/components/conversation/useDirectionalHistoryLoads.test.ts
+++ b/apps/fluux/src/components/conversation/useDirectionalHistoryLoads.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { DirectionalHistoryBrowserAdapter } from './directionalHistoryBrowserAdapter'
+import type { DirectionalHistoryWindowCoordinator } from './directionalHistoryWindowCoordinator'
+import type { DirectionalHistoryExecutor } from './positioningController'
+import {
+  useDirectionalHistoryLoads,
+  type DirectionalHistoryLoadPorts,
+  type UseDirectionalHistoryLoadsInput,
+} from './useDirectionalHistoryLoads'
+
+const snapshot = (overrides: Record<string, unknown> = {}) => ({
+  requestId: 1,
+  conversationId: 'room-a',
+  direction: 'older' as const,
+  anchorMessageId: 'm-5',
+  anchorOffsetFromTop: 120,
+  distanceFromBottom: 900,
+  oldFirstId: 'm-0',
+  oldMessageCount: 200,
+  restored: false,
+  ...overrides,
+})
+
+function harness(input: {
+  available?: boolean
+  beginResult?: unknown
+  requestGeneration?: number | null
+} = {}) {
+  const scheduleSettlement = vi.fn((_callback: () => void) => {})
+  const browser = {
+    isAvailable: () => input.available ?? true,
+    capture: vi.fn(() => ({
+      facts: {
+        anchorMessageId: 'm-5',
+        anchorOffsetFromTop: 120,
+        distanceFromBottom: 900,
+        firstMessageId: 'm-0',
+        messageCount: 200,
+      },
+      anchor: { messageId: 'm-5' },
+      geometry: { scrollTop: 100, scrollHeight: 5_000, clientHeight: 600 },
+    })),
+    scheduleSettlement,
+  } as unknown as DirectionalHistoryBrowserAdapter
+
+  const begin = vi.fn((_input: Record<string, unknown>) =>
+    input.beginResult === undefined
+      ? { kind: 'started', snapshot: snapshot(), clearTravel: false }
+      : input.beginResult,
+  )
+  const invokeLoad = vi.fn(
+    (
+      _saved: unknown,
+      _run: () => unknown,
+      _settle: (requestId: number) => void,
+    ) => {},
+  )
+  const attachGeneration = vi.fn()
+  const releaseSettledWithoutShift = vi.fn(() => ({ kind: 'none' as const }))
+  const coordinator = {
+    begin,
+    invokeLoad,
+    attachGeneration,
+    releaseSettledWithoutShift,
+  } as unknown as DirectionalHistoryWindowCoordinator
+
+  const beginDirectionalHistory = vi.fn(() =>
+    input.requestGeneration === null
+      ? null
+      : { generation: input.requestGeneration ?? 42 },
+  )
+  const cancelWithoutShift = vi.fn()
+  const clearTravel = vi.fn()
+  const hasTravelledAway = vi.fn(() => true)
+
+  // A FRESH ports object per render, exactly as the caller supplies it. Reusing one object would
+  // let a `[ports]` dependency look stable and hide an identity regression.
+  const makePorts = (): DirectionalHistoryLoadPorts => ({
+    getBrowser: () => browser,
+    getCoordinator: () => coordinator,
+    getActiveConversationId: () => 'room-a',
+    getLiveWindow: () => ({ messageCount: 250, firstMessageId: 'older-0' }),
+    hasTravelledAway,
+    clearTravel,
+    buildExecutor: vi.fn(() => ({}) as DirectionalHistoryExecutor),
+    beginDirectionalHistory,
+    cancelWithoutShift,
+    log: vi.fn(),
+  })
+
+  const makeProps = (
+    overrides: Partial<UseDirectionalHistoryLoadsInput> = {},
+  ): UseDirectionalHistoryLoadsInput => ({
+    ports: makePorts(),
+    conversationId: 'room-a',
+    firstMessageId: 'm-0',
+    messageCount: 200,
+    windowAtLiveEdge: false,
+    isLoadingOlder: false,
+    isLoadingNewer: false,
+    isHistoryComplete: false,
+    onScrollToTop: vi.fn(),
+    onLoadNewer: vi.fn(),
+    ...overrides,
+  })
+
+  const rendered = renderHook(
+    (p: UseDirectionalHistoryLoadsInput) => useDirectionalHistoryLoads(p),
+    { initialProps: makeProps() },
+  )
+  return {
+    ...rendered,
+    makeProps,
+    browser,
+    begin,
+    invokeLoad,
+    attachGeneration,
+    releaseSettledWithoutShift,
+    beginDirectionalHistory,
+    cancelWithoutShift,
+    clearTravel,
+    hasTravelledAway,
+    scheduleSettlement,
+  }
+}
+
+describe('useDirectionalHistoryLoads', () => {
+  it('keeps applyReleaseDecision stable so the live-edge effect does not re-fire on appends', () => {
+    const h = harness()
+    const before = h.result.current.applyReleaseDecision
+    h.rerender(h.makeProps({ messageCount: 201, firstMessageId: 'm-1' }))
+    h.rerender(h.makeProps({ messageCount: 202 }))
+    expect(h.result.current.applyReleaseDecision).toBe(before)
+  })
+
+  it('cancels only for a cancel decision', () => {
+    const h = harness()
+    h.result.current.applyReleaseDecision({ kind: 'none' })
+    expect(h.cancelWithoutShift).not.toHaveBeenCalled()
+
+    h.result.current.applyReleaseDecision({
+      kind: 'cancel',
+      generation: 7,
+      snapshot: snapshot(),
+    } as Parameters<typeof h.result.current.applyReleaseDecision>[0])
+    expect(h.cancelWithoutShift).toHaveBeenCalledWith({
+      conversationId: 'room-a',
+      generation: 7,
+    })
+  })
+
+  it('does not consult the coordinator when the browser cannot capture', () => {
+    const h = harness({ available: false })
+    h.result.current.triggerLoadOlder()
+    expect(h.begin).not.toHaveBeenCalled()
+    expect(h.invokeLoad).not.toHaveBeenCalled()
+  })
+
+  it('starts no request and no load when the coordinator blocks', () => {
+    const h = harness({
+      beginResult: { kind: 'blocked', reason: 'recently-restored' },
+    })
+    h.result.current.triggerLoadOlder()
+    expect(h.beginDirectionalHistory).not.toHaveBeenCalled()
+    expect(h.invokeLoad).not.toHaveBeenCalled()
+  })
+
+  it('submits a top-offset anchor request and attaches its generation', () => {
+    const h = harness()
+    h.result.current.triggerLoadOlder()
+
+    expect(h.beginDirectionalHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'room-a',
+        desired: {
+          kind: 'anchor',
+          messageId: 'm-5',
+          placement: { kind: 'top-offset', offsetPx: 120 },
+        },
+        distanceFromBottom: 900,
+      }),
+    )
+    expect(h.attachGeneration).toHaveBeenCalledWith(1, 42)
+    expect(h.invokeLoad).toHaveBeenCalledOnce()
+  })
+
+  it('still runs the load when the controller declines to create a request', () => {
+    // The batch must not be stranded just because positioning is unavailable.
+    const h = harness({ requestGeneration: null })
+    h.result.current.triggerLoadOlder()
+    expect(h.attachGeneration).not.toHaveBeenCalled()
+    expect(h.invokeLoad).toHaveBeenCalledOnce()
+  })
+
+  it('clears the travel latch only when the coordinator asks', () => {
+    const h = harness()
+    h.result.current.triggerLoadOlder()
+    expect(h.clearTravel).not.toHaveBeenCalled()
+
+    const asked = harness({
+      beginResult: { kind: 'started', snapshot: snapshot(), clearTravel: true },
+    })
+    asked.result.current.triggerLoadOlder()
+    expect(asked.clearTravel).toHaveBeenCalledWith('room-a', 'top')
+  })
+
+  it('routes each direction to its own loader, edge and in-flight flag', () => {
+    const h = harness()
+    h.result.current.triggerLoadOlder()
+    expect(h.begin.mock.calls[0][0]).toMatchObject({
+      direction: 'older',
+      mode: 'automatic',
+      loaderAvailable: true,
+      loading: false,
+    })
+    expect(h.hasTravelledAway).toHaveBeenLastCalledWith('room-a', 'top')
+
+    h.begin.mockClear()
+    h.result.current.triggerLoadNewer()
+    expect(h.begin.mock.calls[0][0]).toMatchObject({ direction: 'newer' })
+    expect(h.hasTravelledAway).toHaveBeenLastCalledWith('room-a', 'bottom')
+  })
+
+  it('marks the explicit command so it can bypass the travel requirement', () => {
+    const h = harness()
+    h.result.current.handleLoadEarlier()
+    expect(h.begin.mock.calls[0][0]).toMatchObject({
+      direction: 'older',
+      mode: 'explicit',
+    })
+  })
+
+  it('reports the in-flight loading flag for the requested direction only', () => {
+    const h = harness()
+    h.rerender(h.makeProps({ isLoadingOlder: true }))
+    h.result.current.triggerLoadOlder()
+    expect(h.begin.mock.calls[0][0]).toMatchObject({ loading: true })
+
+    h.begin.mockClear()
+    h.result.current.triggerLoadNewer()
+    expect(h.begin.mock.calls[0][0]).toMatchObject({ loading: false })
+  })
+
+  it('settles against the CURRENT live window, not the one captured at load start', () => {
+    const h = harness()
+    h.result.current.triggerLoadOlder()
+    h.invokeLoad.mock.calls[0][2](1)
+    // scheduleSettlement received the callback; run it as the adapter's frame would.
+    h.scheduleSettlement.mock.calls[0][0]()
+    // A load that shifted the window changes firstMessageId; releasing against a stale value would
+    // cancel a request that actually landed.
+    expect(h.releaseSettledWithoutShift).toHaveBeenCalledWith({
+      requestId: 1,
+      conversationId: 'room-a',
+      firstMessageId: 'older-0',
+    })
+  })
+})

--- a/apps/fluux/src/components/conversation/useDirectionalHistoryLoads.ts
+++ b/apps/fluux/src/components/conversation/useDirectionalHistoryLoads.ts
@@ -1,0 +1,254 @@
+/**
+ * useDirectionalHistoryLoads - starting and settling load-older / load-newer batches
+ *
+ * Eligibility, cooldown, monotonic load identity and no-shift completion are already decided by the
+ * value-only `DirectionalHistoryWindowCoordinator`; visual anchor capture and the pre-paint restore
+ * belong to `DirectionalHistoryBrowserAdapter`. This hook is the wiring between them: it starts a
+ * load, submits the positioning request that will hold the reading position across the window
+ * shift, invokes the caller's loader, and releases the request when a load settles without shifting
+ * the window.
+ *
+ * It owns no eligibility rule and no pixel write of its own.
+ */
+
+import { useCallback, useRef } from 'react'
+import type {
+  DirectionalHistoryBrowserAdapter,
+  DirectionalHistoryBrowserCapture,
+} from './directionalHistoryBrowserAdapter'
+import type {
+  DirectionalHistoryReleaseDecision,
+  DirectionalHistorySnapshot,
+  DirectionalHistoryWindowCoordinator,
+} from './directionalHistoryWindowCoordinator'
+import { runScrollShadowSafely } from './scrollPositionShadow'
+import { pixelOffset } from './scrollPositionModel'
+import type { DirectionalHistoryExecutor } from './positioningController'
+
+export interface DirectionalHistoryLoadPorts {
+  getBrowser: () => DirectionalHistoryBrowserAdapter
+  getCoordinator: () => DirectionalHistoryWindowCoordinator | null
+  getActiveConversationId: () => string
+  /** Live window as of NOW, for the settlement callback that runs a frame later. */
+  getLiveWindow: () => { messageCount: number; firstMessageId: string | undefined }
+  hasTravelledAway: (conversationId: string, edge: 'top' | 'bottom') => boolean
+  clearTravel: (conversationId: string, edge: 'top' | 'bottom') => void
+  buildExecutor: (saved: DirectionalHistorySnapshot) => DirectionalHistoryExecutor
+  beginDirectionalHistory: (input: {
+    conversationId: string
+    desired: {
+      kind: 'anchor'
+      messageId: string
+      placement: { kind: 'top-offset'; offsetPx: ReturnType<typeof pixelOffset> }
+    }
+    distanceFromBottom: ReturnType<typeof pixelOffset>
+    executor: DirectionalHistoryExecutor
+  }) => { generation: number } | null | undefined
+  cancelWithoutShift: (input: {
+    conversationId: string
+    generation: number
+  }) => void
+  log: (action: string, data?: Record<string, unknown>) => void
+}
+
+export interface UseDirectionalHistoryLoadsInput {
+  ports: DirectionalHistoryLoadPorts
+  conversationId: string
+  firstMessageId: string | undefined
+  messageCount: number
+  windowAtLiveEdge: boolean | undefined
+  isLoadingOlder: boolean | undefined
+  isLoadingNewer: boolean | undefined
+  isHistoryComplete: boolean | undefined
+  onScrollToTop: (() => unknown) | undefined
+  onLoadNewer: (() => unknown) | undefined
+}
+
+export interface DirectionalHistoryLoads {
+  /** Boundary-triggered older load (scroll to top, wheel at the top). */
+  triggerLoadOlder: () => void
+  /** Boundary-triggered newer load; the coordinator permits it only in a slid-up window. */
+  triggerLoadNewer: () => void
+  /** Explicit "load earlier messages" command, which bypasses the travel requirement. */
+  handleLoadEarlier: () => void
+  /**
+   * Apply a coordinator release decision. Stable identity: an effect observing the live-edge
+   * transition depends on it.
+   */
+  applyReleaseDecision: (decision: DirectionalHistoryReleaseDecision) => void
+}
+
+export function useDirectionalHistoryLoads({
+  ports,
+  conversationId,
+  firstMessageId,
+  messageCount,
+  windowAtLiveEdge,
+  isLoadingOlder,
+  isLoadingNewer,
+  isHistoryComplete,
+  onScrollToTop,
+  onLoadNewer,
+}: UseDirectionalHistoryLoadsInput): DirectionalHistoryLoads {
+  // Read through a ref so the two stable callbacks below need no dependency on `ports`, which is
+  // supplied fresh each render.
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  const applyReleaseDecision = useCallback(
+    (decision: DirectionalHistoryReleaseDecision) => {
+      if (decision.kind !== 'cancel') return
+      const active = portsRef.current
+      active.log('DIRECTIONAL HISTORY RELEASE (without window shift)', {
+        requestId: decision.snapshot.requestId,
+        oldFirstId: decision.snapshot.oldFirstId,
+        oldMessageCount: decision.snapshot.oldMessageCount,
+        messageCount: active.getLiveWindow().messageCount,
+        generation: decision.generation,
+      })
+      active.cancelWithoutShift({
+        conversationId: decision.snapshot.conversationId,
+        generation: decision.generation,
+      })
+    },
+    // Stable on purpose: the live-edge transition effect depends on this identity.
+    [],
+  )
+
+  const settleAfterFrame = useCallback(
+    (browser: DirectionalHistoryBrowserAdapter, requestId: number) => {
+      browser.scheduleSettlement(() => {
+        const active = portsRef.current
+        applyReleaseDecision(
+          active.getCoordinator()?.releaseSettledWithoutShift({
+            requestId,
+            conversationId: active.getActiveConversationId(),
+            firstMessageId: active.getLiveWindow().firstMessageId ?? '',
+          }) ?? { kind: 'none' },
+        )
+      })
+    },
+    [applyReleaseDecision],
+  )
+
+  const beginLoad = (
+    direction: 'older' | 'newer',
+    mode: 'automatic' | 'explicit',
+  ): {
+    saved: DirectionalHistorySnapshot
+    capture: DirectionalHistoryBrowserCapture | null
+  } | null => {
+    const browser = ports.getBrowser()
+    if (!browser.isAvailable()) return null
+    let capture: DirectionalHistoryBrowserCapture | null = null
+    const edge = direction === 'older' ? 'top' : 'bottom'
+    const result = ports.getCoordinator()?.begin({
+      conversationId,
+      direction,
+      mode,
+      now: Date.now(),
+      loaderAvailable:
+        direction === 'older' ? Boolean(onScrollToTop) : Boolean(onLoadNewer),
+      loading:
+        direction === 'older' ? Boolean(isLoadingOlder) : Boolean(isLoadingNewer),
+      historyComplete: Boolean(isHistoryComplete),
+      windowAtLiveEdge: windowAtLiveEdge !== false,
+      travelledAway: ports.hasTravelledAway(conversationId, edge),
+      capture: () => {
+        capture = browser.capture(firstMessageId ?? '', messageCount)
+        return capture?.facts ?? {
+          anchorMessageId: '',
+          anchorOffsetFromTop: 0,
+          distanceFromBottom: 0,
+          firstMessageId: firstMessageId ?? '',
+          messageCount,
+        }
+      },
+    })
+    if (!result || result.kind === 'blocked') {
+      if (result?.reason === 'recently-restored') {
+        ports.log('LOAD BLOCKED (recently restored)')
+      }
+      return null
+    }
+    if (result.clearTravel) ports.clearTravel(conversationId, edge)
+
+    const saved = result.snapshot
+    const request = runScrollShadowSafely({
+      event: 'directional-history-capture',
+      conversationId,
+      fallback: null,
+      observe: () => ports.beginDirectionalHistory({
+        conversationId,
+        desired: {
+          kind: 'anchor',
+          messageId: saved.anchorMessageId,
+          placement: {
+            kind: 'top-offset',
+            offsetPx: pixelOffset(saved.anchorOffsetFromTop),
+          },
+        },
+        distanceFromBottom: pixelOffset(saved.distanceFromBottom),
+        executor: ports.buildExecutor(saved),
+      }) ?? null,
+    })
+    if (request) {
+      ports.getCoordinator()?.attachGeneration(saved.requestId, request.generation)
+    }
+    return { saved, capture }
+  }
+
+  const runLoad = (saved: DirectionalHistorySnapshot, run: () => unknown): void => {
+    const browser = ports.getBrowser()
+    ports.getCoordinator()?.invokeLoad(saved, run, (requestId) =>
+      settleAfterFrame(browser, requestId),
+    )
+  }
+
+  const logStart = (
+    label: string,
+    saved: DirectionalHistorySnapshot,
+    capture: DirectionalHistoryBrowserCapture | null,
+  ) => {
+    ports.log(label, {
+      anchor: capture?.anchor ?? null,
+      distanceFromBottom: saved.distanceFromBottom,
+      scrollHeight: capture?.geometry.scrollHeight,
+      scrollTop: capture?.geometry.scrollTop,
+      clientHeight: capture?.geometry.clientHeight,
+      firstMessageId,
+      messageCount,
+    })
+  }
+
+  const triggerLoadOlder = () => {
+    const started = beginLoad('older', 'automatic')
+    if (!started) return
+    logStart('PREPEND START', started.saved, started.capture)
+    runLoad(started.saved, () => onScrollToTop?.())
+  }
+
+  // Loading newer APPENDS a batch and EVICTS the oldest (opposite end), so it shifts every offset
+  // up; the same anchor prepend uses holds the viewport steady. The evicted rows are the OLDEST —
+  // far above the viewport — so the top-visible anchor survives, making the restore
+  // direction-agnostic.
+  const triggerLoadNewer = () => {
+    const started = beginLoad('newer', 'automatic')
+    if (!started) return
+    runLoad(started.saved, () => onLoadNewer?.())
+  }
+
+  const handleLoadEarlier = () => {
+    const started = beginLoad('older', 'explicit')
+    if (!started) return
+    logStart('LOAD EARLIER', started.saved, started.capture)
+    runLoad(started.saved, () => onScrollToTop?.())
+  }
+
+  return {
+    triggerLoadOlder,
+    triggerLoadNewer,
+    handleLoadEarlier,
+    applyReleaseDecision,
+  }
+}

--- a/apps/fluux/src/components/conversation/useMediaGrowthPreservation.ts
+++ b/apps/fluux/src/components/conversation/useMediaGrowthPreservation.ts
@@ -1,0 +1,200 @@
+/**
+ * useMediaGrowthPreservation - one scroll correction per media-load batch
+ *
+ * Images, videos and link previews change content height when they decode. A batch captures the
+ * reader's intent at its START — at the live edge, or reading at a particular anchor — resets a
+ * debounce on every subsequent load, and applies exactly one correction once decoding quiesces.
+ * Without the batch a run of images produces a run of scroll writes, which is visible as jitter.
+ *
+ * The hook owns the snapshot and the timer. What a settled batch should do is a pure function in
+ * `mediaGrowthDecisions`.
+ */
+
+import { useCallback, useRef } from 'react'
+import type { ScrollAnchor } from '@/utils/scrollStateManager'
+import { findBottomAnchor } from './bottomAnchor'
+import {
+  decideMediaBatchOutcome,
+  isGenuineScrollDuringBatch,
+} from './mediaGrowthDecisions'
+import { runScrollShadowSafely } from './scrollPositionShadow'
+import { messageFraction, type AnchorPreservationRequest } from './scrollPositionModel'
+import type { AnchorPreservationExecutor } from './positioningController'
+
+/** Debounce window for batching media load events. */
+export const MEDIA_LOAD_DEBOUNCE_MS = 150
+
+interface MediaBatchSnapshot {
+  wasAtBottom: boolean
+  userScrolled: boolean
+  anchor: ScrollAnchor | null
+}
+
+export interface MediaGrowthPorts {
+  getScroller: () => HTMLElement | null
+  isAtBottom: () => boolean
+  reconcileLiveEdge: (trigger: string) => void
+  beginMediaPreservation: (input: {
+    conversationId: string
+    desired: AnchorPreservationRequest['desired']
+    executor: AnchorPreservationExecutor
+  }) => void
+  log: (action: string, data?: Record<string, unknown>) => void
+}
+
+export interface UseMediaGrowthPreservationInput {
+  ports: MediaGrowthPorts
+  conversationId: string
+  /** Identity churns with the live window; kept in the callback dependencies deliberately. */
+  createAnchorPreservationExecutor: (
+    loopLabel: 'media-anchor',
+  ) => AnchorPreservationExecutor
+}
+
+export interface MediaGrowthPreservation {
+  /** A media element finished decoding. Starts or extends the current batch. */
+  handleMediaLoad: () => void
+  /** True while a batch is open; the content observer defers to the debounced correction. */
+  isBatchActive: () => boolean
+  /**
+   * Feed a scroll observation to the open batch. Only a genuine reader move counts — media growth
+   * fires scroll events of its own.
+   */
+  observeScroll: (input: {
+    controllerOwnsPixels: boolean
+    previousScrollHeight: number | null | undefined
+    scrollHeight: number
+  }) => void
+  /** Conversation switch or unmount: drop the batch and its pending timer. */
+  cancelBatch: () => void
+}
+
+export function useMediaGrowthPreservation({
+  ports,
+  conversationId,
+  createAnchorPreservationExecutor,
+}: UseMediaGrowthPreservationInput): MediaGrowthPreservation {
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  const snapshotRef = useRef<MediaBatchSnapshot | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelBatch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    snapshotRef.current = null
+  }, [])
+
+  const isBatchActive = useCallback(() => snapshotRef.current !== null, [])
+
+  const observeScroll = useCallback(
+    (input: {
+      controllerOwnsPixels: boolean
+      previousScrollHeight: number | null | undefined
+      scrollHeight: number
+    }) => {
+      const snapshot = snapshotRef.current
+      if (!snapshot) return
+      if (
+        isGenuineScrollDuringBatch({
+          batchActive: true,
+          controllerOwnsPixels: input.controllerOwnsPixels,
+          previousScrollHeight: input.previousScrollHeight,
+          scrollHeight: input.scrollHeight,
+        })
+      ) {
+        snapshot.userScrolled = true
+      }
+    },
+    [],
+  )
+
+  const handleMediaLoad = useCallback(() => {
+    const active = portsRef.current
+    const scroller = active.getScroller()
+    if (!scroller) return
+
+    // Capture on the first load in the batch (the reader's intent at its start). The anchor is taken
+    // BEFORE the media grows the layout, so a scrolled-up reader can be re-pinned once it settles:
+    // media above the viewport would otherwise push their position down and out of view.
+    if (!snapshotRef.current) {
+      snapshotRef.current = {
+        wasAtBottom: active.isAtBottom(),
+        userScrolled: false,
+        anchor: findBottomAnchor(scroller),
+      }
+      active.log('MEDIA LOAD: batch started', {
+        wasAtBottom: snapshotRef.current.wasAtBottom,
+        scrollTop: scroller.scrollTop,
+        scrollHeight: scroller.scrollHeight,
+      })
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    debounceRef.current = setTimeout(() => {
+      const settled = portsRef.current
+      const currentScroller = settled.getScroller()
+      const snapshot = snapshotRef.current
+      if (!currentScroller || !snapshot) return
+
+      const { wasAtBottom, userScrolled, anchor } = snapshot
+      const outcome = decideMediaBatchOutcome({
+        wasAtBottom,
+        userScrolled,
+        hasAnchor: Boolean(anchor),
+      })
+
+      if (outcome.kind === 'live-edge') {
+        settled.log('MEDIA LOAD: batch complete, scrolling to bottom', {
+          wasAtBottom,
+          userScrolled,
+          scrollHeight: currentScroller.scrollHeight,
+        })
+        settled.reconcileLiveEdge('media-load')
+      } else if (outcome.kind === 'preserve-anchor' && anchor) {
+        // Media that decoded ABOVE the viewport grew the content and pushed the reading position
+        // down. Re-pin to the anchor captured BEFORE the growth so the reader stays put. Mirrors
+        // live-edge reconciliation, but for a held position.
+        runScrollShadowSafely({
+          event: 'media-preservation',
+          conversationId,
+          fallback: undefined,
+          observe: () => {
+            const desired: AnchorPreservationRequest['desired'] = {
+              kind: 'anchor',
+              messageId: anchor.messageId,
+              placement: {
+                kind: 'bottom-fraction',
+                fraction: messageFraction(anchor.fraction),
+              },
+            }
+            settled.beginMediaPreservation({
+              conversationId,
+              desired,
+              executor: createAnchorPreservationExecutor('media-anchor'),
+            })
+          },
+        })
+        settled.log('MEDIA LOAD: batch complete, re-anchoring scrolled-up position', {
+          wasAtBottom,
+          anchorId: anchor.messageId,
+        })
+      } else {
+        settled.log('MEDIA LOAD: batch complete, no correction', {
+          wasAtBottom,
+          userScrolled,
+          outcome: outcome.kind,
+        })
+      }
+
+      snapshotRef.current = null
+      debounceRef.current = null
+    }, MEDIA_LOAD_DEBOUNCE_MS)
+  }, [conversationId, createAnchorPreservationExecutor])
+
+  return { handleMediaLoad, isBatchActive, observeScroll, cancelBatch }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -18,12 +18,26 @@
  */
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
-import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
 // Still used by the composer/container resize observer below, a separate owner from the content
 // observer that moved into useScrollContainerBinding.
 import { createResizeLoopMonitor } from './resizeLoopMonitor'
 import type { ControllerFrameLoopRegistration } from './controllerFrameLoop'
 import { useScrollContainerBinding } from './useScrollContainerBinding'
+import { useAmbientAnchorPreservation } from './useAmbientAnchorPreservation'
+import { useMediaGrowthPreservation } from './useMediaGrowthPreservation'
+import { useDirectionalHistoryLoads } from './useDirectionalHistoryLoads'
+import {
+  arbitrateEntry,
+  shouldSupersedeWithLateSyncedLiveEdge,
+} from './entryArbitration'
+import {
+  decideMarkerClear,
+  isMarkerAboveViewport,
+  planScrollEvent,
+  planWheelEvent,
+} from './scrollEventDecisions'
+import { findBottomAnchor } from './bottomAnchor'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
 import { signalAnomaly } from '@/utils/anomalySignal'
@@ -32,15 +46,7 @@ import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 import { ViewportSession } from './viewportSession'
 import { ScrollPersistenceAdapter } from './scrollPersistenceAdapter'
-import {
-  DirectionalHistoryWindowCoordinator,
-  type DirectionalHistoryReleaseDecision,
-  type DirectionalHistorySnapshot,
-} from './directionalHistoryWindowCoordinator'
-import type {
-  DirectionalHistoryBrowserAdapter,
-  DirectionalHistoryBrowserCapture,
-} from './directionalHistoryBrowserAdapter'
+import { DirectionalHistoryWindowCoordinator } from './directionalHistoryWindowCoordinator'
 import { TARGET_HIGHLIGHT_MS } from './explicitTargetBrowserAdapter'
 import { BOTTOM_PIN_TOLERANCE } from './liveEdgeBrowserAdapter'
 import { useScrollExecutors } from './useScrollExecutors'
@@ -53,9 +59,6 @@ import {
   readScrollGeometry,
 } from './scrollPositionFacts'
 import {
-  messageFraction,
-  pixelOffset,
-  type AnchorPreservationRequest,
   type DesiredPosition,
   type ExplicitTargetRequest,
   type ReachabilityFacts,
@@ -114,7 +117,6 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 // AT_BOTTOM_THRESHOLD is imported from scrollStateManager (shared with wasAtBottom persistence).
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
-const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
 // BOTTOM_PIN_TOLERANCE is imported from liveEdgeBrowserAdapter, which owns bottom-pin geometry.
 
 /**
@@ -140,53 +142,6 @@ function useStableCallback<Args extends unknown[]>(
 // ANCHOR HELPERS (content-stable scroll restoration)
 // ============================================================================
 
-const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
-
-/**
- * Capture a CONTENT anchor: the bottom-most visible message and the FRACTION (0..1) of its
- * height at which the viewport bottom sits. fraction=1 → the message's bottom edge is at the
- * window bottom; 0.5 → the window bottom cuts its middle.
- *
- * Storing a fraction (not a pixel gap) makes the position INDEPENDENT OF RENDERING: on return we
- * re-derive pixels from the message's CURRENT measured height, so a re-measure, a width change, or
- * a virtualization re-window can't corrupt it. The previous implementation stored a pixel gap found
- * via a BINARY SEARCH over `offsetTop` assuming rows were in sorted document order — false under
- * virtualization (the DOM holds an unsorted/stale window), which produced a wildly wrong gap and
- * flung the view to the bottom on return. This is a linear max-scan over the (small) rendered
- * window using each row's own `offsetTop`/`offsetHeight`, so DOM order no longer matters.
- */
-function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
-  const rows = scroller.querySelectorAll('.message-row[data-message-id]')
-  if (rows.length === 0) return null
-  // Measure with getBoundingClientRect (relative to the scroller), NOT offsetTop. Under
-  // virtualization each `.message-row` sits inside its own `position:absolute` `[data-index]`
-  // wrapper, which is the row's offsetParent — so `offsetTop` is ~0 for EVERY row and the old
-  // "greatest offsetTop" pick always returned the top-most MOUNTED row instead of the bottom-most
-  // visible one. That wrong anchor was saved/restored (masked by consistency-only tests) and is a
-  // root cause of the conversation-switch "drifts back in time" report. Bounding rects reflect the
-  // real on-screen position for both the virtualized and the normal-flow paths.
-  const sTop = scroller.getBoundingClientRect().top
-  const viewportH = scroller.clientHeight
-  // Bottom-most row whose TOP is still within the viewport (greatest scroller-relative top < height).
-  let best: HTMLElement | null = null
-  let bestTop = -Infinity
-  for (const node of rows) {
-    const el = node as HTMLElement
-    if (el.offsetHeight <= 0) continue
-    const top = el.getBoundingClientRect().top - sTop
-    if (top < viewportH && top > bestTop) {
-      best = el
-      bestTop = top
-    }
-  }
-  if (best === null) best = rows[rows.length - 1] as HTMLElement
-  const messageId = best.dataset.messageId
-  if (!messageId) return null
-  const rect = best.getBoundingClientRect()
-  const height = rect.height || 1
-  const topRel = rect.top - sTop
-  return { messageId, fraction: clamp01((viewportH - topRel) / height) }
-}
 
 // ============================================================================
 // TYPES
@@ -491,34 +446,9 @@ export function useMessageListScroll({
   // Media load batching (for images, videos, link previews)
   // When multiple media elements load in quick succession, we batch them and apply
   // a single scroll correction at the end to avoid jitter.
-  const mediaLoadSnapshotRef = useRef<{ wasAtBottom: boolean; userScrolled: boolean; anchor: ScrollAnchor | null } | null>(null)
-  const mediaLoadDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Divider movement is an ambient layout mutation, not a navigation command. Keep its last
-  // pre-mutation anchor inside the scroll owner so restoration can share the controller lease.
-  const dividerAnchorRef = useRef<ScrollAnchor | null>(null)
-  const dividerTrackingRef = useRef({
-    conversationId,
-    dividerId: firstNewMessageId,
-  })
-
-  // A mid-array message insertion is the same shape of ambient layout mutation as a divider move,
-  // so it keeps its own pre-mutation anchor on the same terms. Tracked by BOTH ends of the resident
-  // array, not by count: at the resident bound `appendLive` trims the oldest row as it inserts, so
-  // the count does not change and only the first id moves.
-  const insertionAnchorRef = useRef<ScrollAnchor | null>(null)
-  const insertionGeometryRef = useRef<{
-    scrollTop: number
-    scrollHeight: number
-    clientHeight: number
-  } | null>(null)
-  const insertionTrackingRef = useRef({
-    conversationId,
-    messageCount,
-    firstMessageId,
-    lastMessageId,
-    interiorPlacementVersion,
-  })
+  // Divider movement and mid-array insertion are ambient layout mutations, not navigation commands.
+  // Their pre-mutation anchors and tracking live in useAmbientAnchorPreservation.
 
   // Track whether user has scrolled at least once since the marker was set.
   // Prevents the marker from being cleared immediately on initial load/scroll-to-marker.
@@ -594,36 +524,6 @@ export function useMessageListScroll({
   const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround })
   useEffect(() => {
     latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround }
-  })
-
-  const {
-    setScrollContainerRef,
-    setContentRef,
-    teardownContentObserver,
-    detachUserInputListeners,
-  } = useScrollContainerBinding({
-    setScroller: (el) => {
-      scrollerRef.current = el
-      const external = latestRef.current.externalScrollerRef
-      if (external) {
-        (external as React.MutableRefObject<HTMLElement | null>).current = el
-      }
-    },
-    getScroller: () => scrollerRef.current,
-    getVirtualizer: () => latestRef.current.virtualizer,
-    isStaticMode: () => latestRef.current.staticMode,
-    isAtBottom: () => latestRef.current.isAtBottomRef.current,
-    getActiveConversationId: () => activeConversationIdRef.current,
-    getLoggedConversationId: () => latestRef.current.conversationId,
-    isDirectionalHistoryPending: (id) =>
-      positioningControllerRef.current?.isDirectionalHistoryPending(id) ?? false,
-    isMediaLoadBatchActive: () => mediaLoadSnapshotRef.current !== null,
-    reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
-    recordUserInput: (id, at) =>
-      viewportSessionRef.current?.recordUserInput(id, at),
-    observeUserInput: (id) =>
-      positioningControllerRef.current?.observeUserInput(id),
-    log: debugLog,
   })
 
   // Executor construction is delegated to useScrollExecutors. Its factory identities intentionally
@@ -707,219 +607,31 @@ export function useMessageListScroll({
     rememberBottomIntent()
   }, [rememberBottomIntent])
 
-  // Keep a pre-mutation divider anchor while the reader is scrolled up. On the render where the
-  // divider moves, the id mismatch deliberately prevents this effect from replacing the old
-  // geometry with a post-mutation measurement.
-  useLayoutEffect(() => {
-    const tracked = dividerTrackingRef.current
-    if (
-      tracked.conversationId !== conversationId ||
-      tracked.dividerId !== firstNewMessageId ||
-      !showScrollToBottom
-    ) {
-      return
-    }
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const anchor = findBottomAnchor(scroller)
-    dividerAnchorRef.current = anchor
-    viewportSessionRef.current?.recordBottomAnchor(conversationId, anchor)
-  }, [
-    bottomVisibleMessageId,
-    conversationId,
-    firstNewMessageId,
-    showScrollToBottom,
-  ])
-
-  // Divider mutation is ambient layout preservation. It may correct immediately before paint when
-  // no requested navigation owns the controller, but the model rejects it while an entry restore,
-  // explicit target, Home/End command, or other active positioning request is still in flight.
-  useLayoutEffect(() => {
-    const tracked = dividerTrackingRef.current
-    if (tracked.conversationId !== conversationId) {
-      dividerTrackingRef.current = {
-        conversationId,
-        dividerId: firstNewMessageId,
-      }
-      dividerAnchorRef.current = null
-      return
-    }
-    if (tracked.dividerId === firstNewMessageId) return
-
-    const anchor =
-      viewportSessionRef.current?.snapshotFor(conversationId)?.bottomAnchor ??
-      dividerAnchorRef.current
-    if (showScrollToBottom && anchor) {
-      runScrollShadowSafely({
-        event: 'divider-anchor-preservation',
-        conversationId,
-        fallback: undefined,
-        observe: () => {
-          const desired: AnchorPreservationRequest['desired'] = {
-            kind: 'anchor',
-            messageId: anchor.messageId,
-            placement: {
-              kind: 'bottom-fraction',
-              fraction: messageFraction(anchor.fraction),
-            },
-          }
-          positioningControllerRef.current?.beginLayoutPreservation({
-            conversationId,
-            desired,
-            reason: 'divider-mutation',
-            executor: createAnchorPreservationExecutor('divider-anchor'),
-          })
-        },
-      })
-    }
-    dividerTrackingRef.current = {
-      conversationId,
-      dividerId: firstNewMessageId,
-    }
-  }, [
-    conversationId,
-    createAnchorPreservationExecutor,
-    firstNewMessageId,
-    showScrollToBottom,
-  ])
-
-  const refreshInsertionAnchor = useCallback(
-    (scroller: HTMLElement, measuredAnchor?: ScrollAnchor | null) => {
-      const { scrollTop, scrollHeight, clientHeight } = scroller
-      insertionGeometryRef.current = { scrollTop, scrollHeight, clientHeight }
-      if (scrollHeight - scrollTop - clientHeight < AT_BOTTOM_THRESHOLD) {
-        insertionAnchorRef.current = null
-        return
-      }
-      const anchor =
-        measuredAnchor === undefined ? findBottomAnchor(scroller) : measuredAnchor
-      insertionAnchorRef.current = anchor
+  // Ambient layout preservation for divider movement and mid-array insertion. It owns the
+  // pre-mutation anchors and their tracking; every branch decision is a pure function in
+  // ambientAnchorDecisions.
+  const { refreshInsertionAnchorIfStable } = useAmbientAnchorPreservation({
+    ports: {
+      getScroller: () => scrollerRef.current,
+      getSessionBottomAnchor: (id) =>
+        viewportSessionRef.current?.snapshotFor(id)?.bottomAnchor,
+      recordBottomAnchor: (id, anchor) =>
+        viewportSessionRef.current?.recordBottomAnchor(id, anchor),
+      isDirectionalLoadLanding: (id, first) =>
+        directionalWindowRef.current?.isPendingWindowShift(id, first) ?? false,
+      beginLayoutPreservation: (input) =>
+        positioningControllerRef.current?.beginLayoutPreservation(input),
     },
-    [],
-  )
-
-  // Keep a pre-mutation insertion anchor while the reader is scrolled up, on the same terms as the
-  // divider anchor above: on the render where the resident array mutates, the mismatch below stops
-  // this effect replacing the old geometry with a post-mutation measurement.
-  //
-  // No dependency array. The anchor has to survive a virtualizer RE-MEASURE, which re-renders and
-  // moves every row's content offset without changing the message identifiers, `bottomVisibleMessageId`,
-  // or firing a scroll event — keyed on any of those the snapshot silently ages out and the restore
-  // lands on geometry the reader already left. `findBottomAnchor` is a per-row measurement scan, so
-  // it is gated on the two cheap scalar reads that between them cover every way the geometry can
-  // move: `scrollTop` (the reader scrolled) and `scrollHeight` (rows re-measured, viewport resized).
-  useLayoutEffect(() => {
-    const tracked = insertionTrackingRef.current
-    if (
-      tracked.conversationId !== conversationId ||
-      tracked.messageCount !== messageCount ||
-      tracked.firstMessageId !== firstMessageId ||
-      tracked.lastMessageId !== lastMessageId ||
-      tracked.interiorPlacementVersion !== interiorPlacementVersion
-    ) {
-      return
-    }
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const { scrollTop, scrollHeight, clientHeight } = scroller
-    const geometry = insertionGeometryRef.current
-    if (
-      geometry &&
-      geometry.scrollTop === scrollTop &&
-      geometry.scrollHeight === scrollHeight &&
-      geometry.clientHeight === clientHeight
-    ) {
-      return
-    }
-    refreshInsertionAnchor(scroller)
-  })
-
-  // A delayed arrival — offline replay, gateway/MUC history, the MAM `{ids}` fetch — reaches the
-  // LIVE path carrying an OLD timestamp, so `appendLive` sorts it into the MIDDLE of the resident
-  // array. Landing above a scrolled-up reader it pushes the reading position down by the inserted
-  // height: the reader drifts backwards in time.
-  //
-  // Nothing else covers it. The media-growth compensation is reachable only from `onMediaLoad` and
-  // an insertion fires no media event; the new-message effect deliberately does nothing for an
-  // incoming message while scrolled up; and browser-native CSS scroll anchoring — which does handle
-  // this in normal flow — is inert under virtualization, because the virtualizer rewrites every
-  // row's inline `top` on each commit, and WebKit does not implement it at all.
-  //
-  // Like divider movement this is ambient layout preservation, NOT navigation: it goes through the
-  // same request source, so the model rejects it while an entry restore, explicit target, or
-  // Home/End command is still in flight rather than superseding what the reader asked for.
-  useLayoutEffect(() => {
-    const tracked = insertionTrackingRef.current
-    const next = {
-      conversationId,
-      messageCount,
-      firstMessageId,
-      lastMessageId,
-      interiorPlacementVersion,
-    }
-    if (tracked.conversationId !== conversationId) {
-      insertionTrackingRef.current = next
-      insertionAnchorRef.current = null
-      insertionGeometryRef.current = null
-      return
-    }
-
-    // A live-edge arrival moves the LAST row: the reader is scrolled up, so content added below
-    // cannot move them, and the bottom-pin loop owns that case when they are at the bottom.
-    const bottomMoved = tracked.lastMessageId !== lastMessageId
-    // A load-older/load-newer batch also changes the resident array without moving the bottom row,
-    // and owns its own directional-history restore, which must not be fought here. It is
-    // distinguished by an in-flight snapshot that is landing in THIS commit — not merely by a
-    // first-id change, because at the resident bound an insertion evicts the oldest row and so
-    // moves the first id too. This effect is declared before the directional restore effect, so
-    // the snapshot is still unrestored here when its load genuinely lands.
-    const directionalLoad =
-      directionalWindowRef.current?.isPendingWindowShift(
-        conversationId,
-        firstMessageId ?? '',
-      ) ?? false
-    const residentChanged =
-      tracked.messageCount !== messageCount || tracked.firstMessageId !== firstMessageId
-
-    const anchor = insertionAnchorRef.current
-    const interiorPlacementAdvanced =
-      interiorPlacementVersion > tracked.interiorPlacementVersion
-    const inserted =
-      !directionalLoad &&
-      (interiorPlacementAdvanced || (residentChanged && !bottomMoved))
-
-    if (inserted && anchor) {
-      runScrollShadowSafely({
-        event: 'insertion-anchor-preservation',
-        conversationId,
-        fallback: undefined,
-        observe: () => {
-          const desired: AnchorPreservationRequest['desired'] = {
-            kind: 'anchor',
-            messageId: anchor.messageId,
-            placement: {
-              kind: 'bottom-fraction',
-              fraction: messageFraction(anchor.fraction),
-            },
-          }
-          positioningControllerRef.current?.beginLayoutPreservation({
-            conversationId,
-            desired,
-            reason: 'message-insertion',
-            executor: createAnchorPreservationExecutor('insertion-anchor'),
-          })
-        },
-      })
-    }
-    insertionTrackingRef.current = next
-  }, [
     conversationId,
-    createAnchorPreservationExecutor,
-    firstMessageId,
-    interiorPlacementVersion,
-    lastMessageId,
+    firstNewMessageId,
+    showScrollToBottom,
+    bottomVisibleMessageId,
     messageCount,
-  ])
+    firstMessageId,
+    lastMessageId,
+    interiorPlacementVersion,
+    createAnchorPreservationExecutor,
+  })
 
   const requestMessageTargetImpl = useCallback((messageReference: string) => {
     if (staticMode) {
@@ -1093,288 +805,94 @@ export function useMessageListScroll({
   // LOAD OLDER MESSAGES
   // ==========================================================================
 
-  const applyDirectionalReleaseDecision = useCallback(
-    (decision: DirectionalHistoryReleaseDecision) => {
-      if (decision.kind !== 'cancel') return
-      debugLog('DIRECTIONAL HISTORY RELEASE (without window shift)', {
-        requestId: decision.snapshot.requestId,
-        oldFirstId: decision.snapshot.oldFirstId,
-        oldMessageCount: decision.snapshot.oldMessageCount,
-        messageCount: liveWindowRef.current.messageCount,
-        generation: decision.generation,
-      })
-      positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
-        conversationId: decision.snapshot.conversationId,
-        generation: decision.generation,
-      })
+  const {
+    triggerLoadOlder,
+    triggerLoadNewer,
+    handleLoadEarlier,
+    applyReleaseDecision: applyDirectionalReleaseDecision,
+  } = useDirectionalHistoryLoads({
+    ports: {
+      getBrowser: getDirectionalHistoryBrowser,
+      getCoordinator: () => directionalWindowRef.current,
+      getActiveConversationId: () => activeConversationIdRef.current,
+      getLiveWindow: () => liveWindowRef.current,
+      hasTravelledAway: (id, edge) =>
+        viewportSessionRef.current?.hasTravelledAway(id, edge) ?? false,
+      clearTravel: (id, edge) =>
+        viewportSessionRef.current?.clearTravel(id, edge),
+      buildExecutor: buildDirectionalHistoryExecutor,
+      beginDirectionalHistory: (input) =>
+        positioningControllerRef.current?.beginDirectionalHistory(input),
+      cancelWithoutShift: (input) =>
+        positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift(input),
+      log: debugLog,
     },
-    [],
-  )
-
-  const settleDirectionalHistoryAfterFrame = useCallback(
-    (browser: DirectionalHistoryBrowserAdapter, requestId: number) => {
-      browser.scheduleSettlement(() => {
-        const activeConversationId = activeConversationIdRef.current
-        applyDirectionalReleaseDecision(
-          directionalWindowRef.current?.releaseSettledWithoutShift({
-            requestId,
-            conversationId: activeConversationId,
-            firstMessageId: liveWindowRef.current.firstMessageId ?? '',
-          }) ?? { kind: 'none' },
-        )
-      })
-    },
-    [applyDirectionalReleaseDecision],
-  )
-
-  const beginDirectionalHistoryLoad = (
-    direction: 'older' | 'newer',
-    mode: 'automatic' | 'explicit',
-  ): {
-    saved: DirectionalHistorySnapshot
-    capture: DirectionalHistoryBrowserCapture | null
-  } | null => {
-    const browser = getDirectionalHistoryBrowser()
-    if (!browser.isAvailable()) return null
-    let capture: DirectionalHistoryBrowserCapture | null = null
-    const result = directionalWindowRef.current?.begin({
-      conversationId,
-      direction,
-      mode,
-      now: Date.now(),
-      loaderAvailable:
-        direction === 'older' ? Boolean(onScrollToTop) : Boolean(onLoadNewer),
-      loading:
-        direction === 'older' ? Boolean(isLoadingOlder) : Boolean(isLoadingNewer),
-      historyComplete: Boolean(isHistoryComplete),
-      windowAtLiveEdge: windowAtLiveEdge !== false,
-      travelledAway:
-        viewportSessionRef.current?.hasTravelledAway(
-          conversationId,
-          direction === 'older' ? 'top' : 'bottom',
-        ) ?? false,
-      capture: () => {
-        capture = browser.capture(firstMessageId ?? '', messageCount)
-        return capture?.facts ?? {
-          anchorMessageId: '',
-          anchorOffsetFromTop: 0,
-          distanceFromBottom: 0,
-          firstMessageId: firstMessageId ?? '',
-          messageCount,
-        }
-      },
-    })
-    if (!result || result.kind === 'blocked') {
-      if (result?.reason === 'recently-restored') {
-        debugLog('LOAD BLOCKED (recently restored)')
-      }
-      return null
-    }
-    if (result.clearTravel) {
-      viewportSessionRef.current?.clearTravel(
-        conversationId,
-        direction === 'older' ? 'top' : 'bottom',
-      )
-    }
-    const saved = result.snapshot
-    const request = runScrollShadowSafely({
-      event: 'directional-history-capture',
-      conversationId,
-      fallback: null,
-      observe: () => positioningControllerRef.current?.beginDirectionalHistory({
-        conversationId,
-        desired: {
-          kind: 'anchor',
-          messageId: saved.anchorMessageId,
-          placement: {
-            kind: 'top-offset',
-            offsetPx: pixelOffset(saved.anchorOffsetFromTop),
-          },
-        },
-        distanceFromBottom: pixelOffset(saved.distanceFromBottom),
-        executor: buildDirectionalHistoryExecutor(saved),
-      }) ?? null,
-    })
-    if (request) {
-      directionalWindowRef.current?.attachGeneration(
-        saved.requestId,
-        request.generation,
-      )
-    }
-    return { saved, capture }
-  }
-
-  const runDirectionalHistoryLoad = (
-    saved: DirectionalHistorySnapshot,
-    run: () => unknown,
-  ): void => {
-    const browser = getDirectionalHistoryBrowser()
-    directionalWindowRef.current?.invokeLoad(
-      saved,
-      run,
-      (requestId) => settleDirectionalHistoryAfterFrame(browser, requestId),
-    )
-  }
-
-  const triggerLoadOlder = () => {
-    const started = beginDirectionalHistoryLoad('older', 'automatic')
-    if (!started) return
-    const { saved, capture } = started
-
-    debugLog('PREPEND START', {
-      anchor: capture?.anchor ?? null,
-      distanceFromBottom: saved.distanceFromBottom,
-      scrollHeight: capture?.geometry.scrollHeight,
-      scrollTop: capture?.geometry.scrollTop,
-      clientHeight: capture?.geometry.clientHeight,
-      firstMessageId,
-      messageCount,
-    })
-
-    runDirectionalHistoryLoad(saved, () => onScrollToTop?.())
-  }
-
-  // Sliding window: mirror of triggerLoadOlder for the newer direction. The coordinator permits it
-  // only when the reader is in a slid-up window. Loading newer APPENDS a batch and EVICTS the
-  // oldest (opposite end), so it shifts every
-  // offset up; we save the same anchor prepend uses and let the shared restore effect hold the
-  // viewport steady. The evicted rows are the OLDEST — far above the viewport — so the top-visible
-  // anchor survives, making the anchor-based restore direction-agnostic.
-  const triggerLoadNewer = () => {
-    const started = beginDirectionalHistoryLoad('newer', 'automatic')
-    if (!started) return
-    runDirectionalHistoryLoad(started.saved, () => onLoadNewer?.())
-  }
-
-  const handleLoadEarlier = () => {
-    const started = beginDirectionalHistoryLoad('older', 'explicit')
-    if (!started) return
-    const { saved, capture } = started
-
-    debugLog('LOAD EARLIER', {
-      anchor: capture?.anchor ?? null,
-      distanceFromBottom: saved.distanceFromBottom,
-      scrollHeight: capture?.geometry.scrollHeight,
-      scrollTop: capture?.geometry.scrollTop,
-      clientHeight: capture?.geometry.clientHeight,
-      firstMessageId,
-      messageCount,
-    })
-
-    runDirectionalHistoryLoad(saved, () => onScrollToTop?.())
-  }
+    conversationId,
+    firstMessageId,
+    messageCount,
+    windowAtLiveEdge,
+    isLoadingOlder,
+    isLoadingNewer,
+    isHistoryComplete,
+    onScrollToTop,
+    onLoadNewer,
+  })
 
   // ==========================================================================
   // MEDIA LOAD HANDLER (images, videos, link previews)
   // ==========================================================================
-  //
-  // When media loads, it can change the content height. We use a snapshot+debounce
-  // pattern to batch multiple rapid loads and apply a single scroll correction:
-  //
-  // 1. First load in batch: capture wasAtBottom snapshot
-  // 2. Each subsequent load: reset debounce timer
-  // 3. After debounce: apply correction based on snapshot
-  //
-  // This prevents jitter from multiple images loading in sequence.
 
-  const handleMediaLoadImpl = useCallback(() => {
-    const scroller = scrollerRef.current
-    if (!scroller) return
-
-    // Capture snapshot on first load in batch (user's intent at start of batch). Also snapshot the
-    // bottom-most-visible reading anchor BEFORE the media grows the layout, so a scrolled-up reader
-    // can be re-pinned to it once the batch settles (media above the viewport would otherwise push
-    // their position down/out — the conversation-switch "drifts back in time" bug).
-    if (!mediaLoadSnapshotRef.current) {
-      mediaLoadSnapshotRef.current = {
-        wasAtBottom: isAtBottomRef.current,
-        userScrolled: false,
-        anchor: findBottomAnchor(scroller),
-      }
-      debugLog('MEDIA LOAD: batch started', {
-        wasAtBottom: isAtBottomRef.current,
-        scrollTop: scroller.scrollTop,
-        scrollHeight: scroller.scrollHeight,
-      })
-    }
-
-    // Clear existing timer and set new one (debounce)
-    if (mediaLoadDebounceRef.current) {
-      clearTimeout(mediaLoadDebounceRef.current)
-    }
-
-    mediaLoadDebounceRef.current = setTimeout(() => {
-      const currentScroller = scrollerRef.current
-      if (!currentScroller || !mediaLoadSnapshotRef.current) return
-
-      const { wasAtBottom, userScrolled, anchor } = mediaLoadSnapshotRef.current
-
-      if (wasAtBottom) {
-        if (!userScrolled) {
-          // User didn't scroll during the batch - scroll to bottom
-          debugLog('MEDIA LOAD: batch complete, scrolling to bottom', {
-            wasAtBottom,
-            userScrolled,
-            scrollHeight: currentScroller.scrollHeight,
-          })
-          reconcileLiveEdge('media-load')
-        } else {
-          // User actively scrolled during the batch - respect their position
-          debugLog('MEDIA LOAD: batch complete, user scrolled away', {
-            wasAtBottom,
-            userScrolled,
-          })
-        }
-      } else if (!userScrolled && anchor) {
-        runScrollShadowSafely({
-          event: 'media-preservation',
-          conversationId,
-          fallback: undefined,
-          observe: () => {
-            const desired: AnchorPreservationRequest['desired'] = {
-              kind: 'anchor',
-              messageId: anchor.messageId,
-              placement: {
-                kind: 'bottom-fraction',
-                fraction: messageFraction(anchor.fraction),
-              },
-            }
-            positioningControllerRef.current?.beginMediaPreservation({
-              conversationId,
-              desired,
-              executor: createAnchorPreservationExecutor('media-anchor'),
-            })
-          },
-        })
-        // Scrolled up and the user did NOT genuinely scroll during the batch: media that decoded
-        // ABOVE the viewport grew the content and pushed the reading position down/out. Re-pin to the
-        // anchor captured BEFORE the growth so the reader stays put (the conversation-switch + media
-        // "drifts back in time" bug). Mirrors live-edge reconciliation, but for a held position.
-        debugLog('MEDIA LOAD: batch complete, re-anchoring scrolled-up position', {
-          wasAtBottom,
-          anchorId: anchor.messageId,
-        })
-      } else {
-        debugLog('MEDIA LOAD: batch complete, was not at bottom (user scrolled / no anchor)', {
-          wasAtBottom,
-          userScrolled,
-        })
-      }
-
-      // Clear for next batch
-      mediaLoadSnapshotRef.current = null
-      mediaLoadDebounceRef.current = null
-    }, MEDIA_LOAD_DEBOUNCE_MS)
-  }, [
+  const {
+    handleMediaLoad: handleMediaLoadImpl,
+    isBatchActive: isMediaBatchActive,
+    observeScroll: observeMediaBatchScroll,
+    cancelBatch: cancelMediaBatch,
+  } = useMediaGrowthPreservation({
+    ports: {
+      getScroller: () => scrollerRef.current,
+      isAtBottom: () => isAtBottomRef.current,
+      reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
+      beginMediaPreservation: (input) =>
+        positioningControllerRef.current?.beginMediaPreservation(input),
+      log: debugLog,
+    },
     conversationId,
     createAnchorPreservationExecutor,
-    isAtBottomRef,
-    reconcileLiveEdge,
-  ])
-  // The implementation above must close over the current conversation and executors, so its
-  // identity legitimately changes on appends/window updates. Message rows must not observe that
-  // churn: a changed onMediaLoad prop bypasses their memo bailout and re-renders the whole mounted
-  // window. Publish a stable shell that always invokes the latest implementation, matching the
+  })
+
+  const {
+    setScrollContainerRef,
+    setContentRef,
+    teardownContentObserver,
+    detachUserInputListeners,
+  } = useScrollContainerBinding({
+    setScroller: (el) => {
+      scrollerRef.current = el
+      const external = latestRef.current.externalScrollerRef
+      if (external) {
+        (external as React.MutableRefObject<HTMLElement | null>).current = el
+      }
+    },
+    getScroller: () => scrollerRef.current,
+    getVirtualizer: () => latestRef.current.virtualizer,
+    isStaticMode: () => latestRef.current.staticMode,
+    isAtBottom: () => latestRef.current.isAtBottomRef.current,
+    getActiveConversationId: () => activeConversationIdRef.current,
+    getLoggedConversationId: () => latestRef.current.conversationId,
+    isDirectionalHistoryPending: (id) =>
+      positioningControllerRef.current?.isDirectionalHistoryPending(id) ?? false,
+    isMediaLoadBatchActive: isMediaBatchActive,
+    reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
+    recordUserInput: (id, at) =>
+      viewportSessionRef.current?.recordUserInput(id, at),
+    observeUserInput: (id) =>
+      positioningControllerRef.current?.observeUserInput(id),
+    log: debugLog,
+  })
+  // The implementation must close over the current conversation and executors, so its identity
+  // legitimately changes on appends/window updates. Message rows must not observe that churn: a
+  // changed onMediaLoad prop bypasses their memo bailout and re-renders the whole mounted window.
+  // Publish a stable shell that always invokes the latest implementation, matching the
   // requestMessageTarget/scrollToBottom contract.
   const handleMediaLoad = useStableCallback(handleMediaLoadImpl)
 
@@ -1414,49 +932,30 @@ export function useMessageListScroll({
       now,
     })
     // Keep the pre-mutation insertion anchor current on the same measurement the session already
-    // took — only while the resident array is unchanged, so the commit that mutates it still sees
-    // the geometry from BEFORE the mutation.
-    const insertionTracking = insertionTrackingRef.current
-    if (
-      insertionTracking.conversationId === conversationId &&
-      insertionTracking.messageCount === messageCount &&
-      insertionTracking.firstMessageId === firstMessageId &&
-      insertionTracking.lastMessageId === lastMessageId &&
-      insertionTracking.interiorPlacementVersion === interiorPlacementVersion
-    ) {
-      refreshInsertionAnchor(el, bottomAnchor)
-    }
-    // Do NOT recompute at-bottom from a GROWTH-driven scroll event fired while a programmatic loop
-    // owns scrollTop. The pin-bottom comment's assumption that "programmatic growth doesn't move
-    // scrollTop, so it never flips isAtBottom" is FALSE on WebKitGTK (Tauri): when the just-pinned
-    // bottom row measures taller than its estimate AFTER paint (a group-START send — avatar + sender
-    // header, ± a date separator — or media), scrollHeight grows and the engine fires a 'scroll'
-    // event at the same scrollTop, so distFromBottom is transiently large. Reading it here flipped
-    // isAtBottomRef false and the pin loop BAILED, stranding the send below the fold (the reported
-    // Tauri send-stick bug). We skip the write ONLY when a loop is running AND scrollHeight grew —
-    // the measurement-noise signature. A genuine user scroll-UP during a loop (e.g. scrolling back
-    // while the entry pin is still settling) leaves scrollHeight unchanged, so it still registers
-    // and correctly flips isAtBottom false. The loops also detect deliberate takeover via
-    // viewport session's input timestamp. Mirrors the same height-unchanged discriminator used by
-    // the save gate.
-    const growthDrivenDuringLoop =
-      viewportObservation?.growthDrivenDuringControllerScroll ?? false
-    if (!growthDrivenDuringLoop) {
-      setMeasuredAtBottom(distFromBottom < AT_BOTTOM_THRESHOLD)
-    }
+    // took. The owner applies the resident-array-unchanged gate itself.
+    refreshInsertionAnchorIfStable(el, bottomAnchor)
+    const plan = planScrollEvent({
+      scrollTop,
+      distanceFromBottom: distFromBottom,
+      controllerOwnsPixels: programmaticScroll,
+      growthDrivenDuringControllerScroll:
+        viewportObservation?.growthDrivenDuringControllerScroll ?? false,
+      genuineUserScroll: viewportObservation?.genuineUserScroll ?? false,
+      staticMode,
+      hasTravelledAwayFromTop:
+        viewportSessionRef.current?.hasTravelledAway(conversationId, 'top') ?? false,
+      atBottomThreshold: AT_BOTTOM_THRESHOLD,
+      loadNewerThreshold: LOAD_NEWER_THRESHOLD,
+    })
 
-    // Track user scroll during a media load batch — but ONLY a GENUINE user scroll, not the
-    // measurement/growth-driven scroll events the media itself produces (same height-unchanged +
-    // not-programmatic discriminator the save gate below uses). A growth event marking userScrolled
-    // is exactly what made the media handler "respect" a position the user never moved — leaving the
-    // view drifted (at the bottom: no re-pin; scrolled up: no re-anchor).
-    if (
-      mediaLoadSnapshotRef.current &&
-      !programmaticScroll &&
-      viewportObservation?.previousScrollHeight === scrollHeight
-    ) {
-      mediaLoadSnapshotRef.current.userScrolled = true
-    }
+    if (plan.recordMeasuredAtBottom) setMeasuredAtBottom(plan.atBottom)
+
+    // Track user scroll during a media load batch — the owner applies the genuine-move test.
+    observeMediaBatchScroll({
+      controllerOwnsPixels: programmaticScroll,
+      previousScrollHeight: viewportObservation?.previousScrollHeight,
+      scrollHeight,
+    })
 
     // FAB visibility (only React state in scroll handler). Suppressed while the pin-bottom loop owns
     // scrollTop: on WebKit a tall bottom row's post-paint growth fires 'scroll' events reporting a
@@ -1465,59 +964,28 @@ export function useMessageListScroll({
     const shouldShowFab = shouldShowScrollToBottomFab(distFromBottom, FAB_THRESHOLD, pinBottomClaim().isHeld())
     setShowScrollToBottom(prev => prev !== shouldShowFab ? shouldShowFab : prev)
 
-    // Jump-to-last-read pill visibility: is the first-new-message divider currently scrolled
-    // ABOVE the viewport? Same cadence as the FAB above — no separate listener. Compare the
-    // marker's pixel offset (content-relative, from the content top) against the live scrollTop
-    // — works whether or not the marker row is currently mounted. NOTE: this intentionally does
-    // NOT compare against getVirtualItems()[0].index: for a short/medium conversation the
-    // rendered window (visible range + overscan) can cover the ENTIRE item list, so the first
-    // rendered item's index stays 0 regardless of scroll position — an index comparison would
-    // never fire the pill for such conversations. The offset comparison is windowing-agnostic.
     if (firstNewMessageId) {
       const v = latestRef.current.virtualizer
-      let shouldShowMarkerPill = false
+      let markerOffset: number | null
       if (v) {
-        const offset = v.getOffsetForMessageId(firstNewMessageId)
-        shouldShowMarkerPill = offset != null && offset < scrollTop
+        markerOffset = v.getOffsetForMessageId(firstNewMessageId)
       } else {
         const escapedId = CSS.escape(firstNewMessageId)
         const markerEl = el.querySelector(`[data-message-id="${escapedId}"]`) as HTMLElement | null
-        shouldShowMarkerPill = markerEl != null && markerEl.offsetTop < scrollTop
+        markerOffset = markerEl ? markerEl.offsetTop : null
       }
+      const shouldShowMarkerPill = isMarkerAboveViewport(markerOffset, scrollTop)
       setMarkerAboveViewport(prev => prev !== shouldShowMarkerPill ? shouldShowMarkerPill : prev)
     } else {
       setMarkerAboveViewport(prev => prev ? false : prev)
     }
 
-    // Track the bottom-most-visible message ONLY on genuine (non-programmatic) user scroll — this
-    // drives the divider-snap trigger in MessageList (snap the "New messages" divider to the read
-    // pointer when the reader scrolls back up). Skipping programmatic scrolls (the entry
-    // scroll-to-marker re-assert, FAB jumps) prevents the divider from drifting during entry
-    // positioning. Conversation switch resets this to null, so the snap can't fire until the reader
-    // actually scrolls.
-    if (!programmaticScroll) {
+    if (plan.trackBottomVisibleMessage) {
       const bottomId = bottomAnchor?.messageId ?? null
       setBottomVisibleMessageId(prev => (prev !== bottomId ? bottomId : prev))
     }
 
-    // `programmaticScroll` (computed above) also gates the marker-clear and position-save below: a
-    // re-assert loop owns scrollTop while it runs, so its scroll events must not (a) clear the marker
-    // (the marker-positioning loop scrolls TO the marker, momentarily landing at/near the bottom for
-    // a last-message marker, which would trip the "reached bottom" clear), nor (b) save the position
-    // (the transient scrollTop:0 of the virtualized initial render was saved as a "scrolled-up"
-    // position, poisoning the next re-entry into restore-position and bypassing the marker entirely).
-
-    // Open the save gate when this is a genuine user scroll: content height UNCHANGED from the
-    // previous scroll event (a media/measurement-driven shift changes the height; a wheel / touch /
-    // scrollbar-drag does not). Complements the input-event listeners so scrollbar-drag — which
-    // fires no wheel/touch — also counts. Excluded: programmatic loop scrolls AND the
-    // post-restore / post-re-pin measurement settle (isProgrammaticScroll's window, refreshed on the
-    // height change just above) — that settle is height-unchanged on its final frames too, so without
-    // the window a settle frame looked like a scrollbar drag, opened the gate, and persisted a
-    // drifted position that crept older on every re-open. Genuine user scrolls still open the gate
-    // via the input-event listeners / handleWheel, unaffected.
-    const genuineUserScroll = viewportObservation?.genuineUserScroll ?? false
-    if (genuineUserScroll) {
+    if (plan.observeGenuineInput) {
       positioningControllerRef.current?.observeUserInput(conversationId)
       runScrollShadowSafely({
         event: 'settled-user-geometry',
@@ -1532,31 +1000,23 @@ export function useMessageListScroll({
       })
     }
 
-    // Clear new message marker when user scrolls past it or reaches the bottom.
-    // Skip on the very first scroll events after marker setup to avoid clearing
-    // the marker before the user has a chance to see it.
-    if (firstNewMessageId && clearFirstNewMessageId && !programmaticScroll) {
-      const lastUserIntentAt =
-        viewportSessionRef.current?.lastUserIntentAt(conversationId) ?? 0
-      const recentUserScrollIntent =
-        lastUserIntentAt > 0 && now - lastUserIntentAt < 1500
-      if (
-        !userHasScrolledSinceMarkerRef.current &&
-        !(distFromBottom < AT_BOTTOM_THRESHOLD && recentUserScrollIntent)
-      ) {
-        // First scroll after marker was set — arm the flag for next time
-        userHasScrolledSinceMarkerRef.current = true
-        debugLog('MARKER CLEAR armed (first scroll)', { firstNewMessageId, distFromBottom })
-      } else if (distFromBottom < AT_BOTTOM_THRESHOLD) {
-        // User genuinely read through to the bottom — the "skipped vs read-through" clear.
-        // NOTE: gated by `!programmaticScroll` above, so a FAB jump-to-present (which drives a
-        // reassert loop) does NOT clear the anchor — the jump-to-last-read pill (#870) needs the
-        // per-visit divider anchor to survive a skip. Scrolled-past / DOM-trimmed no longer clear:
-        // those are exactly the states where the pill must show (moved toward the present without
-        // reading). The anchor now clears only on read-through, Esc, mark-all-read, or deactivation.
-        debugLog('MARKER CLEAR (reached bottom)', { firstNewMessageId, distFromBottom })
-        clearFirstNewMessageId()
-      }
+    const markerAction = decideMarkerClear({
+      hasMarker: Boolean(firstNewMessageId),
+      canClear: Boolean(clearFirstNewMessageId),
+      controllerOwnsPixels: programmaticScroll,
+      armed: userHasScrolledSinceMarkerRef.current,
+      distanceFromBottom: distFromBottom,
+      atBottomThreshold: AT_BOTTOM_THRESHOLD,
+      lastUserIntentAt:
+        viewportSessionRef.current?.lastUserIntentAt(conversationId) ?? 0,
+      now,
+    })
+    if (markerAction === 'arm') {
+      userHasScrolledSinceMarkerRef.current = true
+      debugLog('MARKER CLEAR armed (first scroll)', { firstNewMessageId, distFromBottom })
+    } else if (markerAction === 'clear') {
+      debugLog('MARKER CLEAR (reached bottom)', { firstNewMessageId, distFromBottom })
+      clearFirstNewMessageId?.()
     }
 
     // Persist only through the adapter. It consumes the snapshot recorded above and owns the
@@ -1570,36 +1030,14 @@ export function useMessageListScroll({
       now,
     })
 
-    // Track if the USER scrolled away from top (allows a later return to re-trigger load). A
-    // controller-owned animation can cross this threshold too — most notably Home's smooth trip
-    // from the bottom — but that is not evidence of a separate pagination gesture.
-    if (!programmaticScroll && scrollTop > 50) {
+    if (plan.markTravelAwayFromTop) {
       viewportSessionRef.current?.markTravelAway(conversationId, 'top')
     }
-    // Mirror for the newer direction (sliding window): away from the resident bottom.
-    if (distFromBottom > 50) {
+    if (plan.markTravelAwayFromBottom) {
       viewportSessionRef.current?.markTravelAway(conversationId, 'bottom')
     }
-
-    // Auto-trigger load when at top (disabled in static mode — preview starts at scrollTop=0).
-    // Gate on scrolledAwayFromTop: a PASSIVE scroll reaching the top must only auto-load when the
-    // user genuinely scrolled up to it (was away from the top and returned). On a fresh entry the
-    // list briefly renders at scrollTop=0 before the auto-scroll-to-bottom settles; that transient
-    // must NOT spuriously load older — doing so prepends a batch and clears isAtBottom, breaking
-    // bottom-stick for the next incoming message. A wheel-up (handleWheel) is explicit intent and
-    // is intentionally NOT gated this way.
-    if (
-      scrollTop === 0 &&
-      !staticMode &&
-      viewportSessionRef.current?.hasTravelledAway(conversationId, 'top')
-    ) {
-      triggerLoadOlder()
-    }
-
-    // Sliding window: when the window is slid up, reaching the resident bottom means newer
-    // messages exist in cache below. The coordinator rejects this at the live edge, where
-    // bottom-stick remains authoritative.
-    if (distFromBottom <= LOAD_NEWER_THRESHOLD && !staticMode) triggerLoadNewer()
+    if (plan.loadOlder) triggerLoadOlder()
+    if (plan.loadNewer) triggerLoadNewer()
   }
 
   const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
@@ -1610,18 +1048,21 @@ export function useMessageListScroll({
     // native wheel listener; kept here so it fires even when wheel arrives via the React handler.
     positioningControllerRef.current?.observeUserInput(conversationId)
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget
-    const distFromBottom = scrollHeight - scrollTop - clientHeight
-    if (scrollTop === 0 && e.deltaY < 0 && !staticMode) triggerLoadOlder()
-    if (scrollTop === 0 && e.deltaY > 0) {
+    const wheelPlan = planWheelEvent({
+      scrollTop,
+      distanceFromBottom: scrollHeight - scrollTop - clientHeight,
+      deltaY: e.deltaY,
+      staticMode,
+      loadNewerThreshold: LOAD_NEWER_THRESHOLD,
+    })
+    if (wheelPlan.markTravelAwayFromTop) {
       viewportSessionRef.current?.markTravelAway(conversationId, 'top')
     }
-    // Sliding window mirror: a wheel-DOWN pinned at the resident bottom fires no scroll event
-    // (already at max scrollTop), so trigger load-newer here — same reason handleWheel handles the
-    // pinned-top load-older case above.
-    if (distFromBottom <= LOAD_NEWER_THRESHOLD && e.deltaY > 0 && !staticMode) triggerLoadNewer()
-    if (distFromBottom > 50 && e.deltaY < 0) {
+    if (wheelPlan.markTravelAwayFromBottom) {
       viewportSessionRef.current?.markTravelAway(conversationId, 'bottom')
     }
+    if (wheelPlan.loadOlder) triggerLoadOlder()
+    if (wheelPlan.loadNewer) triggerLoadNewer()
   }
 
   // Mount marker (diagnostic). Fires once when the message view is freshly created — i.e. after a
@@ -1702,11 +1143,7 @@ export function useMessageListScroll({
     setBottomVisibleMessageId(null)
 
     // Clear any pending media load batch
-    if (mediaLoadDebounceRef.current) {
-      clearTimeout(mediaLoadDebounceRef.current)
-      mediaLoadDebounceRef.current = null
-    }
-    mediaLoadSnapshotRef.current = null
+    cancelMediaBatch()
     // Drop any repaint-burst debt from the room we're leaving so it can't flush into the new one.
     // The executor hook performs this without constructing an adapter for a list that never pinned.
     resetLiveEdgeRepaintDebt()
@@ -1732,36 +1169,39 @@ export function useMessageListScroll({
         )
       const firstOpenThisSession =
         persistenceEntry?.firstOpenThisSession ?? true
-      let action = persistenceEntry?.action ?? 'scroll-to-bottom'
+      const action = persistenceEntry?.action ?? 'scroll-to-bottom'
       const savedPos = persistenceEntry?.savedOffsetPx ?? null
       const savedAnchor = persistenceEntry?.savedAnchor ?? null
       const savedReadPositionId =
         persistenceEntry?.savedReadPositionId
-      const syncedLiveEdge =
-        action === 'restore-position' &&
-        firstNewMessageId === undefined &&
-        readPointerId !== undefined &&
-        readPointerId === lastMessageId &&
-        readPointerId !== savedReadPositionId
-
-      if (action === 'restore-position') {
-        pendingSyncedLiveEdgeRef.current = { conversationId, savedReadPositionId }
-        // The remote pointer can resolve before this mount. When it now identifies the newest
-        // downloaded row, a saved position tied to an older pointer must not win merely because
-        // there was never an unread divider.
-        if (syncedLiveEdge) {
-          scrollPersistenceRef.current?.clearSavedPosition(conversationId)
-          pendingSyncedLiveEdgeRef.current = null
-          action = 'scroll-to-bottom'
-          debugLog('MDS LIVE EDGE: synced read supersedes saved position on entry', {
-            conversationId,
-            savedReadPositionId,
-            readPointerId,
-          })
-        }
+      const arbitration = arbitrateEntry({
+        persistedAction: action,
+        savedReadPositionId,
+        firstUnreadMessageId: firstNewMessageId,
+        readPointerId,
+        lastMessageId,
+        targetMessageId,
+      })
+      const syncedLiveEdge = arbitration.syncedLiveEdgeSupersedes
+      pendingSyncedLiveEdgeRef.current = arbitration.armPendingSyncedLiveEdge
+        ? { conversationId, savedReadPositionId }
+        : null
+      if (arbitration.clearSavedPosition) {
+        scrollPersistenceRef.current?.clearSavedPosition(conversationId)
+        debugLog('MDS LIVE EDGE: synced read supersedes saved position on entry', {
+          conversationId,
+          savedReadPositionId,
+          readPointerId,
+        })
       }
 
-      debugLog('CONVERSATION ACTION', { action, savedPos, firstOpenThisSession, scrollHeight: scroller.scrollHeight })
+      debugLog('CONVERSATION ACTION', {
+        action,
+        branch: arbitration.branch,
+        savedPos,
+        firstOpenThisSession,
+        scrollHeight: scroller.scrollHeight,
+      })
       const entryFacts = runScrollShadowSafely({
         event: 'entry-facts',
         conversationId,
@@ -1790,7 +1230,7 @@ export function useMessageListScroll({
         }),
       })
 
-      if (action === 'restore-position') {
+      if (arbitration.branch === 'saved-position') {
         isAtBottomRef.current = false
         const request = entryExecutionFacts
           ? positioningControllerRef.current?.beginSavedPositionEntry({
@@ -1806,7 +1246,7 @@ export function useMessageListScroll({
           isAtBottomRef.current = true
           emergencyLiveEdgeWrite()
         }
-      } else if (firstNewMessageId) {
+      } else if (arbitration.branch === 'unread-marker') {
         // Has unread messages — position the first-unread marker ~1/3 down from the top so the
         // user reads forward from where they left off. Mark NOT at bottom up front (mirrors the
         // targetMessageId branch) so the content-growth ResizeObserver doesn't auto-pin to the
@@ -1827,7 +1267,7 @@ export function useMessageListScroll({
           isAtBottomRef.current = true
           emergencyLiveEdgeWrite()
         }
-      } else if (targetMessageId) {
+      } else if (arbitration.branch === 'defer-to-target') {
         // Has a target message to scroll to — skip scroll-to-bottom.
         // The targetMessageId effect will handle scrolling.
         // Mark as NOT at bottom so the ResizeObserver doesn't auto-scroll
@@ -1855,7 +1295,7 @@ export function useMessageListScroll({
         //
         // Note: Async content loading (MAM) is handled by the separate "new message" effect
         // which triggers when messageCount changes.
-        isAtBottomRef.current = true
+        isAtBottomRef.current = arbitration.entersAtBottom
         const request = entryFacts
           ? positioningControllerRef.current?.beginLiveEdgeEntry({
             conversationId,
@@ -1886,6 +1326,7 @@ export function useMessageListScroll({
     isAtBottomRef,
     lastMessageId,
     messageCount,
+    cancelMediaBatch,
     readPointerId,
     resetLiveEdgeRepaintDebt,
     staticMode,
@@ -1898,22 +1339,28 @@ export function useMessageListScroll({
   // observing that pointer transition is the only signal that the restore became obsolete.
   useLayoutEffect(() => {
     const pending = pendingSyncedLiveEdgeRef.current
-    if (!pending || pending.conversationId !== conversationId) return
     if (
-      staticMode ||
-      viewportSessionRef.current?.hasGenuineInput(conversationId)
+      !shouldSupersedeWithLateSyncedLiveEdge({
+        armedForConversation: pending?.conversationId,
+        conversationId,
+        staticMode,
+        hasGenuineInput:
+          viewportSessionRef.current?.hasGenuineInput(conversationId) ?? false,
+        firstUnreadMessageId: firstNewMessageId,
+        readPointerId,
+        lastMessageId,
+        armedSavedReadPositionId: pending?.savedReadPositionId,
+      })
     ) {
       return
     }
-    if (firstNewMessageId !== undefined || readPointerId === undefined) return
-    if (readPointerId !== lastMessageId || readPointerId === pending.savedReadPositionId) return
 
     pendingSyncedLiveEdgeRef.current = null
     scrollPersistenceRef.current?.clearSavedPosition(conversationId)
     isAtBottomRef.current = true
     debugLog('MDS LIVE EDGE: late synced read supersedes restored position', {
       conversationId,
-      savedReadPositionId: pending.savedReadPositionId,
+      savedReadPositionId: pending?.savedReadPositionId,
       readPointerId,
     })
     const request = positioningControllerRef.current?.beginLiveEdgeRequest({
@@ -2156,13 +1603,11 @@ export function useMessageListScroll({
 
   useEffect(() => {
     return () => {
-      if (mediaLoadDebounceRef.current) {
-        clearTimeout(mediaLoadDebounceRef.current)
-      }
+      cancelMediaBatch()
       teardownContentObserver()
       disposeDirectionalHistoryBrowser()
     }
-  }, [disposeDirectionalHistoryBrowser, teardownContentObserver])
+  }, [cancelMediaBatch, disposeDirectionalHistoryBrowser, teardownContentObserver])
 
   // ==========================================================================
   // EFFECT: Returned to the live edge → drop any stale directional-load anchor.

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -79,8 +79,9 @@ load keeps its snapshot until its own first-id shift can reconcile. Conversation
 departed conversation's snapshot, and delayed settlement or window observation from that snapshot
 cannot mutate the active conversation. A dedicated `DirectionalHistoryBrowserAdapter` owns visual
 anchor capture, the one-frame settlement scheduler, reachability probes, WebKit kinetic-scroll
-cancellation, and anchor/fallback pixel writes under the controller lease. The hook constructs and
-invokes the adapter and supplies lifecycle completion callbacks. The coordinator imports no DOM,
+cancellation, and anchor/fallback pixel writes under the controller lease.
+`useDirectionalHistoryLoads` invokes the adapter and supplies lifecycle completion callbacks; the
+orchestration hook only wires its ports and consumes its triggers. The coordinator imports no DOM,
 virtualizer, frame scheduler, positioning controller, or pixel-write capability.
 
 Saved-position reconciliation likewise runs through a dedicated browser adapter. It owns
@@ -381,9 +382,10 @@ reconcilers implement measurement convergence; they are not separate positioning
 There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
 Executor construction lives in `useScrollExecutors` without exception: it supplies each adapter's
 value ports and hands the finished executor back for the hook to submit, so no `createExecutor` call
-appears in `useMessageListScroll`. The hook still reaches the directional-history adapter directly
-for its availability probe and its one-frame settlement scheduler, neither of which builds an
-executor. Exactly three pixel writes remain in the hook, and none of them is a positioning owner —
+appears in `useMessageListScroll`. Directional-history availability probes and one-frame settlement
+scheduling are encapsulated by `useDirectionalHistoryLoads`, which builds no executor and owns no
+pixel write. Exactly three pixel writes remain in the orchestration hook, and none is a positioning
+owner —
 the two isolated static-preview operations documented below, and the emergency bottom write that
 keeps the list usable when the controller itself cannot be constructed.
 
@@ -538,18 +540,27 @@ kinetic scrolling and stale-paint behavior.
      - [x] Extract unread-marker and explicit-target reachability, passive conversation handoff,
        leased positioning, around loading, and target completion behind dedicated browser adapters.
      - [x] Extract the remaining live-edge, fixed-anchor, and resident-top browser executors.
-   - [ ] Leave the React hook as thin lifecycle orchestration. Taken one cohesive unit at a time so
+   - [x] Leave the React hook as thin lifecycle orchestration. Taken one cohesive unit at a time so
      each step keeps the scroll invariants as its gate:
      - [x] Move executor construction — the frame-loop factory, the adapters that outlive one
        execution, and every `create*`/`build*Executor` — into `useScrollExecutors`.
      - [x] Extract the scroller/content callback refs, their genuine-input listeners, and the
        non-virtualized content-growth observer into `useScrollContainerBinding`.
-     - [ ] Extract ambient divider/insertion anchor tracking.
-     - [ ] Extract media-growth snapshotting and debouncing.
-     - [ ] Extract directional-history release and post-frame settling.
-     - [ ] Reduce the scroll event handler to a value-only interpretation of geometry.
-     - [ ] Express conversation-entry arbitration as a pure model over facts, leaving a thin effect
-       that applies its verdict.
+     - [x] Extract ambient divider/insertion anchor tracking into
+       `useAmbientAnchorPreservation`, with every branch decision as a pure function in
+       `ambientAnchorDecisions`.
+     - [x] Extract media-growth snapshotting and debouncing into
+       `useMediaGrowthPreservation`, with the settled-batch outcome and the genuine-scroll
+       discriminator as pure functions in `mediaGrowthDecisions`.
+     - [x] Extract directional-history load start, release and post-frame settling into
+       `useDirectionalHistoryLoads`. It adds no eligibility rule of its own: the coordinator still
+       decides, and the browser adapter still captures and writes.
+     - [x] Reduce the scroll and wheel handlers to a value-only interpretation of geometry in
+       `scrollEventDecisions`, leaving the handlers to read facts once and apply the plan.
+     - [x] Express conversation-entry arbitration as a pure model over facts in
+       `entryArbitration`, leaving a thin effect that applies its verdict. The five-condition
+       synced-live-edge predicate and its late-resolving twin are now separately testable, including
+       the empty-conversation case where a bare pointer comparison would discard a saved position.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove
 one previous source of scroll authority.


### PR DESCRIPTION
Completes the decomposition of `useMessageListScroll`, which drops from 2674 to 2119 lines (3229 before this series started). Five cohesive units move out, each keeping the hook as the thing that decides *when* a position is requested rather than how the request is made.

- **Ambient anchor preservation** covers the two mutations that move a scrolled-up reader without them asking: the unread divider changing position, and a delayed arrival sorting into the middle of the resident array.
- **Media growth** keeps its snapshot-and-debounce, so a run of decoding images produces one correction rather than jitter.
- **Directional history** owns starting a load and releasing a request that settled without shifting the window.
- **Scroll and wheel handlers** now read geometry once and apply a plan.
- **Conversation entry arbitration** becomes a model over facts.

Where a slice carried real branch logic, that logic became a pure function with paired controls, because the dense inline expressions were the part no test could reach. Three are worth naming:

- Distinguishing a mid-array insertion from a live-edge arrival, a directional batch and an interior placement bump decides whether a reading position is held or handed to another owner.
- A scroll during a media batch counts as the reader only when the content height stood still, since growth fires scroll events of its own.
- A synced read pointer invalidates a saved position only under five conditions at once. Without the resolved-pointer guard, an empty conversation compares `undefined` to `undefined`, reads that as the pointer being at the tail, and discards a good saved position.

The directional slice deliberately adds no pure model: eligibility already belongs to the window coordinator and pixel writes to the browser adapter, so a decision layer there would have been ceremony.

Behaviour is unchanged. The contract document tracks the remaining state of the migration.