### PR TITLE
refactor(sdk): declare read-state and archive-coverage types in core/types

### DIFF
--- a/packages/fluux-sdk/src/core/types/chat.ts
+++ b/packages/fluux-sdk/src/core/types/chat.ts
@@ -6,7 +6,7 @@
  */
 
 import type { BaseMessage } from './message-base'
-import type { ReadPointer } from '../../stores/shared/readPointer'
+import type { ReadPointer } from './readState'
 
 /**
  * Chat state notification types (XEP-0085).

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -98,12 +98,25 @@ export type {
   MAMQueryOptions,
   MAMResult,
   MAMQueryState,
+  MAMQueryDirection,
+  CoverageRecord,
+  MergeArchiveExtras,
   RoomMAMQueryOptions,
   RoomMAMResult,
   MAMSearchOptions,
   RoomMAMSearchOptions,
   MAMPagingSearchOptions,
 } from './pagination'
+
+// Read-state types (cache order and read pointer)
+export type {
+  CacheOrderKey,
+  ExactPosition,
+  FloorPosition,
+  PointerOrder,
+  PointerIdentity,
+  ReadPointer,
+} from './readState'
 
 // Admin types
 export type {

--- a/packages/fluux-sdk/src/core/types/layering.test.ts
+++ b/packages/fluux-sdk/src/core/types/layering.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * `core/types` is the SDK's leaf layer: the domain vocabulary every other layer
+ * names its own contracts in. A type declared here must not reach back into a
+ * state implementation — doing so makes the whole core one mutually recursive
+ * blob, forbids typechecking a protocol module in isolation, and hardwires
+ * Zustand into a package documented as store-agnostic.
+ *
+ * Exactly one file is still allowed to, and it is tracked debt: `client.ts`
+ * derives `StoreBindings` from the concrete store state types via
+ * `Pick<ChatState, …>`. Emptying this allowlist is the point of that follow-up
+ * work: the port has to be declared in domain terms, with the stores proving
+ * conformance to it rather than the reverse.
+ *
+ * When you remove the last entry, assert an empty array — do not delete the
+ * test.
+ */
+const ALLOWED_TO_IMPORT_STORES = ['client.ts']
+
+const TYPES_DIR = dirname(fileURLToPath(import.meta.url))
+
+/** Relative specifiers that resolve somewhere under `src/stores/`. */
+function storeImportsOf(source: string): string[] {
+  const specifiers = source.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]*)['"]/g)
+  return [...specifiers].map(m => m[1]).filter(spec => spec.split('/').includes('stores'))
+}
+
+describe('core/types layering', () => {
+  const files = readdirSync(TYPES_DIR).filter(f => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+
+  it('has files to check', () => {
+    expect(files.length).toBeGreaterThan(10)
+  })
+
+  it('declares domain types without importing a store', () => {
+    const offenders = Object.fromEntries(
+      files
+        .map(file => [file, storeImportsOf(readFileSync(join(TYPES_DIR, file), 'utf8'))] as const)
+        .filter(([, imports]) => imports.length > 0)
+    )
+
+    expect(Object.keys(offenders).sort()).toEqual([...ALLOWED_TO_IMPORT_STORES].sort())
+  })
+})

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -253,3 +253,59 @@ export interface MAMQueryState {
    */
   coverageBottomUnproven?: boolean
 }
+
+/**
+ * Query direction for MAM queries.
+ *
+ * @category MAM
+ */
+export type MAMQueryDirection = 'backward' | 'forward'
+
+/**
+ * Persisted contiguous-with-live coverage.
+ *
+ * A `CoverageRecord` is POSITIVE, DURABLE data: the archive id of the oldest
+ * entry proven contiguous with the live edge for this device. Unlike a gap
+ * interval (which describes a hole and vanishes when the hole closes) or
+ * {@link MAMQueryState.coverageBottomUnproven} (session-scoped), the record
+ * survives fresh sessions and gap closure, so:
+ * - the read-pointer stitch seeds its backward walk from it and never from a
+ *   disjoint cache island (e.g. a fetchContext window);
+ * - a signal-only fetch-latest walk resumes BELOW prior coverage instead of
+ *   re-walking the same newest pages every session (`topId` marks re-entry
+ *   into covered territory; the walk jumps to `bottomId`).
+ *
+ * Advancing `bottomId` past a page that carries persistable messages must be
+ * gated on the durable IndexedDB commit of that page (same invariant as gap
+ * transitions): the record must never point past data that was never stored.
+ *
+ * @category MAM
+ */
+export interface CoverageRecord {
+  /** Archive id of the OLDEST entry proven contiguous with the live edge. */
+  bottomId: string
+  /** Archive id of the NEWEST entry seen by the fetch-latest walk that
+   *  established this record (page-1 rsm.last). */
+  topId?: string
+}
+
+/**
+ * Extra merge inputs carried on the mam-messages emit (both entity kinds).
+ *
+ * @category MAM
+ */
+export interface MergeArchiveExtras {
+  /** The `before` cursor the query was started with ('' = fetch-latest). */
+  initialBefore?: string
+  /** rsm.last of the FIRST page of a backward walk (newest covered entry). */
+  fetchLatestTopId?: string
+  /** The walk contained the existing coverage record's top entry — the only
+   *  accepted proof of contiguity with the record (Codex r4 #3). */
+  sawCoverageTop?: boolean
+  /** The walk carried corrections/retractions/reactions/fastenings, whose
+   *  cache effects are fire-and-forget — certification is blocked (r4 #2). */
+  walkCarriedModifications?: boolean
+  /** FORWARD only: the `after` cursor the catch-up resumed from — the bootstrap
+   *  anchor when that catch-up reports complete. */
+  initialAfter?: string
+}

--- a/packages/fluux-sdk/src/core/types/readState.ts
+++ b/packages/fluux-sdk/src/core/types/readState.ts
@@ -1,0 +1,143 @@
+/**
+ * Read-position type definitions: cache order, and the read pointer.
+ *
+ * These are domain types, not store internals — they are part of the SDK's
+ * public surface, and `core/types` must stay a leaf layer that no state
+ * implementation can reach into. The pure functions that build and compare
+ * these values live in `stores/shared/readState.ts` and
+ * `stores/shared/readPointer.ts`, which re-export the types declared here.
+ *
+ * @packageDocumentation
+ * @module Types/ReadState
+ */
+
+/**
+ * The IndexedDB message cache's own tie-break key for a message, built from the
+ * CLIENT message id. It has never held an archive id, and could not: XEP-0313
+ * §6.2 makes archive ids opaque strings with no guarantee of being numeric,
+ * sequenced or globally unique, and unique only per archive — they carry no
+ * ordering. This key is chosen to agree with the cache's cursors, and is
+ * kind-discriminated because chat and room break same-millisecond ties
+ * differently:
+ *
+ * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'`,
+ *   `messageCache.ts:140`).
+ * - Room breaks ties by `from` then `id` (the `room_ts_from_id` index).
+ *
+ * Chat messages also carry `from`, so a generic "from then id" comparator
+ * would be wrong for chat — the `kind` discriminant is what keeps the two
+ * apart. Do not generalise this into a single shape.
+ *
+ * @category Read state
+ */
+export type CacheOrderKey = { kind: 'chat'; id: string } | { kind: 'room'; from: string; id: string }
+
+/**
+ * A position that is exactly located in message-cache order: a timestamp
+ * refined by the tie-break that resolves its millisecond.
+ *
+ * Every real message yields one, because `makeCacheOrderKey` always
+ * produces a key — use `exactPosition` rather than assembling the literal.
+ *
+ * `role` is not redundant with the presence of `tiebreak`: it is what makes
+ * {@link PointerOrder} a DISCRIMINATED union, so narrowing reads as
+ * `order.role === 'floor'` at every consumer instead of as an incidental
+ * "the optional field happens to be missing" test. A weaker position cannot be
+ * passed where an exact one is required (#1173).
+ *
+ * @category Read state
+ */
+export interface ExactPosition {
+  readonly role: 'exact'
+  readonly timestamp: number
+  readonly tiebreak: CacheOrderKey
+}
+
+/**
+ * A position known only to a millisecond: "at least here", not "exactly here".
+ *
+ * This is what a pointer migrated from the pre-#1081 `lastSeenMessageId` +
+ * `lastReadAt` pair carries — `lastReadAt` sits at or behind the message the
+ * pointer names, with no provable position inside its millisecond. It is also
+ * where an {@link ExactPosition} degrades when its persisted tie-break comes
+ * back unusable: dropping to a floor over-counts (the safe direction) rather
+ * than trusting a key we cannot rebuild.
+ *
+ * Deliberately has NO `tiebreak` property at all rather than an optional one:
+ * with `role` discriminating, `order.tiebreak` does not typecheck on this
+ * variant, so nothing can read a key off a floor and nothing can smuggle one in.
+ *
+ * @category Read state
+ */
+export interface FloorPosition {
+  readonly role: 'floor'
+  readonly timestamp: number
+}
+
+/**
+ * Where a read pointer sits in message-cache order — see {@link ReadPointer}.
+ *
+ * The two variants are the two things a stored position can honestly claim, and
+ * every comparator answers them differently on purpose. Note that
+ * `readonly` here stops a position being MUTATED, not rebuilt: a consumer can
+ * still construct a fresh order object with a different timestamp. Never moving
+ * a stored position stays a review concern (`stores/shared/readPointer.ts`),
+ * which the type makes visible — you have to name `order` — rather than
+ * impossible.
+ *
+ * @category Read state
+ */
+export type PointerOrder = ExactPosition | FloorPosition
+
+/**
+ * How a read position can be NAMED.
+ *
+ * `messageId` is on both variants — it always exists, and it is the pointer's
+ * ONE local name. `archiveId` exists only on `addressable`, so reaching for it
+ * forces the consumer to say what it does when the position has no wire name.
+ *
+ * - **`addressable`** — the named message carried an XEP-0359 archive id when
+ *   the pointer was minted. Publishable as-is: the XEP-0490 publisher reads
+ *   `archiveId` and is done, with no lookup, no residency requirement and no
+ *   cache read.
+ * - **`local`** — degraded, and EXPLICITLY so. The archive id genuinely does not
+ *   exist yet (or, for the user's own 1:1 sends, may never: the server does not
+ *   echo them back, so the only id they ever have is a client-generated
+ *   `origin-id`, which is not publishable). No model can conjure one. What the
+ *   variant buys is that the state is named once instead of being rediscovered
+ *   at each consumer, and that the publisher's at-or-behind fallback (#1189) is
+ *   the DEFINITION of this branch rather than a patch bolted onto it.
+ *
+ * XEP-0359's `by` is deliberately NOT stored: it is a function of the entity
+ * (`isRoom(jid) ? jid : ownBareJid()`), so storing it would be a second
+ * derivable copy of something the publisher already knows.
+ *
+ * @category Read state
+ */
+export type PointerIdentity =
+  | { readonly state: 'addressable'; readonly messageId: string; readonly archiveId: string }
+  | { readonly state: 'local'; readonly messageId: string }
+
+/**
+ * Where the user has read to. Written atomically or not at all.
+ *
+ * ONE deliberate exception to "the timestamp is the message's own": pointers
+ * built by the #1081 migration from a legacy `lastSeenMessageId` + `lastReadAt`
+ * PAIR carry `lastReadAt` as the timestamp, which is not necessarily the
+ * timestamp of the message the identity names. Those pointers carry a
+ * `role: 'floor'` order, which says exactly that: "at least here". That is the
+ * status quo preserved exactly — `lastReadAt` is the floor today's unread
+ * derivation already counts from, and it is at or behind the named message. Do
+ * not "fix" this by resolving the message's real timestamp: that could move the
+ * floor FORWARD, and the pointer is forward-only, so a position lost that way is
+ * unrecoverable. Only `order` is used for ordering; nothing derives a message
+ * from it.
+ *
+ * @category Read state
+ */
+export interface ReadPointer {
+  /** Where this position sits in message-cache order. NEVER rewritten. */
+  readonly order: PointerOrder
+  /** What this position is called — locally, and on the wire when we can. */
+  readonly identity: PointerIdentity
+}

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -8,7 +8,7 @@
 import type { PresenceShow } from './roster'
 import type { MentionReference } from './chat'
 import type { BaseMessage } from './message-base'
-import type { ReadPointer } from '../../stores/shared/readPointer'
+import type { ReadPointer } from './readState'
 
 /**
  * Room affiliation level (XEP-0045).

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -18,7 +18,7 @@ import type { HttpUploadService } from './upload'
 import type { WebPushService, WebPushStatus } from './webpush'
 import type { AdminCommand, AdminSession, ServerStats } from './admin'
 import type { RSMResponse } from './pagination'
-import type { MAMQueryDirection } from '../../stores/shared/mamState'
+import type { MAMQueryDirection } from './pagination'
 import type { SystemNotificationType } from './events'
 import type { XMPPErrorType, XMPPStanzaError } from '../../utils/xmppError'
 

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -210,16 +210,19 @@ export type { EntityNotificationState, NotificationMessage, EntityContext, Badge
 // carries the XEP-0359 archive id that XEP-0490 publishes, `local` says the
 // position has no wire name yet — so a consumer that wants to publish a position
 // has to say what it does when there isn't one. `order` is likewise `exact` or
-// `floor`. See `stores/shared/readPointer.ts` for why neither name can replace
-// the other.
-export type { ReadPointer, PointerIdentity, PointerSource } from './stores/shared/readPointer'
-export { makeReadPointer, withArchiveId, isAhead, advance } from './stores/shared/readPointer'
+// `floor`. The shapes are declared in `core/types/readState.ts`, which explains
+// why neither name can replace the other; the constructors and comparators live
+// in `stores/shared/readPointer.ts`.
 export type {
+  ReadPointer,
+  PointerIdentity,
   CacheOrderKey,
   PointerOrder,
   ExactPosition,
   FloorPosition,
-} from './stores/shared/readState'
+} from './core/types'
+export type { PointerSource } from './stores/shared/readPointer'
+export { makeReadPointer, withArchiveId, isAhead, advance } from './stores/shared/readPointer'
 
 // Viewport evidence (read-state PR B, Task 11): SDK-owned, generation-scoped
 // "is the viewport genuinely at the live edge" state. `beginViewportGeneration`

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -1,34 +1,19 @@
-import { resolveArchivePosition } from '../../utils/messageCache'
-import type { ExactPosition } from './readState'
-
 /**
- * Persisted contiguous-with-live coverage (Codex r3 #3/#4).
- *
- * A `CoverageRecord` is POSITIVE, DURABLE data: the archive id of the oldest
- * entry proven contiguous with the live edge for this device. Unlike a
- * `GapInterval` (which describes a hole and vanishes when the hole closes) or
- * `coverageBottomUnproven` (session-scoped), the record survives fresh
- * sessions and gap closure, so:
- * - Phase B (read-pointer stitch) seeds its backward walk from it and never
- *   from a disjoint cache island (e.g. a fetchContext window);
- * - a signal-only fetch-latest walk resumes BELOW prior coverage instead of
- *   re-walking the same newest pages every session (`topId` marks re-entry
- *   into covered territory; the walk jumps to `bottomId`).
- *
- * Advancing `bottomId` past a page that carries persistable messages must be
- * gated on the durable IndexedDB commit of that page (same invariant as gap
- * transitions): the record must never point past data that was never stored.
+ * Coverage transitions for the persisted contiguous-with-live record
+ * ({@link CoverageRecord}, Codex r3 #3/#4).
  *
  * @module Stores/Shared/MamCoverage
  */
 
-export interface CoverageRecord {
-  /** Archive id of the OLDEST entry proven contiguous with the live edge. */
-  bottomId: string
-  /** Archive id of the NEWEST entry seen by the fetch-latest walk that
-   *  established this record (page-1 rsm.last). */
-  topId?: string
-}
+import { resolveArchivePosition } from '../../utils/messageCache'
+import type { CoverageRecord, ExactPosition } from '../../core/types'
+
+/**
+ * The coverage shapes are declared in `core/types/pagination.ts` — they ride on
+ * SDK events, so `core/types` must be able to name them without depending on a
+ * store. Re-exported here, where the transition logic lives.
+ */
+export type { CoverageRecord, MergeArchiveExtras } from '../../core/types'
 
 /**
  * What a merge did to the record — the persistence layer's durability input.
@@ -63,23 +48,6 @@ export interface CoverageSyncResult {
   /** Copy-on-write: the SAME reference as the input when nothing changed. */
   coverage: Map<string, CoverageRecord>
   transition: CoverageTransition
-}
-
-/** Extra merge inputs carried on the mam-messages emit (both entity kinds). */
-export interface MergeArchiveExtras {
-  /** The `before` cursor the query was started with ('' = fetch-latest). */
-  initialBefore?: string
-  /** rsm.last of the FIRST page of a backward walk (newest covered entry). */
-  fetchLatestTopId?: string
-  /** The walk contained the existing coverage record's top entry — the only
-   *  accepted proof of contiguity with the record (Codex r4 #3). */
-  sawCoverageTop?: boolean
-  /** The walk carried corrections/retractions/reactions/fastenings, whose
-   *  cache effects are fire-and-forget — certification is blocked (r4 #2). */
-  walkCarriedModifications?: boolean
-  /** FORWARD only: the `after` cursor the catch-up resumed from — the bootstrap
-   *  anchor when that catch-up reports complete. */
-  initialAfter?: string
 }
 
 /** Serialize the coverage map for localStorage (`[id, CoverageRecord][]`). */

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -13,7 +13,7 @@
  * - `isCaughtUpToLive`: Synced with real-time (no gap to present)
  */
 
-import type { MAMQueryState } from '../../core/types'
+import type { MAMQueryDirection, MAMQueryState } from '../../core/types'
 
 /**
  * Default MAM query state for conversations/rooms that haven't been queried yet.
@@ -88,9 +88,10 @@ export function setCoverageBottomUnproven(
 }
 
 /**
- * Query direction for MAM queries.
+ * Query direction for MAM queries. Declared in `core/types/pagination.ts` and
+ * re-exported here, where the helpers that consume it live.
  */
-export type MAMQueryDirection = 'backward' | 'forward'
+export type { MAMQueryDirection } from '../../core/types'
 
 /**
  * Newest fetched message timestamp (epoch ms), for gap marker positioning by

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -31,56 +31,20 @@
  * All functions here are pure.
  */
 
-import { mayAdvanceTo, exactPosition, type CacheOrderKey, type PointerOrder } from './readState'
+import { mayAdvanceTo, exactPosition } from './readState'
+import type {
+  CacheOrderKey,
+  PointerIdentity,
+  ReadPointer,
+} from '../../core/types/readState'
 
 /**
- * How a read position can be NAMED.
- *
- * `messageId` is on both variants — it always exists, and it is the pointer's
- * ONE local name. `archiveId` exists only on `addressable`, so reaching for it
- * forces the consumer to say what it does when the position has no wire name.
- *
- * - **`addressable`** — the named message carried an XEP-0359 archive id when
- *   the pointer was minted. Publishable as-is: the XEP-0490 publisher reads
- *   `archiveId` and is done, with no lookup, no residency requirement and no
- *   cache read.
- * - **`local`** — degraded, and EXPLICITLY so. The archive id genuinely does not
- *   exist yet (or, for the user's own 1:1 sends, may never: the server does not
- *   echo them back, so the only id they ever have is a client-generated
- *   `origin-id`, which is not publishable). No model can conjure one. What the
- *   variant buys is that the state is named once instead of being rediscovered
- *   at each consumer, and that the publisher's at-or-behind fallback (#1189) is
- *   the DEFINITION of this branch rather than a patch bolted onto it.
- *
- * XEP-0359's `by` is deliberately NOT stored: it is a function of the entity
- * (`isRoom(jid) ? jid : ownBareJid()`), so storing it would be a second
- * derivable copy of something the publisher already knows.
+ * The pointer types are declared in `core/types/readState.ts` — they are domain
+ * types on the SDK's public surface, and `core/types` must not depend on a
+ * store. They are re-exported here because this module owns the constructors
+ * and comparators, and every consumer of those wants both.
  */
-export type PointerIdentity =
-  | { readonly state: 'addressable'; readonly messageId: string; readonly archiveId: string }
-  | { readonly state: 'local'; readonly messageId: string }
-
-/**
- * Where the user has read to. Written atomically or not at all.
- *
- * ONE deliberate exception to "the timestamp is the message's own": pointers
- * built by the #1081 migration from a legacy `lastSeenMessageId` + `lastReadAt`
- * PAIR carry `lastReadAt` as the timestamp, which is not necessarily the
- * timestamp of the message the identity names. Those pointers carry a
- * `role: 'floor'` order, which says exactly that: "at least here". That is the
- * status quo preserved exactly — `lastReadAt` is the floor today's unread
- * derivation already counts from, and it is at or behind the named message. Do
- * not "fix" this by resolving the message's real timestamp: that could move the
- * floor FORWARD, and the pointer is forward-only, so a position lost that way is
- * unrecoverable. Only `order` is used for ordering; nothing derives a message
- * from it.
- */
-export interface ReadPointer {
-  /** Where this position sits in message-cache order. NEVER rewritten. */
-  readonly order: PointerOrder
-  /** What this position is called — locally, and on the wire when we can. */
-  readonly identity: PointerIdentity
-}
+export type { PointerIdentity, ReadPointer } from '../../core/types/readState'
 
 /**
  * The order as it is written to disk: everything the tie-break needs EXCEPT its

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -9,7 +9,12 @@
  * All functions here are pure.
  */
 
-import type { ReadPointer } from './readPointer'
+import type {
+  CacheOrderKey,
+  ExactPosition,
+  PointerOrder,
+  ReadPointer,
+} from '../../core/types/readState'
 
 /**
  * Re-exported so the live `+1` fast path (`notificationState.ts`) and the
@@ -20,78 +25,17 @@ import type { ReadPointer } from './readPointer'
 export { isRenderableStoredMessage, type RenderabilityCheckFields } from '../../utils/messageRenderability'
 
 /**
- * The IndexedDB message cache's own tie-break key for a message, built from the
- * CLIENT message id. It has never held an archive id, and could not: XEP-0313
- * §6.2 makes archive ids opaque strings with no guarantee of being numeric,
- * sequenced or globally unique, and unique only per archive — they carry no
- * ordering. This key is chosen to agree with the cache's cursors, and is
- * kind-discriminated because chat and room break same-millisecond ties
- * differently:
- *
- * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'`,
- *   `messageCache.ts:140`).
- * - Room breaks ties by `from` then `id` (the `room_ts_from_id` index).
- *
- * Chat messages also carry `from`, so a generic "from then id" comparator
- * would be wrong for chat — the `kind` discriminant is what keeps the two
- * apart. Do not generalise this into a single shape.
+ * The cache-order types are declared in `core/types/readState.ts` — they are
+ * domain types on the SDK's public surface, and `core/types` must not depend on
+ * a store. They are re-exported here because this module owns the comparators
+ * that operate on them, and every consumer of a comparator wants both.
  */
-export type CacheOrderKey = { kind: 'chat'; id: string } | { kind: 'room'; from: string; id: string }
+export type { CacheOrderKey, ExactPosition, FloorPosition, PointerOrder } from '../../core/types/readState'
 
 /** Build the kind-appropriate order key for a message. */
 export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'chat' | 'room'): CacheOrderKey {
   return kind === 'room' ? { kind: 'room', from: msg.from ?? '', id: msg.id } : { kind: 'chat', id: msg.id }
 }
-
-/**
- * A position that is exactly located in message-cache order: a timestamp
- * refined by the tie-break that resolves its millisecond.
- *
- * Every real message yields one, because {@link makeCacheOrderKey} always
- * produces a key — use {@link exactPosition} rather than assembling the literal.
- *
- * `role` is not redundant with the presence of `tiebreak`: it is what makes
- * {@link PointerOrder} a DISCRIMINATED union, so narrowing reads as
- * `order.role === 'floor'` at every consumer instead of as an incidental
- * "the optional field happens to be missing" test. A weaker position cannot be
- * passed where an exact one is required (#1173).
- */
-export interface ExactPosition {
-  readonly role: 'exact'
-  readonly timestamp: number
-  readonly tiebreak: CacheOrderKey
-}
-
-/**
- * A position known only to a millisecond: "at least here", not "exactly here".
- *
- * This is what a pointer migrated from the pre-#1081 `lastSeenMessageId` +
- * `lastReadAt` pair carries — `lastReadAt` sits at or behind the message the
- * pointer names, with no provable position inside its millisecond. It is also
- * where an {@link ExactPosition} degrades when its persisted tie-break comes
- * back unusable: dropping to a floor over-counts (the safe direction) rather
- * than trusting a key we cannot rebuild.
- *
- * Deliberately has NO `tiebreak` property at all rather than an optional one:
- * with `role` discriminating, `order.tiebreak` does not typecheck on this
- * variant, so nothing can read a key off a floor and nothing can smuggle one in.
- */
-export interface FloorPosition {
-  readonly role: 'floor'
-  readonly timestamp: number
-}
-
-/**
- * Where a read pointer sits in message-cache order — see {@link ReadPointer}.
- *
- * The two variants are the two things a stored position can honestly claim, and
- * every comparator below answers them differently on purpose. Note that
- * `readonly` here stops a position being MUTATED, not rebuilt: a consumer can
- * still construct a fresh order object with a different timestamp. Never moving
- * a stored position stays a review concern (`readPointer.ts`), which the type
- * makes visible — you have to name `order` — rather than impossible.
- */
-export type PointerOrder = ExactPosition | FloorPosition
 
 /**
  * The exact cache-order position of a real message.


### PR DESCRIPTION
`core/types` is the SDK's leaf layer: the vocabulary every other layer names its own contracts in. Six read-position types (`ReadPointer`, `PointerIdentity`, `CacheOrderKey`, `ExactPosition`, `FloorPosition`, `PointerOrder`) and three archive-coverage types (`MAMQueryDirection`, `CoverageRecord`, `MergeArchiveExtras`) were declared under `stores/shared/`. So `core/types/chat.ts`, `room.ts` and `sdk-events.ts` had to import from a state implementation just to name them, which made `core/types` depend on the stores that depend on it.

The declarations move to `core/types/readState.ts` (new) and `core/types/pagination.ts`. The `stores/shared` modules keep the constructors and comparators, and re-export the types, so no consumer changes. The public type surface is unchanged.

This also removes the `readPointer` / `readState` import cycle, which existed only because each module declared a type the other needed.

`client.ts` still derives `StoreBindings` from the concrete store state types via `Pick<ChatState, ...>`. The new `core/types/layering.test.ts` allows exactly that one file and fails on any new store import from `core/types`, so the remaining debt is named rather than open-ended.