### PR TITLE
refactor(sdk): declare the store-binding port instead of deriving it

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1,11 +1,11 @@
 import { Client, Element } from '@xmpp/client'
 import { createActor, type Subscription, type Snapshot } from 'xstate'
 import type { EventHook } from './EventHook'
+import type { XMPPClientConfig } from './clientConfig'
 import type {
   ConnectOptions,
   StoreBindings,
   XMPPClientEvents,
-  XMPPClientConfig,
   SDKEvents,
   SDKEventHandler,
   StorageAdapter,

--- a/packages/fluux-sdk/src/core/clientConfig.ts
+++ b/packages/fluux-sdk/src/core/clientConfig.ts
@@ -1,0 +1,101 @@
+/**
+ * {@link XMPPClient} construction options.
+ *
+ * This is wiring, not vocabulary: alongside the adapter contracts it carries a
+ * live {@link SDKStores} bundle, which is a handle on a concrete state
+ * implementation. That is why it lives here next to the client rather than in
+ * `core/types`, which stays a leaf layer no store can be reached from.
+ *
+ * @packageDocumentation
+ * @module Core
+ */
+
+import type { SDKStores } from '../stores/sdkStores'
+import type { StorageAdapter } from './types/storage'
+import type { ProxyAdapter } from './types/proxy'
+import type { PresenceOptions, PrivacyOptions } from './types/client'
+
+/**
+ * XMPPClient configuration options.
+ *
+ * @category Core
+ */
+export interface XMPPClientConfig {
+  /** Enable debug logging */
+  debug?: boolean
+  /**
+   * Store bundle backing this client. Defaults to the process-wide singletons
+   * ({@link defaultStores}).
+   *
+   * @internal Partial seam — NOT a supported multi-account switch yet, and not
+   * part of the public API. A custom {@link SDKStores} bundle is honored by
+   * `connect()` account-switch and the SDK event → store bindings, but the
+   * store-based side effects (MAM catch-up, read-marker / MDS sync, background
+   * sync), the SM-resumable state snapshot, and the Poll module still read and
+   * write the process-global singletons regardless of what is passed here.
+   * Two clients with different bundles therefore cross-contaminate on that
+   * state — do not use this to run multiple accounts. Full isolation also needs
+   * a `createStores()` factory and a per-instance storage scope; see the
+   * checklist in `stores/sdkStores.ts`. Single-account apps must omit this.
+   */
+  stores?: SDKStores
+  /**
+   * Options for integrating an external presence state machine.
+   * Only needed when using XState for presence management (e.g., in React apps).
+   * Bots typically don't need this - default presence handling is sufficient.
+   */
+  presenceOptions?: PresenceOptions
+  /**
+   * Privacy options for controlling data exposure.
+   * @see {@link PrivacyOptions}
+   */
+  privacyOptions?: PrivacyOptions
+  /**
+   * Storage adapter for session persistence.
+   *
+   * Provides platform-specific storage for:
+   * - XEP-0198 Stream Management session state (for fast reconnection)
+   * - User credentials (for "Remember Me" functionality)
+   * - Cached roster, rooms, and server info (for faster startup)
+   *
+   * The SDK provides `sessionStorageAdapter` as a default for web apps.
+   * Desktop apps can provide a custom adapter using OS keychain.
+   *
+   * @example
+   * ```tsx
+   * // Web app - uses default sessionStorageAdapter
+   * <XMPPProvider>
+   *   <App />
+   * </XMPPProvider>
+   *
+   * // Desktop app with OS keychain
+   * <XMPPProvider storageAdapter={tauriStorageAdapter}>
+   *   <App />
+   * </XMPPProvider>
+   * ```
+   */
+  storageAdapter?: StorageAdapter
+  /**
+   * Proxy adapter for WebSocket-to-TCP bridging.
+   *
+   * Desktop apps can provide a proxy adapter to enable native TCP/TLS
+   * connections to XMPP servers instead of WebSocket.
+   *
+   * When provided, the SDK will use this adapter to start/stop the proxy
+   * for each connection. When not provided, connections use WebSocket directly.
+   *
+   * @example
+   * ```tsx
+   * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
+   *   <App />
+   * </XMPPProvider>
+   * ```
+   */
+  proxyAdapter?: ProxyAdapter
+  /**
+   * Pull-based predicate the SDK evaluates before each automatic reconnect
+   * attempt. Return `false` to suppress auto-reconnect (e.g., after an
+   * explicit logout). Evaluated live — no cached copy. Defaults to always-on.
+   */
+  shouldAutoReconnect?: () => boolean
+}

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -8,10 +8,13 @@ export { createDefaultStoreBindings } from './defaultStoreBindings'
 export { xml } from '@xmpp/client'
 export type { Element } from '@xmpp/client'
 
+// Client construction options (carries the store bundle, so it lives outside
+// the leaf type layer).
+export type { XMPPClientConfig } from './clientConfig'
+
 // Types
 export type {
   ConnectOptions,
-  XMPPClientConfig,
   XMPPClientEvents,
   StoreBindings,
   PresenceOptions,

--- a/packages/fluux-sdk/src/core/storeBindingKeys.ts
+++ b/packages/fluux-sdk/src/core/storeBindingKeys.ts
@@ -1,16 +1,19 @@
 /**
- * Single source of truth for the store methods exposed through {@link StoreBindings}.
+ * The store methods that are passed through to XMPPClient verbatim.
  *
- * Each list enumerates the methods of one Zustand store that are passed
- * through to XMPPClient verbatim. Three artifacts are derived from it:
+ * Each list names the members of one {@link StoreBindings} namespace that a
+ * store implements by simple delegation, so two artifacts can be generated
+ * from it instead of hand-written three times:
  *
- * - the `StoreBindings` interface (`Pick<State, key>` in types/client.ts)
  * - `createDefaultStoreBindings()` (late-bound delegation to the global store)
  * - `createMockStores()` (a `vi.fn()` per key in test-utils)
  *
- * Adding a store method to the client surface = add it to the store, then add
- * its name here. The `satisfies` clauses reject typos at compile time, and
- * storeBindingKeys.test.ts keeps the three artifacts in lockstep.
+ * The `satisfies` clauses check the names against the PORT, not against the
+ * store: the contract is `types/storeBindings.ts`, and a store proves it
+ * conforms in `stores/storeBindingsConformance.ts`. Adding a method to the
+ * client surface therefore means declaring it in the port, implementing it in
+ * the store, and adding its name here — the compiler rejects any two of the
+ * three without the last.
  *
  * NOT listed here: presence-machine bridge members (they come from
  * PresenceOptions, not a store), plain state getters (`getStatus`,
@@ -22,14 +25,7 @@
  * @module Core
  */
 
-import type { ConnectionState } from '../stores/connectionStore'
-import type { ChatState } from '../stores/chatStore'
-import type { RosterState } from '../stores/rosterStore'
-import type { ConsoleState } from '../stores/consoleStore'
-import type { EventsState } from '../stores/eventsStore'
-import type { RoomState } from '../stores/roomStore'
-import type { AdminState } from '../stores/adminStore'
-import type { BlockingState } from '../stores/blockingStore'
+import type { StoreBindings } from './types/storeBindings'
 
 export const connectionBindingMethodKeys = [
   'setStatus',
@@ -53,7 +49,7 @@ export const connectionBindingMethodKeys = [
   // Web Push (p1:push)
   'setWebPushStatus',
   'setWebPushServices',
-] as const satisfies readonly (keyof ConnectionState)[]
+] as const satisfies readonly (keyof StoreBindings['connection'])[]
 
 export const chatBindingMethodKeys = [
   'addMessage',
@@ -83,7 +79,7 @@ export const chatBindingMethodKeys = [
   'archiveConversation',
   'unarchiveConversation',
   'mergeServerConversations',
-] as const satisfies readonly (keyof ChatState)[]
+] as const satisfies readonly (keyof StoreBindings['chat'])[]
 
 export const rosterBindingMethodKeys = [
   'setContacts',
@@ -99,12 +95,12 @@ export const rosterBindingMethodKeys = [
   'getOfflineContacts',
   'sortedContacts',
   'resetAllPresence',
-] as const satisfies readonly (keyof RosterState)[]
+] as const satisfies readonly (keyof StoreBindings['roster'])[]
 
 export const consoleBindingMethodKeys = [
   'addPacket',
   'addEvent',
-] as const satisfies readonly (keyof ConsoleState)[]
+] as const satisfies readonly (keyof StoreBindings['console'])[]
 
 export const eventsBindingMethodKeys = [
   'addSubscriptionRequest',
@@ -115,7 +111,7 @@ export const eventsBindingMethodKeys = [
   'removeMucInvitation',
   'addSystemNotification',
   'clearSystemNotifications',
-] as const satisfies readonly (keyof EventsState)[]
+] as const satisfies readonly (keyof StoreBindings['events'])[]
 
 export const roomBindingMethodKeys = [
   'addRoom',
@@ -159,7 +155,7 @@ export const roomBindingMethodKeys = [
   'hydratePreviewsFromCache',
   'mergeRoomMembers',
   'updateMemberAffiliation',
-] as const satisfies readonly (keyof RoomState)[]
+] as const satisfies readonly (keyof StoreBindings['room'])[]
 
 export const adminBindingMethodKeys = [
   'setIsAdmin',
@@ -172,7 +168,7 @@ export const adminBindingMethodKeys = [
   'setVhosts',
   'setSelectedVhost',
   'reset',
-] as const satisfies readonly (keyof AdminState)[]
+] as const satisfies readonly (keyof StoreBindings['admin'])[]
 
 export const blockingBindingMethodKeys = [
   'setBlocklist',
@@ -181,4 +177,4 @@ export const blockingBindingMethodKeys = [
   'clearBlocklist',
   'isBlocked',
   'getBlockedJids',
-] as const satisfies readonly (keyof BlockingState)[]
+] as const satisfies readonly (keyof StoreBindings['blocking'])[]

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -6,145 +6,27 @@
  */
 
 import type { Element } from '@xmpp/client'
-import type { ConnectionStatus } from './connection'
 import type { Message } from './chat'
-import type { RoomMessage } from './room'
 import type { PresenceStatus, Contact } from './roster'
-import type { ServerInfo } from './discovery'
-import type { HttpUploadService } from './upload'
-import type { WebPushService } from './webpush'
-import type { AdminCommand, AdminSession } from './admin'
-import type { StorageAdapter } from './storage'
-import type { ProxyAdapter } from './proxy'
-import type { ConnectionState } from '../../stores/connectionStore'
-import type { ChatState } from '../../stores/chatStore'
-import type { RosterState } from '../../stores/rosterStore'
-import type { ConsoleState } from '../../stores/consoleStore'
-import type { EventsState } from '../../stores/eventsStore'
-import type { RoomState } from '../../stores/roomStore'
-import type { AdminState } from '../../stores/adminStore'
-import type { BlockingState } from '../../stores/blockingStore'
-import type { SDKStores } from '../../stores/sdkStores'
-import {
-  connectionBindingMethodKeys,
-  chatBindingMethodKeys,
-  rosterBindingMethodKeys,
-  consoleBindingMethodKeys,
-  eventsBindingMethodKeys,
-  roomBindingMethodKeys,
-  adminBindingMethodKeys,
-  blockingBindingMethodKeys,
-} from '../storeBindingKeys'
 
 // ============================================================================
 // Store Bindings (Internal)
 // ============================================================================
 
-/**
- * Store bindings interface for injecting store methods into XMPPClient.
- *
- * The bulk of each namespace is DERIVED from the corresponding store state
- * type via the key lists in storeBindingKeys.ts — the store's method
- * signature is the binding's signature, by construction. Only three kinds of
- * members are declared here by hand:
- *
- * - presence-machine bridge members (`Required<PresenceOptions>`) — they come
- *   from an external state machine, not a store
- * - plain state getters (`getStatus`, `getJid`, …)
- * - composite getters with real logic (`getAllConversations`, …)
- *
- * @internal
- * This interface is used internally by XMPPProvider to bind Zustand stores
- * to the XMPP client. Application code should use the React hooks instead.
- *
- * @category Internal
- */
-export interface StoreBindings {
-  connection: Pick<ConnectionState, (typeof connectionBindingMethodKeys)[number]> & {
-      // State getters
-      getStatus: () => ConnectionStatus
-      getOwnNickname: () => string | null
-      getJid: () => string | null
-      getHttpUploadService: () => HttpUploadService | null
-      getWebPushServices: () => WebPushService[]
-      getWebPushEnabled: () => boolean
-      // Server info getter (for MAM support detection)
-      getServerInfo?: () => ServerInfo | null
-    }
-  chat: Pick<ChatState, (typeof chatBindingMethodKeys)[number]> & {
-    // Get all conversations for MAM catch-up
-    getAllConversations: () => Array<{ id: string; messages: Message[] }>
-    // Persisted forward-gap boundary for automatic catch-up recovery
-    getConversationGapStart?: (conversationId: string) => number | undefined
-    // Archive id of the recorded gap's coverage edge (GapInterval.startId) —
-    // id-exact resume cursor, preferred over the timestamp fallback above.
-    getConversationGapStartId?: (conversationId: string) => string | undefined
-    // Archive id of the recorded gap's contiguous-coverage bottom (GapInterval.endId) —
-    // the proven upper edge of the contiguous-from-live region.
-    getConversationGapEndId?: (conversationId: string) => string | undefined
-    // True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
-    // as unproven (no gap edge, no resident boundary) — the seeder must not
-    // trust cache-oldest as contiguous-to-live (finding 10).
-    getConversationCoverageUnproven?: (conversationId: string) => boolean | undefined
-    // XEP-0490 stanza-id of the remote read position, kept unresolved when it
-    // can't be matched locally — seeds a forward `after` catch-up on an
-    // empty-cache new device.
-    getConversationPendingStanzaId?: (conversationId: string) => string | undefined
-    // Currently ACTIVE conversation id (null when none). Re-checked at every
-    // Phase B iteration of the pointer-stitch walk: backward pages into the
-    // active resident window would keep-oldest-evict its live edge.
-    getActiveConversationId?: () => string | null
-    // Smart MAM: archived conversation preview refresh
-    getArchivedConversations?: () => Array<{ id: string; messages: Message[] }>
-    getLastMessage?: (conversationId: string) => Message | undefined
-    // Every stored conversation (archived INCLUDED) with its in-memory
-    // messages. Read seam for the deferred-decrypt engine, which must retry
-    // pending encrypted payloads regardless of archive state — unlike
-    // getAllConversations, which returns only the active set.
-    getAllStoredMessages: () => Array<{ id: string; messages: Message[] }>
-    // In-memory messages for a single conversation (archived included). Read
-    // seam for peer-scoped deferred-decrypt retry on a PEP key change.
-    getConversationMessages: (conversationId: string) => Message[]
-    // Every conversation whose sidebar preview still carries an
-    // `encryptedPayload` (archived INCLUDED). Read seam for the deferred-decrypt
-    // engine's preview-level heal: a preview can hold ciphertext that no message
-    // store reaches (its message evicted, already decrypted in IndexedDB, or set
-    // preview-only) — so it must be re-decrypted straight from its own stash.
-    getEncryptedPreviews?: () => Array<{ conversationId: string; lastMessage: Message }>
-  }
-  roster: Pick<RosterState, (typeof rosterBindingMethodKeys)[number]>
-  console: Pick<ConsoleState, (typeof consoleBindingMethodKeys)[number]>
-  events: Pick<EventsState, (typeof eventsBindingMethodKeys)[number]>
-  room: Pick<RoomState, (typeof roomBindingMethodKeys)[number]> & {
-    // Persisted forward-gap boundary for automatic catch-up recovery
-    getRoomGapStart?: (roomJid: string) => number | undefined
-    // Archive id of the recorded gap's coverage edge (GapInterval.startId) —
-    // id-exact resume cursor, preferred over the timestamp fallback above.
-    getRoomGapStartId?: (roomJid: string) => string | undefined
-    // Archive id of the recorded gap's contiguous-coverage bottom (GapInterval.endId) —
-    // the proven upper edge of the contiguous-from-live region.
-    getRoomGapEndId?: (roomJid: string) => string | undefined
-    // True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
-    // as unproven (no gap edge, no resident boundary) — the seeder must not
-    // trust cache-oldest as contiguous-to-live (finding 10).
-    getRoomCoverageUnproven?: (roomJid: string) => boolean | undefined
-    // XEP-0490 stanza-id of the remote read position, kept unresolved when it
-    // can't be matched locally — seeds a forward `after` catch-up on an
-    // empty-cache new device.
-    getRoomPendingStanzaId?: (roomJid: string) => string | undefined
-    // Every room with its in-memory runtime messages. Read seam for the
-    // deferred-decrypt engine (mirrors chat.getAllStoredMessages for MUC).
-    getAllRoomMessages: () => Array<{ jid: string; messages: RoomMessage[] }>
-  }
-  admin: Pick<AdminState, (typeof adminBindingMethodKeys)[number]> & {
-    // State getters
-    getCommands: () => AdminCommand[]
-    getCurrentSession: () => AdminSession | null
-    getMucServiceJid: () => string | null
-    selectedVhost: string | null
-  }
-  blocking: Pick<BlockingState, (typeof blockingBindingMethodKeys)[number]>
-}
+// The port itself lives in `./storeBindings`, declared in domain terms with no
+// dependency on a store. Re-exported here so the historical import path — and
+// the `core/types` barrel — keep working unchanged.
+export type {
+  StoreBindings,
+  ConnectionBindings,
+  ChatBindings,
+  RosterBindings,
+  ConsoleBindings,
+  EventsBindings,
+  RoomBindings,
+  AdminBindings,
+  BlockingBindings,
+} from './storeBindings'
 
 // ============================================================================
 // XMPP Client Events
@@ -248,89 +130,4 @@ export interface PrivacyOptions {
    * @default false
    */
   disableOccupantAvatarsInAnonymousRooms?: boolean
-}
-
-/**
- * XMPPClient configuration options.
- *
- * @category Core
- */
-export interface XMPPClientConfig {
-  /** Enable debug logging */
-  debug?: boolean
-  /**
-   * Store bundle backing this client. Defaults to the process-wide singletons
-   * ({@link defaultStores}).
-   *
-   * @internal Partial seam — NOT a supported multi-account switch yet, and not
-   * part of the public API. A custom {@link SDKStores} bundle is honored by
-   * `connect()` account-switch and the SDK event → store bindings, but the
-   * store-based side effects (MAM catch-up, read-marker / MDS sync, background
-   * sync), the SM-resumable state snapshot, and the Poll module still read and
-   * write the process-global singletons regardless of what is passed here.
-   * Two clients with different bundles therefore cross-contaminate on that
-   * state — do not use this to run multiple accounts. Full isolation also needs
-   * a `createStores()` factory and a per-instance storage scope; see the
-   * checklist in `stores/sdkStores.ts`. Single-account apps must omit this.
-   */
-  stores?: SDKStores
-  /**
-   * Options for integrating an external presence state machine.
-   * Only needed when using XState for presence management (e.g., in React apps).
-   * Bots typically don't need this - default presence handling is sufficient.
-   */
-  presenceOptions?: PresenceOptions
-  /**
-   * Privacy options for controlling data exposure.
-   * @see {@link PrivacyOptions}
-   */
-  privacyOptions?: PrivacyOptions
-  /**
-   * Storage adapter for session persistence.
-   *
-   * Provides platform-specific storage for:
-   * - XEP-0198 Stream Management session state (for fast reconnection)
-   * - User credentials (for "Remember Me" functionality)
-   * - Cached roster, rooms, and server info (for faster startup)
-   *
-   * The SDK provides `sessionStorageAdapter` as a default for web apps.
-   * Desktop apps can provide a custom adapter using OS keychain.
-   *
-   * @example
-   * ```tsx
-   * // Web app - uses default sessionStorageAdapter
-   * <XMPPProvider>
-   *   <App />
-   * </XMPPProvider>
-   *
-   * // Desktop app with OS keychain
-   * <XMPPProvider storageAdapter={tauriStorageAdapter}>
-   *   <App />
-   * </XMPPProvider>
-   * ```
-   */
-  storageAdapter?: StorageAdapter
-  /**
-   * Proxy adapter for WebSocket-to-TCP bridging.
-   *
-   * Desktop apps can provide a proxy adapter to enable native TCP/TLS
-   * connections to XMPP servers instead of WebSocket.
-   *
-   * When provided, the SDK will use this adapter to start/stop the proxy
-   * for each connection. When not provided, connections use WebSocket directly.
-   *
-   * @example
-   * ```tsx
-   * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
-   *   <App />
-   * </XMPPProvider>
-   * ```
-   */
-  proxyAdapter?: ProxyAdapter
-  /**
-   * Pull-based predicate the SDK evaluates before each automatic reconnect
-   * attempt. Return `false` to suppress auto-reconnect (e.g., after an
-   * explicit logout). Evaluated live — no cached copy. Defaults to always-on.
-   */
-  shouldAutoReconnect?: () => boolean
 }

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -140,14 +140,29 @@ export type {
   LastActivityEntry,
 } from './admin'
 
-// Client types
+// Client types.
+//
+// `XMPPClientConfig` is deliberately NOT here: it carries a live `SDKStores`
+// bundle, so re-exporting it would make this leaf barrel depend on a concrete
+// store. It is exported from `core/clientConfig` instead.
 export type {
   StoreBindings,
   XMPPClientEvents,
-  XMPPClientConfig,
   PresenceOptions,
   PrivacyOptions,
 } from './client'
+
+// The store-binding port, declared in domain terms (see `./storeBindings`).
+export type {
+  ConnectionBindings,
+  ChatBindings,
+  RosterBindings,
+  ConsoleBindings,
+  EventsBindings,
+  RoomBindings,
+  AdminBindings,
+  BlockingBindings,
+} from './storeBindings'
 
 // Storage types
 export type {

--- a/packages/fluux-sdk/src/core/types/layering.test.ts
+++ b/packages/fluux-sdk/src/core/types/layering.test.ts
@@ -10,39 +10,59 @@ import { fileURLToPath } from 'node:url'
  * blob, forbids typechecking a protocol module in isolation, and hardwires
  * Zustand into a package documented as store-agnostic.
  *
- * Exactly one file is still allowed to, and it is tracked debt: `client.ts`
- * derives `StoreBindings` from the concrete store state types via
- * `Pick<ChatState, …>`. Emptying this allowlist is the point of that follow-up
- * work: the port has to be declared in domain terms, with the stores proving
- * conformance to it rather than the reverse.
+ * The layer is clean, and staying clean is the invariant. Two ways to break it:
+ * importing a store directly, or importing a `core/` module that does (today
+ * `clientConfig.ts`, which names the `SDKStores` bundle — that is exactly why
+ * `XMPPClientConfig` lives there and not here).
  *
- * When you remove the last entry, assert an empty array — do not delete the
- * test.
+ * If you need a type here that a store also needs, declare it here and let the
+ * store import it. Do not add an entry to either list below.
  */
-const ALLOWED_TO_IMPORT_STORES = ['client.ts']
+const ALLOWED_TO_IMPORT_STORES: string[] = []
+
+/** `core/` modules that reach a store, so importing them re-creates the edge. */
+const CORE_MODULES_THAT_REACH_STORES = ['clientConfig']
 
 const TYPES_DIR = dirname(fileURLToPath(import.meta.url))
 
-/** Relative specifiers that resolve somewhere under `src/stores/`. */
-function storeImportsOf(source: string): string[] {
+function importSpecifiersOf(source: string): string[] {
   const specifiers = source.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]*)['"]/g)
-  return [...specifiers].map(m => m[1]).filter(spec => spec.split('/').includes('stores'))
+  return [...specifiers].map(m => m[1])
+}
+
+/** Specifiers resolving somewhere under `src/stores/`. */
+function storeImportsOf(source: string): string[] {
+  return importSpecifiersOf(source).filter(spec => spec.split('/').includes('stores'))
+}
+
+/** Specifiers resolving to a `core/` module known to reach a store. */
+function transitiveStoreImportsOf(source: string): string[] {
+  return importSpecifiersOf(source).filter(spec =>
+    CORE_MODULES_THAT_REACH_STORES.some(mod => spec === `../${mod}`)
+  )
 }
 
 describe('core/types layering', () => {
   const files = readdirSync(TYPES_DIR).filter(f => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+
+  const offendersBy = (find: (source: string) => string[]) =>
+    Object.fromEntries(
+      files
+        .map(file => [file, find(readFileSync(join(TYPES_DIR, file), 'utf8'))] as const)
+        .filter(([, imports]) => imports.length > 0)
+    )
 
   it('has files to check', () => {
     expect(files.length).toBeGreaterThan(10)
   })
 
   it('declares domain types without importing a store', () => {
-    const offenders = Object.fromEntries(
-      files
-        .map(file => [file, storeImportsOf(readFileSync(join(TYPES_DIR, file), 'utf8'))] as const)
-        .filter(([, imports]) => imports.length > 0)
+    expect(Object.keys(offendersBy(storeImportsOf)).sort()).toEqual(
+      [...ALLOWED_TO_IMPORT_STORES].sort()
     )
+  })
 
-    expect(Object.keys(offenders).sort()).toEqual([...ALLOWED_TO_IMPORT_STORES].sort())
+  it('does not reach a store through a core module either', () => {
+    expect(Object.keys(offendersBy(transitiveStoreImportsOf))).toEqual([])
   })
 })

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -1,0 +1,578 @@
+/**
+ * The state surface {@link XMPPClient} writes through.
+ *
+ * This is a PORT: it is declared here, in the SDK's leaf type layer, in terms
+ * of domain types only. It used to be derived from the Zustand stores with
+ * `Pick<ChatState, …>`, which made the contract a shadow of one particular
+ * implementation and pulled every store into the core's dependency graph.
+ *
+ * The conformance direction is now the other way round: each store proves it
+ * satisfies its interface here (`stores/storeBindingsConformance.ts`), and the
+ * key lists in `core/storeBindingKeys.ts` are checked against these interfaces
+ * rather than against the store state. Adding a method to the client surface
+ * means declaring it here first, then implementing it in the store — the
+ * compiler rejects either half on its own.
+ *
+ * @packageDocumentation
+ * @module Types/StoreBindings
+ */
+
+import type { ConnectionStatus, ConnectionMethod } from './connection'
+import type { ServerInfo } from './discovery'
+import type { HttpUploadService } from './upload'
+import type { WebPushService, WebPushStatus } from './webpush'
+import type { Contact, PresenceShow, VCardInfo } from './roster'
+import type { Message, Conversation } from './chat'
+import type { Room, RoomMessage, RoomOccupant, RoomAffiliation } from './room'
+import type { SystemNotificationType } from './events'
+import type { AdminCommand, AdminSession, ServerStats } from './admin'
+import type {
+  MAMQueryState,
+  MAMQueryDirection,
+  CoverageRecord,
+  MergeArchiveExtras,
+  RSMResponse,
+} from './pagination'
+import type { GetMessagesOptions } from '../../utils/messageCache'
+
+/**
+ * Connection-store surface the client writes to.
+ *
+ * @category Internal
+ */
+export interface ConnectionBindings {
+  // Actions - state setters only (connect/disconnect moved to hooks)
+  setStatus: (status: ConnectionStatus) => void
+  setIsVerifying: (isVerifying: boolean) => void
+  setJid: (jid: string | null) => void
+  setError: (error: string | null) => void
+  setReconnectState: (attempt: number, reconnectTargetTime: number | null) => void
+  setServerInfo: (info: ServerInfo | null) => void
+  setConnectionMethod: (method: ConnectionMethod | null) => void
+  setAuthMechanism: (mechanism: string | null) => void
+  setAuthMethod: (method: 'fast-token' | 'password' | null) => void
+
+  // Own profile actions
+  setOwnAvatar: (avatar: string | null, hash?: string | null) => void
+  setOwnNickname: (nickname: string | null) => void
+  setOwnVCard: (vcard: VCardInfo | null) => void
+  updateOwnResource: (resource: string, show: PresenceShow | null, priority: number, status?: string, lastInteraction?: Date, client?: string) => void
+  removeOwnResource: (resource: string) => void
+  clearOwnResources: () => void
+
+  // HTTP Upload actions
+  setHttpUploadService: (service: HttpUploadService | null) => void
+
+  // Web Push actions
+  setWebPushStatus: (status: WebPushStatus) => void
+  setWebPushServices: (services: WebPushService[]) => void
+
+  // ----- State getters -----
+
+  getStatus: () => ConnectionStatus
+  getOwnNickname: () => string | null
+  getJid: () => string | null
+  getHttpUploadService: () => HttpUploadService | null
+  getWebPushServices: () => WebPushService[]
+  getWebPushEnabled: () => boolean
+  /** Server info getter (for MAM support detection). */
+  getServerInfo?: () => ServerInfo | null
+}
+
+/**
+ * 1:1 conversation surface the client writes to, plus the read seams
+ * MAM catch-up and deferred decrypt need.
+ *
+ * @category Internal
+ */
+export interface ChatBindings {
+  addMessage: (msg: Message) => void
+  addConversation: (conv: Conversation) => void
+  updateConversationName: (id: string, name: string) => void
+  hasConversation: (id: string) => boolean
+  setTyping: (conversationId: string, jid: string, isTyping: boolean) => void
+  updateReactions: (conversationId: string, messageId: string, reactorJid: string, emojis: string[]) => void
+  updateMessage: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+
+  /**
+   * Hard-remove a message from the conversation, the search index, and the
+   * durable cache. Used when a stanza that was provisionally stored as a
+   * message turns out not to be one — e.g. a deferred-decrypted bodiless
+   * signal (XEP-0444 reaction) whose "[could not decrypt]" placeholder must
+   * disappear once the real reaction is applied to its target.
+   */
+  removeMessage: (conversationId: string, messageId: string) => void
+
+  /**
+   * Reconcile a non-active conversation's unread count against the durable
+   * archive (PR B): a coverage-gated cursor count from the effective read
+   * boundary, plus the transient (`noLocalStore`) overlay, capped at 999 —
+   * never a bounded resident/cache slice. Commits only on an exact
+   * derivation; every uncertain case (un-migrated/pending read state,
+   * pointerless-with-count, incomplete coverage) leaves the last TRUSTED
+   * count untouched rather than writing a provisional one. `mentionsCount` is
+   * never written here (see `readState.ts`'s `RecomputeOutcome` doc). Latest-
+   * wins across concurrent recounts for the same conversation.
+   *
+   * Called after a deferred-decrypt drops a bodiless-signal placeholder
+   * (reaction/retraction) that had been provisionally counted as unread —
+   * {@link removeMessage} clears the row but not the phantom badge it left
+   * behind — and after any transient-overlay mutation that reports a change.
+   *
+   * No-op for the active conversation by default: most triggers (message
+   * arrival, deferred-decrypt, transient-overlay changes) are already
+   * reconciled for the active conversation by their own synchronous path
+   * (`onMessageReceived`'s live-edge convergence, Task 11), so racing an async
+   * archive recompute against that would be redundant at best. The one
+   * exception is `{ allowActive: true }` (read-state PR B, final
+   * whole-branch-review FIX 3): a remote XEP-0490 marker can advance the
+   * ACTIVE entity's read position without that convergence path running at
+   * all, and since FIX 2 removed activation's unconditional zero, nothing
+   * else re-derives the active entity's count after such an advance — pass
+   * `allowActive: true` ONLY from that trigger.
+   */
+  recomputeUnreadForConversation: (conversationId: string, options?: { allowActive?: boolean }) => Promise<void>
+
+  /**
+   * XEP-0424: apply an incoming retraction, deferring it when its target is not
+   * resident. Applies immediately (and writes through to the durable cache) when
+   * the target is in the window; otherwise records it and replays it the moment
+   * the target arrives live or loads from the cache. Only the message's own
+   * author can retract it — a mismatched actor is dropped, never tombstoned.
+   *
+   * @param actorJid - Bare JID the retraction came from.
+   */
+  recordPendingRetraction: (conversationId: string, targetId: string, actorJid: string) => void
+  getMessage: (conversationId: string, messageId: string) => Message | undefined
+  triggerAnimation: (conversationId: string, animation: string, senderName?: string) => void
+
+  // XEP-0313: MAM (Message Archive Management)
+  setMAMLoading: (conversationId: string, isLoading: boolean) => void
+  setMAMError: (conversationId: string, error: string | null) => void
+
+  /**
+   * Merge MAM messages into conversation and update query state.
+   * @param conversationId - Conversation JID
+   * @param messages - Messages from MAM query
+   * @param rsm - RSM pagination response
+   * @param complete - Whether server indicated query is complete
+   * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
+   */
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
+  getMAMQueryState: (conversationId: string) => MAMQueryState
+  resetMAMStates: () => void
+
+  /** Persisted contiguous-with-live coverage record, if any. */
+  getConversationCoverage: (conversationId: string) => CoverageRecord | undefined
+
+  /** Drop the coverage record; with `ifBottomId`, only when it matches
+   *  `bottomId` (purge-event guard — the anchor is known gone). */
+  clearConversationCoverage: (conversationId: string, ifBottomId?: string) => void
+
+  /**
+   * Update only the lastMessage preview for a conversation without affecting the messages array.
+   * Used for background preview refresh to sync sidebar with server state after being offline.
+   * @param conversationId - Conversation JID
+   * @param lastMessage - The most recent message from MAM
+   */
+  updateLastMessagePreview: (conversationId: string, lastMessage: Message) => void
+
+  /**
+   * Apply an in-place content update to a conversation's lastMessage preview,
+   * but only when the preview IS the referenced message (matched across the
+   * XEP-0359 id tiers). Used by the durable-cache deferred-decrypt pass: when a
+   * conversation's preview message is decrypted while its messages aren't loaded
+   * in memory, {@link updateMessage} can't reach it and the timestamp-gated
+   * {@link updateLastMessagePreview} won't replace a same-timestamp message — so
+   * the sidebar would keep showing "[OpenPGP-encrypted message]". This refreshes
+   * the preview's content (body/securityContext/attachment/encryptedPayload)
+   * without touching the messages array.
+   * @param conversationId - Conversation JID
+   * @param messageId - id / stanzaId / originId of the decrypted message
+   * @param updates - Partial content to merge into the preview message
+   */
+  refreshLastMessageContent: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+
+  // IndexedDB message loading. `oldest` flips the latest-N default to the
+  // OLDEST-N ascending slice (true cache bottom) — pointer-walk seeding; use
+  // with `peek` (an oldest slice must never become the resident window).
+  loadMessagesFromCache: (conversationId: string, options?: { limit?: number; before?: Date; peek?: boolean; oldest?: boolean }) => Promise<Message[]>
+
+  /**
+   * Epoch ms of the conversation's persisted last-known message (the entity
+   * preview), or undefined. Used as a last-resort forward catch-up cursor so a
+   * persisted conversation whose message cache is empty this run still
+   * forward-fills its offline gap instead of a `before:''` fetch-latest.
+   */
+  getConversationLastTimestamp: (conversationId: string) => number | undefined
+  archiveConversation: (id: string) => void
+  unarchiveConversation: (id: string) => void
+
+  /** Batch-add/update conversations from server sync in a single state update. */
+  mergeServerConversations: (convs: Array<{ id: string; name: string; type: 'chat' | 'groupchat'; archived: boolean }>) => void
+
+  // ----- Composite getters -----
+
+  /** Every non-archived conversation with its in-memory messages, for MAM catch-up. */
+  getAllConversations: () => Array<{ id: string; messages: Message[] }>
+  /** Persisted forward-gap boundary for automatic catch-up recovery. */
+  getConversationGapStart?: (conversationId: string) => number | undefined
+  /**
+   * Archive id of the recorded gap's coverage edge (GapInterval.startId) —
+   * id-exact resume cursor, preferred over the timestamp fallback above.
+   */
+  getConversationGapStartId?: (conversationId: string) => string | undefined
+  /**
+   * Archive id of the recorded gap's contiguous-coverage bottom (GapInterval.endId) —
+   * the proven upper edge of the contiguous-from-live region.
+   */
+  getConversationGapEndId?: (conversationId: string) => string | undefined
+  /**
+   * True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
+   * as unproven (no gap edge, no resident boundary) — the seeder must not
+   * trust cache-oldest as contiguous-to-live (finding 10).
+   */
+  getConversationCoverageUnproven?: (conversationId: string) => boolean | undefined
+  /**
+   * XEP-0490 stanza-id of the remote read position, kept unresolved when it
+   * can't be matched locally — seeds a forward `after` catch-up on an
+   * empty-cache new device.
+   */
+  getConversationPendingStanzaId?: (conversationId: string) => string | undefined
+  /**
+   * Currently ACTIVE conversation id (null when none). Re-checked at every
+   * Phase B iteration of the pointer-stitch walk: backward pages into the
+   * active resident window would keep-oldest-evict its live edge.
+   */
+  getActiveConversationId?: () => string | null
+  /** Smart MAM: archived conversation preview refresh. */
+  getArchivedConversations?: () => Array<{ id: string; messages: Message[] }>
+  getLastMessage?: (conversationId: string) => Message | undefined
+  /**
+   * Every stored conversation (archived INCLUDED) with its in-memory
+   * messages. Read seam for the deferred-decrypt engine, which must retry
+   * pending encrypted payloads regardless of archive state — unlike
+   * getAllConversations, which returns only the active set.
+   */
+  getAllStoredMessages: () => Array<{ id: string; messages: Message[] }>
+  /**
+   * In-memory messages for a single conversation (archived included). Read
+   * seam for peer-scoped deferred-decrypt retry on a PEP key change.
+   */
+  getConversationMessages: (conversationId: string) => Message[]
+  /**
+   * Every conversation whose sidebar preview still carries an
+   * `encryptedPayload` (archived INCLUDED). Read seam for the deferred-decrypt
+   * engine's preview-level heal: a preview can hold ciphertext that no message
+   * store reaches (its message evicted, already decrypted in IndexedDB, or set
+   * preview-only) — so it must be re-decrypted straight from its own stash.
+   */
+  getEncryptedPreviews?: () => Array<{ conversationId: string; lastMessage: Message }>
+}
+
+/**
+ * Roster surface the client writes to.
+ *
+ * @category Internal
+ */
+export interface RosterBindings {
+  // Actions
+  setContacts: (contacts: Contact[]) => void
+  addOrUpdateContact: (contact: Contact) => void
+  updateContact: (jid: string, update: Partial<Contact>) => void
+  updatePresence: (
+    fullJid: string,
+    show: PresenceShow | null,
+    priority: number,
+    statusMessage?: string,
+    lastInteraction?: Date,
+    client?: string
+  ) => void
+  removePresence: (fullJid: string) => void
+  setPresenceError: (jid: string, error: string) => void
+  updateAvatar: (jid: string, avatar: string | null, avatarHash?: string) => void
+  removeContact: (jid: string) => void
+  hasContact: (jid: string) => boolean
+  getContact: (jid: string) => Contact | undefined
+  getOfflineContacts: () => Contact[]
+  sortedContacts: () => Contact[]
+  resetAllPresence: () => void
+}
+
+/**
+ * XMPP console surface (raw packet and event tap).
+ *
+ * @category Internal
+ */
+export interface ConsoleBindings {
+  addPacket: (direction: 'incoming' | 'outgoing', xml: string) => void
+  addEvent: (message: string, category?: 'connection' | 'error' | 'sm' | 'presence' | 'e2ee') => void
+}
+
+/**
+ * Pending-event surface (subscription requests, invitations, stranger messages).
+ *
+ * @category Internal
+ */
+export interface EventsBindings {
+  // Actions
+  addSubscriptionRequest: (from: string) => void
+  removeSubscriptionRequest: (from: string) => void
+  addStrangerMessage: (from: string, body: string) => void
+  removeStrangerMessages: (from: string) => void
+  addMucInvitation: (roomJid: string, from: string, reason?: string, password?: string, isDirect?: boolean, isQuickChat?: boolean) => void
+  removeMucInvitation: (roomJid: string) => void
+  addSystemNotification: (type: SystemNotificationType, title: string, message: string) => void
+  clearSystemNotifications: () => void
+}
+
+/**
+ * MUC surface the client writes to, plus the read seams MAM catch-up
+ * and deferred decrypt need.
+ *
+ * @category Internal
+ */
+export interface RoomBindings {
+  // Actions
+  addRoom: (room: Room) => void
+  updateRoom: (roomJid: string, update: Partial<Room>) => void
+  removeRoom: (roomJid: string) => void
+  setRoomJoined: (roomJid: string, joined: boolean) => void
+  addOccupant: (roomJid: string, occupant: RoomOccupant) => void
+  batchAddOccupants: (roomJid: string, occupants: RoomOccupant[]) => void
+  removeOccupant: (roomJid: string, nick: string) => void
+  setSelfOccupant: (roomJid: string, occupant: RoomOccupant) => void
+
+  /** Batch variant of updateOccupantAvatar — one state update for N resolved avatars (e.g. after joining a large room) */
+  updateOccupantAvatars: (roomJid: string, updates: Array<{ nick?: string; occupantId?: string; avatar: string | null; avatarHash: string | null }>) => void
+  getRoom: (roomJid: string) => Room | undefined
+
+  // Message actions
+  addMessage: (roomJid: string, message: RoomMessage, options?: {
+    incrementUnread?: boolean
+    incrementMentions?: boolean
+  }) => void
+  updateReactions: (roomJid: string, messageId: string, reactorNick: string, emojis: string[]) => void
+  updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
+
+  /**
+   * XEP-0424: apply an incoming retraction, deferring it when its target is not
+   * resident. Applies immediately (and writes through to the durable cache) when
+   * the target is in the window; otherwise records it and replays it the moment
+   * the target arrives live or loads from the cache. Only the message's own
+   * author can retract it — a mismatched actor is dropped, never tombstoned.
+   *
+   * @param actorJid - Full room JID (room@service/nick) the retraction came from.
+   * @param actorOccupantId - XEP-0421 occupant-id when advertised; preferred over the nick.
+   */
+  recordPendingRetraction: (roomJid: string, targetId: string, actorJid: string, actorOccupantId?: string) => void
+  getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
+
+  /**
+   * Reconcile a non-active room's unread count against the durable archive
+   * (PR B): a coverage-gated cursor count from the effective read boundary,
+   * plus the transient (`noLocalStore`) overlay, capped at 999 — never a
+   * bounded resident/cache slice. Commits only on an exact derivation; every
+   * uncertain case (pointerless-with-count, incomplete coverage) leaves the
+   * last TRUSTED count untouched rather than writing a provisional one.
+   * `mentionsCount` is never written here (see `readState.ts`'s
+   * `RecomputeOutcome` doc) — rooms keep it on the live `+1` path. Latest-wins
+   * across concurrent recounts for the same room.
+   *
+   * Called after a deferred-decrypt resolves an encrypted room message (the
+   * badge it may have provisionally inflated needs reconciling once the
+   * message settles), after a forward MAM merge past the floor, after a
+   * remote read-marker advance, at cold-start rehydrate, and after any
+   * transient-overlay mutation that reports a change.
+   *
+   * No-op for the active room by default: most triggers are already
+   * reconciled for the active room by their own synchronous path
+   * (`onMessageReceived`'s live-edge convergence, Task 11). The one exception
+   * is `{ allowActive: true }` (read-state PR B, final whole-branch-review
+   * FIX 3): a remote XEP-0490 marker can advance the ACTIVE room's read
+   * position without that convergence path running at all, and since FIX 2
+   * removed activation's unconditional zero, nothing else re-derives the
+   * active room's count after such an advance — pass `allowActive: true`
+   * ONLY from that trigger.
+   */
+  recomputeUnreadForRoom: (roomJid: string, options?: { allowActive?: boolean }) => Promise<void>
+  markAsRead: (roomJid: string) => void
+  getActiveRoomJid: () => string | null
+  setTyping: (roomJid: string, nick: string, isTyping: boolean) => void
+
+  // Bookmark actions
+  setBookmark: (roomJid: string, bookmark: { name: string; nick: string; autojoin?: boolean; password?: string; notifyAll?: boolean }) => void
+  removeBookmark: (roomJid: string) => void
+
+  /** Whether the user has already acknowledged this room's real-JID exposure. */
+  isNonAnonymousRoomAcknowledged: (roomJid: string) => boolean
+
+  // Notification settings
+  setNotifyAll: (roomJid: string, notifyAll: boolean, persistent?: boolean) => void
+
+  // Computed
+  joinedRooms: () => Room[]
+
+  /**
+   * Epoch ms of the room's persisted last-known message (the entity preview),
+   * or undefined. Used as a last-resort forward catch-up cursor so a persisted
+   * room whose message cache is empty this run still forward-fills its offline
+   * gap instead of a `before:''` fetch-latest.
+   */
+  getRoomLastTimestamp: (roomJid: string) => number | undefined
+
+  // Easter egg animations
+  triggerAnimation: (roomJid: string, animation: string, senderName?: string) => void
+
+  // MAM state management (XEP-0313 for MUC rooms)
+  setRoomMAMLoading: (roomJid: string, isLoading: boolean) => void
+  setRoomMAMError: (roomJid: string, error: string | null) => void
+
+  /**
+   * Merge MAM messages into room and update query state.
+   * @param roomJid - Room JID
+   * @param messages - Messages from MAM query
+   * @param rsm - RSM pagination response
+   * @param complete - Whether server indicated query is complete
+   * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
+   */
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
+  getRoomMAMQueryState: (roomJid: string) => MAMQueryState
+  resetRoomMAMStates: () => void
+
+  /** Persisted contiguous-with-live coverage record, if any. */
+  getRoomCoverage: (roomJid: string) => CoverageRecord | undefined
+
+  /** Drop the coverage record; with `ifBottomId`, only when it matches
+   *  `bottomId` (purge-event guard — the anchor is known gone). */
+  clearRoomCoverage: (roomJid: string, ifBottomId?: string) => void
+
+  /** Reset joined/isJoining for all rooms (called on fresh session after reconnect) */
+  markAllRoomsNotJoined: () => void
+
+  /** Update only the lastMessage preview without affecting message history */
+  updateLastMessagePreview: (roomJid: string, lastMessage: RoomMessage) => void
+
+  // IndexedDB cache loading. `oldest` flips the latest-N default to the
+  // OLDEST-N ascending slice (true cache bottom) — pointer-walk seeding; use
+  // with `peek` (an oldest slice must never become the resident window).
+  loadMessagesFromCache: (roomJid: string, options?: GetMessagesOptions & { peek?: boolean; oldest?: boolean }) => Promise<RoomMessage[]>
+
+  /** Load only the latest message from cache for sidebar preview (doesn't modify messages array) */
+  loadPreviewFromCache: (roomJid: string) => Promise<RoomMessage | null>
+
+  /**
+   * Populate sidebar-ordering previews for all bookmarked/joined rooms from the
+   * durable IndexedDB cache in a SINGLE batched store write.
+   *
+   * At launch the room list is rebuilt from bookmarks with no `lastMessage`, so
+   * every room sorts at epoch 0 until its per-room preview lands (on join, or the
+   * delayed catch-up) - leaving the sidebar mis-ordered and making the active room
+   * "jump" to the top once opened. This reads each room's newest cached message in
+   * parallel (network-free) and applies all previews at once, so the sidebar
+   * re-sorts a single time instead of once per room. Never downgrades a fresher
+   * preview, so it is safe alongside the join / catch-up preview paths.
+   */
+  hydratePreviewsFromCache: () => Promise<void>
+  mergeRoomMembers: (roomJid: string, members: Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }>, contactAvatarLookup?: (jid: string) => string | null) => void
+
+  /**
+   * Apply a single affiliation change to the cached `affiliatedMembers` list (XEP-0045 admin set).
+   * owner/admin/member upsert the member; none/outcast remove them. Keeps the occupant
+   * sidebar's offline-member list in sync after a change without a full member re-query.
+   */
+  updateMemberAffiliation: (roomJid: string, userJid: string, affiliation: RoomAffiliation) => void
+
+  // ----- Composite getters -----
+
+  /** Persisted forward-gap boundary for automatic catch-up recovery. */
+  getRoomGapStart?: (roomJid: string) => number | undefined
+  /**
+   * Archive id of the recorded gap's coverage edge (GapInterval.startId) —
+   * id-exact resume cursor, preferred over the timestamp fallback above.
+   */
+  getRoomGapStartId?: (roomJid: string) => string | undefined
+  /**
+   * Archive id of the recorded gap's contiguous-coverage bottom (GapInterval.endId) —
+   * the proven upper edge of the contiguous-from-live region.
+   */
+  getRoomGapEndId?: (roomJid: string) => string | undefined
+  /**
+   * True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
+   * as unproven (no gap edge, no resident boundary) — the seeder must not
+   * trust cache-oldest as contiguous-to-live (finding 10).
+   */
+  getRoomCoverageUnproven?: (roomJid: string) => boolean | undefined
+  /**
+   * XEP-0490 stanza-id of the remote read position, kept unresolved when it
+   * can't be matched locally — seeds a forward `after` catch-up on an
+   * empty-cache new device.
+   */
+  getRoomPendingStanzaId?: (roomJid: string) => string | undefined
+  /**
+   * Every room with its in-memory runtime messages. Read seam for the
+   * deferred-decrypt engine (mirrors chat.getAllStoredMessages for MUC).
+   */
+  getAllRoomMessages: () => Array<{ jid: string; messages: RoomMessage[] }>
+}
+
+/**
+ * Admin (XEP-0133) surface the client writes to.
+ *
+ * @category Internal
+ */
+export interface AdminBindings {
+  // Actions
+  setIsAdmin: (isAdmin: boolean) => void
+  setCommands: (commands: AdminCommand[]) => void
+  setCurrentSession: (session: AdminSession | null) => void
+  setIsDiscovering: (loading: boolean) => void
+  setIsExecuting: (loading: boolean) => void
+  setMucServiceJid: (jid: string | null) => void
+  setServerStats: (stats: ServerStats | null) => void
+  setVhosts: (vhosts: string[]) => void
+  setSelectedVhost: (vhost: string | null) => void
+  reset: () => void
+
+  // ----- State getters -----
+
+  getCommands: () => AdminCommand[]
+  getCurrentSession: () => AdminSession | null
+  getMucServiceJid: () => string | null
+  selectedVhost: string | null
+}
+
+/**
+ * Blocklist (XEP-0191) surface the client writes to.
+ *
+ * @category Internal
+ */
+export interface BlockingBindings {
+  // Actions
+  setBlocklist: (jids: string[]) => void
+  addBlockedJids: (jids: string[]) => void
+  removeBlockedJids: (jids: string[]) => void
+  clearBlocklist: () => void
+  isBlocked: (jid: string) => boolean
+  getBlockedJids: () => string[]
+}
+
+/**
+ * Store bindings interface for injecting store methods into XMPPClient.
+ *
+ * @internal
+ * This interface is used internally by XMPPProvider to bind Zustand stores
+ * to the XMPP client. Application code should use the React hooks instead.
+ *
+ * @category Internal
+ */
+export interface StoreBindings {
+  connection: ConnectionBindings
+  chat: ChatBindings
+  roster: RosterBindings
+  console: ConsoleBindings
+  events: EventsBindings
+  room: RoomBindings
+  admin: AdminBindings
+  blocking: BlockingBindings
+}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -311,8 +311,7 @@ export type {
   PollSettings,
   PollClosedData,
 
-  // Client types
-  XMPPClientConfig,
+  // Client types (XMPPClientConfig is exported separately, below)
   XMPPClientEvents,
   StoreBindings,
   PresenceOptions,
@@ -346,6 +345,11 @@ export type {
   MAMResult,
   MAMQueryState,
 } from './core/types'
+
+// Client construction options. Exported from `core/clientConfig` rather than
+// the type barrel: it carries a live store bundle, and `core/types` is a leaf
+// layer that must not name a concrete store.
+export type { XMPPClientConfig } from './core/clientConfig'
 
 // Events types
 export type { SubscriptionRequest, StrangerMessage, MucInvitation, SystemNotification, SystemNotificationType } from './core/types'

--- a/packages/fluux-sdk/src/provider/XMPPProvider.shouldAutoReconnect.test.tsx
+++ b/packages/fluux-sdk/src/provider/XMPPProvider.shouldAutoReconnect.test.tsx
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
-import type { XMPPClientConfig } from '../core/types/client'
+import type { XMPPClientConfig } from '../core/clientConfig'
 
 const { capturedConfigs, makeStubClient } = vi.hoisted(() => {
   const configs: Array<XMPPClientConfig | undefined> = []

--- a/packages/fluux-sdk/src/provider/XMPPProvider.tsx
+++ b/packages/fluux-sdk/src/provider/XMPPProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useRef, useEffect, useMemo, type ReactNode } from 'react'
 import { XMPPClient } from '../core/XMPPClient'
-import type { XMPPClientConfig } from '../core/types/client'
+import type { XMPPClientConfig } from '../core/clientConfig'
 import type { StorageAdapter } from '../core/types/storage'
 import type { ProxyAdapter } from '../core/types/proxy'
 import { sessionStorageAdapter } from '../utils/sessionStorageAdapter'

--- a/packages/fluux-sdk/src/stores/storeBindingsConformance.ts
+++ b/packages/fluux-sdk/src/stores/storeBindingsConformance.ts
@@ -1,0 +1,93 @@
+/**
+ * Compile-time proof that each Zustand store implements its binding port.
+ *
+ * `StoreBindings` used to be `Pick<ChatState, …>`: the contract was derived
+ * from the implementation, so it could not disagree with it — but it also made
+ * the SDK's leaf type layer depend on the stores, and left the package unable
+ * to describe its own state surface without naming Zustand.
+ *
+ * The port is now declared independently in `core/types/storeBindings.ts`, and
+ * the drift protection lives here instead, pointing the other way: if a store
+ * drops a member the port promises, or narrows a signature the port requires,
+ * these assignments stop compiling. If a store ADDS a member the port does not
+ * mention, nothing breaks — extra state is a store's business, and the client
+ * only ever sees the port.
+ *
+ * This file is type-only. It emits no runtime code and is never imported.
+ *
+ * @packageDocumentation
+ * @module Stores
+ */
+
+import type { StoreBindings } from '../core/types/storeBindings'
+import type { ConnectionState } from './connectionStore'
+import type { ChatState } from './chatStore'
+import type { RosterState } from './rosterStore'
+import type { ConsoleState } from './consoleStore'
+import type { EventsState } from './eventsStore'
+import type { RoomState } from './roomStore'
+import type { AdminState } from './adminStore'
+import type { BlockingState } from './blockingStore'
+
+/**
+ * Structural conformance: `State` must be assignable to the port namespace.
+ *
+ * Composite getters (`getAllConversations`, `getRoomGapStart`, …) are NOT
+ * store members — `createDefaultStoreBindings` builds them over the raw state —
+ * so they are excluded from the obligation here.
+ */
+type StoreMembersOf<Namespace> = Omit<Namespace, ComputedBindingKey>
+
+/**
+ * Members of a port namespace that `defaultStoreBindings.ts` synthesises
+ * rather than delegating. Keep in sync with the handwritten entries there.
+ */
+type ComputedBindingKey =
+  | 'getStatus'
+  | 'getOwnNickname'
+  | 'getJid'
+  | 'getHttpUploadService'
+  | 'getWebPushServices'
+  | 'getWebPushEnabled'
+  | 'getServerInfo'
+  | 'getAllConversations'
+  | 'getConversationGapStart'
+  | 'getConversationGapStartId'
+  | 'getConversationGapEndId'
+  | 'getConversationCoverageUnproven'
+  | 'getConversationPendingStanzaId'
+  | 'getActiveConversationId'
+  | 'getArchivedConversations'
+  | 'getLastMessage'
+  | 'getAllStoredMessages'
+  | 'getConversationMessages'
+  | 'getEncryptedPreviews'
+  | 'getRoomGapStart'
+  | 'getRoomGapStartId'
+  | 'getRoomGapEndId'
+  | 'getRoomCoverageUnproven'
+  | 'getRoomPendingStanzaId'
+  | 'getAllRoomMessages'
+  | 'getCommands'
+  | 'getCurrentSession'
+  | 'getMucServiceJid'
+  | 'selectedVhost'
+
+/** Compiles only when `T` is `true`; otherwise reports the constraint failure. */
+type Assert<T extends true> = T
+
+/** Whether a store's state is usable wherever its port namespace is required. */
+type Implements<State, Namespace> = State extends StoreMembersOf<Namespace> ? true : false
+
+// Each alias below fails to compile — "Type 'false' does not satisfy the
+// constraint 'true'" — when its store stops satisfying its port namespace. The
+// alias name says which one; compare the store's state interface against
+// `core/types/storeBindings.ts` to find the member that drifted.
+export type ConnectionStoreImplementsPort = Assert<Implements<ConnectionState, StoreBindings['connection']>>
+export type ChatStoreImplementsPort = Assert<Implements<ChatState, StoreBindings['chat']>>
+export type RosterStoreImplementsPort = Assert<Implements<RosterState, StoreBindings['roster']>>
+export type ConsoleStoreImplementsPort = Assert<Implements<ConsoleState, StoreBindings['console']>>
+export type EventsStoreImplementsPort = Assert<Implements<EventsState, StoreBindings['events']>>
+export type RoomStoreImplementsPort = Assert<Implements<RoomState, StoreBindings['room']>>
+export type AdminStoreImplementsPort = Assert<Implements<AdminState, StoreBindings['admin']>>
+export type BlockingStoreImplementsPort = Assert<Implements<BlockingState, StoreBindings['blocking']>>

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -8,7 +8,12 @@
  */
 
 import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
-import type { Message, RoomMessage } from '../core/types'
+// Imported from the declaring modules rather than the `core/types` barrel:
+// the barrel also re-exports the store-binding port, which names
+// `GetMessagesOptions` from this file, so going through it would make the two
+// mutually recursive.
+import type { Message } from '../core/types/chat'
+import type { RoomMessage } from '../core/types/room'
 import { getStorageScopeJid } from './storageScope'
 import { roomCanonicalKey, roomIdentityKeys, roomStanzaKey, roomOriginKey } from './roomMessageIdentity'
 import {


### PR DESCRIPTION
`StoreBindings` was `Pick<ChatState, …>`: the contract the client writes through was a projection of one particular Zustand implementation. That made `core/types` — the SDK's leaf vocabulary — import eight store modules, and left a package documented as headless unable to describe its own state surface without naming its state library.

## What changes

The port is now declared in `core/types/storeBindings.ts` in domain terms, as eight named interfaces (`ChatBindings`, `RoomBindings`, …), with the store JSDoc carried over.

The drift protection that `Pick` gave for free is kept, pointed the other way:

- `storeBindingKeys.ts` checks its key lists against the **port**, not the store;
- `stores/storeBindingsConformance.ts` asserts each store still implements its namespace, so a store dropping or narrowing a member fails to compile.

`XMPPClientConfig` moves to `core/clientConfig.ts`. It carries a live `SDKStores` bundle, so it is wiring rather than vocabulary — and it turned out to be the single edge holding the core's dependency blob together. It is still exported from the same entry points.

`messageCache.ts` now imports `Message`/`RoomMessage` from their declaring modules rather than the `core/types` barrel, which re-exports the port that names `GetMessagesOptions` from that same file.

## Effect

| | before | after |
|---|---|---|
| `core/types` → stores edges | 9 | **0** |
| largest strongly connected component | 63 modules | **17** |

`core/types/layering.test.ts` now asserts an empty allowlist, and also fails on an indirect store import through a `core/` module.

## Compatibility

The resolved type of `StoreBindings` is unchanged: 8 namespaces, 152 properties, no signature altered. No consumer, mock or test needed a change. In the emitted `.d.ts`, no declaration is removed and none but `StoreBindings` itself is modified; the eight namespace interfaces are added.