### PR TITLE
build(tauri): drop dependency debug info from the dev profile

### DIFF
--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -139,6 +139,22 @@ objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplicat
 objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNNotificationAttachment", "UNNotificationSettings", "UNError", "block2"] }
 block2 = "0.6"
 
+[profile.dev]
+# Backtraces keep file and line; only type information is dropped. Full debug
+# info over an 850-crate dependency tree dominates both the size of
+# target/debug and the time spent linking.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+# Dependencies are never stepped through in a debugger, so they carry no debug
+# info at all.
+debug = false
+
+[profile.dev.build-override]
+# Same rule for build scripts and proc macros, which Cargo builds with the dev
+# profile by default.
+debug = false
+
 [profile.release]
 panic = "abort"
 codegen-units = 1


### PR DESCRIPTION
Debug builds carried full debug info for the entire dependency tree, which dominates both the size of `target/debug` and the time spent linking.

Dependencies, build scripts, and proc macros now carry no debug info. The application crate keeps line tables, so panic backtraces still resolve to file and line.

On a cold debug build of the same crate set, `target/debug` drops from 3.1 GB to 2.4 GB. The trade-off is that stepping through dependency code in a debugger no longer shows their source lines; the application crate is unaffected.