### PR TITLE
refactor(sdk): keep the stores below core in the import graph

### DIFF
--- a/packages/fluux-sdk/eslint.config.js
+++ b/packages/fluux-sdk/eslint.config.js
@@ -1,6 +1,27 @@
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 
+// The stores barrel is for consumers only. Internal modules must import the
+// concrete store file, otherwise stores/index.ts lands back in an import cycle
+// with core/ and Rollup emits "reexported through ... circular dependency
+// between chunks" warnings when it bundles the type declarations.
+const noStoresBarrel = {
+  // Only the barrel itself ('./stores', '../stores', '../../stores'),
+  // never the concrete modules underneath it ('../stores/chatStore').
+  regex: '^(\\.{1,2}/)+stores$',
+  message:
+    "Import the concrete store module (e.g. '../stores/chatStore') instead of the '../stores' barrel - the barrel is the public entry point and re-exporting through it creates an import cycle with core/.",
+}
+
+// Mirror restriction, applied inside stores/ only: the core barrel re-exports
+// XMPPClient, so a store reaching for a TYPE through it drags the whole client
+// into the graph and puts the store back inside core's dependency cycle.
+const noCoreBarrel = {
+  regex: '^(\\.{1,2}/)+core$',
+  message:
+    "Import from '../core/types' (or the declaring module) instead of the '../core' barrel - the barrel re-exports XMPPClient, so a store importing through it re-creates the core/stores import cycle.",
+}
+
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -29,24 +50,14 @@ export default tseslint.config(
       'prefer-const': 'error',
       // Allow console - SDK needs logging for debugging and error reporting
       'no-console': 'off',
-      // The stores barrel is for consumers only. Internal modules must import the
-      // concrete store file, otherwise stores/index.ts lands back in an import cycle
-      // with core/ and Rollup emits "reexported through ... circular dependency
-      // between chunks" warnings when it bundles the type declarations.
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              // Only the barrel itself ('./stores', '../stores', '../../stores'),
-              // never the concrete modules underneath it ('../stores/chatStore').
-              regex: '^(\\.{1,2}/)+stores$',
-              message:
-                "Import the concrete store module (e.g. '../stores/chatStore') instead of the '../stores' barrel - the barrel is the public entry point and re-exporting through it creates an import cycle with core/.",
-            },
-          ],
-        },
-      ],
+      'no-restricted-imports': ['error', { patterns: [noStoresBarrel] }],
+    },
+  },
+  {
+    // Stores sit BELOW core: they may name core's types, never reach its client.
+    files: ['src/stores/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', { patterns: [noStoresBarrel, noCoreBarrel] }],
     },
   },
   {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
-import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core'
+import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'

--- a/packages/fluux-sdk/src/stores/consoleStore.ts
+++ b/packages/fluux-sdk/src/stores/consoleStore.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla'
-import type { XmppPacket } from '../core'
+import type { XmppPacket } from '../core/types'
 import { generateUUID } from '../utils/uuid'
 
 const MAX_ENTRIES = 2000

--- a/packages/fluux-sdk/src/stores/layering.test.ts
+++ b/packages/fluux-sdk/src/stores/layering.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Stores sit BELOW core in the SDK's dependency order.
+ *
+ * A store may name core's domain types; it must never end up in an import cycle
+ * with core. When it does, no protocol module can be typechecked or reasoned
+ * about without the whole state layer coming with it, and the package can no
+ * longer describe its own state surface without naming its state library.
+ *
+ * The ESLint `no-restricted-imports` rule in `eslint.config.js` blocks the easy
+ * way back in (a store importing the `../core` barrel, which re-exports
+ * XMPPClient). This test covers the rest: a direct import of a core module that
+ * imports stores back, however long the path between them.
+ *
+ * When this fails, the reported cycle names the modules; break the edge that
+ * points from a store UP into core, not the one pointing down.
+ */
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) return sourceFiles(path)
+    if (!path.endsWith('.ts') && !path.endsWith('.tsx')) return []
+    // Tests, helpers and mock factories are not part of the build graph.
+    if (/\.test\.tsx?$/.test(path) || /testHelpers|test-utils/.test(path)) return []
+    return [path]
+  })
+}
+
+const files = sourceFiles(SRC)
+const known = new Set(files)
+
+/** Resolve a relative specifier the way the bundler does: file, then index. */
+function resolveImport(from: string, specifier: string): string | undefined {
+  if (!specifier.startsWith('.')) return undefined
+  const base = resolve(dirname(from), specifier)
+  return [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx'), base].find(
+    candidate => known.has(candidate)
+  )
+}
+
+function buildGraph(): Map<string, string[]> {
+  const graph = new Map<string, string[]>()
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8')
+    const specifiers = [...source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)]
+    const edges = specifiers
+      .map(match => resolveImport(file, match[1]))
+      .filter((target): target is string => target !== undefined && target !== file)
+    graph.set(file, [...new Set(edges)])
+  }
+  return graph
+}
+
+/** Tarjan, iterative: the graph is ~800 modules deep enough to blow the stack. */
+function stronglyConnectedComponents(graph: Map<string, string[]>): string[][] {
+  const index = new Map<string, number>()
+  const lowlink = new Map<string, number>()
+  const onStack = new Set<string>()
+  const stack: string[] = []
+  const components: string[][] = []
+  let counter = 0
+
+  for (const root of graph.keys()) {
+    if (index.has(root)) continue
+    const work: Array<{ node: string; edge: number }> = [{ node: root, edge: 0 }]
+
+    while (work.length > 0) {
+      const frame = work[work.length - 1]
+      const { node } = frame
+
+      if (frame.edge === 0) {
+        index.set(node, counter)
+        lowlink.set(node, counter)
+        counter++
+        stack.push(node)
+        onStack.add(node)
+      }
+
+      const edges = graph.get(node) ?? []
+      if (frame.edge < edges.length) {
+        const next = edges[frame.edge]
+        frame.edge++
+        if (!index.has(next)) work.push({ node: next, edge: 0 })
+        else if (onStack.has(next)) lowlink.set(node, Math.min(lowlink.get(node)!, index.get(next)!))
+        continue
+      }
+
+      if (lowlink.get(node) === index.get(node)) {
+        const component: string[] = []
+        for (;;) {
+          const member = stack.pop()!
+          onStack.delete(member)
+          component.push(member)
+          if (member === node) break
+        }
+        components.push(component)
+      }
+
+      work.pop()
+      const parent = work[work.length - 1]
+      if (parent) {
+        lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(node)!))
+      }
+    }
+  }
+
+  return components
+}
+
+describe('stores layering', () => {
+  const components = stronglyConnectedComponents(buildGraph())
+
+  it('sees the whole SDK source graph', () => {
+    expect(files.length).toBeGreaterThan(200)
+  })
+
+  it('keeps no store in an import cycle with core', () => {
+    const mixed = components
+      .filter(component => component.length > 1)
+      .map(component => component.map(file => relative(SRC, file)).sort())
+      .filter(
+        component =>
+          component.some(file => file.startsWith('stores/')) &&
+          component.some(file => file.startsWith('core/'))
+      )
+
+    expect(mixed).toEqual([])
+  })
+})


### PR DESCRIPTION
`chatStore` and `consoleStore` reached for domain types through the `../core` barrel. That barrel also re-exports `XMPPClient`, so **two type imports** were enough to put both stores back inside the client's dependency cycle.

Importing from `../core/types` instead is the whole fix.

## Effect

| | before | after |
|---|---|---|
| largest strongly connected component | 17 modules | **11** |
| stores inside a cycle with `core/` | 2 | **0** |

The remaining component is `XMPPClient` plus its side-effect modules — the target of the follow-up work. `core/index.ts`, `core/clientConfig.ts`, `core/defaultStoreBindings.ts` and `stores/sdkStores.ts` fall out of it as a side effect of this change.

## Guards

Two, because neither alone is enough:

- **ESLint** blocks the `../core` barrel from inside `stores/`. This is the mirror of the restriction the config already carries for the `../stores` barrel, with the same rationale; the two patterns are now named constants rather than inline literals.
- **`stores/layering.test.ts`** covers what a lint rule cannot: a store importing a core module *directly* (not via the barrel) that imports stores back, however long the path. It builds the real import graph and fails if any strongly connected component contains both a store and a core module, naming the offending modules.

Test files keep their barrel exemption — they are not part of the build graph.

## Compatibility

Type-import paths only. The emitted `.d.ts` surface is unchanged: 262 declarations, none added, removed or modified.