### PR TITLE
refactor(sdk): give the side effects a contract instead of the whole client

### DIFF
--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -16,7 +16,7 @@
  * @module Bindings
  */
 
-import type { XMPPClient } from '../core/XMPPClient'
+import type { SDKEventSource } from '../core/types/eventSource'
 // Import concrete store modules rather than the '../stores' barrel: the barrel
 // sits in an import cycle with core/, so re-exporting through it makes Rollup
 // split the declaration bundle into mutually dependent chunks.
@@ -65,7 +65,7 @@ export type UnsubscribeBindings = () => void
  * Call this once when initializing the XMPP client (e.g., in XMPPProvider).
  * Returns an unsubscribe function to clean up all event subscriptions.
  *
- * @param client - The XMPPClient instance to bind
+ * @param client - The SDK event source to bind to
  * @param getStores - Function that returns current store state (called lazily)
  * @returns Unsubscribe function to remove all bindings
  *
@@ -82,7 +82,7 @@ export type UnsubscribeBindings = () => void
  * ```
  */
 export function createStoreBindings(
-  client: XMPPClient,
+  client: SDKEventSource,
   getStores: () => StoreRefs
 ): UnsubscribeBindings {
   const unsubscribers: Array<() => void> = []

--- a/packages/fluux-sdk/src/core/EventHook.ts
+++ b/packages/fluux-sdk/src/core/EventHook.ts
@@ -27,7 +27,7 @@
  * @module Core/EventHook
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SDKEventSource } from './types/eventSource'
 import type { SDKEvents, SDKEventHandler } from './types/sdk-events'
 
 /**
@@ -35,7 +35,7 @@ import type { SDKEvents, SDKEventHandler } from './types/sdk-events'
  *
  * Subclass this to create modular event processors that subscribe to
  * SDK events with automatic lifecycle cleanup. Register hooks on
- * `XMPPClient` via `client.registerHook(hook)`.
+ * the client via `client.registerHook(hook)`.
  *
  * @category Core
  */
@@ -45,12 +45,19 @@ export abstract class EventHook {
   /** Human-readable name */
   abstract readonly name: string
 
-  /** The XMPPClient instance this hook is bound to */
-  protected client: XMPPClient
+  /**
+   * The event source this hook is bound to.
+   *
+   * Narrowed to the SDK bus on purpose: a hook reacts to events, and giving it
+   * the whole client would let a hook drive protocol operations from inside an
+   * event handler. Use {@link on} rather than subscribing through this
+   * directly — it registers the cleanup.
+   */
+  protected client: SDKEventSource
 
   private _subscriptions: Array<() => void> = []
 
-  constructor(client: XMPPClient) {
+  constructor(client: SDKEventSource) {
     this.client = client
   }
 

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -18,7 +18,7 @@
  * @module Core/BackgroundSync
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { connectionStore } from '../stores/connectionStore'
 import { chatStore } from '../stores/chatStore'
@@ -60,12 +60,12 @@ import {
  * replayed stanzas. Only joined, inactive rooms that still need archive coverage
  * receive a resume seed query.
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up the subscriptions
  */
 export function setupBackgroundSyncSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: SideEffectsOptions = {}
 ): () => void {
   const { debug: _debug = false } = options

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -11,7 +11,7 @@
  * @module Core/ChatSideEffects
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { NS_MAM } from './namespaces'
@@ -37,12 +37,12 @@ export interface SideEffectsOptions {
  * 1. Loads messages from IndexedDB cache immediately
  * 2. Triggers background MAM fetch when connected
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up the subscription
  */
 export function setupChatSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: SideEffectsOptions = {}
 ): () => void {
   const { debug = false } = options

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
@@ -12,7 +12,7 @@
  * @module Core/ConversationSyncSideEffects
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
@@ -29,12 +29,12 @@ const PUBLISH_DEBOUNCE_MS = 3_000
  * disabled until the fresh session fetch+merge completes, preventing premature
  * publishes during initialization.
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up all subscriptions
  */
 export function setupConversationSyncSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: SideEffectsOptions = {}
 ): () => void {
   const { debug: _debug = false } = options

--- a/packages/fluux-sdk/src/core/layering.test.ts
+++ b/packages/fluux-sdk/src/core/layering.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { importCycles } from '../importGraph.testHelpers'
+
+/**
+ * The SDK core is layered, and stays layered.
+ *
+ * It used to be one strongly connected component of 64 modules: XMPPClient,
+ * every protocol module, every store and every side effect could only be read,
+ * typechecked or replaced together. Nothing in the code said so, so it grew
+ * that way one convenient import at a time.
+ *
+ * What is left is listed below. Two modules that genuinely describe each other
+ * are a cycle a reader can hold in their head; anything wider is the old shape
+ * coming back, and it always arrives as a single innocuous import — a barrel
+ * that re-exports the client, a contract typed as its own implementation, a
+ * helper that names the object it is called from.
+ *
+ * Adding an entry here is a decision, not a formality: say why the two modules
+ * cannot be split, in the entry itself.
+ */
+const KNOWN_CYCLES = [
+  // A message's base shape and the chat message that extends it. Splitting
+  // these would mean a third module naming both halves of one type.
+  ['core/types/chat.ts', 'core/types/message-base.ts'],
+  // The room store and its selectors: the selectors read the store's state
+  // type, the store reuses their derivations to keep results referentially
+  // stable for React.
+  ['stores/roomSelectors.ts', 'stores/roomStore.ts'],
+]
+
+describe('core layering', () => {
+  const cycles = importCycles()
+
+  it('has no import cycle beyond the documented pairs', () => {
+    expect(cycles).toEqual(KNOWN_CYCLES.map(cycle => [...cycle].sort()))
+  })
+
+  it('holds every cycle to two modules', () => {
+    expect(cycles.map(cycle => cycle.length)).toEqual(cycles.map(() => 2))
+  })
+})

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -36,7 +36,7 @@
  * @module Core/MdsSideEffects
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import type { DisplayedMarker, DisplayedMarkerFetchResult } from './modules/Mds'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { chatStore } from '../stores/chatStore'
@@ -83,12 +83,12 @@ const CACHE_LOOKBACK = 50
 /**
  * Sets up the MDS read-position publisher side effect.
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up all subscriptions
  */
 export function setupMdsSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: SideEffectsOptions = {}
 ): () => void {
   const { debug: _debug = false } = options

--- a/packages/fluux-sdk/src/core/roomMamHandoff.ts
+++ b/packages/fluux-sdk/src/core/roomMamHandoff.ts
@@ -1,4 +1,4 @@
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 
 type RoomMamHandoffEvent =
   | {
@@ -32,16 +32,16 @@ interface RoomMamForegroundCoverageState {
 }
 
 const roomMamHandoffHandlers = new WeakMap<
-  XMPPClient,
+  SideEffectHost,
   Set<RoomMamHandoffHandler>
 >()
 const roomMamForegroundCoverage = new WeakMap<
-  XMPPClient,
+  SideEffectHost,
   RoomMamForegroundCoverageState
 >()
 
 function getRoomMamForegroundCoverageState(
-  client: XMPPClient,
+  client: SideEffectHost,
 ): RoomMamForegroundCoverageState {
   let state = roomMamForegroundCoverage.get(client)
   if (!state) {
@@ -52,7 +52,7 @@ function getRoomMamForegroundCoverageState(
 }
 
 export function beginRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
   roomJid: string,
   membershipEpoch: number,
 ): RoomMamForegroundCoverage {
@@ -67,7 +67,7 @@ export function beginRoomMamForegroundCoverage(
 }
 
 export function completeRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
   owner: RoomMamForegroundCoverage,
 ): void {
   const state = roomMamForegroundCoverage.get(client)
@@ -88,7 +88,7 @@ export function completeRoomMamForegroundCoverage(
 }
 
 export function releaseRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
   owner: RoomMamForegroundCoverage,
 ): void {
   const state = roomMamForegroundCoverage.get(client)
@@ -102,14 +102,14 @@ export function releaseRoomMamForegroundCoverage(
 }
 
 export function releaseRoomMamForegroundCoverageForRoom(
-  client: XMPPClient,
+  client: SideEffectHost,
   roomJid: string,
 ): void {
   roomMamForegroundCoverage.get(client)?.rooms.delete(roomJid)
 }
 
 export function releaseInFlightRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
 ): void {
   const state = roomMamForegroundCoverage.get(client)
   if (!state) return
@@ -121,7 +121,7 @@ export function releaseInFlightRoomMamForegroundCoverage(
 }
 
 export function resetRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
 ): void {
   const state = getRoomMamForegroundCoverageState(client)
   state.generation += 1
@@ -129,7 +129,7 @@ export function resetRoomMamForegroundCoverage(
 }
 
 export function hasRoomMamForegroundCoverage(
-  client: XMPPClient,
+  client: SideEffectHost,
   roomJid: string,
   membershipEpoch: number,
 ): boolean {
@@ -143,7 +143,7 @@ export function hasRoomMamForegroundCoverage(
 }
 
 export function requestRoomMamHandoff(
-  client: XMPPClient,
+  client: SideEffectHost,
   owner: RoomMamForegroundCoverage,
 ): void {
   roomMamHandoffHandlers.get(client)?.forEach((handler) => {
@@ -156,7 +156,7 @@ export function requestRoomMamHandoff(
 }
 
 export function subscribeRoomMamHandoff(
-  client: XMPPClient,
+  client: SideEffectHost,
   handler: RoomMamHandoffHandler,
 ): () => void {
   let handlers = roomMamHandoffHandlers.get(client)

--- a/packages/fluux-sdk/src/core/roomMembershipEpoch.ts
+++ b/packages/fluux-sdk/src/core/roomMembershipEpoch.ts
@@ -1,4 +1,4 @@
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 
 interface RoomMembershipState {
   epoch: number
@@ -6,12 +6,12 @@ interface RoomMembershipState {
 }
 
 const clientRoomMemberships = new WeakMap<
-  XMPPClient,
+  SideEffectHost,
   Map<string, RoomMembershipState>
 >()
 
 function getClientRoomMemberships(
-  client: XMPPClient,
+  client: SideEffectHost,
 ): Map<string, RoomMembershipState> {
   let memberships = clientRoomMemberships.get(client)
   if (!memberships) {
@@ -22,7 +22,7 @@ function getClientRoomMemberships(
 }
 
 export function recordRoomMembership(
-  client: XMPPClient,
+  client: SideEffectHost,
   roomJid: string,
   joined: boolean,
 ): number {
@@ -40,13 +40,13 @@ export function recordRoomMembership(
 }
 
 export function getRoomMembershipEpoch(
-  client: XMPPClient,
+  client: SideEffectHost,
   roomJid: string,
 ): number {
   return clientRoomMemberships.get(client)?.get(roomJid)?.epoch ?? 0
 }
 
-export function invalidateRoomMemberships(client: XMPPClient): void {
+export function invalidateRoomMemberships(client: SideEffectHost): void {
   const memberships = clientRoomMemberships.get(client)
   if (!memberships) return
   for (const membership of memberships.values()) {

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -14,7 +14,7 @@
  * @module Core/RoomSideEffects
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { roomStore } from '../stores/roomStore'
 import { connectionStore } from '../stores/connectionStore'
@@ -47,12 +47,12 @@ import {
  * 2. Triggers foreground MAM catch-up when connected, MAM-enabled, and joined
  *    in the current fresh session (or preserved by a successful SM resume)
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up the subscription
  */
 export function setupRoomSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: SideEffectsOptions = {}
 ): () => void {
   const { debug = false } = options

--- a/packages/fluux-sdk/src/core/sideEffectHost.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHost.ts
@@ -1,0 +1,116 @@
+/**
+ * What a store-based side effect needs from the client that drives it.
+ *
+ * The side effects used to name `XMPPClient` itself. That single type import
+ * was enough to tie them together: the client constructs the side effects, the
+ * side effects name the client, and everything reachable from either ended up
+ * in one strongly connected component that no part could be read or typechecked
+ * without.
+ *
+ * Nothing about a side effect actually needs the whole client. Each one reacts
+ * to a bus and calls a handful of protocol methods, and that is what is declared
+ * here — narrowed per concern, so a reader can see the blast radius of a side
+ * effect from its signature. `XMPPClient` satisfies this structurally; the
+ * assertion in `sideEffectHostConformance.ts` fails to compile if it stops.
+ *
+ * This lives beside the client rather than in `core/types` because it names
+ * module-level result shapes (MDS markers, synced conversations) that are not
+ * part of the SDK's public vocabulary.
+ *
+ * @packageDocumentation
+ * @module Core
+ */
+
+import type { SDKEventSource, ClientEventSource } from './types/eventSource'
+import type { RoomAffiliation } from './types/room'
+import type { ConversationTarget } from './e2ee/types'
+import type { DisplayedMarkerFetchResult } from './modules/Mds'
+import type { SyncedConversation } from './modules/ConversationSync'
+
+/** A message as the catch-up entry points read it: position, not content. */
+export interface ArchivePosition {
+  timestamp?: Date
+  stanzaId?: string
+}
+
+/** Options shared by the two history catch-up entry points. */
+export interface CatchUpHistoryOptions {
+  sessionStartTime?: number
+  stitchReadPointer?: boolean
+}
+
+/** The archive operations background sync and the history side effects drive. */
+export interface MamSideEffectHost {
+  catchUpAllConversations(options?: {
+    concurrency?: number
+    exclude?: string | null
+    sessionStartTime?: number
+  }): Promise<void>
+  catchUpConversationHistory(
+    conversationId: string,
+    messages: ArchivePosition[],
+    options?: CatchUpHistoryOptions
+  ): Promise<void>
+  catchUpRoom(roomJid: string, sessionStartTime?: number): Promise<void>
+  catchUpRoomHistory(
+    roomJid: string,
+    messages: ArchivePosition[],
+    options?: CatchUpHistoryOptions
+  ): Promise<void>
+  discoverNewConversationsFromRoster(options?: { concurrency?: number }): Promise<void>
+  fetchPreviewForRoom(roomJid: string): Promise<void>
+  refreshArchivedConversationPreviews(options?: { concurrency?: number }): Promise<void>
+}
+
+/** The MUC operation background sync drives. */
+export interface MucSideEffectHost {
+  queryRoomMembers(
+    roomJid: string
+  ): Promise<Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }>>
+}
+
+/** The XEP-0490 operations the read-marker side effect drives. */
+export interface MdsSideEffectHost {
+  fetchAllDisplayedResult(timeoutMs?: number): Promise<DisplayedMarkerFetchResult>
+  publishDisplayed(conversationJid: string, stanzaId: string, stanzaIdBy: string): Promise<void>
+  retractDisplayed(conversationJid: string): Promise<void>
+}
+
+/** The discovery probe background sync runs once per session. */
+export interface DiscoverySideEffectHost {
+  discoverMAMSearchCapability(): Promise<void>
+}
+
+/** The XEP-0489 publish the conversation-sync side effect drives. */
+export interface ConversationSyncSideEffectHost {
+  publishConversations(conversations: SyncedConversation[]): Promise<void>
+}
+
+/**
+ * The encryption capability probe background sync warms.
+ *
+ * Deliberately one method rather than the whole `E2EEManager`: the warm-up is
+ * the only thing a side effect does with encryption, and widening this would
+ * hand every side effect the key material surface.
+ */
+export interface E2EEWarmupHost {
+  canEncryptTo(target: ConversationTarget): Promise<boolean>
+}
+
+/**
+ * The client surface every store-based side effect is written against.
+ *
+ * @category Internal
+ */
+export interface SideEffectHost extends SDKEventSource, ClientEventSource {
+  isConnected(): boolean
+  /** Re-runs decryption for payloads stashed while the key was unavailable. */
+  retryPendingDecrypts(): Promise<number>
+  /** Null until an identity is logged in — every caller must handle that. */
+  readonly e2ee: E2EEWarmupHost | null
+  readonly mam: MamSideEffectHost
+  readonly muc: MucSideEffectHost
+  readonly mds: MdsSideEffectHost
+  readonly discovery: DiscoverySideEffectHost
+  readonly conversationSync: ConversationSyncSideEffectHost
+}

--- a/packages/fluux-sdk/src/core/sideEffectHostConformance.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHostConformance.ts
@@ -1,0 +1,34 @@
+/**
+ * Compile-time proof that {@link XMPPClient} still provides what the side
+ * effects are written against.
+ *
+ * The side effects used to name the client directly, so the two could not
+ * disagree. Now that they name {@link SideEffectHost} instead, this is where
+ * the obligation lives: narrow or rename a member the host promises and this
+ * stops compiling, instead of the mismatch surfacing at every call site.
+ *
+ * The reverse direction is deliberately NOT asserted. The client is free to
+ * grow members the host does not mention — that is the point of the narrowing.
+ *
+ * This file is type-only. It emits no runtime code and is never imported.
+ *
+ * @packageDocumentation
+ * @module Core
+ */
+
+import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
+import type { SDKEventSource, ClientEventSource } from './types/eventSource'
+
+/** Compiles only when `T` is `true`; otherwise reports the constraint failure. */
+type Assert<T extends true> = T
+
+/** Whether the client is usable wherever the contract is required. */
+type Provides<Contract> = XMPPClient extends Contract ? true : false
+
+// Each alias fails to compile — "Type 'false' does not satisfy the constraint
+// 'true'" — when the client stops satisfying that contract. Compare the client
+// against the interface named in the alias to find the member that drifted.
+export type ClientProvidesSideEffectHost = Assert<Provides<SideEffectHost>>
+export type ClientProvidesSDKEventSource = Assert<Provides<SDKEventSource>>
+export type ClientProvidesClientEventSource = Assert<Provides<ClientEventSource>>

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -5,7 +5,7 @@
  */
 import { vi } from 'vitest'
 import { connectionStore } from '../stores/connectionStore'
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 
 // Mock localStorage for tests that need it
 export const localStorageMock = (() => {
@@ -28,7 +28,7 @@ export const localStorageMock = (() => {
 })()
 
 /**
- * Create a minimal mock XMPPClient with event emitter support.
+ * Create a minimal mock side-effect host with event emitter support.
  */
 export function createMockClient() {
   // Internal events (on/emit pattern: 'online', 'resumed', etc.)
@@ -79,7 +79,7 @@ export function createMockClient() {
     },
   }
 
-  return client as typeof client & XMPPClient
+  return client as typeof client & SideEffectHost
 }
 
 /**

--- a/packages/fluux-sdk/src/core/sideEffects.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.ts
@@ -8,7 +8,7 @@
  * @module Core/SideEffects
  */
 
-import type { XMPPClient } from './XMPPClient'
+import type { SideEffectHost } from './sideEffectHost'
 import { setupChatSideEffects } from './chatSideEffects'
 import { setupRoomSideEffects } from './roomSideEffects'
 import { setupBackgroundSyncSideEffects } from './backgroundSync'
@@ -29,7 +29,7 @@ export { setupMdsSideEffects } from './mdsSideEffects'
  * subscriptions that respond to state changes and trigger appropriate
  * side effects (loading cache, fetching history, etc.).
  *
- * @param client - The XMPPClient instance
+ * @param client - The client driving these side effects
  * @param options - Configuration options
  * @returns Unsubscribe function to clean up all subscriptions
  *
@@ -43,7 +43,7 @@ export { setupMdsSideEffects } from './mdsSideEffects'
  * ```
  */
 export function setupStoreSideEffects(
-  client: XMPPClient,
+  client: SideEffectHost,
   options: { debug?: boolean } = {}
 ): () => void {
   const unsubscribeChat = setupChatSideEffects(client, options)

--- a/packages/fluux-sdk/src/core/types/eventSource.ts
+++ b/packages/fluux-sdk/src/core/types/eventSource.ts
@@ -1,0 +1,39 @@
+/**
+ * The two event buses a consumer can attach to, as contracts rather than as
+ * "whatever XMPPClient happens to expose".
+ *
+ * The SDK has two buses on purpose, and they are not interchangeable:
+ *
+ * - {@link SDKEventSource} carries the typed, domain-level `SDKEvents` that
+ *   store bindings and side effects react to.
+ * - {@link ClientEventSource} carries the lower-level `XMPPClientEvents` that
+ *   describe the connection and stanza lifecycle.
+ *
+ * Naming them here lets a module say which bus it needs without importing the
+ * client that provides both — which is what kept the client, its bindings and
+ * every side effect in one mutually recursive component.
+ *
+ * @packageDocumentation
+ * @module Types/EventSource
+ */
+
+import type { XMPPClientEvents } from './client'
+import type { SDKEvents, SDKEventHandler } from './sdk-events'
+
+/**
+ * Subscribes to typed SDK events. Returns an unsubscribe function.
+ *
+ * @category Internal
+ */
+export interface SDKEventSource {
+  subscribe<K extends keyof SDKEvents>(event: K, handler: SDKEventHandler<K>): () => void
+}
+
+/**
+ * Subscribes to low-level client events. Returns an unsubscribe function.
+ *
+ * @category Internal
+ */
+export interface ClientEventSource {
+  on<K extends keyof XMPPClientEvents>(event: K, handler: XMPPClientEvents[K]): () => void
+}

--- a/packages/fluux-sdk/src/importGraph.testHelpers.ts
+++ b/packages/fluux-sdk/src/importGraph.testHelpers.ts
@@ -1,0 +1,130 @@
+/**
+ * The SDK's own import graph, for layering tests.
+ *
+ * Layering is an invariant no single file can state: it is a property of how
+ * the modules point at each other. These helpers read the real sources and
+ * expose that shape so a test can assert on it, rather than trusting that a
+ * lint rule covers every way back into a cycle.
+ *
+ * Test-only. Excluded from the graph it builds, along with every other test
+ * file, because none of them are part of the build.
+ *
+ * @packageDocumentation
+ * @module Core
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** `packages/fluux-sdk/src`, resolved from this file's own location. */
+export const SDK_SRC = dirname(fileURLToPath(import.meta.url))
+
+/** Every module the bundler would see: sources only, no tests or helpers. */
+export function sdkSourceFiles(dir: string = SDK_SRC): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) return sdkSourceFiles(path)
+    if (!path.endsWith('.ts') && !path.endsWith('.tsx')) return []
+    if (/\.test\.tsx?$/.test(path) || /testHelpers|test-utils/.test(path)) return []
+    return [path]
+  })
+}
+
+/** Resolve a relative specifier the way the bundler does: file, then index. */
+function resolveImport(from: string, specifier: string, known: Set<string>): string | undefined {
+  if (!specifier.startsWith('.')) return undefined
+  const base = resolve(dirname(from), specifier)
+  return [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx'), base].find(
+    candidate => known.has(candidate)
+  )
+}
+
+/**
+ * Adjacency over relative imports.
+ *
+ * Type-only imports are edges too: they do not survive to runtime, but they are
+ * what a reader and the typechecker have to follow, and they are how the core
+ * became one mutually recursive component in the first place.
+ */
+export function buildImportGraph(files: string[] = sdkSourceFiles()): Map<string, string[]> {
+  const known = new Set(files)
+  const graph = new Map<string, string[]>()
+  for (const file of files) {
+    const specifiers = [
+      ...readFileSync(file, 'utf8').matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g),
+    ]
+    const edges = specifiers
+      .map(match => resolveImport(file, match[1], known))
+      .filter((target): target is string => target !== undefined && target !== file)
+    graph.set(file, [...new Set(edges)])
+  }
+  return graph
+}
+
+/** Tarjan, iterative: the graph is deep enough to blow the call stack. */
+export function stronglyConnectedComponents(graph: Map<string, string[]>): string[][] {
+  const index = new Map<string, number>()
+  const lowlink = new Map<string, number>()
+  const onStack = new Set<string>()
+  const stack: string[] = []
+  const components: string[][] = []
+  let counter = 0
+
+  for (const root of graph.keys()) {
+    if (index.has(root)) continue
+    const work: Array<{ node: string; edge: number }> = [{ node: root, edge: 0 }]
+
+    while (work.length > 0) {
+      const frame = work[work.length - 1]
+      const { node } = frame
+
+      if (frame.edge === 0) {
+        index.set(node, counter)
+        lowlink.set(node, counter)
+        counter++
+        stack.push(node)
+        onStack.add(node)
+      }
+
+      const edges = graph.get(node) ?? []
+      if (frame.edge < edges.length) {
+        const next = edges[frame.edge]
+        frame.edge++
+        if (!index.has(next)) work.push({ node: next, edge: 0 })
+        else if (onStack.has(next)) lowlink.set(node, Math.min(lowlink.get(node)!, index.get(next)!))
+        continue
+      }
+
+      if (lowlink.get(node) === index.get(node)) {
+        const component: string[] = []
+        for (;;) {
+          const member = stack.pop()!
+          onStack.delete(member)
+          component.push(member)
+          if (member === node) break
+        }
+        components.push(component)
+      }
+
+      work.pop()
+      const parent = work[work.length - 1]
+      if (parent) {
+        lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(node)!))
+      }
+    }
+  }
+
+  return components
+}
+
+/**
+ * Every import cycle, as sorted `src`-relative paths. Single modules are not
+ * cycles and are dropped.
+ */
+export function importCycles(): string[][] {
+  return stronglyConnectedComponents(buildImportGraph())
+    .filter(component => component.length > 1)
+    .map(component => component.map(file => relative(SDK_SRC, file)).sort())
+    .sort((a, b) => b.length - a.length || (a[0] < b[0] ? -1 : 1))
+}

--- a/packages/fluux-sdk/src/stores/layering.test.ts
+++ b/packages/fluux-sdk/src/stores/layering.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { importCycles, sdkSourceFiles } from '../importGraph.testHelpers'
 
 /**
  * Stores sit BELOW core in the SDK's dependency order.
@@ -19,117 +17,17 @@ import { fileURLToPath } from 'node:url'
  * When this fails, the reported cycle names the modules; break the edge that
  * points from a store UP into core, not the one pointing down.
  */
-
-const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-
-function sourceFiles(dir: string): string[] {
-  return readdirSync(dir).flatMap(entry => {
-    const path = join(dir, entry)
-    if (statSync(path).isDirectory()) return sourceFiles(path)
-    if (!path.endsWith('.ts') && !path.endsWith('.tsx')) return []
-    // Tests, helpers and mock factories are not part of the build graph.
-    if (/\.test\.tsx?$/.test(path) || /testHelpers|test-utils/.test(path)) return []
-    return [path]
-  })
-}
-
-const files = sourceFiles(SRC)
-const known = new Set(files)
-
-/** Resolve a relative specifier the way the bundler does: file, then index. */
-function resolveImport(from: string, specifier: string): string | undefined {
-  if (!specifier.startsWith('.')) return undefined
-  const base = resolve(dirname(from), specifier)
-  return [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx'), base].find(
-    candidate => known.has(candidate)
-  )
-}
-
-function buildGraph(): Map<string, string[]> {
-  const graph = new Map<string, string[]>()
-  for (const file of files) {
-    const source = readFileSync(file, 'utf8')
-    const specifiers = [...source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)]
-    const edges = specifiers
-      .map(match => resolveImport(file, match[1]))
-      .filter((target): target is string => target !== undefined && target !== file)
-    graph.set(file, [...new Set(edges)])
-  }
-  return graph
-}
-
-/** Tarjan, iterative: the graph is ~800 modules deep enough to blow the stack. */
-function stronglyConnectedComponents(graph: Map<string, string[]>): string[][] {
-  const index = new Map<string, number>()
-  const lowlink = new Map<string, number>()
-  const onStack = new Set<string>()
-  const stack: string[] = []
-  const components: string[][] = []
-  let counter = 0
-
-  for (const root of graph.keys()) {
-    if (index.has(root)) continue
-    const work: Array<{ node: string; edge: number }> = [{ node: root, edge: 0 }]
-
-    while (work.length > 0) {
-      const frame = work[work.length - 1]
-      const { node } = frame
-
-      if (frame.edge === 0) {
-        index.set(node, counter)
-        lowlink.set(node, counter)
-        counter++
-        stack.push(node)
-        onStack.add(node)
-      }
-
-      const edges = graph.get(node) ?? []
-      if (frame.edge < edges.length) {
-        const next = edges[frame.edge]
-        frame.edge++
-        if (!index.has(next)) work.push({ node: next, edge: 0 })
-        else if (onStack.has(next)) lowlink.set(node, Math.min(lowlink.get(node)!, index.get(next)!))
-        continue
-      }
-
-      if (lowlink.get(node) === index.get(node)) {
-        const component: string[] = []
-        for (;;) {
-          const member = stack.pop()!
-          onStack.delete(member)
-          component.push(member)
-          if (member === node) break
-        }
-        components.push(component)
-      }
-
-      work.pop()
-      const parent = work[work.length - 1]
-      if (parent) {
-        lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(node)!))
-      }
-    }
-  }
-
-  return components
-}
-
 describe('stores layering', () => {
-  const components = stronglyConnectedComponents(buildGraph())
-
   it('sees the whole SDK source graph', () => {
-    expect(files.length).toBeGreaterThan(200)
+    expect(sdkSourceFiles().length).toBeGreaterThan(200)
   })
 
   it('keeps no store in an import cycle with core', () => {
-    const mixed = components
-      .filter(component => component.length > 1)
-      .map(component => component.map(file => relative(SRC, file)).sort())
-      .filter(
-        component =>
-          component.some(file => file.startsWith('stores/')) &&
-          component.some(file => file.startsWith('core/'))
-      )
+    const mixed = importCycles().filter(
+      component =>
+        component.some(file => file.startsWith('stores/')) &&
+        component.some(file => file.startsWith('core/'))
+    )
 
     expect(mixed).toEqual([])
   })


### PR DESCRIPTION
Eleven modules named `XMPPClient` to describe what drives them. That one type import was enough to close the loop — the client builds the side effects, the side effects name the client — and everything reachable from either end sat in a single strongly connected component that no part could be read, typechecked or replaced on its own.

## What they actually needed

Measured against the sources rather than guessed: two event buses and eleven protocol methods, between all eleven modules. Four of them (`sideEffects`, `roomMamHandoff`, `roomMembershipEpoch`, and the test helper) use **no** client member at all — two of them only ever use it as a `WeakMap` key.

`core/sideEffectHost.ts` declares that, narrowed per concern rather than as one flat bag, so a side effect's blast radius is legible from its signature: background sync can warm the encryption cache (`canEncryptTo`) but cannot reach key material.

`core/types/eventSource.ts` names the two buses separately — `SDKEventSource` and `ClientEventSource` — because `EventHook` and the store bindings only ever subscribe.

`XMPPClient` satisfies all three structurally. `sideEffectHostConformance.ts` fails to compile if it stops.

## Effect

| | before this arc | before this PR | after |
|---|---|---|---|
| largest import cycle | 64 modules | 11 | **2** |

`core/layering.test.ts` holds it there: it lists the two remaining pairs with the reason each cannot be split, and fails on any wider component. The import-graph machinery moves out of `stores/layering.test.ts` into a shared test helper, so the three layering tests share one implementation.

## Compatibility

No declaration is removed or modified in the emitted `.d.ts`; 11 interfaces are added. Two public signatures **widen**, accepting strictly more than before:

- `createStoreBindings(client: SDKEventSource, …)`
- `EventHook`'s constructor

One member **narrows**, and it is worth stating plainly: `EventHook`'s `protected client` is now `SDKEventSource`, so a subclass reaching past the bus into protocol modules (`this.client.chat…`) would no longer compile. Nothing in the repository does, and neither does the pattern in `docs/EVENT_HOOKS.md`, which uses the `on()` helper. Flagging it because it is the one change here an external consumer could feel, and the pre-first-release window is where it costs least.