### PR TITLE
refactor(app): name the platform capabilities the utils branch on

### DIFF
--- a/apps/fluux/eslint.config.js
+++ b/apps/fluux/eslint.config.js
@@ -59,6 +59,34 @@ export default tseslint.config(
     },
   },
   {
+    // `isTauri()` reads as one question but answers at least six, and the real
+    // answers already diverge: in-app updates are desktop-except-Linux, the tray
+    // preference is desktop-on-Windows-and-Linux, taskbar attention is
+    // desktop-on-Windows-only. Branch on a named capability from '@/platform'
+    // instead, so a call site says WHY it branches and a new target can be
+    // described rather than guessed at.
+    //
+    // Scoped to the layer that has been migrated. Widen it to hooks and
+    // components as they follow; do not add exceptions.
+    files: ['src/utils/**/*.ts'],
+    // `tauri.ts` owns the remaining probes; its own test has to import them.
+    ignores: ['src/utils/tauri.ts', 'src/utils/*.test.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              regex: '^(\\.{1,2}/)*(@/utils/)?tauri$',
+              message:
+                "Branch on a named capability from '@/platform' (e.g. platform().nativeKeychain) rather than on isTauri() - the platform is not binary, and the capability name is what tells the next reader why this code differs per host.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // Relaxed rules for test files
     files: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {

--- a/apps/fluux/src/platform/capabilities.test.ts
+++ b/apps/fluux/src/platform/capabilities.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { deriveCapabilities, type PlatformCapabilities } from './capabilities'
+import { platform, setPlatformForTesting, resetPlatformDetection } from './index'
+
+describe('deriveCapabilities', () => {
+  it('grants no native capability on the web, whatever the OS', () => {
+    for (const os of ['macos', 'windows', 'linux', 'other'] as const) {
+      const web = deriveCapabilities('web', os)
+      const granted = Object.entries(web)
+        .filter(([key, value]) => value === true && key !== 'shell' && key !== 'os')
+        .map(([key]) => key)
+      expect(granted, `web/${os}`).toEqual([])
+    }
+  })
+
+  it('reserves taskbar attention for desktop Windows', () => {
+    expect(deriveCapabilities('desktop', 'windows').canRequestWindowAttention).toBe(true)
+    expect(deriveCapabilities('desktop', 'macos').canRequestWindowAttention).toBe(false)
+    expect(deriveCapabilities('desktop', 'linux').canRequestWindowAttention).toBe(false)
+    expect(deriveCapabilities('web', 'windows').canRequestWindowAttention).toBe(false)
+  })
+
+  it('offers the tray preference on desktop Windows and Linux only', () => {
+    expect(deriveCapabilities('desktop', 'windows').canKeepInSystemTray).toBe(true)
+    expect(deriveCapabilities('desktop', 'linux').canKeepInSystemTray).toBe(true)
+    // macOS hides the window on close; there is nothing to configure.
+    expect(deriveCapabilities('desktop', 'macos').canKeepInSystemTray).toBe(false)
+  })
+
+  it('withholds in-app updates from Linux, which updates through its distro', () => {
+    expect(deriveCapabilities('desktop', 'macos').hasInAppUpdates).toBe(true)
+    expect(deriveCapabilities('desktop', 'windows').hasInAppUpdates).toBe(true)
+    expect(deriveCapabilities('desktop', 'linux').hasInAppUpdates).toBe(false)
+    expect(deriveCapabilities('web', 'macos').hasInAppUpdates).toBe(false)
+  })
+
+  it('treats every capability as a boolean the caller can read', () => {
+    const desktop = deriveCapabilities('desktop', 'macos')
+    for (const [key, value] of Object.entries(desktop)) {
+      if (key === 'shell' || key === 'os') continue
+      expect(typeof value, key).toBe('boolean')
+    }
+  })
+})
+
+describe('platform override', () => {
+  afterEach(() => {
+    resetPlatformDetection()
+  })
+
+  it('serves the override, then restores what was there before', () => {
+    const before = platform()
+    const restore = setPlatformForTesting({ shell: 'desktop', os: 'linux' })
+    expect(platform().shell).toBe('desktop')
+    expect(platform().hasInAppUpdates).toBe(false)
+    restore()
+    expect(platform()).toEqual(before)
+  })
+
+  it('accepts a full record for a host that no derivation produces', () => {
+    const impossible: PlatformCapabilities = {
+      ...deriveCapabilities('web', 'other'),
+      nativeKeychain: true,
+    }
+    const restore = setPlatformForTesting(impossible)
+    expect(platform().shell).toBe('web')
+    expect(platform().nativeKeychain).toBe(true)
+    restore()
+  })
+})

--- a/apps/fluux/src/platform/capabilities.ts
+++ b/apps/fluux/src/platform/capabilities.ts
@@ -1,0 +1,105 @@
+/**
+ * What this build of Fluux can do, as a value rather than a runtime probe.
+ *
+ * The app used to ask `isTauri()` at each decision point. That reads as one
+ * question but is at least six: whether there is an OS keychain, whether links
+ * open in the system browser, whether the window can ask for attention. Some
+ * answers already diverge — in-app updates are desktop-except-Linux, the tray
+ * preference is desktop-on-Windows-and-Linux, taskbar attention is
+ * desktop-on-Windows-only — so the codebase already carries a capability model,
+ * spelled as boolean algebra over `isTauri()`, `isWindows()` and `isLinux()` at
+ * every site that needs one.
+ *
+ * Naming the capabilities puts that model in one place. A call site says WHY it
+ * branches, so a reader can tell what a new target would have to provide, and a
+ * test can grant one capability without pretending to be a whole platform.
+ *
+ * Add a member when a call site asks a question none of the existing ones
+ * answers. Do not add a member that just means "is desktop" — that is
+ * {@link PlatformCapabilities.shell}, and reaching for it is the signal that
+ * the branch has not been understood yet.
+ *
+ * @packageDocumentation
+ * @module Platform
+ */
+
+/** Which shell the UI is running inside. */
+export type PlatformShell = 'desktop' | 'web'
+
+/** Host operating system, as far as the shell can tell. */
+export type PlatformOS = 'macos' | 'windows' | 'linux' | 'other'
+
+export interface PlatformCapabilities {
+  readonly shell: PlatformShell
+  readonly os: PlatformOS
+
+  /** Credentials live in the OS keychain instead of browser storage. */
+  readonly nativeKeychain: boolean
+  /** Attachments are saved through a native file dialog, not a download link. */
+  readonly nativeDownloads: boolean
+  /** Media is cached on the filesystem instead of in CacheStorage. */
+  readonly nativeMediaCache: boolean
+  /** Images can be read from the system clipboard through the OS. */
+  readonly nativeClipboardImages: boolean
+  /** Files can be dropped onto the window through the OS, not the DOM. */
+  readonly nativeFileDrop: boolean
+  /** Notification icons must be file paths rather than blob URLs. */
+  readonly notificationsNeedFileUrls: boolean
+  /** External links are handed to the system browser rather than a new tab. */
+  readonly opensLinksInSystemBrowser: boolean
+  /** In-app link clicks must be intercepted before the webview navigates. */
+  readonly interceptsInAppNavigation: boolean
+  /** HTTP requests can bypass CORS through the native side. */
+  readonly nativeHttpFetch: boolean
+  /** The window can ask the OS for the user's attention. */
+  readonly canRequestWindowAttention: boolean
+  /** Closing the window can be redirected to a system tray. */
+  readonly canKeepInSystemTray: boolean
+  /** The app updates itself rather than through a package manager or store. */
+  readonly hasInAppUpdates: boolean
+  /**
+   * Storage survives without asking the browser to keep it.
+   *
+   * False on web, where the origin can be evicted under storage pressure and
+   * the app must request persistence.
+   */
+  readonly storageIsDurable: boolean
+  /**
+   * The install has one stable identity across restarts.
+   *
+   * True on desktop, where a single app instance owns its XMPP resource. On
+   * web every tab is an independent client, so the resource is per-session.
+   */
+  readonly hasStableInstallIdentity: boolean
+}
+
+/**
+ * Derive the capability record from a shell and an OS.
+ *
+ * Pure, so a test can build any combination — including ones no real host
+ * produces — without touching globals.
+ */
+export function deriveCapabilities(shell: PlatformShell, os: PlatformOS): PlatformCapabilities {
+  const desktop = shell === 'desktop'
+  return {
+    shell,
+    os,
+    nativeKeychain: desktop,
+    nativeDownloads: desktop,
+    nativeMediaCache: desktop,
+    nativeClipboardImages: desktop,
+    nativeFileDrop: desktop,
+    notificationsNeedFileUrls: desktop,
+    opensLinksInSystemBrowser: desktop,
+    interceptsInAppNavigation: desktop,
+    nativeHttpFetch: desktop,
+    // Windows is the only host with a taskbar attention request behind it.
+    canRequestWindowAttention: desktop && os === 'windows',
+    // macOS hides the window on close instead; there is no tray preference.
+    canKeepInSystemTray: desktop && (os === 'windows' || os === 'linux'),
+    // Linux desktops update through the distro package manager.
+    hasInAppUpdates: desktop && os !== 'linux',
+    storageIsDurable: desktop,
+    hasStableInstallIdentity: desktop,
+  }
+}

--- a/apps/fluux/src/platform/index.ts
+++ b/apps/fluux/src/platform/index.ts
@@ -1,0 +1,95 @@
+/**
+ * The platform this build is running on, detected once.
+ *
+ * Detection reads globals, so it happens here and nowhere else. Everything
+ * downstream takes the resulting {@link PlatformCapabilities} record, which
+ * makes a call site's platform assumption visible in its code and lets a test
+ * state one directly instead of impersonating a host.
+ *
+ * @packageDocumentation
+ * @module Platform
+ */
+
+import {
+  deriveCapabilities,
+  type PlatformCapabilities,
+  type PlatformOS,
+  type PlatformShell,
+} from './capabilities'
+
+export {
+  deriveCapabilities,
+  type PlatformCapabilities,
+  type PlatformOS,
+  type PlatformShell,
+} from './capabilities'
+
+/**
+ * Tauri injects `__TAURI_INTERNALS__` into the webview before any app code
+ * runs, which is the only signal available synchronously at module scope.
+ */
+function detectShell(): PlatformShell {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window ? 'desktop' : 'web'
+}
+
+/**
+ * Sniffs `navigator`, matching the substrings the app has always matched so
+ * the capabilities derived from the OS keep their current answers exactly.
+ *
+ * Android reports `Linux` in its user agent and lands on `'linux'` here, as it
+ * always has. Telling a phone from a desktop needs the Tauri OS plugin, which
+ * only answers asynchronously — see `utils/tauriPlatform.ts`. Do not add a
+ * `'mobile'` member here until this can resolve one.
+ */
+export function detectOS(): PlatformOS {
+  if (typeof navigator === 'undefined') return 'other'
+  const haystack = `${navigator.platform ?? ''} ${navigator.userAgent ?? ''}`.toLowerCase()
+  // Linux is tested first so an ambiguous string resolves to the conservative
+  // answer: `hasInAppUpdates` is the capability that turns on Linux's absence,
+  // and shipping a self-updater into a distro-managed install is the costly
+  // direction to get wrong. No real host matches two of these.
+  if (haystack.includes('linux')) return 'linux'
+  if (haystack.includes('win')) return 'windows'
+  if (haystack.includes('mac')) return 'macos'
+  return 'other'
+}
+
+let current: PlatformCapabilities | null = null
+
+/**
+ * The current platform.
+ *
+ * Detected on first call and cached: the host cannot change under a running
+ * app, and several callers read this at module scope.
+ */
+export function platform(): PlatformCapabilities {
+  current ??= deriveCapabilities(detectShell(), detectOS())
+  return current
+}
+
+/**
+ * Override the platform for a test, and restore it afterwards.
+ *
+ * Prefer this to mocking the module: it exercises the real capability
+ * derivation, so a test cannot describe a platform that could not exist.
+ *
+ * @example
+ * ```ts
+ * const restore = setPlatformForTesting({ shell: 'desktop', os: 'windows' })
+ * afterEach(restore)
+ * ```
+ */
+export function setPlatformForTesting(
+  host: { shell: PlatformShell; os?: PlatformOS } | PlatformCapabilities
+): () => void {
+  const previous = current
+  current = 'nativeKeychain' in host ? host : deriveCapabilities(host.shell, host.os ?? 'other')
+  return () => {
+    current = previous
+  }
+}
+
+/** Forget the cached detection so the next {@link platform} call re-runs it. */
+export function resetPlatformDetection(): void {
+  current = null
+}

--- a/apps/fluux/src/utils/attention.test.ts
+++ b/apps/fluux/src/utils/attention.test.ts
@@ -1,16 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setPlatformForTesting } from '@/platform'
 
 const mockRequestUserAttention = vi.fn().mockResolvedValue(undefined)
-let mockTauri = true
-let mockWindows = true
 let mockWindowVisible = false
+let restorePlatform: () => void
 
 vi.mock('@fluux/sdk', () => ({
   connectionStore: { getState: () => ({ windowVisible: mockWindowVisible }) },
-}))
-vi.mock('./tauri', () => ({
-  isTauri: () => mockTauri,
-  isWindows: () => mockWindows,
 }))
 vi.mock('@tauri-apps/api/window', () => ({
   UserAttentionType: { Critical: 1 },
@@ -21,10 +18,13 @@ import { requestAttention } from './attention'
 
 describe('requestAttention', () => {
   beforeEach(() => {
-    mockTauri = true
-    mockWindows = true
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'windows' })
     mockWindowVisible = false
     mockRequestUserAttention.mockClear()
+  })
+
+  afterEach(() => {
+    restorePlatform()
   })
 
   it('requests critical attention on unfocused Windows Tauri', async () => {
@@ -39,10 +39,9 @@ describe('requestAttention', () => {
   })
 
   it('does nothing outside Windows Tauri', () => {
-    mockWindows = false
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
     requestAttention()
-    mockWindows = true
-    mockTauri = false
+    restorePlatform = setPlatformForTesting({ shell: 'web', os: 'windows' })
     requestAttention()
     expect(mockRequestUserAttention).not.toHaveBeenCalled()
   })

--- a/apps/fluux/src/utils/attention.ts
+++ b/apps/fluux/src/utils/attention.ts
@@ -1,9 +1,9 @@
 import { connectionStore } from '@fluux/sdk'
-import { isTauri, isWindows } from './tauri'
+import { platform } from '@/platform'
 
 /** Request persistent Windows taskbar attention for an unfocused Fluux window. */
 export function requestAttention(): void {
-  if (!isTauri() || !isWindows() || connectionStore.getState().windowVisible) return
+  if (!platform().canRequestWindowAttention || connectionStore.getState().windowVisible) return
 
   void import('@tauri-apps/api/window')
     .then(({ getCurrentWindow, UserAttentionType }) =>

--- a/apps/fluux/src/utils/download.test.ts
+++ b/apps/fluux/src/utils/download.test.ts
@@ -6,22 +6,25 @@
  * fetch can fail (or return a non-OK status). Those must surface as an error
  * toast — a cancelled save dialog must NOT.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 const { saveMock, writeFileMock } = vi.hoisted(() => ({
   saveMock: vi.fn(),
   writeFileMock: vi.fn(),
 }))
 
-vi.mock('./tauri', () => ({ isTauri: () => true }))
 vi.mock('@tauri-apps/plugin-dialog', () => ({ save: saveMock }))
 vi.mock('@tauri-apps/plugin-fs', () => ({ writeFile: writeFileMock }))
 
+import { setPlatformForTesting } from '@/platform'
 import { downloadFile } from './download'
 import { useToastStore } from '@/stores/toastStore'
 
 describe('downloadFile error feedback', () => {
+  let restorePlatform: () => void
+
   beforeEach(() => {
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
     useToastStore.setState({ toasts: [] })
     saveMock.mockReset()
     writeFileMock.mockReset()
@@ -30,6 +33,10 @@ describe('downloadFile error feedback', () => {
       status: 200,
       arrayBuffer: async () => new ArrayBuffer(4),
     }) as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    restorePlatform()
   })
 
   it('shows an error toast when the write fails (e.g. saving outside $HOME)', async () => {

--- a/apps/fluux/src/utils/download.ts
+++ b/apps/fluux/src/utils/download.ts
@@ -1,4 +1,4 @@
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 import { useToastStore } from '@/stores/toastStore'
 import type { FileAttachment } from '@fluux/sdk'
 
@@ -19,7 +19,7 @@ export async function downloadFile(
   options?: { errorMessage?: string },
 ): Promise<void> {
   try {
-    if (isTauri()) {
+    if (platform().nativeDownloads) {
       const { save } = await import('@tauri-apps/plugin-dialog')
       const { writeFile } = await import('@tauri-apps/plugin-fs')
 
@@ -68,9 +68,9 @@ export async function downloadAttachment(
     let resolvedUrl = attachment.url
     if (attachment.encryption) {
       const { resolveEncryptedMediaUrl, resolveWebEncryptedMediaUrl } = await import('./mediaCache')
-      const resolve = isTauri() ? resolveEncryptedMediaUrl : resolveWebEncryptedMediaUrl
+      const resolve = platform().nativeDownloads ? resolveEncryptedMediaUrl : resolveWebEncryptedMediaUrl
       resolvedUrl = await resolve(attachment.url, attachment.encryption)
-    } else if (isTauri()) {
+    } else if (platform().nativeDownloads) {
       const { resolveMediaUrl } = await import('./mediaCache')
       resolvedUrl = await resolveMediaUrl(attachment.url)
     }

--- a/apps/fluux/src/utils/downloadAttachment.test.ts
+++ b/apps/fluux/src/utils/downloadAttachment.test.ts
@@ -7,14 +7,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const {
-  isTauriMock,
   saveMock,
   writeFileMock,
   resolvePlaintextTauriMock,
   resolveTauriMock,
   resolveWebMock,
 } = vi.hoisted(() => ({
-  isTauriMock: vi.fn(),
   saveMock: vi.fn(),
   writeFileMock: vi.fn(),
   resolvePlaintextTauriMock: vi.fn(),
@@ -22,7 +20,16 @@ const {
   resolveWebMock: vi.fn(),
 }))
 
-vi.mock('./tauri', () => ({ isTauri: isTauriMock }))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform: `usePlatform` swaps the capability record, and the
+// derivation decides what that host can do.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
+
 vi.mock('@tauri-apps/plugin-dialog', () => ({ save: saveMock }))
 vi.mock('@tauri-apps/plugin-fs', () => ({ writeFile: writeFileMock }))
 vi.mock('./mediaCache', () => ({
@@ -58,7 +65,7 @@ describe('downloadAttachment', () => {
   })
 
   it('Tauri: encrypted → resolves decrypted URL and saves that, never the ciphertext URL', async () => {
-    isTauriMock.mockReturnValue(true)
+    usePlatform('desktop')
     resolveTauriMock.mockResolvedValue('asset://localhost/decrypted.dec')
     saveMock.mockResolvedValue('/Users/me/doc.pdf')
 
@@ -77,7 +84,7 @@ describe('downloadAttachment', () => {
   })
 
   it('web: encrypted → resolves via the web resolver', async () => {
-    isTauriMock.mockReturnValue(false)
+    usePlatform('web')
     resolveWebMock.mockResolvedValue('blob:decrypted')
     const createEl = vi.spyOn(document, 'createElement')
 
@@ -95,7 +102,7 @@ describe('downloadAttachment', () => {
   })
 
   it('Tauri: plaintext → resolves through the native cache before saving', async () => {
-    isTauriMock.mockReturnValue(true)
+    usePlatform('desktop')
     resolvePlaintextTauriMock.mockResolvedValue('asset://localhost/cached.txt')
     saveMock.mockResolvedValue('/Users/me/note.txt')
 
@@ -108,7 +115,7 @@ describe('downloadAttachment', () => {
   })
 
   it('web: plaintext → keeps the direct URL without invoking a resolver', async () => {
-    isTauriMock.mockReturnValue(false)
+    usePlatform('web')
     const createEl = vi.spyOn(document, 'createElement')
 
     await downloadAttachment({ url: 'https://up/note.txt', name: 'note.txt' })
@@ -124,7 +131,7 @@ describe('downloadAttachment', () => {
   })
 
   it('encrypted resolve failure → error toast, nothing written', async () => {
-    isTauriMock.mockReturnValue(true)
+    usePlatform('desktop')
     resolveTauriMock.mockRejectedValue(new Error('auth tag mismatch'))
 
     await downloadAttachment(

--- a/apps/fluux/src/utils/externalLinkHandler.test.ts
+++ b/apps/fluux/src/utils/externalLinkHandler.test.ts
@@ -3,9 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // The handler dynamically imports the Tauri shell plugin; capture the mock.
 const openMock = vi.hoisted(() => vi.fn())
 vi.mock('@tauri-apps/plugin-shell', () => ({ open: openMock }))
-// Force the Tauri branch so the handler actually registers.
-vi.mock('./tauri', () => ({ isTauri: () => true }))
 
+import { setPlatformForTesting } from '@/platform'
 import { setupExternalLinkHandler } from './externalLinkHandler'
 
 function click(el: Element) {
@@ -14,14 +13,18 @@ function click(el: Element) {
 
 describe('setupExternalLinkHandler', () => {
   let cleanup: (() => void) | undefined
+  let restorePlatform: () => void
 
   beforeEach(() => {
+    // The handler only registers where in-app navigation is intercepted.
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
     openMock.mockClear()
     cleanup = setupExternalLinkHandler()
   })
 
   afterEach(() => {
     cleanup?.()
+    restorePlatform()
     document.body.innerHTML = ''
   })
 

--- a/apps/fluux/src/utils/externalLinkHandler.ts
+++ b/apps/fluux/src/utils/externalLinkHandler.ts
@@ -4,7 +4,7 @@
  * default browser. In web mode, links open normally.
  */
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 function isExternalUrl(href: string): boolean {
   try {
@@ -26,7 +26,7 @@ async function openInSystemBrowser(url: string): Promise<void> {
  * Returns a cleanup function, or undefined in web mode.
  */
 export function setupExternalLinkHandler(): (() => void) | undefined {
-  if (!isTauri()) return undefined
+  if (!platform().interceptsInAppNavigation) return undefined
 
   const handler = (event: MouseEvent) => {
     const target = event.target as Element | null

--- a/apps/fluux/src/utils/keychain.test.ts
+++ b/apps/fluux/src/utils/keychain.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Mock the tauri utility before importing keychain
-const mockIsTauri = vi.fn()
-vi.mock('./tauri', () => ({
-  isTauri: () => mockIsTauri(),
-}))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform: `usePlatform` swaps the capability record, and the
+// derivation decides what that host can do.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 // Mock the Tauri invoke function
 const mockInvoke = vi.fn()
@@ -21,10 +25,11 @@ describe('keychain utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    mockIsTauri.mockReturnValue(true)
+    usePlatform('desktop')
   })
 
   afterEach(() => {
+    restorePlatform?.()
     localStorage.clear()
   })
 
@@ -46,7 +51,7 @@ describe('keychain utilities', () => {
 
   describe('saveCredentials', () => {
     it('should not call invoke when not in Tauri', async () => {
-      mockIsTauri.mockReturnValue(false)
+      usePlatform('web')
       // Silence expected console.warn
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -88,7 +93,7 @@ describe('keychain utilities', () => {
 
   describe('getCredentials', () => {
     it('should return null when not in Tauri', async () => {
-      mockIsTauri.mockReturnValue(false)
+      usePlatform('web')
 
       const result = await getCredentials()
 
@@ -144,7 +149,7 @@ describe('keychain utilities', () => {
   describe('deleteCredentials', () => {
     it('should clear localStorage flag on skip path', async () => {
       localStorage.setItem(STORAGE_KEY, 'true')
-      mockIsTauri.mockReturnValue(false)
+      usePlatform('web')
 
       await deleteCredentials()
 

--- a/apps/fluux/src/utils/keychain.ts
+++ b/apps/fluux/src/utils/keychain.ts
@@ -5,7 +5,7 @@
 
 // Note: invoke is imported dynamically inside functions to avoid loading Tauri APIs in web mode
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 export interface StoredCredentials {
   jid: string
@@ -41,7 +41,7 @@ export async function saveCredentials(
   password: string,
   server: string | null
 ): Promise<void> {
-  if (!isTauri()) {
+  if (!platform().nativeKeychain) {
     console.warn('Keychain storage is only available in the desktop app')
     return
   }
@@ -59,7 +59,7 @@ export async function saveCredentials(
  * Returns null if no credentials are stored or if not running in Tauri
  */
 export async function getCredentials(): Promise<StoredCredentials | null> {
-  if (!isTauri()) {
+  if (!platform().nativeKeychain) {
     return null
   }
 
@@ -95,7 +95,7 @@ export async function deleteCredentials(options: DeleteCredentialsOptions = {}):
   // stale local state.
   const hadCredentials = localStorage.getItem(STORAGE_KEY_HAS_CREDENTIALS) === 'true'
 
-  if (!isTauri() || (!hadCredentials && !force)) {
+  if (!platform().nativeKeychain || (!hadCredentials && !force)) {
     localStorage.removeItem(STORAGE_KEY_HAS_CREDENTIALS)
     console.log('[Fluux] Keychain: delete skipped (no credentials flag, not Tauri, or not forced)')
     return

--- a/apps/fluux/src/utils/linkPreview.ts
+++ b/apps/fluux/src/utils/linkPreview.ts
@@ -4,7 +4,7 @@
  */
 
 // Note: invoke is imported dynamically inside functions to avoid loading Tauri APIs in web mode
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 export interface UrlMetadata {
   url: string
@@ -19,7 +19,7 @@ export interface UrlMetadata {
  * Returns null if not running in Tauri or if fetch fails
  */
 export async function fetchUrlMetadata(url: string): Promise<UrlMetadata | null> {
-  if (!isTauri()) {
+  if (!platform().nativeHttpFetch) {
     console.warn('Link preview is only available in the desktop app')
     return null
   }

--- a/apps/fluux/src/utils/mediaCache.test.ts
+++ b/apps/fluux/src/utils/mediaCache.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Mock tauri detection
-const mockIsTauri = vi.fn()
-vi.mock('./tauri', () => ({
-  isTauri: () => mockIsTauri(),
-}))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform: `usePlatform` swaps the capability record, and the
+// derivation decides what that host can do.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 // Mock Tauri path API
 const mockAppCacheDir = vi.fn()
@@ -63,7 +67,7 @@ describe('mediaCache', () => {
     vi.clearAllMocks()
     resetMediaUrlCache()
 
-    mockIsTauri.mockReturnValue(true)
+    usePlatform('desktop')
     mockAppCacheDir.mockResolvedValue('/Users/test/Library/Caches/com.processone.fluux')
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
     mockExists.mockResolvedValue(false)
@@ -194,7 +198,7 @@ describe('mediaCache', () => {
 
   describe('getMediaCacheSize', () => {
     it('should return 0 when not in Tauri', async () => {
-      mockIsTauri.mockReturnValue(false)
+      usePlatform('web')
       const size = await getMediaCacheSize()
       expect(size).toBe(0)
     })
@@ -219,7 +223,7 @@ describe('peekMediaCache (Tauri, network-free)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(true)
+    usePlatform('desktop')
     mockAppCacheDir.mockResolvedValue('/cache/com.processone.fluux')
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
     mockMkdir.mockResolvedValue(undefined)
@@ -245,7 +249,7 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(true)
+    usePlatform('desktop')
     mockAppCacheDir.mockResolvedValue('/cache/com.processone.fluux')
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
     mockExists.mockResolvedValue(false)
@@ -323,7 +327,7 @@ describe('peekEncryptedMediaCache (Tauri, network-free)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(true)
+    usePlatform('desktop')
     mockAppCacheDir.mockResolvedValue('/cache/com.processone.fluux')
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
     mockMkdir.mockResolvedValue(undefined)
@@ -350,7 +354,7 @@ describe('peekWebMediaCache (web Cache API, network-free)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(false)
+    usePlatform('web')
     matchResult = undefined
     vi.stubGlobal('caches', {
       open: async () => ({ match: async () => matchResult }),
@@ -384,7 +388,7 @@ describe('resolveWebEncryptedMediaUrl (web Cache API, scheme safety)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(false)
+    usePlatform('web')
     store = new Map()
     // Faithful Cache API mock: like a real browser, put() rejects any request
     // whose URL scheme is not http/https. This is what catches a cache key
@@ -450,7 +454,7 @@ describe('resolveWebMediaUrl (web Cache API, scheme safety)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(false)
+    usePlatform('web')
     store = new Map()
     // Same faithful Cache API mock as the encrypted suite: put() rejects any
     // request whose URL scheme is not http/https, mirroring the real browser.
@@ -518,7 +522,7 @@ describe('peekWebEncryptedMediaCache (web Cache API, encrypted, network-free)', 
   beforeEach(() => {
     vi.clearAllMocks()
     resetMediaUrlCache()
-    mockIsTauri.mockReturnValue(false)
+    usePlatform('web')
     matchResult = undefined
     vi.stubGlobal('caches', {
       open: async () => ({ match: async () => matchResult }),

--- a/apps/fluux/src/utils/mediaCache.ts
+++ b/apps/fluux/src/utils/mediaCache.ts
@@ -8,7 +8,7 @@
  */
 
 import { decryptFile, type FileEncryption } from '@fluux/sdk'
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 export class MediaRetrievalError extends Error {
   constructor(message: string, readonly status?: number) {
@@ -495,7 +495,7 @@ export async function clearMediaCache(): Promise<void> {
     }
   }
 
-  if (!isTauri()) return
+  if (!platform().nativeMediaCache) return
 
   try {
     const { remove, mkdir } = await import('@tauri-apps/plugin-fs')
@@ -516,7 +516,7 @@ export async function getMediaCacheSize(): Promise<number> {
   let totalSize = 0
 
   // Web Cache API size estimation
-  if (!isTauri() && typeof caches !== 'undefined') {
+  if (!platform().nativeMediaCache && typeof caches !== 'undefined') {
     try {
       const cache = await caches.open(WEB_CACHE_NAME)
       const keys = await cache.keys()
@@ -533,7 +533,7 @@ export async function getMediaCacheSize(): Promise<number> {
     return totalSize
   }
 
-  if (!isTauri()) return 0
+  if (!platform().nativeMediaCache) return 0
 
   try {
     const { readDir, stat } = await import('@tauri-apps/plugin-fs')

--- a/apps/fluux/src/utils/nativeClipboard.ts
+++ b/apps/fluux/src/utils/nativeClipboard.ts
@@ -6,7 +6,7 @@
  * tauri-plugin-clipboard-manager to read images directly from the system clipboard.
  */
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 /**
  * Attempt to read an image from the system clipboard using Tauri's native plugin.
@@ -16,7 +16,7 @@ import { isTauri } from './tauri'
  * where WebKitGTK's clipboard support for images is incomplete.
  */
 export async function readClipboardImage(): Promise<File | null> {
-  if (!isTauri()) return null
+  if (!platform().nativeClipboardImages) return null
 
   try {
     const { readImage } = await import('@tauri-apps/plugin-clipboard-manager')

--- a/apps/fluux/src/utils/notificationAvatar.ts
+++ b/apps/fluux/src/utils/notificationAvatar.ts
@@ -6,7 +6,7 @@
  * blob URLs to temp files for Tauri, with caching to avoid rewrites.
  */
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 // Cache of hash -> file path to avoid rewriting same avatars
 const avatarFileCache = new Map<string, string>()
@@ -27,7 +27,7 @@ export async function getNotificationAvatarUrl(
   if (!blobUrl) return undefined
 
   // Web notifications can use blob URLs directly
-  if (!isTauri()) {
+  if (!platform().notificationsNeedFileUrls) {
     return blobUrl
   }
 

--- a/apps/fluux/src/utils/openInBrowser.test.ts
+++ b/apps/fluux/src/utils/openInBrowser.test.ts
@@ -1,16 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setPlatformForTesting } from '@/platform'
 
 const openMock = vi.fn()
 vi.mock('@tauri-apps/plugin-shell', () => ({ open: openMock }))
 
 describe('openInBrowser', () => {
+  let restorePlatform: (() => void) | undefined
+
   beforeEach(() => {
-    vi.resetModules()
     openMock.mockReset()
   })
 
+  afterEach(() => {
+    restorePlatform?.()
+  })
+
   it('uses window.open on web', async () => {
-    vi.doMock('./tauri', () => ({ isTauri: () => false }))
+    restorePlatform = setPlatformForTesting({ shell: 'web' })
     const winOpen = vi.spyOn(window, 'open').mockImplementation(() => null)
     const { openInBrowser } = await import('./openInBrowser')
     await openInBrowser('https://example.com')
@@ -19,7 +25,7 @@ describe('openInBrowser', () => {
   })
 
   it('uses the Tauri shell open on desktop', async () => {
-    vi.doMock('./tauri', () => ({ isTauri: () => true }))
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
     const { openInBrowser } = await import('./openInBrowser')
     await openInBrowser('https://example.com')
     expect(openMock).toHaveBeenCalledWith('https://example.com')

--- a/apps/fluux/src/utils/openInBrowser.ts
+++ b/apps/fluux/src/utils/openInBrowser.ts
@@ -1,4 +1,4 @@
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 /**
  * Open a URL in the user's default browser.
@@ -8,7 +8,7 @@ import { isTauri } from './tauri'
  * back to `window.open` with `noopener,noreferrer`.
  */
 export async function openInBrowser(url: string): Promise<void> {
-  if (isTauri()) {
+  if (platform().opensLinksInSystemBrowser) {
     const { open } = await import('@tauri-apps/plugin-shell')
     await open(url)
   } else {

--- a/apps/fluux/src/utils/persistStorage.test.ts
+++ b/apps/fluux/src/utils/persistStorage.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Control platform detection per test.
-const isTauri = vi.fn(() => false)
-vi.mock('./tauri', () => ({ isTauri: () => isTauri() }))
-
+import { setPlatformForTesting } from '@/platform'
 import { requestPersistentStorage } from './persistStorage'
+
+// Control the platform per test: only the web build asks for persistence.
+let restorePlatform: () => void
 
 function stubStorage(storage: unknown) {
   vi.stubGlobal('navigator', { storage })
@@ -12,10 +12,11 @@ function stubStorage(storage: unknown) {
 
 describe('requestPersistentStorage', () => {
   beforeEach(() => {
-    isTauri.mockReturnValue(false)
+    restorePlatform = setPlatformForTesting({ shell: 'web' })
   })
 
   afterEach(() => {
+    restorePlatform()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
@@ -44,7 +45,7 @@ describe('requestPersistentStorage', () => {
   })
 
   it('is a no-op under Tauri', async () => {
-    isTauri.mockReturnValue(true)
+    restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
     const persist = vi.fn().mockResolvedValue(true)
     stubStorage({ persist, persisted: vi.fn().mockResolvedValue(false) })
 

--- a/apps/fluux/src/utils/persistStorage.ts
+++ b/apps/fluux/src/utils/persistStorage.ts
@@ -1,4 +1,4 @@
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 /**
  * Best-effort request for persistent storage on the web/PWA build.
@@ -15,7 +15,7 @@ import { isTauri } from './tauri'
  * persistent after the call.
  */
 export async function requestPersistentStorage(): Promise<boolean> {
-  if (isTauri()) return false
+  if (platform().storageIsDurable) return false
 
   const storage = typeof navigator !== 'undefined' ? navigator.storage : undefined
   if (!storage || typeof storage.persist !== 'function') return false

--- a/apps/fluux/src/utils/tauri.ts
+++ b/apps/fluux/src/utils/tauri.ts
@@ -1,6 +1,12 @@
 /**
- * Tauri platform detection utilities
+ * Tauri platform detection utilities.
+ *
+ * Superseded by `@/platform`, which derives every platform-dependent answer
+ * once and names it. These probes remain for the hooks and components that
+ * still branch on them directly; do not add callers.
  */
+
+import { platform } from '@/platform'
 
 /**
  * Check if running in Tauri (desktop app) vs web browser
@@ -33,5 +39,5 @@ export function isWindows(): boolean {
  * Enabled only in Tauri on macOS and Windows (not Linux, not web).
  */
 export function isUpdaterEnabled(): boolean {
-  return isTauri() && !isLinux()
+  return platform().hasInAppUpdates
 }

--- a/apps/fluux/src/utils/tauriFileDrop.ts
+++ b/apps/fluux/src/utils/tauriFileDrop.ts
@@ -5,13 +5,13 @@
  * so it's ready before any React components render.
  */
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 type DragStateListener = (isDragging: boolean) => void
 type FileDropListener = (paths: string[]) => void
 
 // Evaluate once at module load time
-const isRunningInTauri = isTauri()
+const isRunningInTauri = platform().nativeFileDrop
 
 // Global state
 let isDragging = false

--- a/apps/fluux/src/utils/windowBehavior.ts
+++ b/apps/fluux/src/utils/windowBehavior.ts
@@ -1,12 +1,12 @@
 import { invoke } from '@tauri-apps/api/core'
-import { isLinux, isTauri, isWindows } from './tauri'
+import { platform } from '@/platform'
 
 export interface TrayStatus {
   enabled: boolean
   available: boolean
 }
 export function supportsTrayPreference(): boolean {
-  return isTauri() && (isWindows() || isLinux())
+  return platform().canKeepInSystemTray
 }
 
 export async function setKeepInSystemTray(enabled: boolean): Promise<TrayStatus | null> {

--- a/apps/fluux/src/utils/xmppResource.test.ts
+++ b/apps/fluux/src/utils/xmppResource.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { generateResource, isValidResource } from './xmppResource'
 
-// Mock isTauri — must be before importing getResource
-vi.mock('./tauri', () => ({
-  isTauri: vi.fn(() => false),
-}))
-
-import { isTauri } from './tauri'
 
 function createStorageMock(): Storage {
   const store: Record<string, string> = {}
@@ -98,54 +92,58 @@ describe('xmppResource', () => {
       vi.restoreAllMocks()
     })
 
-    async function loadGetResource() {
+    /**
+     * Load `getResource` against a stated platform.
+     *
+     * `vi.resetModules()` above gives each test a fresh module registry, so the
+     * platform seam has to be taken from that same registry — a
+     * `setPlatformForTesting` imported statically at the top of this file would
+     * configure a different module instance than the one `xmppResource` reads.
+     */
+    async function loadGetResource(shell: 'desktop' | 'web') {
+      const { setPlatformForTesting } = await import('@/platform')
+      setPlatformForTesting({ shell, os: 'macos' })
       const mod = await import('./xmppResource')
       return mod.getResource
     }
 
     it('should generate a new web resource when sessionStorage is empty', async () => {
-      vi.mocked(isTauri).mockReturnValue(false)
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('web')
       const resource = getRes()
       expect(resource).toMatch(/^web-[a-z0-9]{6}$/)
       expect(mockSessionStorage.setItem).toHaveBeenCalledWith('xmpp-resource', resource)
     })
 
     it('should return existing valid web resource from sessionStorage', async () => {
-      vi.mocked(isTauri).mockReturnValue(false)
       mockSessionStorage.setItem('xmpp-resource', 'web-abc123')
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('web')
       expect(getRes()).toBe('web-abc123')
     })
 
     it('should regenerate when sessionStorage has bare "web" (stale value)', async () => {
-      vi.mocked(isTauri).mockReturnValue(false)
       mockSessionStorage.setItem('xmpp-resource', 'web')
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('web')
       const resource = getRes()
       expect(resource).toMatch(/^web-[a-z0-9]{6}$/)
       expect(resource).not.toBe('web')
     })
 
     it('should generate a new desktop resource when localStorage is empty', async () => {
-      vi.mocked(isTauri).mockReturnValue(true)
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('desktop')
       const resource = getRes()
       expect(resource).toMatch(/^desktop-[a-z0-9]{6}$/)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('xmpp-resource', resource)
     })
 
     it('should return existing valid desktop resource from localStorage', async () => {
-      vi.mocked(isTauri).mockReturnValue(true)
       mockLocalStorage.setItem('xmpp-resource', 'desktop-xyz789')
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('desktop')
       expect(getRes()).toBe('desktop-xyz789')
     })
 
     it('should regenerate when localStorage has bare "desktop" (stale value)', async () => {
-      vi.mocked(isTauri).mockReturnValue(true)
       mockLocalStorage.setItem('xmpp-resource', 'desktop')
-      const getRes = await loadGetResource()
+      const getRes = await loadGetResource('desktop')
       const resource = getRes()
       expect(resource).toMatch(/^desktop-[a-z0-9]{6}$/)
       expect(resource).not.toBe('desktop')

--- a/apps/fluux/src/utils/xmppResource.ts
+++ b/apps/fluux/src/utils/xmppResource.ts
@@ -13,7 +13,7 @@
  *   as independent clients, while a page reload reconnects with the same resource.
  */
 
-import { isTauri } from './tauri'
+import { platform } from '@/platform'
 
 const RESOURCE_KEY = 'xmpp-resource'
 
@@ -48,7 +48,7 @@ export function isValidResource(resource: string): boolean {
  * from before the random suffix system), it is regenerated.
  */
 export function getResource(): string {
-  if (isTauri()) {
+  if (platform().hasStableInstallIdentity) {
     // Desktop: Use persistent random resource (survives app restarts)
     let resource = localStorage.getItem(RESOURCE_KEY)
     if (!resource || !isValidResource(resource)) {


### PR DESCRIPTION
`isTauri()` reads as one question and answers at least six: whether there is an OS keychain, whether links leave for the system browser, whether notification icons must be file paths, whether storage can be evicted.

The platform is not binary either, and the code already knew it — it just spelled the model as boolean algebra at each site:

```ts
isUpdaterEnabled  = isTauri() && !isLinux()            // desktop except Linux
supportsTray      = isTauri() && (isWindows() || isLinux())
requestAttention  = isTauri() && isWindows()
```

`@/platform` derives that model once and names it. Each capability answers one question a call site asks, so the site says **why** it differs per host, and a new target can be described rather than guessed at.

## Scope

The 14 `utils/` modules, which are leaf, non-visual and well covered. `isTauri()` in the app source goes from **89 to 70** occurrences; `utils/` goes to zero.

The rest is deliberately left, because it is not the same problem and not mechanical:

| Layer | Left | Why |
|---|---|---|
| `hooks/` | 38 | `usePlatformState.ts` alone holds 9, wired into its idle-detection and wake state machine |
| `components/` + `App.tsx` | 27 | UI gating; needs demo-mode validation per surface |
| `e2ee/`, `anomaly/` | 2 | small, but they belong with their own layer's pass |

`utils/tauriPlatform.ts` is also untouched: it probes the OS **asynchronously** through the Tauri plugin and is the only thing that can tell iOS/Android from desktop. Reconciling it with the synchronous record needs an async init, and that is a design decision, not a rename.

## Behaviour

Unchanged for every real host. The OS sniffing keeps the exact substrings `isWindows()`/`isLinux()` always matched, and Linux is tested first so an ambiguous string resolves toward withholding the self-updater — the costly direction to get wrong on a distro-managed install.

## Tests

Nine test files impersonated a platform in five different ways: `vi.mock('./tauri')`, `vi.doMock`, hoisted mock functions, a module-level mutable flag, and poking `window.__TAURI_INTERNALS__`. They now state a host through `setPlatformForTesting`, which runs the real derivation — a test cannot describe a platform that could not exist. Two of them were also overriding without restoring; lint caught it.

An ESLint rule keeps `utils/` on the capability names, scoped to the migrated layer and widened as the others follow.