### PR TITLE
refactor(app): branch the components on platform capabilities

### DIFF
--- a/apps/fluux/eslint.config.js
+++ b/apps/fluux/eslint.config.js
@@ -66,18 +66,21 @@ export default tseslint.config(
     // instead, so a call site says WHY it branches and a new target can be
     // described rather than guessed at.
     //
-    // Scoped to the layer that has been migrated. Widen it to hooks and
-    // components as they follow; do not add exceptions.
-    files: ['src/utils/**/*.ts'],
+    // Scoped to the layers that have been migrated. `hooks/` is the last one
+    // left; widen this when it follows, and do not add exceptions.
+    files: ['src/utils/**/*.ts', 'src/components/**/*.ts', 'src/components/**/*.tsx', 'src/App.tsx'],
     // `tauri.ts` owns the remaining probes; its own test has to import them.
-    ignores: ['src/utils/tauri.ts', 'src/utils/*.test.ts'],
+    ignores: ['src/utils/tauri.ts', '**/*.test.ts', '**/*.test.tsx'],
     rules: {
       'no-restricted-imports': [
         'error',
         {
           patterns: [
             {
-              regex: '^(\\.{1,2}/)*(@/utils/)?tauri$',
+              // Any path landing on utils/tauri: './tauri', './utils/tauri',
+              // '../utils/tauri', '@/utils/tauri'. Never '@tauri-apps/*', and
+              // never '@/utils/tauriPlatform'.
+              regex: '(^|/)tauri$',
               message:
                 "Branch on a named capability from '@/platform' (e.g. platform().nativeKeychain) rather than on isTauri() - the platform is not binary, and the capability name is what tells the next reader why this code differs per host.",
             },

--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -37,10 +37,9 @@ import { clearLocalData } from './utils/clearLocalData'
 import { startMemoryProbe } from './utils/memoryProbe'
 import { startSystemNotificationEffect } from '@/effects/systemNotificationEffect'
 import { markConnectActive } from './utils/reconnectIntent'
-import { isTauri } from './utils/tauri'
+import { platform } from './platform'
 
 // macOS detection (for title bar overlay - only applies on macOS)
-const isMacOS = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
 // Fixed title bar height for macOS traffic lights (only used in Tauri on macOS)
 const TITLEBAR_HEIGHT = 28
@@ -48,9 +47,9 @@ const TITLEBAR_HEIGHT = 28
 function TitleBar() {
   const isFullscreen = useFullscreen()
 
-  // Only render on macOS in Tauri (for traffic light spacing)
-  // Windows and Linux use native title bars
-  if (!isTauri() || !isMacOS || isFullscreen) return null
+  // Reserves room for the macOS traffic lights; Windows and Linux keep a
+  // native title bar, so there is nothing to draw.
+  if (!platform().hasCustomTitleBar || isFullscreen) return null
 
   return (
     <div
@@ -96,7 +95,7 @@ function App() {
   // Listen for --clear-storage CLI flag (Tauri only)
   // This clears all local data on startup when the flag is passed
   useEffect(() => {
-    if (!isTauri()) return
+    if (!platform().hasCommandLineFlags) return
 
     let disposed = false
     let unlisten: (() => void) | null = null
@@ -300,7 +299,7 @@ function App() {
         // Web-only: a stored-but-locked key needs the session passphrase.
         // Try the opt-in 24h cache first so the user skips re-entry; fall back
         // to the interactive dialog on miss or any failure (e.g. rotated key).
-        if (!isTauri() && isKeyLocked()) {
+        if (platform().keyNeedsSessionPassphrase && isKeyLocked()) {
           await attemptCachedUnlockOrPrompt({
             accountJid,
             getUnlockPlugin: () =>
@@ -417,7 +416,7 @@ function App() {
   }
 
   // Show tab coordination screen when blocked or taken over (web only)
-  if (!isTauri() && (tabCoordination.blocked || tabCoordination.takenOver)) {
+  if (platform().needsTabCoordination && (tabCoordination.blocked || tabCoordination.takenOver)) {
     return (
       <>
         <TitleBar />

--- a/apps/fluux/src/components/AppBar.test.tsx
+++ b/apps/fluux/src/components/AppBar.test.tsx
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { AppBar } from './AppBar'
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 // Reactive gates — toggled per test.
 let mockIsDesktop = true
@@ -37,13 +45,18 @@ function renderAppBar() {
 }
 
 describe('AppBar', () => {
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = undefined
+  })
+
   beforeEach(() => {
     mockIsDesktop = true
     mockHasHover = true
     navigateSpy.mockClear()
     toggleSpy.mockClear()
     // Default to the web build; the desktop-app tests opt in explicitly.
-    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    usePlatform('web')
     // Reset history position so each test starts at index 0 (start = end).
     window.history.replaceState(null, '')
   })
@@ -62,7 +75,7 @@ describe('AppBar', () => {
   })
 
   it('still renders on the desktop app in a narrow window (Tauri, below the breakpoint)', () => {
-    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+    usePlatform('desktop')
     mockIsDesktop = false
     mockHasHover = false
     renderAppBar()

--- a/apps/fluux/src/components/AppBar.tsx
+++ b/apps/fluux/src/components/AppBar.tsx
@@ -6,6 +6,7 @@ import { useIsDesktop } from '@/hooks/useIsDesktop'
 import { useHasHover } from '@/hooks/useHasHover'
 import { useFullscreen } from '@/hooks/useFullscreen'
 import { useModalStore } from '@/stores/modalStore'
+import { platform } from '@/platform'
 
 // Minimal shape of the Tauri window methods we drive for window dragging.
 type DraggableWindow = { startDragging: () => Promise<void>; toggleMaximize: () => Promise<void> }
@@ -13,7 +14,6 @@ type DraggableWindow = { startDragging: () => Promise<void>; toggleMaximize: () 
 // macOS detection — only macOS overlays native traffic lights onto the webview,
 // so only there does the bar need to reserve space at its start. Tauri detection
 // is read at render time (see component body) so tests can toggle it.
-const isMacOS = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
 // Width reserved at the bar's start for the macOS traffic lights so the first
 // control (the back arrow) never overlaps them. The lights cluster spans ~70px
@@ -61,14 +61,15 @@ export const AppBar = memo(function AppBar() {
   const { t } = useTranslation()
   const toggleModal = useModalStore((s) => s.toggle)
 
-  // Read at render time (not module scope) so tests can toggle it per case.
-  const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+  // Read at render time (not module scope) so a test can state a host per case.
+  const { shell, os, hasCustomTitleBar } = platform()
+  const isDesktopShell = shell === 'desktop'
 
   // Pre-resolve the Tauri window so the mousedown drag handler stays synchronous
   // (an async import there would miss the gesture). Null in the browser.
   const dragWindowRef = useRef<DraggableWindow | null>(null)
   useEffect(() => {
-    if (!isTauri) return
+    if (!isDesktopShell) return
     let cancelled = false
     void import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
       if (!cancelled) dragWindowRef.current = getCurrentWindow() as unknown as DraggableWindow
@@ -76,7 +77,7 @@ export const AppBar = memo(function AppBar() {
     return () => {
       cancelled = true
     }
-  }, [isTauri])
+  }, [isDesktopShell])
 
   // React Router stores a numeric index in history state; re-read it on every
   // navigation (useLocation re-renders us). `currentIdx` is the position in the
@@ -102,9 +103,9 @@ export const AppBar = memo(function AppBar() {
   // hidden on touch devices even when they're wide — e.g. a phone in landscape
   // (>768px) or a tablet — where its mouse-sized controls would be hard to tap and
   // the single-pane touch affordances own navigation.
-  if (!isTauri && (!isDesktop || !hasHover)) return null
+  if (!isDesktopShell && (!isDesktop || !hasHover)) return null
 
-  const needsTrafficLightInset = isTauri && isMacOS && !isFullscreen
+  const needsTrafficLightInset = hasCustomTitleBar && !isFullscreen
 
   const canGoBack = currentIdx > 0
   const canGoForward = currentIdx < maxIdx
@@ -123,7 +124,7 @@ export const AppBar = memo(function AppBar() {
 
   // macOS convention omits the separator (⌘K); elsewhere join with '+' (Ctrl+K),
   // matching formatShortcutKey used by the shortcut help pane.
-  const shortcutHint = isMacOS ? '⌘K' : 'Ctrl+K'
+  const shortcutHint = os === 'macos' ? '⌘K' : 'Ctrl+K'
   const iconButton =
     'flex items-center justify-center size-7 rounded-md text-fluux-muted hover:text-fluux-text hover:bg-fluux-bg/60 transition-colors disabled:opacity-40 disabled:pointer-events-none'
 

--- a/apps/fluux/src/components/AttachmentDownloadButton.tsx
+++ b/apps/fluux/src/components/AttachmentDownloadButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Download, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { downloadAttachment } from '@/utils/download'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 import type { FileAttachment } from '@fluux/sdk'
 
 interface Props {
@@ -34,7 +34,7 @@ export function AttachmentDownloadButton({ attachment, className, iconClassName,
     ? <>{glyph}<span>{label}</span></>
     : glyph
 
-  if (!attachment.encryption && !isTauri()) {
+  if (!attachment.encryption && !platform().nativeDownloads) {
     return (
       <a
         href={attachment.url}

--- a/apps/fluux/src/components/FileAttachments.test.tsx
+++ b/apps/fluux/src/components/FileAttachments.test.tsx
@@ -19,11 +19,10 @@ function fireMediaError(element: HTMLMediaElement, code: number) {
 }
 
 // Spy created via vi.hoisted so it exists when the hoisted vi.mock factory runs.
-const { useAttachmentUrlSpy, useCachedMediaUrlSpy, downloadAttachmentSpy, isTauriSpy } = vi.hoisted(() => ({
+const { useAttachmentUrlSpy, useCachedMediaUrlSpy, downloadAttachmentSpy } = vi.hoisted(() => ({
   useAttachmentUrlSpy: vi.fn(),
   useCachedMediaUrlSpy: vi.fn(),
   downloadAttachmentSpy: vi.fn(),
-  isTauriSpy: vi.fn(() => false),
 }))
 
 // Mock react-i18next
@@ -59,14 +58,19 @@ vi.mock('@/utils/download', () => ({
   downloadAttachment: downloadAttachmentSpy,
 }))
 
-vi.mock('@/utils/tauri', () => ({
-  isTauri: isTauriSpy,
-}))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 describe('FileAttachments', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    isTauriSpy.mockReturnValue(false)
+    usePlatform('web')
     __resetApprovedMediaUrlsForTest()
     // Default: return successful proxied URL
     useAttachmentUrlSpy.mockReturnValue({
@@ -702,7 +706,7 @@ describe('FileAttachmentCard download', () => {
 describe('encrypted media download controls', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    isTauriSpy.mockReturnValue(false)
+    usePlatform('web')
     downloadAttachmentSpy.mockResolvedValue(undefined)
     useAttachmentUrlSpy.mockReturnValue({ url: 'blob:play', isLoading: false, error: null })
     useCachedMediaUrlSpy.mockReturnValue({ cachedUrl: null, isPeeking: false })
@@ -736,7 +740,7 @@ describe('encrypted media download controls', () => {
   })
 
   it('Tauri plaintext unsupported-media download → uses the native save path', () => {
-    isTauriSpy.mockReturnValue(true)
+    usePlatform('desktop')
     vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockImplementation(
       (type: string) => (type === 'video/mp4' ? 'maybe' : '') as CanPlayTypeResult,
     )

--- a/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import { LoginScreen } from './LoginScreen'
 import { markLoggedOut, markConnectActive } from '@/utils/reconnectIntent'
@@ -18,7 +18,17 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/hooks', () => ({ useWindowDrag: () => ({ dragRegionProps: {} }) }))
 vi.mock('@/hooks/useSessionPersistence', () => ({ saveSession: vi.fn() }))
 vi.mock('@/utils/xmppResource', () => ({ getResource: () => 'test-resource' }))
-vi.mock('@/utils/tauri', () => ({ isTauri: () => true }))
+import { setPlatformForTesting } from '@/platform'
+
+// These suites describe the desktop app: keychain auto-connect and the
+// webview reload before a second login are both desktop-only behaviours.
+let restorePlatform: (() => void) | undefined
+beforeEach(() => {
+  restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
+})
+afterEach(() => {
+  restorePlatform?.()
+})
 vi.mock('@/utils/keychain', () => ({
   hasSavedCredentials: () => true,
   getCredentials: vi.fn().mockResolvedValue({

--- a/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import { LoginScreen } from './LoginScreen'
 import { markConnectActive } from '@/utils/reconnectIntent'
@@ -19,7 +19,17 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/hooks', () => ({ useWindowDrag: () => ({ dragRegionProps: {} }) }))
 vi.mock('@/hooks/useSessionPersistence', () => ({ saveSession: vi.fn() }))
 vi.mock('@/utils/xmppResource', () => ({ getResource: () => 'test-resource' }))
-vi.mock('@/utils/tauri', () => ({ isTauri: () => true }))
+import { setPlatformForTesting } from '@/platform'
+
+// These suites describe the desktop app: keychain auto-connect and the
+// webview reload before a second login are both desktop-only behaviours.
+let restorePlatform: (() => void) | undefined
+beforeEach(() => {
+  restorePlatform = setPlatformForTesting({ shell: 'desktop', os: 'macos' })
+})
+afterEach(() => {
+  restorePlatform?.()
+})
 vi.mock('@/utils/keychain', () => ({
   hasSavedCredentials: () => true,
   getCredentials: vi.fn().mockResolvedValue({

--- a/apps/fluux/src/components/LoginScreen.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.test.tsx
@@ -87,8 +87,7 @@ const { mockGetDomainFromJid, mockGetWebsocketUrlForDomain } = vi.hoisted(() => 
 // Keychain + Tauri detection are overridable per-test so the desktop
 // (keychain-backed) paths can be exercised. Defaults keep the web behaviour
 // (not Tauri, no saved credentials) used by the bulk of the suite.
-const { mockIsTauri, mockHasSavedCredentials, mockGetCredentials, mockSaveCredentials, mockDeleteCredentials } = vi.hoisted(() => ({
-    mockIsTauri: vi.fn(() => false),
+const { mockHasSavedCredentials, mockGetCredentials, mockSaveCredentials, mockDeleteCredentials } = vi.hoisted(() => ({
     mockHasSavedCredentials: vi.fn(() => false),
     mockGetCredentials: vi.fn(),
     mockSaveCredentials: vi.fn(),
@@ -102,9 +101,14 @@ vi.mock('@/utils/keychain', () => ({
     deleteCredentials: mockDeleteCredentials,
 }))
 
-vi.mock('@/utils/tauri', () => ({
-    isTauri: mockIsTauri,
-}))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 vi.mock('@/config/wellKnownServers', () => ({
     getDomainFromJid: (...args: unknown[]) => mockGetDomainFromJid(...args),
@@ -451,7 +455,7 @@ describe('LoginScreen', () => {
     // credential over a hiccup, leaving the user to re-enter it every restart.
     describe('keychain credential preservation on auth error (desktop)', () => {
         beforeEach(() => {
-            mockIsTauri.mockReturnValue(true)
+            usePlatform('desktop')
             mockHasSavedCredentials.mockReturnValue(true)
             mockGetCredentials.mockResolvedValue({
                 jid: 'user@example.com',
@@ -462,7 +466,7 @@ describe('LoginScreen', () => {
         })
 
         afterEach(() => {
-            mockIsTauri.mockReturnValue(false)
+            usePlatform('web')
             mockHasSavedCredentials.mockReturnValue(false)
             mockGetCredentials.mockReset()
         })

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -9,7 +9,7 @@ import { Loader2, KeyRound, Eye, EyeOff, Wrench } from 'lucide-react'
 import { saveSession } from '@/hooks/useSessionPersistence'
 import { getResource } from '@/utils/xmppResource'
 import { hasSavedCredentials, getCredentials, saveCredentials, deleteCredentials } from '@/utils/keychain'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 import { getDomainFromJid, getWebsocketUrlForDomain } from '@/config/wellKnownServers'
 import { useWindowDrag } from '@/hooks'
 import { isOpenpgpEnabled } from '@/stores/encryptionSettingsStore'
@@ -36,7 +36,7 @@ const STORAGE_KEY_REMEMBER = 'xmpp-remember-me'
  * with visible latency). So we log and move on; never block the user.
  */
 async function prewarmOpenpgpUnlock(jid: string): Promise<void> {
-  if (!isTauri()) return
+  if (!platform().nativeKeychain) return
   if (!isOpenpgpEnabled()) return
   const bareJid = getBareJid(jid)
   if (!bareJid || !bareJid.includes('@')) return
@@ -104,7 +104,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   // After reload, the flag is gone (cleared here before reload) → no loop.
   // See: https://github.com/tauri-apps/wry/issues/184
   useEffect(() => {
-    if (!isTauri()) return
+    if (!platform().needsWebviewReloadBeforeRelogin) return
     // Not while quitting: this mount is the app tearing down, not a live
     // disconnect the user has to keep interacting with. Reloading here destroys
     // the JS context that still owes the shutdown handler its `stop_xmpp_proxy`
@@ -162,8 +162,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     hasLoadedCredentials.current = true
 
     const loadCredentials = async () => {
-      // Check if we're in Tauri
-      const inTauri = isTauri()
+      const inTauri = platform().shell === 'desktop'
       setIsDesktopApp(inTauri)
 
       // Load remember me preference
@@ -347,7 +346,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
         // first fingerprint / encrypted send after `online`.
         void prewarmOpenpgpUnlock(jid)
         const resource = getResource()
-        await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: isTauri(), rememberSession: true })
+        await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: true })
         // Save session for auto-reconnect on page reload
         saveSession(jid, password, actualServer)
       } catch {
@@ -409,7 +408,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
       // KDF (~500 ms) overlaps with the TCP/TLS/XMPP handshake.
       void prewarmOpenpgpUnlock(jid)
       const resource = linkResourceRef.current || getResource()
-      await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: isTauri(), rememberSession: rememberMe })
+      await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: rememberMe })
       // Save session for auto-reconnect on page reload
       saveSession(jid, password, actualServer)
 

--- a/apps/fluux/src/components/SaveToPasswordManagerButton.tsx
+++ b/apps/fluux/src/components/SaveToPasswordManagerButton.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { KeyRound, Check } from 'lucide-react'
 import { saveCredentialToManager } from '@/utils/saveCredentialToManager'
 import { USE_V6_KEYS } from '@/e2ee/passphraseGenerator'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 
 interface SaveToPasswordManagerButtonProps {
   /** Stable credential identifier; matches the dialog's hidden username so save and autofill share an entry. */
@@ -54,7 +54,7 @@ export function SaveToPasswordManagerButton({
     setTimeout(() => setFeedback(null), 2000)
   }, [id, name, passphrase])
 
-  if (!isTauri() || !USE_V6_KEYS) return null
+  if (!platform().nativeKeychain || !USE_V6_KEYS) return null
 
   const isFallback = feedback === 'fallback'
   const isSaved = feedback === 'saved'

--- a/apps/fluux/src/components/UnlockEncryptionDialog.tsx
+++ b/apps/fluux/src/components/UnlockEncryptionDialog.tsx
@@ -6,7 +6,7 @@ import { getBareJid } from '@fluux/sdk'
 import { KeyPickerDialog } from './KeyPickerDialog'
 import { KeyPickerRequiredError, NoRecoveryAvailableError } from '@/e2ee/recoveryErrors'
 import type { KeyBundle, BackupProbeResult } from '@/e2ee/OpenPGPPluginBase'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 import { ModalOverlay } from './ModalOverlay'
 import {
   cachePassphrase,
@@ -126,7 +126,7 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
       // Persist the remember-passphrase choice and (un)cache accordingly. Only
       // meaningful on web; on Tauri the checkbox is not rendered and the jid
       // guard below makes this a no-op anyway.
-      if (mode === 'unlock' && !isTauri()) {
+      if (mode === 'unlock' && platform().keyNeedsSessionPassphrase) {
         const full = client.getJid()
         const bareJid = full ? getBareJid(full) : null
         setRememberPassphrasePreference(rememberPassphrase)
@@ -275,7 +275,7 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
             </>
           )}
 
-          {mode === 'unlock' && !isTauri() && (
+          {mode === 'unlock' && platform().keyNeedsSessionPassphrase && (
             <label className="flex items-start gap-2 mb-3 cursor-pointer select-none">
               <input
                 type="checkbox"

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -9,7 +9,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { TextInput, TextArea } from './ui/TextInput'
 import { Tooltip } from './Tooltip'
 import { ModalOverlay } from './ModalOverlay'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
@@ -475,7 +475,7 @@ export function XmppConsole() {
     const defaultFilename = `xmpp-log-${format(new Date(), 'yyyy-MM-dd-HHmmss')}.txt`
 
     // Use native save dialog in Tauri, fallback to blob download for web
-    if (isTauri()) {
+    if (platform().nativeDownloads) {
       try {
         const { save } = await import('@tauri-apps/plugin-dialog')
         const { writeTextFile } = await import('@tauri-apps/plugin-fs')

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
@@ -38,11 +38,14 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
   }
 })
 
-let mockIsTauri = false
-vi.mock('@/utils/tauri', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/tauri')>()
-  return { ...actual, isTauri: () => mockIsTauri }
-})
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -69,7 +72,7 @@ describe('EncryptionSettings PEP support', () => {
     localStorage.clear()
     mockStatus = 'online'
     mockPlugin = null
-    mockIsTauri = false
+    usePlatform('web')
     mockCheckPepSupport.mockResolvedValue(true)
     useEncryptionSettingsStore.setState({
       openpgpEnabled: false,
@@ -568,7 +571,7 @@ describe('EncryptionSettings PEP support', () => {
       // Over-publishing a backup that did not exist is harmless. Leaving a
       // real one encrypted to the retired key is not, so `unknown` takes the
       // same path as in-sync: through the passphrase dialog.
-      mockIsTauri = true
+      usePlatform('desktop')
 
       render(<EncryptionSettings />)
 
@@ -592,7 +595,7 @@ describe('EncryptionSettings PEP support', () => {
       // The confirmation copy must agree with the routing in
       // handleRotateConfirm: `unknown` re-publishes, so the dialog the user
       // sees before confirming has to say so.
-      mockIsTauri = true
+      usePlatform('desktop')
 
       render(<EncryptionSettings />)
 
@@ -612,7 +615,7 @@ describe('EncryptionSettings PEP support', () => {
       // Control test for the case above: proves the assertion pair
       // discriminates between two live outcomes instead of asserting a
       // constant that would pass regardless of `backupProbe`.
-      mockIsTauri = true
+      usePlatform('desktop')
       mockProbe.mockResolvedValue('absent')
 
       render(<EncryptionSettings />)
@@ -630,7 +633,7 @@ describe('EncryptionSettings PEP support', () => {
     })
 
     it('rotates directly without the passphrase dialog when the probe confirms no backup', async () => {
-      mockIsTauri = true
+      usePlatform('desktop')
       mockProbe.mockResolvedValue('absent')
 
       render(<EncryptionSettings />)
@@ -704,7 +707,7 @@ describe('EncryptionSettings PEP support', () => {
         registrationError: null,
       })
       // The rotate row is desktop-only (openpgp.js v6 rotation is deferred).
-      mockIsTauri = true
+      usePlatform('desktop')
     })
 
     /** Rotate button -> confirm -> acknowledge the passphrase -> publish. */

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -24,7 +24,7 @@ import {
   SecretKeyBackupProbeError,
 } from '@/e2ee/secretKeyProbe'
 import { isKeyLocked } from '@/e2ee/webPassphraseStore'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 
 type PluginStatus =
   | 'disabled'
@@ -191,7 +191,8 @@ export function EncryptionSettings() {
   // A typed registration failure means no plugin got registered at all —
   // it outranks the web "locked" state, whose unlock flow needs a
   // registered plugin to act on.
-  const webLocked = !isTauri() && openpgpEnabled && isKeyLocked() && !registrationError
+  const webLocked =
+    platform().keyNeedsSessionPassphrase && openpgpEnabled && isKeyLocked() && !registrationError
   const pluginStatus: PluginStatus = !openpgpEnabled
     ? 'disabled'
     : !online
@@ -346,7 +347,7 @@ export function EncryptionSettings() {
   // `keychainBacked: false` means IndexedDB + session passphrase, not
   // cleartext on disk.
   useEffect(() => {
-    if (!isTauri() || !fingerprint) {
+    if (!platform().nativeKeychain || !fingerprint) {
       setKeychainBacked(null)
       return
     }
@@ -382,7 +383,7 @@ export function EncryptionSettings() {
         return
       }
       const bareJid = jid ? getBareJid(jid) : null
-      if (!isTauri()) {
+      if (!platform().nativeKeychain) {
         // Web: same defence-in-depth as desktop — never silently generate
         // when the server already advertises an OpenPGP identity for this
         // account. The crypto-layer guard in WebOpenPGPPlugin would refuse
@@ -1257,7 +1258,7 @@ export function EncryptionSettings() {
 
         {/* Rotation — primary fingerprint stays stable so peer trust survives.
             Not available on web (openpgp.js v6 key rotation is MVP-deferred). */}
-        {pluginStatus === 'ready' && isTauri() && (
+        {pluginStatus === 'ready' && platform().supportsKeyRotation && (
           <div className="space-y-2 pt-2 border-t border-fluux-hover">
             <div className="flex items-center gap-1.5">
               <label className="text-sm font-medium text-fluux-text">
@@ -1290,7 +1291,7 @@ export function EncryptionSettings() {
             </button>
           </div>
         )}
-        {pluginStatus === 'ready' && !isTauri() && (
+        {pluginStatus === 'ready' && !platform().supportsKeyRotation && (
           <div className="pt-2 border-t border-fluux-hover">
             <p className="text-xs text-fluux-muted leading-snug">
               {t('settings.encryption.rotateNotSupportedWeb')}

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
@@ -14,11 +14,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 // Mutable mock state — `mock`-prefixed so vitest permits referencing them
 // inside the hoisted vi.mock factories.
-let mockIsTauri = true
 let mockIsMac = true
 let mockPermState = 'granted'
-let mockIsWindows = false
-let mockIsLinux = false
 const mockGetTrayStatus = vi.fn().mockResolvedValue({ enabled: true, available: true })
 const mockInvoke = vi.fn(async (cmd: string) =>
   cmd === 'notification_permission_state' ? mockPermState : undefined,
@@ -41,20 +38,19 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
   }
 })
 
-vi.mock('./types', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./types')>()
-  return { ...actual, isTauri: () => mockIsTauri }
-})
-
 vi.mock('@/utils/tauriPlatform', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/tauriPlatform')>()
   return { ...actual, isMacOSDesktop: () => Promise.resolve(mockIsMac) }
 })
 
-vi.mock('@/utils/tauri', () => ({
-  isWindows: () => mockIsWindows,
-  isLinux: () => mockIsLinux,
-}))
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
 
 vi.mock('@/utils/windowBehavior', () => ({
   getTrayStatus: () => mockGetTrayStatus(),
@@ -79,11 +75,9 @@ const LINK = 'settings.openSystemNotificationSettings'
 
 describe('NotificationsSettings — system notification settings link', () => {
   beforeEach(() => {
-    mockIsTauri = true
+    usePlatform('desktop')
     mockIsMac = true
     mockPermState = 'granted'
-    mockIsWindows = false
-    mockIsLinux = false
     mockGetTrayStatus.mockReset().mockResolvedValue({ enabled: true, available: true })
     useSettingsStore.setState({ keepInSystemTray: true })
     mockInvoke.mockClear()
@@ -166,7 +160,7 @@ describe('NotificationsSettings — system notification settings link', () => {
   })
 
   it('does not render the link in the web build (not Tauri)', async () => {
-    mockIsTauri = false
+    usePlatform('web')
     mockIsMac = false
 
     render(<NotificationsSettings />)
@@ -187,7 +181,7 @@ describe('NotificationsSettings — system notification settings link', () => {
   })
 
   it('shows and updates the tray preference on Windows', async () => {
-    mockIsWindows = true
+    usePlatform('desktop', 'windows')
     mockIsMac = false
     render(<NotificationsSettings />)
 
@@ -201,7 +195,7 @@ describe('NotificationsSettings — system notification settings link', () => {
   })
 
   it('keeps Linux close-to-tray unavailable without a StatusNotifier host', async () => {
-    mockIsLinux = true
+    usePlatform('desktop', 'linux')
     mockIsMac = false
     mockGetTrayStatus.mockResolvedValue({ enabled: true, available: false })
     render(<NotificationsSettings />)

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Bell, BellOff, ExternalLink, Send } from 'lucide-react'
 import { useConnection, useXMPPContext, connectionStore } from '@fluux/sdk'
-import { isTauri } from './types'
 import { isMacOSDesktop } from '@/utils/tauriPlatform'
 import {
   refreshNotificationPermission,
@@ -12,14 +11,14 @@ import { isWebPushSupported, requestWebPushRegistration } from '@/hooks/useWebPu
 import { SettingsSection } from '@/components/ui/SettingsSection'
 import { Toggle } from '@/components/ui/Toggle'
 import { useSettingsStore } from '@/stores/settingsStore'
-import { isLinux, isWindows } from '@/utils/tauri'
 import { getTrayStatus, type TrayStatus } from '@/utils/windowBehavior'
+import { platform } from '@/platform'
 
 type NotificationStatus = 'checking' | 'granted' | 'denied' | 'default' | 'unavailable'
 
 async function checkNotificationPermission(): Promise<NotificationStatus> {
   try {
-    if (isTauri()) {
+    if (platform().notificationsManagedByOS) {
       // macOS uses the native UNUserNotificationCenter command — the same
       // source of truth as the posting gate — so Settings can't disagree with
       // whether notifications actually fire. It also distinguishes "not yet
@@ -104,7 +103,7 @@ export function NotificationsSettings() {
   const { t } = useTranslation()
   // "Desktop notifications" only makes sense on the desktop (Tauri) build; on
   // web/PWA — including phones — the copy must stay platform-neutral.
-  const desktopBuild = isTauri()
+  const desktopBuild = platform().shell === 'desktop'
   const { client } = useXMPPContext()
   const { webPushStatus, webPushEnabled, isConnected } = useConnection()
   const [notificationStatus, setNotificationStatus] = useState<NotificationStatus>('checking')
@@ -114,8 +113,8 @@ export function NotificationsSettings() {
   const keepInSystemTray = useSettingsStore((state) => state.keepInSystemTray)
   const setKeepInSystemTray = useSettingsStore((state) => state.setKeepInSystemTray)
   const [trayStatus, setTrayStatus] = useState<TrayStatus | null>(null)
-  const linuxDesktop = desktopBuild && isLinux()
-  const windowsDesktop = desktopBuild && isWindows()
+  const linuxDesktop = desktopBuild && platform().os === 'linux'
+  const windowsDesktop = desktopBuild && platform().os === 'windows'
   const showTraySetting = linuxDesktop || windowsDesktop
 
   useEffect(() => {
@@ -210,7 +209,7 @@ export function NotificationsSettings() {
           </div>
 
           {/* Web: request permission in-page */}
-          {!isTauri() && notificationStatus === 'default' && (
+          {!platform().notificationsManagedByOS && notificationStatus === 'default' && (
             <button
               type="button"
               onClick={handleRequestPermission}
@@ -247,7 +246,7 @@ export function NotificationsSettings() {
               (granted/denied) so the target pane actually lists the app; hidden
               while still 'default' (never asked), where the in-card Enable button
               is the correct first action. */}
-          {isTauri() &&
+          {platform().notificationsManagedByOS &&
             (notificationStatus === 'granted' || notificationStatus === 'denied') && (
               <>
                 <button

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.webgate.test.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.webgate.test.tsx
@@ -24,7 +24,7 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
 // Web context (not Tauri, not macOS) so the in-page "Request permission" button renders.
 vi.mock('./types', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./types')>()
-  return { ...actual, isTauri: () => false }
+  return { ...actual }
 })
 vi.mock('@/utils/tauriPlatform', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/tauriPlatform')>()

--- a/apps/fluux/src/components/settings-components/StorageSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/StorageSettings.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { StorageSettings } from './StorageSettings'
 
@@ -41,13 +41,27 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+import { setPlatformForTesting } from '@/platform'
+
+// One seam for the platform, shared with the app code under test.
+let restorePlatform: (() => void) | undefined
+function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux' = 'macos') {
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell, os })
+}
+
 describe('StorageSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetMediaCacheSize.mockResolvedValue(0)
     mockClearMediaCache.mockResolvedValue(undefined)
     mockInvoke.mockClear()
-    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    usePlatform('web')
+  })
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = undefined
   })
 
   it('should show calculating state while loading cache size', () => {
@@ -135,7 +149,7 @@ describe('StorageSettings', () => {
   })
 
   it('opens the logs folder from desktop settings', async () => {
-    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+    usePlatform('desktop')
     render(<StorageSettings />)
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.storage.openLogs' }))

--- a/apps/fluux/src/components/settings-components/StorageSettings.tsx
+++ b/apps/fluux/src/components/settings-components/StorageSettings.tsx
@@ -6,7 +6,7 @@ import { getMediaCacheSize, clearMediaCache } from '@/utils/mediaCache'
 import { rebuildSearchIndex } from '@fluux/sdk'
 import type { RebuildProgress } from '@fluux/sdk'
 import { SettingsSection } from '@/components/ui/SettingsSection'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 
 export function StorageSettings() {
   const { t } = useTranslation()
@@ -153,7 +153,7 @@ export function StorageSettings() {
         </div>
       </SettingsSection>
 
-      {isTauri() && (
+      {platform().hasNativeLogFiles && (
         <SettingsSection
           title={t('settings.storage.logs')}
           description={t('settings.storage.logsDescription')}

--- a/apps/fluux/src/components/settings-components/index.ts
+++ b/apps/fluux/src/components/settings-components/index.ts
@@ -17,6 +17,5 @@ export {
   SETTINGS_CATEGORIES,
   getVisibleCategories,
   resolveSettingsCategory,
-  isTauri,
   DEFAULT_SETTINGS_CATEGORY,
 } from './types'

--- a/apps/fluux/src/components/settings-components/profile/AccountSection.tsx
+++ b/apps/fluux/src/components/settings-components/profile/AccountSection.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { Key, Network } from 'lucide-react'
 import { useConnection } from '@fluux/sdk'
-import { isTauri } from '@/utils/tauri'
+import { platform } from '@/platform'
 import { Tooltip } from '../../Tooltip'
 import { SettingsSection } from '@/components/ui/SettingsSection'
 import { SettingsGroup } from '@/components/ui/SettingsGroup'
@@ -16,7 +16,7 @@ export function AccountSection({ onChangePassword }: AccountSectionProps) {
   const { isConnected, connectionMethod, authMechanism, webPushStatus, supportsPasswordChange } =
     useConnection()
 
-  const showWebPush = !isTauri() && isConnected
+  const showWebPush = platform().usesWebPush && isConnected
   const passwordEnabled = supportsPasswordChange && isConnected
   const passwordTooltip = !isConnected
     ? t('profile.offlineNotice')

--- a/apps/fluux/src/components/settings-components/types.test.ts
+++ b/apps/fluux/src/components/settings-components/types.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { getVisibleCategories, getGroupedVisibleCategories, resolveSettingsCategory } from './types'
 import { useAdvancedModeStore } from '@/stores/advancedModeStore'
+import { setPlatformForTesting } from '@/platform'
 
+let restorePlatform: (() => void) | undefined
 function setTauriEnv(on: boolean) {
-  if (on) (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
-  else delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+  restorePlatform?.()
+  restorePlatform = setPlatformForTesting({ shell: on ? 'desktop' : 'web', os: 'macos' })
 }
 
 describe('getVisibleCategories — advanced category', () => {

--- a/apps/fluux/src/components/settings-components/types.ts
+++ b/apps/fluux/src/components/settings-components/types.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react'
 import { User, Palette, Globe, Bell, Download, Ban, HardDrive, Lock, ShieldCheck, Wrench, Accessibility, Bot } from 'lucide-react'
-import { isTauri, isUpdaterEnabled } from '@/utils/tauri'
+import { platform } from '@/platform'
 import { MCP_FEATURE_ENABLED } from '@/stores/mcpBridgeStore'
 
 export type SettingsCategory =
@@ -25,14 +25,12 @@ export interface SettingsCategoryConfig {
   icon: LucideIcon
   group: SettingsGroup
   /** Only show in Tauri desktop app */
-  tauriOnly?: boolean
+  desktopOnly?: boolean
   /** Only show when in-app updater is enabled (macOS/Windows, not Linux) */
   updaterOnly?: boolean
   /** Temporarily hidden regardless of platform (feature not ready to ship) */
   disabled?: boolean
 }
-
-export { isTauri }
 
 export const SETTINGS_CATEGORIES: SettingsCategoryConfig[] = [
   { id: 'profile', labelKey: 'settings.categories.profile', icon: User, group: 'account' },
@@ -46,11 +44,11 @@ export const SETTINGS_CATEGORIES: SettingsCategoryConfig[] = [
   { id: 'privacy', labelKey: 'settings.categories.privacy', icon: ShieldCheck, group: 'privacy' },
   { id: 'blocked', labelKey: 'settings.categories.blocked', icon: Ban, group: 'privacy' },
 
-  { id: 'storage', labelKey: 'settings.categories.storage', icon: HardDrive, tauriOnly: true, group: 'system' },
+  { id: 'storage', labelKey: 'settings.categories.storage', icon: HardDrive, desktopOnly: true, group: 'system' },
   { id: 'updates', labelKey: 'settings.categories.updates', icon: Download, updaterOnly: true, group: 'system' },
   // MCP bridge is not usable yet: it needs an HTTPS URL that our client cannot
   // easily expose, so the config screen is hidden (and unreachable) for now.
-  { id: 'mcp', labelKey: 'settings.categories.mcp', icon: Bot, tauriOnly: true, group: 'system', disabled: !MCP_FEATURE_ENABLED },
+  { id: 'mcp', labelKey: 'settings.categories.mcp', icon: Bot, desktopOnly: true, group: 'system', disabled: !MCP_FEATURE_ENABLED },
   { id: 'advanced', labelKey: 'settings.categories.advanced', icon: Wrench, group: 'system' },
 ]
 
@@ -58,10 +56,10 @@ export const SETTINGS_CATEGORIES: SettingsCategoryConfig[] = [
  * Get visible categories based on platform (web vs Tauri, Linux vs others)
  */
 export function getVisibleCategories(): SettingsCategoryConfig[] {
-  const updaterEnabled = isUpdaterEnabled()
+  const updaterEnabled = platform().hasInAppUpdates
   return SETTINGS_CATEGORIES.filter(cat => {
     if (cat.disabled) return false
-    if (cat.tauriOnly && !isTauri()) return false
+    if (cat.desktopOnly && platform().shell !== 'desktop') return false
     if (cat.updaterOnly && !updaterEnabled) return false
     return true
   })

--- a/apps/fluux/src/platform/capabilities.test.ts
+++ b/apps/fluux/src/platform/capabilities.test.ts
@@ -3,14 +3,44 @@ import { deriveCapabilities, type PlatformCapabilities } from './capabilities'
 import { platform, setPlatformForTesting, resetPlatformDetection } from './index'
 
 describe('deriveCapabilities', () => {
-  it('grants no native capability on the web, whatever the OS', () => {
+  /**
+   * The web build's whole manifest, listed rather than counted.
+   *
+   * A capability added without a thought for the web lands here as a diff, so
+   * "it defaults to desktop" cannot pass unnoticed — which is the mistake
+   * `isTauri()` made structural.
+   */
+  const WEB_CAPABILITIES = [
+    'keyNeedsSessionPassphrase',
+    'needsTabCoordination',
+    'usesWebPush',
+  ]
+
+  it('grants exactly its own capabilities on the web, whatever the OS', () => {
     for (const os of ['macos', 'windows', 'linux', 'other'] as const) {
-      const web = deriveCapabilities('web', os)
-      const granted = Object.entries(web)
+      const granted = Object.entries(deriveCapabilities('web', os))
         .filter(([key, value]) => value === true && key !== 'shell' && key !== 'os')
         .map(([key]) => key)
-      expect(granted, `web/${os}`).toEqual([])
+        .sort()
+      expect(granted, `web/${os}`).toEqual([...WEB_CAPABILITIES].sort())
     }
+  })
+
+  it('gives desktop and web opposite answers on the ones that pair up', () => {
+    const desktop = deriveCapabilities('desktop', 'macos')
+    const web = deriveCapabilities('web', 'macos')
+    for (const key of WEB_CAPABILITIES) {
+      expect(web[key as keyof typeof web], `web.${key}`).toBe(true)
+      expect(desktop[key as keyof typeof desktop], `desktop.${key}`).toBe(false)
+    }
+  })
+
+  it('reserves the custom title bar for desktop macOS', () => {
+    expect(deriveCapabilities('desktop', 'macos').hasCustomTitleBar).toBe(true)
+    // Windows and Linux keep a native title bar; there is nothing to reserve.
+    expect(deriveCapabilities('desktop', 'windows').hasCustomTitleBar).toBe(false)
+    expect(deriveCapabilities('desktop', 'linux').hasCustomTitleBar).toBe(false)
+    expect(deriveCapabilities('web', 'macos').hasCustomTitleBar).toBe(false)
   })
 
   it('reserves taskbar attention for desktop Windows', () => {

--- a/apps/fluux/src/platform/capabilities.ts
+++ b/apps/fluux/src/platform/capabilities.ts
@@ -71,6 +71,72 @@ export interface PlatformCapabilities {
    * web every tab is an independent client, so the resource is per-session.
    */
   readonly hasStableInstallIdentity: boolean
+
+  // ----- Encryption -----
+
+  /**
+   * The secret key sits in browser storage and a passphrase unlocks it for the
+   * session, rather than living in the OS keychain.
+   *
+   * Drives the unlock prompt, the remember-passphrase choice, and the
+   * "locked" state the settings pane shows.
+   */
+  readonly keyNeedsSessionPassphrase: boolean
+  /**
+   * Key rotation is offered.
+   *
+   * Tracks the plugin behind the shell rather than the host itself: the web
+   * build runs openpgp.js v6, whose rotation is deferred. Move this off the
+   * platform record once the two plugins agree.
+   */
+  readonly supportsKeyRotation: boolean
+
+  // ----- Notifications -----
+
+  /**
+   * Notification permission is granted and revoked through the OS, so the app
+   * reads it from the system and can send the user to the OS settings pane —
+   * rather than requesting it in-page.
+   */
+  readonly notificationsManagedByOS: boolean
+  /** Push arrives over Web Push rather than the OS notification centre. */
+  readonly usesWebPush: boolean
+
+  // ----- Window and process -----
+
+  /**
+   * The app draws its own title bar and must reserve room for the window
+   * controls. macOS only: Windows and Linux keep a native title bar.
+   */
+  readonly hasCustomTitleBar: boolean
+  /** The app is launched from a command line and can be passed flags. */
+  readonly hasCommandLineFlags: boolean
+  /** Diagnostic logs are written to files the user can open. */
+  readonly hasNativeLogFiles: boolean
+  /**
+   * Several instances can share one storage origin, so they must agree on
+   * which of them owns the session.
+   *
+   * True on web, where every tab is an instance.
+   */
+  readonly needsTabCoordination: boolean
+
+  // ----- Connection -----
+
+  /**
+   * Keepalive is driven outside the JS event loop, so the SDK's own Stream
+   * Management interval would be redundant — and, unlike the native timer, is
+   * subject to background throttling.
+   */
+  readonly hasNativeConnectionKeepalive: boolean
+  /**
+   * The webview must be reloaded before a second login in the same process.
+   *
+   * A WebKit/wry limitation: a websocket opened after a prior session's
+   * teardown does not connect until the context is recreated
+   * (tauri-apps/wry#184).
+   */
+  readonly needsWebviewReloadBeforeRelogin: boolean
 }
 
 /**
@@ -101,5 +167,26 @@ export function deriveCapabilities(shell: PlatformShell, os: PlatformOS): Platfo
     hasInAppUpdates: desktop && os !== 'linux',
     storageIsDurable: desktop,
     hasStableInstallIdentity: desktop,
+
+    // Encryption. The key is in the OS keychain on desktop, so nothing has to
+    // be unlocked per session there.
+    keyNeedsSessionPassphrase: !desktop,
+    supportsKeyRotation: desktop,
+
+    // Notifications.
+    notificationsManagedByOS: desktop,
+    usesWebPush: !desktop,
+
+    // Window and process. Only macOS overlays its window controls on the
+    // content; Windows and Linux keep a native title bar.
+    hasCustomTitleBar: desktop && os === 'macos',
+    hasCommandLineFlags: desktop,
+    hasNativeLogFiles: desktop,
+    // Every browser tab is an instance sharing one origin.
+    needsTabCoordination: !desktop,
+
+    // Connection.
+    hasNativeConnectionKeepalive: desktop,
+    needsWebviewReloadBeforeRelogin: desktop,
   }
 }


### PR DESCRIPTION
Finishes for `components/` and `App.tsx` what #1244 started in `utils/`. `isTauri()` in the app source goes from **70 to 41** — components and `App.tsx` are at zero, `hooks/` is the last layer left.

## Naming them separated branches that were never the same question

One predicate was standing in for all of these:

| Was `isTauri()` | Now |
|---|---|
| macOS traffic-light spacing | `hasCustomTitleBar` (desktop **and** macOS) |
| `--clear-storage` CLI flag listener | `hasCommandLineFlags` |
| native log folder section | `hasNativeLogFiles` |
| tab-coordination screen | `needsTabCoordination` (a **web** capability) |
| `disableSmKeepalive` on connect | `hasNativeConnectionKeepalive` |
| webview reload before a second login | `needsWebviewReloadBeforeRelogin` (wry#184) |
| unlock prompt, remember-passphrase | `keyNeedsSessionPassphrase` |
| rotate control vs "not on web" notice | `supportsKeyRotation` |
| OS permission API + OS settings link | `notificationsManagedByOS` |
| Web Push section | `usesWebPush` |

`deriveCapabilities` now answers three of them **for** the web build rather than leaving web as the absence of desktop, and a manifest test lists exactly which — so a capability added without a thought for web lands as a diff.

## Three more probes absorbed

Grepping for `isTauri()` missed them, because they had grown their own copies:

- `AppBar.tsx` and `App.tsx` each carried an inline `'__TAURI_INTERNALS__' in window` and a `/Mac/.test(navigator.platform)`;
- `settings-components/types.ts` **re-exported** `isTauri` through `index.ts` for `NotificationsSettings` to import.

`isLinux()` / `isWindows()` / `isUpdaterEnabled()` callers outside `utils/` move over too, so the tray preference and the updater category read the same record as everything else.

## Tests

Nine files stated a platform in four different ways — `vi.mock` of the module, a hoisted spy, a mutable flag, and writing `__TAURI_INTERNALS__` onto `window`. They now call `setPlatformForTesting`, which runs the real derivation.

## Guard

The ESLint rule widens from `utils/` to the components and `App.tsx`. Its pattern also had a hole: it matched `@/utils/tauri` and `./tauri` but not `./utils/tauri`, which is how `App.tsx` imported it — so `App.tsx` would have passed while re-importing the probe. It now matches any path landing on `utils/tauri`, and still allows `@tauri-apps/*` and `utils/tauriPlatform`.

## Verification

Full suite green (app 452 files / 5981 tests), typecheck, lint, `ux:audit` 16/16.

Interactively in demo mode (web): the settings rail lists 8 categories with Storage, Updates and MCP correctly absent; the encryption pane shows "la rotation de clé n'est pas disponible sur le web" with no rotate control; notifications use the neutral wording with the Web Push section and no tray toggle; no console errors.