### PR TITLE
refactor(sdk): declare PEP nodes once instead of per feature

### DIFF
--- a/packages/fluux-sdk/src/core/modules/ConversationSync.ts
+++ b/packages/fluux-sdk/src/core/modules/ConversationSync.ts
@@ -1,9 +1,8 @@
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
-import { getBareJid } from '../jid'
-import { generateUUID } from '../../utils/uuid'
-import { NS_PUBSUB, NS_CONVERSATIONS } from '../namespaces'
+import { NS_CONVERSATIONS } from '../namespaces'
 import type { ModuleDependencies } from './BaseModule'
+import { PepNode, type PepCodec, type PublishOptions } from './PepNode'
 
 /**
  * A conversation entry synced to/from the server.
@@ -21,19 +20,35 @@ export interface SyncedConversation {
  * Returns an empty array if the item has no `<conversations>` container.
  */
 export function parseConversationsItem(item: Element | undefined): SyncedConversation[] {
-  const container = item?.getChild('conversations', NS_CONVERSATIONS)
-  if (!container) return []
+  return (item && conversationsCodec.decode(item)) || []
+}
 
-  const conversations: SyncedConversation[] = []
-  for (const convEl of container.getChildren('conversation')) {
-    const jid = convEl.attrs.jid
-    if (!jid) continue
-    conversations.push({
-      jid,
-      archived: convEl.attrs.archived === 'true',
-    })
-  }
-  return conversations
+/** XEP-0223 private storage: owner-only, retained across sessions. */
+const CONVERSATIONS_NODE_OPTIONS: PublishOptions = {
+  persistItems: true,
+  accessModel: 'whitelist',
+}
+
+/** The whole list lives in a single item, so its id is a constant. */
+const CURRENT_ITEM_ID = 'current'
+
+const conversationsCodec: PepCodec<SyncedConversation[]> = {
+  encode: (conversations) => xml('conversations', { xmlns: NS_CONVERSATIONS },
+    ...conversations.map((c) => xml('conversation',
+      c.archived ? { jid: c.jid, archived: 'true' } : { jid: c.jid },
+    )),
+  ),
+  decode: (item) => {
+    const container = item.getChild('conversations', NS_CONVERSATIONS)
+    if (!container) return undefined
+    const conversations: SyncedConversation[] = []
+    for (const convEl of container.getChildren('conversation')) {
+      const jid = convEl.attrs.jid
+      if (!jid) continue
+      conversations.push({ jid, archived: convEl.attrs.archived === 'true' })
+    }
+    return conversations
+  },
 }
 
 /**
@@ -46,79 +61,27 @@ export function parseConversationsItem(item: Element | undefined): SyncedConvers
  * request/response methods for fetching and publishing the conversation list.
  */
 export class ConversationSync {
-  private deps: ModuleDependencies
+  private readonly node: PepNode<SyncedConversation[]>
 
   constructor(deps: ModuleDependencies) {
-    this.deps = deps
+    this.node = new PepNode(deps, NS_CONVERSATIONS, conversationsCodec, CONVERSATIONS_NODE_OPTIONS)
   }
 
   /**
    * Fetch the conversation list from private PEP storage (XEP-0223).
-   * Returns the list of conversations with their archived status,
-   * or an empty array if the node does not exist.
+   * Returns the list of conversations with their archived status, or an empty
+   * array when the node, the item, or the session is missing.
    */
   async fetchConversations(timeoutMs?: number): Promise<SyncedConversation[]> {
-    const currentJid = this.deps.getCurrentJid()
-    if (!currentJid) return []
-
-    const bareJid = getBareJid(currentJid)
-    const iq = xml('iq', { type: 'get', to: bareJid, id: `conv_list_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('items', { node: NS_CONVERSATIONS },
-          xml('item', { id: 'current' })
-        )
-      )
-    )
-
-    try {
-      const result = await this.deps.sendIQ(iq, timeoutMs)
-      const item = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')
-      return parseConversationsItem(item)
-    } catch {
-      // Node may not exist yet, or item not found
-      return []
-    }
+    const lists = await this.node.getOr([], { itemId: CURRENT_ITEM_ID, timeoutMs })
+    return lists[0] ?? []
   }
 
   /**
    * Publish the conversation list to private PEP storage (XEP-0223).
-   * Writes the full list as a single item (id="current"), replacing any previous data.
+   * Writes the full list as a single item, replacing any previous data.
    */
   async publishConversations(conversations: SyncedConversation[]): Promise<void> {
-    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
-
-    const convElements = conversations.map(c => {
-      const attrs: Record<string, string> = { jid: c.jid }
-      if (c.archived) {
-        attrs.archived = 'true'
-      }
-      return xml('conversation', attrs)
-    })
-
-    const iq = xml('iq', { type: 'set', id: `conv_list_set_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('publish', { node: NS_CONVERSATIONS },
-          xml('item', { id: 'current' },
-            xml('conversations', { xmlns: NS_CONVERSATIONS }, ...convElements)
-          )
-        ),
-        // XEP-0223: Publish options for private storage
-        xml('publish-options', {},
-          xml('x', { xmlns: 'jabber:x:data', type: 'submit' },
-            xml('field', { var: 'FORM_TYPE', type: 'hidden' },
-              xml('value', {}, 'http://jabber.org/protocol/pubsub#publish-options')
-            ),
-            xml('field', { var: 'pubsub#persist_items' },
-              xml('value', {}, 'true')
-            ),
-            xml('field', { var: 'pubsub#access_model' },
-              xml('value', {}, 'whitelist')
-            )
-          )
-        )
-      )
-    )
-
-    await this.deps.sendIQ(iq)
+    await this.node.publish(CURRENT_ITEM_ID, conversations)
   }
 }

--- a/packages/fluux-sdk/src/core/modules/Ignore.ts
+++ b/packages/fluux-sdk/src/core/modules/Ignore.ts
@@ -1,108 +1,74 @@
 import { xml } from '@xmpp/client'
-import { getBareJid } from '../jid'
-import { generateUUID } from '../../utils/uuid'
-import { NS_PUBSUB, NS_IGNORED_USERS } from '../namespaces'
+import { NS_IGNORED_USERS } from '../namespaces'
 import type { ModuleDependencies } from './BaseModule'
+import { PepNode, type PepCodec, type PublishOptions } from './PepNode'
 import type { IgnoredUser } from '../../stores/ignoreStore'
+
+/** XEP-0223 private storage: owner-only, retained across sessions. */
+const IGNORE_NODE_OPTIONS: PublishOptions = {
+  persistItems: true,
+  accessModel: 'whitelist',
+}
+
+/** One item per room, each holding that room's whole ignore list. */
+const ignoredUsersCodec: PepCodec<IgnoredUser[]> = {
+  encode: (users) => xml('ignored-users', { xmlns: NS_IGNORED_USERS },
+    ...users.map((user) => {
+      const attrs: Record<string, string> = {
+        identifier: user.identifier,
+        name: user.displayName,
+      }
+      if (user.jid) attrs.jid = user.jid
+      return xml('user', attrs)
+    }),
+  ),
+  decode: (item) => {
+    const container = item.getChild('ignored-users', NS_IGNORED_USERS)
+    if (!container) return undefined
+    const users: IgnoredUser[] = []
+    for (const userEl of container.getChildren('user')) {
+      const identifier = userEl.attrs.identifier
+      const displayName = userEl.attrs.name
+      if (!identifier || !displayName) continue
+      const user: IgnoredUser = { identifier, displayName }
+      if (userEl.attrs.jid) user.jid = userEl.attrs.jid
+      users.push(user)
+    }
+    return users
+  },
+}
 
 /**
  * Ignore module for managing per-room ignored users via PEP (XEP-0223).
  *
  * Stores ignored user lists as private PubSub items, one item per room,
- * following the bookmarks pattern (XEP-0402). The PEP node uses
- * `access_model=whitelist` so only the owner can read/write.
+ * following the bookmarks pattern (XEP-0402).
  *
  * This module does not handle incoming stanzas — it only provides
  * request/response methods for fetching and publishing ignore lists.
  */
 export class Ignore {
-  private deps: ModuleDependencies
+  private readonly node: PepNode<IgnoredUser[]>
 
   constructor(deps: ModuleDependencies) {
-    this.deps = deps
+    this.node = new PepNode(deps, NS_IGNORED_USERS, ignoredUsersCodec, IGNORE_NODE_OPTIONS)
   }
 
   /**
    * Fetch ignored users for a specific room from private PEP storage (XEP-0223).
-   * Returns the list of ignored users for that room, or an empty array if none.
+   * Returns the list of ignored users for that room, or an empty array when the
+   * node, the item, or the session is missing.
    */
   async fetchIgnoredUsersForRoom(roomJid: string): Promise<IgnoredUser[]> {
-    const currentJid = this.deps.getCurrentJid()
-    if (!currentJid) return []
-
-    const bareJid = getBareJid(currentJid)
-    const iq = xml('iq', { type: 'get', to: bareJid, id: `ignored_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('items', { node: NS_IGNORED_USERS },
-          xml('item', { id: roomJid })
-        )
-      )
-    )
-
-    try {
-      const result = await this.deps.sendIQ(iq)
-      const item = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')
-      const container = item?.getChild('ignored-users', NS_IGNORED_USERS)
-      if (!container) return []
-
-      const users: IgnoredUser[] = []
-      for (const userEl of container.getChildren('user')) {
-        const identifier = userEl.attrs.identifier
-        const displayName = userEl.attrs.name
-        if (!identifier || !displayName) continue
-        const user: IgnoredUser = { identifier, displayName }
-        if (userEl.attrs.jid) {
-          user.jid = userEl.attrs.jid
-        }
-        users.push(user)
-      }
-      return users
-    } catch {
-      // Node may not exist yet, or item not found
-      return []
-    }
+    const lists = await this.node.getOr([], { itemId: roomJid })
+    return lists[0] ?? []
   }
 
   /**
    * Save ignored users for a room to private PEP storage (XEP-0223).
    */
   async setIgnoredUsers(roomJid: string, users: IgnoredUser[]): Promise<void> {
-    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
-
-    const userElements = users.map(u => {
-      const attrs: Record<string, string> = {
-        identifier: u.identifier,
-        name: u.displayName,
-      }
-      if (u.jid) attrs.jid = u.jid
-      return xml('user', attrs)
-    })
-
-    const iq = xml('iq', { type: 'set', id: `ignored_set_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('publish', { node: NS_IGNORED_USERS },
-          xml('item', { id: roomJid },
-            xml('ignored-users', { xmlns: NS_IGNORED_USERS }, ...userElements)
-          )
-        ),
-        // XEP-0223: Publish options for private storage
-        xml('publish-options', {},
-          xml('x', { xmlns: 'jabber:x:data', type: 'submit' },
-            xml('field', { var: 'FORM_TYPE', type: 'hidden' },
-              xml('value', {}, 'http://jabber.org/protocol/pubsub#publish-options')
-            ),
-            xml('field', { var: 'pubsub#persist_items' },
-              xml('value', {}, 'true')
-            ),
-            xml('field', { var: 'pubsub#access_model' },
-              xml('value', {}, 'whitelist')
-            )
-          )
-        )
-      )
-    )
-
-    await this.deps.sendIQ(iq)
+    await this.node.publish(roomJid, users)
   }
 
   /**
@@ -110,16 +76,6 @@ export class Ignore {
    * Called when a room's ignore list becomes empty.
    */
   async removeIgnoredUsers(roomJid: string): Promise<void> {
-    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
-
-    const iq = xml('iq', { type: 'set', id: `ignored_remove_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('retract', { node: NS_IGNORED_USERS },
-          xml('item', { id: roomJid })
-        )
-      )
-    )
-
-    await this.deps.sendIQ(iq)
+    await this.node.retract(roomJid)
   }
 }

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -1,10 +1,8 @@
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
-import { getBareJid } from '../jid'
-import { generateUUID } from '../../utils/uuid'
-import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS, NS_STANZA_ID } from '../namespaces'
-import { hasErrorCondition } from '../../utils/xmppError'
+import { NS_MDS, NS_CHAT_MARKERS, NS_STANZA_ID } from '../namespaces'
 import type { ModuleDependencies } from './BaseModule'
+import { PepNode, type PepCodec, type PublishOptions } from './PepNode'
 
 /** A per-conversation last-displayed marker (XEP-0490). */
 export interface DisplayedMarker {
@@ -25,21 +23,6 @@ export type DisplayedMarkerFetchResult =
   | { status: 'unknown' }
 
 /**
- * Is this rejection the server telling us the MDS node does not exist?
- *
- * That answer is AUTHORITATIVE — there is genuinely nothing published — and the
- * distinction matters: a brand-new account has no node, and reading its absence
- * as "unknown" would stop the read-position seed from ever publishing.
- *
- * Uses the shared {@link hasErrorCondition} rather than matching `.condition`
- * directly, so a server that carries the condition only in the error text is
- * still recognised.
- */
-function isMissingNodeError(error: unknown): boolean {
-  return hasErrorCondition(error, 'item-not-found')
-}
-
-/**
  * Parse the `<items/>` of an MDS node into markers.
  * Accepts the XEP-0490 payload (`<displayed xmlns='urn:xmpp:mds:displayed:0'>`
  * wrapping a XEP-0359 `<stanza-id/>`) and, as a migration fallback, the
@@ -48,23 +31,45 @@ function isMissingNodeError(error: unknown): boolean {
  * Exported so PubSub can reuse it for incoming `+notify` events.
  */
 export function parseMdsItems(itemsEl: Element): DisplayedMarker[] {
-  const markers: DisplayedMarker[] = []
-  for (const item of itemsEl.getChildren('item')) {
+  return itemsEl.getChildren('item').flatMap((item) => {
+    const marker = mdsCodec.decode(item)
+    return marker ? [marker] : []
+  })
+}
+
+/**
+ * `max_items='max'` retains one item per conversation rather than a single
+ * current value; `send_last_published_item='never'` keeps our own markers from
+ * being replayed to us on every reconnect.
+ */
+const MDS_NODE_OPTIONS: PublishOptions = {
+  persistItems: true,
+  maxItems: 'max',
+  sendLastPublishedItem: 'never',
+  accessModel: 'whitelist',
+}
+
+/** What a publish carries: the marker plus the archive that issued the id. */
+interface DisplayedMarkerWrite {
+  stanzaId: string
+  /** XEP-0359 `by`: our own bare JID for 1:1, the room JID for MUC. */
+  stanzaIdBy: string
+}
+
+const mdsCodec: PepCodec<DisplayedMarker, DisplayedMarkerWrite> = {
+  encode: ({ stanzaId, stanzaIdBy }) => xml('displayed', { xmlns: NS_MDS },
+    xml('stanza-id', { xmlns: NS_STANZA_ID, id: stanzaId, by: stanzaIdBy }),
+  ),
+  decode: (item) => {
     const conversationJid = item.attrs.id
-    if (!conversationJid) continue
-    const stanzaId = item
-      .getChild('displayed', NS_MDS)
-      ?.getChild('stanza-id', NS_STANZA_ID)?.attrs.id
-    if (stanzaId) {
-      markers.push({ conversationJid, stanzaId })
-      continue
-    }
+    if (!conversationJid) return undefined
+    const stanzaId = item.getChild('displayed', NS_MDS)?.getChild('stanza-id', NS_STANZA_ID)?.attrs.id
+    if (stanzaId) return { conversationJid, stanzaId }
     const legacyStanzaId = item.getChild('displayed', NS_CHAT_MARKERS)?.attrs.id
-    if (legacyStanzaId) {
-      markers.push({ conversationJid, stanzaId: legacyStanzaId, legacy: true })
-    }
-  }
-  return markers
+    return legacyStanzaId
+      ? { conversationJid, stanzaId: legacyStanzaId, legacy: true }
+      : undefined
+  },
 }
 
 /**
@@ -76,47 +81,23 @@ export function parseMdsItems(itemsEl: Element): DisplayedMarker[] {
  * Request/response only — incoming `+notify` events are handled in PubSub.
  */
 export class Mds {
-  private deps: ModuleDependencies
+  private readonly deps: ModuleDependencies
+  private readonly node: PepNode<DisplayedMarker, DisplayedMarkerWrite>
 
   constructor(deps: ModuleDependencies) {
     this.deps = deps
+    this.node = new PepNode(deps, NS_MDS, mdsCodec, MDS_NODE_OPTIONS)
   }
 
   /**
    * Publish the last-displayed stanza-id for a conversation.
-   * The node is created on first publish with current-value semantics
-   * (max_items=max so all conversations are retained; one item per JID).
+   * The node is created on first publish with one item per conversation JID.
    *
    * @param stanzaIdBy - XEP-0359 `by`: the archive that assigned the stanza-id
    *   (our own bare JID for 1:1, the room JID for MUC).
    */
   async publishDisplayed(conversationJid: string, stanzaId: string, stanzaIdBy: string): Promise<void> {
-    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
-
-    const iq = xml('iq', { type: 'set', id: `mds_set_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('publish', { node: NS_MDS },
-          xml('item', { id: conversationJid },
-            xml('displayed', { xmlns: NS_MDS },
-              xml('stanza-id', { xmlns: NS_STANZA_ID, id: stanzaId, by: stanzaIdBy }),
-            ),
-          ),
-        ),
-        xml('publish-options', {},
-          xml('x', { xmlns: 'jabber:x:data', type: 'submit' },
-            xml('field', { var: 'FORM_TYPE', type: 'hidden' },
-              xml('value', {}, 'http://jabber.org/protocol/pubsub#publish-options'),
-            ),
-            xml('field', { var: 'pubsub#persist_items' }, xml('value', {}, 'true')),
-            xml('field', { var: 'pubsub#max_items' }, xml('value', {}, 'max')),
-            xml('field', { var: 'pubsub#send_last_published_item' }, xml('value', {}, 'never')),
-            xml('field', { var: 'pubsub#access_model' }, xml('value', {}, 'whitelist')),
-          ),
-        ),
-      ),
-    )
-
-    await this.deps.sendIQ(iq)
+    await this.node.publish(conversationJid, { stanzaId, stanzaIdBy })
   }
 
   /**
@@ -127,17 +108,8 @@ export class Mds {
    */
   async retractDisplayed(conversationJid: string): Promise<void> {
     if (!this.deps.getCurrentJid()) return
-
-    const iq = xml('iq', { type: 'set', id: `mds_retract_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('retract', { node: NS_MDS },
-          xml('item', { id: conversationJid }),
-        ),
-      ),
-    )
-
     try {
-      await this.deps.sendIQ(iq)
+      await this.node.retract(conversationJid)
     } catch {
       // Best-effort: item may not exist, or the node may be absent.
     }
@@ -158,28 +130,11 @@ export class Mds {
    * transport, timeout, and unexpected failures are unknown.
    */
   async fetchAllDisplayedResult(timeoutMs?: number): Promise<DisplayedMarkerFetchResult> {
-    const currentJid = this.deps.getCurrentJid()
-    if (!currentJid) return { status: 'unknown' }
-
-    const bareJid = getBareJid(currentJid)
-    const iq = xml('iq', { type: 'get', to: bareJid, id: `mds_get_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('items', { node: NS_MDS }),
-      ),
-    )
-
-    try {
-      const result = await this.deps.sendIQ(iq, timeoutMs)
-      const items = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')
-      if (!items) return { status: 'unknown' }
-      return {
-        status: 'authoritative',
-        markers: parseMdsItems(items),
-      }
-    } catch (error) {
-      return isMissingNodeError(error)
-        ? { status: 'authoritative', markers: [] }
-        : { status: 'unknown' }
+    const result = await this.node.get({ timeoutMs })
+    switch (result.status) {
+      case 'ok': return { status: 'authoritative', markers: result.items }
+      case 'absent': return { status: 'authoritative', markers: [] }
+      case 'unavailable': return { status: 'unknown' }
     }
   }
 }

--- a/packages/fluux-sdk/src/core/modules/PepNode.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PepNode.test.ts
@@ -1,0 +1,212 @@
+/**
+ * PepNode tests.
+ *
+ * Uses real @xmpp/client (no mocking) so stanza construction and parsing go
+ * through the real `xml` builder, matching the surrounding module tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { xml } from '@xmpp/client'
+import type { Element } from '@xmpp/client'
+import { createPresenceReader } from '../presenceReader'
+import { PepNode, buildPublishOptions, type PepCodec } from './PepNode'
+import type { ModuleDependencies } from './BaseModule'
+
+const NODE = 'urn:example:thing'
+
+interface Thing { id: string; name: string }
+
+const codec: PepCodec<Thing> = {
+  encode: (thing) => xml('thing', { xmlns: NODE, name: thing.name }),
+  decode: (item) => {
+    const name = item.getChild('thing', NODE)?.attrs.name
+    return name ? { id: item.attrs.id, name } : undefined
+  },
+}
+
+function makeDeps(
+  sendIQ: (iq: Element, timeoutMs?: number) => Promise<Element>,
+  currentJid: string | null = 'me@example.com/res',
+): ModuleDependencies {
+  return {
+    stores: null,
+    presence: createPresenceReader(),
+    sendStanza: async () => {},
+    sendIQ,
+    getCurrentJid: () => currentJid,
+    emit: () => {},
+    emitSDK: () => {},
+    getXmpp: () => null,
+  }
+}
+
+function itemsResult(iq: Element, ...items: Element[]): Element {
+  return xml('iq', { type: 'result', id: iq.attrs.id },
+    xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+      xml('items', { node: NODE }, ...items),
+    ),
+  )
+}
+
+function thingItem(id: string, name: string): Element {
+  return xml('item', { id }, xml('thing', { xmlns: NODE, name }))
+}
+
+/** The shape `sendIQ` rejects with when the server answers `item-not-found`. */
+function itemNotFound(): Error & { condition: string } {
+  return Object.assign(new Error('item-not-found'), { condition: 'item-not-found' })
+}
+
+describe('PepNode.get', () => {
+  it('decodes items and reports ok', async () => {
+    const deps = makeDeps(async (iq) => itemsResult(iq, thingItem('a', 'Ada'), thingItem('b', 'Bob')))
+    const result = await new PepNode(deps, NODE, codec).get()
+    expect(result).toEqual({ status: 'ok', items: [{ id: 'a', name: 'Ada' }, { id: 'b', name: 'Bob' }] })
+  })
+
+  it('skips items the codec cannot decode rather than failing the read', async () => {
+    const deps = makeDeps(async (iq) => itemsResult(iq, thingItem('a', 'Ada'), xml('item', { id: 'junk' })))
+    const result = await new PepNode(deps, NODE, codec).get()
+    expect(result).toEqual({ status: 'ok', items: [{ id: 'a', name: 'Ada' }] })
+  })
+
+  it('reads our own bare JID by default, stripping the resource', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return itemsResult(iq) })
+    await new PepNode(deps, NODE, codec).get()
+    expect(captured!.attrs.to).toBe('me@example.com')
+    expect(captured!.attrs.type).toBe('get')
+  })
+
+  it('scopes the request to one item when itemId is given', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return itemsResult(iq) })
+    await new PepNode(deps, NODE, codec).get({ itemId: 'current' })
+    const items = captured!.getChild('pubsub')!.getChild('items')!
+    expect(items.attrs.node).toBe(NODE)
+    expect(items.getChild('item')!.attrs.id).toBe('current')
+  })
+
+  it('passes maxItems and a remote JID through', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return itemsResult(iq) })
+    await new PepNode(deps, NODE, codec).get({ jid: 'them@example.org', maxItems: 1 })
+    expect(captured!.attrs.to).toBe('them@example.org')
+    expect(captured!.getChild('pubsub')!.getChild('items')!.attrs.max_items).toBe('1')
+  })
+
+  it('forwards the timeout to sendIQ', async () => {
+    let seen: number | undefined
+    const deps = makeDeps(async (iq, timeoutMs) => { seen = timeoutMs; return itemsResult(iq) })
+    await new PepNode(deps, NODE, codec).get({ timeoutMs: 1234 })
+    expect(seen).toBe(1234)
+  })
+
+  // The three-way split is the point of this type: `absent` is the server
+  // stating there is nothing published, which callers act on.
+  it('classifies item-not-found as absent, not as an empty read', async () => {
+    const deps = makeDeps(async () => { throw itemNotFound() })
+    expect(await new PepNode(deps, NODE, codec).get()).toEqual({ status: 'absent' })
+  })
+
+  it('classifies any other rejection as unavailable', async () => {
+    const deps = makeDeps(async () => { throw new Error('timeout') })
+    expect(await new PepNode(deps, NODE, codec).get()).toEqual({ status: 'unavailable' })
+  })
+
+  it('treats a result without <items/> as unavailable rather than empty', async () => {
+    const deps = makeDeps(async (iq) => xml('iq', { type: 'result', id: iq.attrs.id }))
+    expect(await new PepNode(deps, NODE, codec).get()).toEqual({ status: 'unavailable' })
+  })
+
+  it('is unavailable with no session and sends nothing', async () => {
+    let sent = false
+    const deps = makeDeps(async (iq) => { sent = true; return itemsResult(iq) }, null)
+    expect(await new PepNode(deps, NODE, codec).get()).toEqual({ status: 'unavailable' })
+    expect(sent).toBe(false)
+  })
+})
+
+describe('PepNode.getOr', () => {
+  it('returns items when the read succeeds', async () => {
+    const deps = makeDeps(async (iq) => itemsResult(iq, thingItem('a', 'Ada')))
+    expect(await new PepNode(deps, NODE, codec).getOr([])).toEqual([{ id: 'a', name: 'Ada' }])
+  })
+
+  it('falls back for both absent and unavailable', async () => {
+    const absent = makeDeps(async () => { throw itemNotFound() })
+    const broken = makeDeps(async () => { throw new Error('nope') })
+    expect(await new PepNode(absent, NODE, codec).getOr([])).toEqual([])
+    expect(await new PepNode(broken, NODE, codec).getOr([])).toEqual([])
+  })
+})
+
+describe('PepNode.publish', () => {
+  it('sends the encoded payload under the item id', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return xml('iq', { type: 'result', id: iq.attrs.id }) })
+    await new PepNode(deps, NODE, codec).publish('current', { id: 'current', name: 'Ada' })
+
+    expect(captured!.attrs.type).toBe('set')
+    const publish = captured!.getChild('pubsub')!.getChild('publish')!
+    expect(publish.attrs.node).toBe(NODE)
+    const item = publish.getChild('item')!
+    expect(item.attrs.id).toBe('current')
+    expect(item.getChild('thing')!.attrs.name).toBe('Ada')
+  })
+
+  it('carries the node publish-options', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return xml('iq', { type: 'result', id: iq.attrs.id }) })
+    const node = new PepNode(deps, NODE, codec, { persistItems: true, accessModel: 'whitelist', maxItems: 'max' })
+    await node.publish('current', { id: 'current', name: 'Ada' })
+
+    const fields = captured!.getChild('pubsub')!.getChild('publish-options')!
+      .getChild('x')!.getChildren('field')
+    const byVar = new Map(fields.map((f: Element) => [f.attrs.var, f.getChild('value')?.text()]))
+    expect(byVar.get('pubsub#persist_items')).toBe('true')
+    expect(byVar.get('pubsub#access_model')).toBe('whitelist')
+    expect(byVar.get('pubsub#max_items')).toBe('max')
+  })
+
+  it('omits publish-options when the node declares none', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return xml('iq', { type: 'result', id: iq.attrs.id }) })
+    await new PepNode(deps, NODE, codec).publish('current', { id: 'current', name: 'Ada' })
+    expect(captured!.getChild('pubsub')!.getChild('publish-options')).toBeUndefined()
+  })
+
+  it('refuses to publish without a session', async () => {
+    const deps = makeDeps(async (iq) => xml('iq', { type: 'result', id: iq.attrs.id }), null)
+    await expect(new PepNode(deps, NODE, codec).publish('current', { id: 'c', name: 'A' }))
+      .rejects.toThrow('Not connected')
+  })
+})
+
+describe('PepNode.retract', () => {
+  it('sends a retract for the item', async () => {
+    let captured: Element | null = null
+    const deps = makeDeps(async (iq) => { captured = iq; return xml('iq', { type: 'result', id: iq.attrs.id }) })
+    await new PepNode(deps, NODE, codec).retract('gone')
+    const retract = captured!.getChild('pubsub')!.getChild('retract')!
+    expect(retract.attrs.node).toBe(NODE)
+    expect(retract.getChild('item')!.attrs.id).toBe('gone')
+  })
+
+  it('propagates a server refusal so the caller can decide', async () => {
+    const deps = makeDeps(async () => { throw itemNotFound() })
+    await expect(new PepNode(deps, NODE, codec).retract('gone')).rejects.toThrow()
+  })
+})
+
+describe('buildPublishOptions', () => {
+  it('is null when there is nothing to say', () => {
+    expect(buildPublishOptions(undefined)).toBeNull()
+    expect(buildPublishOptions({})).toBeNull()
+  })
+
+  it('renders booleans as true/false', () => {
+    const fields = buildPublishOptions({ persistItems: false })!.getChild('x')!.getChildren('field')
+    const byVar = new Map(fields.map((f: Element) => [f.attrs.var, f.getChild('value')?.text()]))
+    expect(byVar.get('pubsub#persist_items')).toBe('false')
+  })
+})

--- a/packages/fluux-sdk/src/core/modules/PepNode.ts
+++ b/packages/fluux-sdk/src/core/modules/PepNode.ts
@@ -1,0 +1,211 @@
+/**
+ * A single typed PEP node (XEP-0163 / XEP-0223 private storage).
+ *
+ * Every feature that keeps account state on a PEP node needs the same four
+ * things: build the `<iq>`, carry the right `publish-options`, tell "the node
+ * does not exist" apart from "we could not reach it", and map `<item>` payloads
+ * to and from a domain type. Declaring the node once with its codec keeps that
+ * in one place instead of once per feature.
+ *
+ * @category Modules
+ */
+import { xml } from '@xmpp/client'
+import type { Element } from '@xmpp/client'
+import { getBareJid } from '../jid'
+import { generateUUID } from '../../utils/uuid'
+import { NS_PUBSUB } from '../namespaces'
+import { hasErrorCondition } from '../../utils/xmppError'
+import type { ModuleDependencies } from './BaseModule'
+
+/**
+ * Node configuration sent as XEP-0060 `publish-options`. The server either
+ * honours them or rejects the publish with `<conflict/>` when the node already
+ * exists with an incompatible configuration.
+ */
+export interface PublishOptions {
+  /** `pubsub#persist_items` — whether the node retains items between sessions. */
+  persistItems?: boolean
+  /** `pubsub#access_model` — who may read the node. */
+  accessModel?: 'open' | 'whitelist' | 'presence' | 'roster' | 'authorize'
+  /**
+   * `pubsub#max_items` — maximum retained items. `1` gives current-value
+   * semantics; `'max'` asks the server for its ceiling, which is what a
+   * one-item-per-entity node (XEP-0490) needs.
+   */
+  maxItems?: number | 'max'
+  /** `pubsub#send_last_published_item` — when to replay to new subscribers. */
+  sendLastPublishedItem?: 'never' | 'on_sub' | 'on_sub_and_presence'
+}
+
+/**
+ * Translates between a domain value and the payload inside `<item>`.
+ *
+ * `TWrite` defaults to `T` but is separate because the two directions can
+ * legitimately differ: XEP-0490 publishes a marker with the archive JID that
+ * assigned the stanza-id, and that attribute is not part of what a reader gets
+ * back.
+ */
+export interface PepCodec<T, TWrite = T> {
+  /** Build the single child element that goes inside `<item>`. */
+  encode(value: TWrite): Element
+  /**
+   * Read one `<item>`. Receives the item element itself, not just its payload,
+   * so a codec can use `item.attrs.id` (XEP-0490 keys markers by conversation
+   * JID that way). Return `undefined` to skip an item that does not parse.
+   */
+  decode(item: Element): T | undefined
+}
+
+/**
+ * Outcome of a read. The three cases are deliberately distinct: `absent` is the
+ * server stating there is nothing published, which is a FACT a caller may act
+ * on (a fresh account seeding its first value), while `unavailable` means we
+ * did not learn anything. Collapsing them into an empty array loses that, and
+ * XEP-0490's read-position seeding depends on the difference.
+ */
+export type PepFetch<T> =
+  | { status: 'ok'; items: T[] }
+  | { status: 'absent' }
+  | { status: 'unavailable' }
+
+/** Read options. Defaults to every item on our own node. */
+export interface PepGetOptions {
+  /** Fetch one item by id instead of the whole node. */
+  itemId?: string
+  /** Cap on returned items, newest first. */
+  maxItems?: number
+  /** Whose node to read. Defaults to our own bare JID. */
+  jid?: string
+  timeoutMs?: number
+}
+
+export class PepNode<T, TWrite = T> {
+  constructor(
+    private readonly deps: ModuleDependencies,
+    /** The node name, which is also its payload namespace for our own nodes. */
+    readonly node: string,
+    private readonly codec: PepCodec<T, TWrite>,
+    /** Applied to every publish, so a node cannot be created two ways. */
+    private readonly publishOptions?: PublishOptions,
+  ) {}
+
+  /**
+   * Read the node. Never throws: a rejection is classified rather than
+   * propagated, because every caller has to make that distinction anyway.
+   */
+  async get(options: PepGetOptions = {}): Promise<PepFetch<T>> {
+    const target = options.jid ?? this.ownBareJid()
+    if (!target) return { status: 'unavailable' }
+
+    const attrs: Record<string, string> = { node: this.node }
+    if (options.maxItems !== undefined) attrs.max_items = String(options.maxItems)
+    const itemsEl = options.itemId !== undefined
+      ? xml('items', attrs, xml('item', { id: options.itemId }))
+      : xml('items', attrs)
+
+    const iq = xml('iq', { type: 'get', to: target, id: `pep_get_${generateUUID()}` },
+      xml('pubsub', { xmlns: NS_PUBSUB }, itemsEl),
+    )
+
+    let result: Element
+    try {
+      result = await this.deps.sendIQ(iq, options.timeoutMs)
+    } catch (error) {
+      // `item-not-found` is the server answering the question: no such node or
+      // item. Anything else (timeout, transport, forbidden) left us uninformed.
+      return hasErrorCondition(error, 'item-not-found')
+        ? { status: 'absent' }
+        : { status: 'unavailable' }
+    }
+
+    const items = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')
+    // A result with no `<items/>` is malformed rather than empty: the server
+    // answered, but not the question we asked.
+    if (!items) return { status: 'unavailable' }
+    return { status: 'ok', items: items.getChildren('item').flatMap((item) => {
+      const decoded = this.codec.decode(item)
+      return decoded === undefined ? [] : [decoded]
+    }) }
+  }
+
+  /** Every item, or `fallback` when the node is absent or unreachable. */
+  async getOr(fallback: T[], options: PepGetOptions = {}): Promise<T[]> {
+    const result = await this.get(options)
+    return result.status === 'ok' ? result.items : fallback
+  }
+
+  /** Publish one item, creating the node with {@link publishOptions} if needed. */
+  async publish(itemId: string, value: TWrite): Promise<void> {
+    this.requireSession()
+    const children: Element[] = [
+      xml('publish', { node: this.node },
+        xml('item', { id: itemId }, this.codec.encode(value)),
+      ),
+    ]
+    const options = buildPublishOptions(this.publishOptions)
+    if (options) children.push(options)
+
+    await this.deps.sendIQ(
+      xml('iq', { type: 'set', id: `pep_pub_${generateUUID()}` },
+        xml('pubsub', { xmlns: NS_PUBSUB }, ...children),
+      ),
+    )
+  }
+
+  /** Remove one item. Rejects if the server refuses; callers decide whether that matters. */
+  async retract(itemId: string): Promise<void> {
+    this.requireSession()
+    await this.deps.sendIQ(
+      xml('iq', { type: 'set', id: `pep_ret_${generateUUID()}` },
+        xml('pubsub', { xmlns: NS_PUBSUB },
+          xml('retract', { node: this.node }, xml('item', { id: itemId })),
+        ),
+      ),
+    )
+  }
+
+  private ownBareJid(): string | null {
+    const jid = this.deps.getCurrentJid()
+    return jid ? getBareJid(jid) : null
+  }
+
+  private requireSession(): void {
+    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
+  }
+}
+
+/**
+ * Serialise `publish-options` as a XEP-0004 submit form.
+ *
+ * Booleans go out as `true`/`false` rather than `1`/`0`: both are valid
+ * `xs:boolean`, and this is the form XEP-0223's own examples use.
+ */
+export function buildPublishOptions(options?: PublishOptions): Element | null {
+  if (!options) return null
+  const fields: Element[] = []
+  if (options.persistItems !== undefined) {
+    fields.push(formField('pubsub#persist_items', options.persistItems ? 'true' : 'false'))
+  }
+  if (options.accessModel !== undefined) {
+    fields.push(formField('pubsub#access_model', options.accessModel))
+  }
+  if (options.maxItems !== undefined) {
+    fields.push(formField('pubsub#max_items', String(options.maxItems)))
+  }
+  if (options.sendLastPublishedItem !== undefined) {
+    fields.push(formField('pubsub#send_last_published_item', options.sendLastPublishedItem))
+  }
+  if (fields.length === 0) return null
+  return xml('publish-options', {},
+    xml('x', { xmlns: 'jabber:x:data', type: 'submit' },
+      xml('field', { var: 'FORM_TYPE', type: 'hidden' },
+        xml('value', {}, 'http://jabber.org/protocol/pubsub#publish-options'),
+      ),
+      ...fields,
+    ),
+  )
+}
+
+function formField(varName: string, value: string): Element {
+  return xml('field', { var: varName }, xml('value', {}, value))
+}

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -1,6 +1,7 @@
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
-import { BaseModule } from './BaseModule'
+import { BaseModule, type ModuleDependencies } from './BaseModule'
+import { PepNode, type PepCodec } from './PepNode'
 import { getBareJid, getLocalPart, getDomain } from '../jid'
 import type { VCardInfo } from '../types/roster'
 import { generateUUID } from '../../utils/uuid'
@@ -58,7 +59,23 @@ import {
  *
  * @category Modules
  */
+/** XEP-0172 keeps a single current value, so its item id is a constant. */
+const NICK_ITEM_ID = 'current'
+
+/** Payload is the bare `<nick/>` text; the node carries no publish-options. */
+const nickCodec: PepCodec<string> = {
+  encode: (nickname) => xml('nick', { xmlns: NS_NICK }, nickname),
+  decode: (item) => item.getChild('nick', NS_NICK)?.text() || undefined,
+}
+
 export class Profile extends BaseModule {
+  private readonly nickNode: PepNode<string>
+
+  constructor(deps: ModuleDependencies) {
+    super(deps)
+    this.nickNode = new PepNode(deps, NS_NICK, nickCodec)
+  }
+
   // Note: PubSub events are now handled by the PubSub module.
   // Profile module focuses on outgoing operations (publish avatar, set nickname)
   // and data fetching (fetchAvatarData, fetchVCardAvatar, fetchRoomAvatar).
@@ -531,50 +548,20 @@ export class Profile extends BaseModule {
    * if desired (e.g., in the contact profile view).
    */
   async fetchContactNickname(jid: string): Promise<string | null> {
-    const bareJid = getBareJid(jid)
-    const iq = xml('iq', { type: 'get', to: bareJid, id: `nick_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('items', { node: NS_NICK, max_items: '1' })
-      )
-    )
-
-    try {
-      const result = await this.deps.sendIQ(iq)
-      const nick = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')?.getChild('nick', NS_NICK)?.text()
-      if (nick) {
-        return nick
-      }
-    } catch {
-      // Contact may not have a nickname set
-    }
-    return null
+    const nicks = await this.nickNode.getOr([], { jid: getBareJid(jid), maxItems: 1 })
+    return nicks[0] ?? null
   }
 
   /**
    * Fetch own nickname from PEP (XEP-0172 User Nickname).
    */
   async fetchOwnNickname(): Promise<string | null> {
-    const currentJid = this.deps.getCurrentJid()
-    if (!currentJid) return null
-
-    const bareJid = getBareJid(currentJid)
-    const iq = xml('iq', { type: 'get', to: bareJid, id: `nick_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('items', { node: NS_NICK, max_items: '1' })
-      )
-    )
-
-    try {
-      const result = await this.deps.sendIQ(iq)
-      const nick = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')?.getChild('nick', NS_NICK)?.text()
-      if (nick) {
-        this.deps.emitSDK('connection:own-nickname', { nickname: nick })
-        return nick
-      }
-    } catch {
-      // Own nickname might not be set
-    }
-    return null
+    if (!this.deps.getCurrentJid()) return null
+    const nicks = await this.nickNode.getOr([], { maxItems: 1 })
+    const nick = nicks[0]
+    if (!nick) return null
+    this.deps.emitSDK('connection:own-nickname', { nickname: nick })
+    return nick
   }
 
   /**
@@ -588,16 +575,7 @@ export class Profile extends BaseModule {
       throw new Error('Nickname cannot be empty')
     }
 
-    const iq = xml('iq', { type: 'set', id: `nick_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('publish', { node: NS_NICK },
-          xml('item', { id: 'current' },
-            xml('nick', { xmlns: NS_NICK }, trimmedNickname)
-          )
-        )
-      )
-    )
-    await this.deps.sendIQ(iq)
+    await this.nickNode.publish(NICK_ITEM_ID, trimmedNickname)
     this.deps.emitSDK('connection:own-nickname', { nickname: trimmedNickname })
   }
 
@@ -605,16 +583,7 @@ export class Profile extends BaseModule {
    * Clear/remove own nickname from PEP (XEP-0172).
    */
   async clearOwnNickname(): Promise<void> {
-    if (!this.deps.getCurrentJid()) throw new Error('Not connected')
-
-    const iq = xml('iq', { type: 'set', id: `nick_clear_${generateUUID()}` },
-      xml('pubsub', { xmlns: NS_PUBSUB },
-        xml('retract', { node: NS_NICK },
-          xml('item', { id: 'current' })
-        )
-      )
-    )
-    await this.deps.sendIQ(iq)
+    await this.nickNode.retract(NICK_ITEM_ID)
     this.deps.emitSDK('connection:own-nickname', { nickname: null })
   }
 

--- a/packages/fluux-sdk/src/core/modules/PubSub.pep.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.pep.test.ts
@@ -78,7 +78,9 @@ describe('PubSub.publish', () => {
     const fields = form?.getChildren('field') ?? []
     const byVar = new Map(fields.map((f: Element) => [f.attrs.var, f.getChild('value')?.text()]))
     expect(byVar.get('FORM_TYPE')).toBe('http://jabber.org/protocol/pubsub#publish-options')
-    expect(byVar.get('pubsub#persist_items')).toBe('1')
+    // `true`, not `1`: both are valid xs:boolean (XEP-0004), and this is the
+    // form XEP-0223's examples use and that every other Fluux PEP node sends.
+    expect(byVar.get('pubsub#persist_items')).toBe('true')
     expect(byVar.get('pubsub#access_model')).toBe('whitelist')
     expect(byVar.get('pubsub#max_items')).toBe('1')
   })

--- a/packages/fluux-sdk/src/core/modules/PubSub.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.ts
@@ -28,21 +28,9 @@ import { generateUUID } from '../../utils/uuid'
 import { dataToElement, elementToData } from '../e2ee/stanzaAdapter'
 import type { PEPItem, Subscription, XMLElementData } from '../e2ee'
 import { parseBookmarkItem } from '../bookmarkItem'
+import { buildPublishOptions, type PublishOptions } from './PepNode'
 
-/**
- * Options accepted by {@link PubSub.publish}. These map to XEP-0060
- * publish-options form fields.
- */
-export interface PublishOptions {
-  /** `pubsub#persist_items` — whether the node retains items between sessions. */
-  persistItems?: boolean
-  /** `pubsub#access_model` — who may read the node. */
-  accessModel?: 'open' | 'whitelist' | 'presence' | 'roster' | 'authorize'
-  /** `pubsub#max_items` — maximum retained items. Use `1` for current-value nodes. */
-  maxItems?: number
-  /** `pubsub#send_last_published_item` — when to replay to new subscribers. */
-  sendLastPublishedItem?: 'never' | 'on_sub' | 'on_sub_and_presence'
-}
+export type { PublishOptions }
 
 const NS_PUBSUB_EVENT = `${NS_PUBSUB}#event`
 
@@ -436,32 +424,3 @@ function parseItems(itemsEl: Element): PEPItem[] {
   })
 }
 
-function buildPublishOptions(options?: PublishOptions) {
-  if (!options) return null
-  const fields: Array<ReturnType<typeof xml>> = []
-  if (options.persistItems !== undefined) {
-    fields.push(formField('pubsub#persist_items', options.persistItems ? '1' : '0'))
-  }
-  if (options.accessModel !== undefined) {
-    fields.push(formField('pubsub#access_model', options.accessModel))
-  }
-  if (options.maxItems !== undefined) {
-    fields.push(formField('pubsub#max_items', String(options.maxItems)))
-  }
-  if (options.sendLastPublishedItem !== undefined) {
-    fields.push(formField('pubsub#send_last_published_item', options.sendLastPublishedItem))
-  }
-  if (fields.length === 0) return null
-  return xml('publish-options', {},
-    xml('x', { xmlns: 'jabber:x:data', type: 'submit' },
-      xml('field', { var: 'FORM_TYPE', type: 'hidden' },
-        xml('value', {}, 'http://jabber.org/protocol/pubsub#publish-options'),
-      ),
-      ...fields,
-    ),
-  )
-}
-
-function formField(varName: string, value: string) {
-  return xml('field', { var: varName }, xml('value', {}, value))
-}


### PR DESCRIPTION
`Ignore`, `Mds`, `ConversationSync` and `Profile`'s nickname node each hand-rolled the same
`<iq><pubsub>` construction, `publish-options` form and error handling. `PepNode<T>` declares a node
once with its codec and options and exposes `get` / `getOr` / `publish` / `retract`, removing about
200 lines of duplicated protocol plumbing. The `PubSub` facade already existed but predated none of
these callers, so none had adopted it.

Reads return a three-way result rather than an array:

```ts
type PepFetch<T> = { status: 'ok'; items: T[] } | { status: 'absent' } | { status: 'unavailable' }
```

`absent` is the server stating nothing is published, which XEP-0490's read-position seeding acts on;
`unavailable` means we learned nothing. `Mds` drew that distinction by hand and the other two
collapsed it into `catch { return [] }`. It is now the shared contract, with `getOr(fallback)` for
callers that genuinely do not need it.

The codec carries a separate write type, because the two directions differ: XEP-0490 publishes the
archive JID that issued the stanza-id and readers never get it back. `maxItems` accepts `'max'`,
which a one-item-per-conversation node needs and the previous options type could not express.

## One wire change worth a look

`publish-options` booleans now serialise as `true` rather than `1`. This affects the E2EE
key-publication path, which was the only caller sending `1`; the three PEP nodes migrated here
already sent `true`. Both are valid `xs:boolean` (XEP-0004) and `true` is the form XEP-0223's own
examples use, but it does change the bytes on OpenPGP public-key publication. Keeping `1` instead
would mean changing the three read-state nodes, so one side has to move.

## Not in scope

`Profile`'s avatar paths keep their hand-rolled queries. They are entangled with vCard fallback,
PEP-forbidden-domain tracking and hash-keyed item fetches, which is a separate change from this one.
Its nickname node is migrated and publishes no options, so that wire is byte-identical.
