### PR TITLE
refactor(sdk): derive stanza routing order from declared claims

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -733,6 +733,7 @@ export class XMPPClient {
       routeStanza(
         stanza,
         [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster],
+        [this.lastActivity],
       )
     })
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -31,6 +31,7 @@ import { detectPlatform } from './platform'
 import { isDeadSocketError } from './modules/connectionUtils'
 import { IQTimeoutError } from './errors'
 import { getBareJid, getDomain } from './jid'
+import { routeStanza } from './stanzaRouting'
 import { createE2EEDiagnosticLogger } from './e2eeDiagnosticLogger'
 import { getStorageScopeJid, setStorageScopeJid } from '../utils/storageScope'
 
@@ -727,20 +728,12 @@ export class XMPPClient {
       // This handles MAM query results without adding temporary listeners
       this.dispatchToMAMCollectors(stanza)
 
-      // Route to modules (order matters - first handler to return true wins)
-      // PubSub before Chat so PubSub events aren't treated as chat messages
-      // Blocking before Roster so blocklist pushes are handled correctly
-      // MUC before Roster so join/nick-change error presences reach failJoin():
-      // Roster claims EVERY presence type='error', and a MUC join error (401
-      // password required, 409 conflict, …) echoes <x muc>, not muc#user, so it
-      // is indistinguishable from a contact presence error at that layer. MUC
-      // only claims presence it recognises (muc#user, or an error matching an
-      // in-flight join/nick change), so regular contact presence still falls
-      // through to Roster.
-      const modules = [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster, this.profile, this.discovery, this.lastActivity]
-      for (const module of modules) {
-        if (module.handle(stanza)) break
-      }
+      // Order is derived from how narrowly each module declares its claims,
+      // not from the position of a module in this list. See core/stanzaRouting.
+      routeStanza(
+        stanza,
+        [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster],
+      )
     })
 
     // Only set up event listeners once

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -80,9 +80,10 @@ export interface ModuleDependencies {
  * by XMPPClient during store binding and share common dependencies.
  *
  * @remarks
- * Subclasses must implement the `handle()` method to process incoming stanzas.
- * Return `true` from `handle()` to indicate the stanza was processed and should
- * not be passed to other modules.
+ * Handling incoming stanzas is opt-in: a module that routes declares `claims`
+ * and implements `handle()` (see `StanzaClaimant` in `core/stanzaRouting`), or
+ * declares `observes` and implements `observe()` when it only watches. Modules
+ * that are purely request/response — Discovery, Profile — declare neither.
  *
  * @example Creating a custom module
  * ```typescript
@@ -106,11 +107,4 @@ export abstract class BaseModule {
   constructor(deps: ModuleDependencies) {
     this.deps = deps
   }
-
-  /**
-   * Handle incoming stanza.
-   * @param stanza The incoming XMPP stanza
-   * @returns true if the stanza was handled and should not be processed further
-   */
-  abstract handle(stanza: Element): boolean | void
 }

--- a/packages/fluux-sdk/src/core/modules/Blocking.ts
+++ b/packages/fluux-sdk/src/core/modules/Blocking.ts
@@ -2,6 +2,7 @@ import { xml, Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { NS_BLOCKING } from '../namespaces'
 import { generateUUID } from '../../utils/uuid'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Blocking module (XEP-0191).
@@ -31,11 +32,21 @@ import { generateUUID } from '../../utils/uuid'
  *
  * @category Modules
  */
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const BLOCKING_CLAIMS: readonly StanzaClaim[] = [
+    { kind: 'iq', type: 'set', child: { name: 'block', ns: NS_BLOCKING } },
+    { kind: 'iq', type: 'set', child: { name: 'unblock', ns: NS_BLOCKING } },
+  ]
+
 export class Blocking extends BaseModule {
   /**
    * Handle incoming IQ stanzas related to blocking.
    * Processes blocklist push notifications from the server.
    */
+  /** XEP-0191 blocklist pushes. Disjoint from Roster's iq claim. */
+  readonly claims = BLOCKING_CLAIMS
+
   handle(stanza: Element): boolean | void {
     if (!stanza.is('iq')) return false
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -67,6 +67,7 @@ import { parsePollElement, parsePollClosedElement } from '../poll'
 import { logWarn } from '../logger'
 import { parseXMPPError, formatXMPPError } from '../../utils/xmppError'
 import type { MAM } from './MAM'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Chat module for 1:1 and group messaging.
@@ -149,6 +150,10 @@ interface E2EEOutboundOptions {
   storeHint?: 'store' | 'no-store' | 'none'
 }
 
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const CHAT_CLAIMS: readonly StanzaClaim[] = [{ kind: 'message' }]
+
 export class Chat extends BaseModule {
   private mamModule: MAM
 
@@ -156,6 +161,12 @@ export class Chat extends BaseModule {
     super(deps)
     this.mamModule = mamModule
   }
+
+  /**
+   * Every message. Narrower message claims (PubSub's event payloads) are
+   * offered the stanza first, so this is the fallthrough rather than a race.
+   */
+  readonly claims = CHAT_CLAIMS
 
   handle(stanza: Element): boolean | void {
     if (stanza.is('message')) {

--- a/packages/fluux-sdk/src/core/modules/Discovery.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.ts
@@ -66,10 +66,6 @@ export class Discovery extends BaseModule {
    */
   private pepSupportProbe: Promise<boolean> | null = null
 
-  handle(_stanza: Element): boolean | void {
-    // Discovery doesn't handle incoming stanzas (responses handled via IQ caller)
-    return false
-  }
 
   /**
    * Whether the logged-in account supports PEP (XEP-0163).

--- a/packages/fluux-sdk/src/core/modules/LastActivity.test.ts
+++ b/packages/fluux-sdk/src/core/modules/LastActivity.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { LastActivity } from './LastActivity'
+import { Roster } from './Roster'
 import { createMockElement, createMockStores, createMockPresenceReader } from '../test-utils'
 import type { Element } from '@xmpp/client'
 import type { ModuleDependencies } from './BaseModule'
+import { routeStanza } from '../stanzaRouting'
 
 /** Helper to create a successful last activity IQ response */
 function createLastActivityResponse(seconds: number) {
@@ -48,12 +50,13 @@ describe('LastActivity module', () => {
   let lastActivity: LastActivity
   let mockStores: ReturnType<typeof createMockStores>
   let sendIQ: ReturnType<typeof vi.fn<ModuleDependencies['sendIQ']>>
+  let deps: ModuleDependencies
 
   beforeEach(() => {
     mockStores = createMockStores()
     sendIQ = vi.fn<ModuleDependencies['sendIQ']>()
 
-    lastActivity = new LastActivity({
+    deps = {
       stores: mockStores,
       presence: createMockPresenceReader(),
       sendStanza: vi.fn(),
@@ -62,7 +65,8 @@ describe('LastActivity module', () => {
       emit: vi.fn(),
       emitSDK: vi.fn(),
       getXmpp: () => null,
-    })
+    }
+    lastActivity = new LastActivity(deps)
   })
 
   describe('queryLastActivity', () => {
@@ -232,20 +236,43 @@ describe('LastActivity module', () => {
       await lastActivity.queryLastActivity('alice@example.com')
       expect(lastActivity.getCached('alice@example.com')).not.toBeNull()
 
-      // Simulate contact coming back online
+      // Simulate contact coming back online. Routed rather than calling
+      // observe() directly: the path is what this is about.
       const presenceStanza = createMockElement('presence', {
         from: 'alice@example.com/desktop',
       })
-      lastActivity.handle(presenceStanza as unknown as Element)
+      routeStanza(presenceStanza as unknown as Element, [], [lastActivity])
 
       expect(lastActivity.getCached('alice@example.com')).toBeNull()
     })
 
-    it('returns false (never consumes stanza)', () => {
-      const stanza = createMockElement('presence', {
+    // Regression: Roster claims essentially all presence and consumes it. While
+    // this module was a CLAIMANT ordered after Roster, it never saw an
+    // available presence and the cache was never invalidated — a contact coming
+    // back online kept its stale "last seen". As an observer it runs regardless
+    // of who claimed.
+    it('still invalidates when Roster consumes the same presence', async () => {
+      setupOfflineContact(mockStores, 'alice@example.com')
+      sendIQ.mockResolvedValue(createLastActivityResponse(600) as unknown as Element)
+      await lastActivity.queryLastActivity('alice@example.com')
+      expect(lastActivity.getCached('alice@example.com')).not.toBeNull()
+
+      const roster = new Roster(deps)
+      const presence = createMockElement('presence', {
         from: 'alice@example.com/desktop',
-      })
-      expect(lastActivity.handle(stanza as unknown as Element)).toBe(false)
+      }) as unknown as Element
+
+      routeStanza(presence, [roster], [lastActivity])
+
+      expect(roster.handle(presence)).toBe(true) // Roster does claim it...
+      expect(lastActivity.getCached('alice@example.com')).toBeNull() // ...and it ran anyway
+    })
+
+    it('observes rather than claims, so it cannot consume a stanza', () => {
+      // Structural: an observer has no `claims`/`handle` for the router to
+      // offer a stanza to, so nothing it does can stop another module handling.
+      expect((lastActivity as unknown as { claims?: unknown }).claims).toBeUndefined()
+      expect((lastActivity as unknown as { handle?: unknown }).handle).toBeUndefined()
     })
 
     it('does not invalidate on unavailable presence', async () => {
@@ -257,21 +284,22 @@ describe('LastActivity module', () => {
 
       await lastActivity.queryLastActivity('alice@example.com')
 
-      // type='unavailable' means going offline — cache should stay
+      // type='unavailable' means going offline — cache should stay. The filter
+      // is the declared claim, so route the stanza rather than calling observe.
       const presenceStanza = createMockElement('presence', {
         from: 'alice@example.com/desktop',
         type: 'unavailable',
       })
-      lastActivity.handle(presenceStanza as unknown as Element)
+      routeStanza(presenceStanza as unknown as Element, [], [lastActivity])
 
       expect(lastActivity.getCached('alice@example.com')).not.toBeNull()
     })
 
-    it('ignores non-presence stanzas', () => {
-      const stanza = createMockElement('message', {
-        from: 'alice@example.com/desktop',
-      })
-      expect(lastActivity.handle(stanza as unknown as Element)).toBe(false)
+    it('is not offered non-presence stanzas', () => {
+      const invalidate = vi.spyOn(lastActivity, 'invalidate')
+      const stanza = createMockElement('message', { from: 'alice@example.com/desktop' })
+      routeStanza(stanza as unknown as Element, [], [lastActivity])
+      expect(invalidate).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/LastActivity.ts
+++ b/packages/fluux-sdk/src/core/modules/LastActivity.ts
@@ -2,6 +2,7 @@ import { xml, Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { NS_LAST } from '../namespaces'
 import { getBareJid } from '../jid'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Cached last activity result for a contact.
@@ -40,14 +41,17 @@ export class LastActivity extends BaseModule {
    * Passively watch for available presence stanzas to invalidate cache.
    * When a contact comes back online, their cached last-activity is stale.
    */
-  handle(stanza: Element): boolean | void {
-    if (stanza.is('presence') && !stanza.attrs.type) {
-      const from = stanza.attrs.from
-      if (from) {
-        this.invalidate(getBareJid(from))
-      }
-    }
-    return false
+  /**
+   * Available presence, as an observer rather than a claimant: this module
+   * never consumes a stanza, it only drops a cache entry when a contact comes
+   * back online. Routing it as an observer means Roster claiming the same
+   * presence cannot stop it from running.
+   */
+  readonly observes: readonly StanzaClaim[] = [{ kind: 'presence', type: null }]
+
+  observe(stanza: Element): void {
+    const from = stanza.attrs.from
+    if (from) this.invalidate(getBareJid(from))
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -46,6 +46,7 @@ import { RoomJoinError } from '../errors'
 import { toHatCommandError } from '../../utils/hatCommandError'
 import { buildDataFormSubmit, parseDataForm } from '../../utils/dataForm'
 import { logInfo, logWarn, logError as logErr } from '../logger'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Multi-User Chat (MUC) module for group chat functionality.
@@ -139,6 +140,13 @@ interface NickChangeDeferred {
   timeoutId: ReturnType<typeof setTimeout>
 }
 
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const MUC_CLAIMS: readonly StanzaClaim[] = [
+    { kind: 'presence', child: { name: 'x', ns: NS_MUC_USER } },
+    { kind: 'presence', type: 'error' },
+  ]
+
 export class MUC extends BaseModule {
   /** Track pending room joins for timeout handling */
   private pendingJoins = new Map<string, PendingJoin>()
@@ -164,6 +172,17 @@ export class MUC extends BaseModule {
    * followed by a restart — clears it.
    */
   private membersForbiddenRooms = new Set<string>()
+
+  /**
+   * Room presence, plus error presence generally.
+   *
+   * The second claim is deliberately wider than what MUC consumes: a join or
+   * nick-change error echoes `<x muc/>` (or nothing) rather than `muc#user`, so
+   * it is indistinguishable from a contact presence error by shape alone.
+   * `handle()` consumes it only when a request is in flight for that room and
+   * otherwise declines, and Roster's broader presence claim picks it up.
+   */
+  readonly claims = MUC_CLAIMS
 
   handle(stanza: Element): boolean | void {
     if (stanza.is('presence')) {

--- a/packages/fluux-sdk/src/core/modules/Poll.ts
+++ b/packages/fluux-sdk/src/core/modules/Poll.ts
@@ -30,6 +30,7 @@ import {
   isPollExpired,
 } from '../poll'
 import { roomStore } from '../../stores/roomStore'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Lightweight metadata for polls created by the local user.
@@ -56,6 +57,12 @@ interface LocalPollEntry {
  *
  * @category Modules
  */
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const POLL_CLAIMS: readonly StanzaClaim[] = [
+    { kind: 'iq', type: 'get', child: { name: 'poll-results', ns: NS_POLL } },
+  ]
+
 export class Poll extends BaseModule {
   private chat: Chat
   /** Polls created by the local user, keyed by message ID */
@@ -71,6 +78,8 @@ export class Poll extends BaseModule {
   /**
    * Handle incoming stanzas — intercepts poll-results IQ queries.
    */
+  readonly claims = POLL_CLAIMS
+
   handle(stanza: Element): boolean {
     if (!stanza.is('iq')) return false
 

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -80,13 +80,6 @@ export class Profile extends BaseModule {
   // Profile module focuses on outgoing operations (publish avatar, set nickname)
   // and data fetching (fetchAvatarData, fetchVCardAvatar, fetchRoomAvatar).
 
-  /**
-   * Handle incoming stanzas.
-   * Profile doesn't handle stanzas directly - PubSub module handles PubSub events.
-   */
-  handle(_stanza: Element): boolean {
-    return false
-  }
 
   /**
    * Fetch avatar data from PEP (XEP-0084) or VCard (XEP-0054).
@@ -612,7 +605,7 @@ export class Profile extends BaseModule {
 
     // Fetch current vCard to preserve PHOTO and other unmanaged fields
     const bareJid = getBareJid(this.deps.getCurrentJid()!)
-    let existingVCardEl: import('@xmpp/client').Element | null = null
+    let existingVCardEl: Element | null = null
     try {
       const getIq = xml('iq', { type: 'get', to: bareJid, id: `vcard_get_${generateUUID()}` },
         xml('vCard', { xmlns: NS_VCARD_TEMP })

--- a/packages/fluux-sdk/src/core/modules/PubSub.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.ts
@@ -29,6 +29,7 @@ import { dataToElement, elementToData } from '../e2ee/stanzaAdapter'
 import type { PEPItem, Subscription, XMLElementData } from '../e2ee'
 import { parseBookmarkItem } from '../bookmarkItem'
 import { buildPublishOptions, type PublishOptions } from './PepNode'
+import type { StanzaClaim } from '../stanzaRouting'
 
 export type { PublishOptions }
 
@@ -45,7 +46,16 @@ const NS_PUBSUB_EVENT = `${NS_PUBSUB}#event`
  *
  * @category Modules
  */
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const PUBSUB_CLAIMS: readonly StanzaClaim[] = [
+    { kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } },
+  ]
+
 export class PubSub extends BaseModule {
+  /** PEP event payloads ride on ordinary messages; Chat claims the rest. */
+  readonly claims = PUBSUB_CLAIMS
+
   /** `(jid \u0000 node)` → set of user-registered callbacks. */
   private readonly subscriptions = new Map<string, Set<(item: PEPItem) => void>>()
 

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -14,6 +14,7 @@ import {
 import type { PresenceShow, Contact } from '../types'
 import { parseXMPPError, formatXMPPError } from '../../utils/xmppError'
 import { logInfo } from '../logger'
+import type { StanzaClaim } from '../stanzaRouting'
 
 /**
  * Roster and presence management module.
@@ -42,10 +43,24 @@ import { logInfo } from '../logger'
  *
  * @category Modules
  */
+/** Stanza shapes this module may handle. Exported so the routing test
+ * checks the real claims rather than a copy of them. */
+export const ROSTER_CLAIMS: readonly StanzaClaim[] = [
+    { kind: 'iq', child: { name: 'query', ns: 'jabber:iq:roster' } },
+    { kind: 'presence' },
+  ]
+
 export class Roster extends BaseModule {
   private capsHash: string | null = null
   /** Track JIDs for which we received 'unsubscribed' but haven't seen the roster push yet */
   private _pendingSubscriptionDenials = new Set<string>()
+
+  /**
+   * All presence that is not MUC's. Deliberately broad: MUC's narrower claims
+   * (muc#user, and error presence for an in-flight join) outrank this one, so
+   * the split no longer depends on which module was listed first.
+   */
+  readonly claims = ROSTER_CLAIMS
 
   handle(stanza: Element): boolean | void {
     if (stanza.is('iq')) {

--- a/packages/fluux-sdk/src/core/stanzaRouting.test.ts
+++ b/packages/fluux-sdk/src/core/stanzaRouting.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Stanza routing: the matcher, the ordering, and the structural guard that no
+ * two modules claim the same shape without saying who goes first.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { xml } from '@xmpp/client'
+import type { Element } from '@xmpp/client'
+import {
+  claimMatches,
+  claimSpecificity,
+  findAmbiguousClaims,
+  routeStanza,
+  selectClaimants,
+  type StanzaClaim,
+  type StanzaClaimant,
+} from './stanzaRouting'
+import { NS_PUBSUB, NS_MUC_USER } from './namespaces'
+import { PUBSUB_CLAIMS } from './modules/PubSub'
+import { BLOCKING_CLAIMS } from './modules/Blocking'
+import { POLL_CLAIMS } from './modules/Poll'
+import { CHAT_CLAIMS } from './modules/Chat'
+import { MUC_CLAIMS } from './modules/MUC'
+import { ROSTER_CLAIMS } from './modules/Roster'
+
+const NS_PUBSUB_EVENT = `${NS_PUBSUB}#event`
+
+function claimant(claims: StanzaClaim[], consumes = true): StanzaClaimant & { seen: Element[] } {
+  const seen: Element[] = []
+  return { claims, seen, handle: (stanza) => { seen.push(stanza); return consumes } }
+}
+
+describe('claimMatches', () => {
+  it('matches on stanza kind', () => {
+    expect(claimMatches({ kind: 'message' }, xml('message'))).toBe(true)
+    expect(claimMatches({ kind: 'message' }, xml('presence'))).toBe(false)
+  })
+
+  it('requires the named child, namespace included', () => {
+    const claim: StanzaClaim = { kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } }
+    expect(claimMatches(claim, xml('message', {}, xml('event', { xmlns: NS_PUBSUB_EVENT })))).toBe(true)
+    expect(claimMatches(claim, xml('message', {}, xml('event', { xmlns: 'urn:other' })))).toBe(false)
+    expect(claimMatches(claim, xml('message'))).toBe(false)
+  })
+
+  it('matches an exact type', () => {
+    const claim: StanzaClaim = { kind: 'presence', type: 'error' }
+    expect(claimMatches(claim, xml('presence', { type: 'error' }))).toBe(true)
+    expect(claimMatches(claim, xml('presence', { type: 'unavailable' }))).toBe(false)
+    expect(claimMatches(claim, xml('presence'))).toBe(false)
+  })
+
+  it('uses null to mean "no type attribute", which is available presence', () => {
+    const claim: StanzaClaim = { kind: 'presence', type: null }
+    expect(claimMatches(claim, xml('presence'))).toBe(true)
+    expect(claimMatches(claim, xml('presence', { from: 'a@b/c' }))).toBe(true)
+    expect(claimMatches(claim, xml('presence', { type: 'unavailable' }))).toBe(false)
+  })
+
+  it('matches any namespace when the child claim omits one', () => {
+    const claim: StanzaClaim = { kind: 'message', child: { name: 'body' } }
+    expect(claimMatches(claim, xml('message', {}, xml('body', { xmlns: 'urn:whatever' })))).toBe(true)
+    expect(claimMatches(claim, xml('message', {}, xml('subject')))).toBe(false)
+  })
+
+  it('treats an empty type attribute as no type', () => {
+    expect(claimMatches({ kind: 'presence', type: null }, xml('presence', { type: '' }))).toBe(true)
+  })
+
+  it('leaves type unconstrained when the claim omits it', () => {
+    const claim: StanzaClaim = { kind: 'presence' }
+    expect(claimMatches(claim, xml('presence'))).toBe(true)
+    expect(claimMatches(claim, xml('presence', { type: 'error' }))).toBe(true)
+  })
+})
+
+describe('claimSpecificity', () => {
+  it('ranks child over type over bare kind', () => {
+    expect(claimSpecificity({ kind: 'presence' })).toBe(0)
+    expect(claimSpecificity({ kind: 'presence', type: 'error' })).toBe(1)
+    expect(claimSpecificity({ kind: 'presence', child: { name: 'x' } })).toBe(2)
+    expect(claimSpecificity({ kind: 'presence', type: 'error', child: { name: 'x' } })).toBe(3)
+  })
+})
+
+describe('selectClaimants', () => {
+  it('offers the most specific claim first', () => {
+    const broad = claimant([{ kind: 'message' }])
+    const narrow = claimant([{ kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } }])
+    const stanza = xml('message', {}, xml('event', { xmlns: NS_PUBSUB_EVENT }))
+    expect(selectClaimants(stanza, [broad, narrow])).toEqual([narrow, broad])
+  })
+
+  it('is independent of the order the claimants are listed in', () => {
+    const broad = claimant([{ kind: 'message' }])
+    const narrow = claimant([{ kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } }])
+    const stanza = xml('message', {}, xml('event', { xmlns: NS_PUBSUB_EVENT }))
+    expect(selectClaimants(stanza, [narrow, broad])).toEqual([narrow, broad])
+    expect(selectClaimants(stanza, [broad, narrow])).toEqual([narrow, broad])
+  })
+
+  it('omits claimants whose claims do not match', () => {
+    const presence = claimant([{ kind: 'presence' }])
+    const message = claimant([{ kind: 'message' }])
+    expect(selectClaimants(xml('presence'), [presence, message])).toEqual([presence])
+  })
+
+  it('ranks a multi-claim module by its strongest matching claim', () => {
+    const multi = claimant([{ kind: 'presence' }, { kind: 'presence', type: 'error' }])
+    const single = claimant([{ kind: 'presence', type: 'error' }])
+    // Equal specificity, so declaration order breaks the tie — but only there.
+    expect(selectClaimants(xml('presence', { type: 'error' }), [single, multi])).toEqual([single, multi])
+  })
+
+  it('breaks an equal-specificity tie with the declared priority', () => {
+    const low = claimant([{ kind: 'iq', type: 'set' }])
+    const high = claimant([{ kind: 'iq', type: 'set', priority: 10 }])
+    expect(selectClaimants(xml('iq', { type: 'set' }), [low, high])).toEqual([high, low])
+  })
+})
+
+describe('routeStanza', () => {
+  it('stops at the first claimant that consumes', () => {
+    const first = claimant([{ kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } }])
+    const second = claimant([{ kind: 'message' }])
+    routeStanza(xml('message', {}, xml('event', { xmlns: NS_PUBSUB_EVENT })), [first, second])
+    expect(first.seen).toHaveLength(1)
+    expect(second.seen).toHaveLength(0)
+  })
+
+  it('continues past a claimant that declines', () => {
+    const declines = claimant([{ kind: 'presence', type: 'error' }], false)
+    const fallback = claimant([{ kind: 'presence' }])
+    routeStanza(xml('presence', { type: 'error' }), [declines, fallback])
+    expect(declines.seen).toHaveLength(1)
+    expect(fallback.seen).toHaveLength(1)
+  })
+
+  it('runs matching observers even when a claimant consumed the stanza', () => {
+    const consumer = claimant([{ kind: 'presence' }])
+    const observe = vi.fn()
+    routeStanza(xml('presence'), [consumer], [{ observes: [{ kind: 'presence', type: null }], observe }])
+    expect(consumer.seen).toHaveLength(1)
+    expect(observe).toHaveBeenCalledTimes(1)
+  })
+
+  it('isolates a throwing observer from the others and from the caller', () => {
+    const later = vi.fn()
+    expect(() => routeStanza(xml('presence'), [], [
+      { observes: [{ kind: 'presence' }], observe: () => { throw new Error('boom') } },
+      { observes: [{ kind: 'presence' }], observe: later },
+    ])).not.toThrow()
+    expect(later).toHaveBeenCalledTimes(1)
+  })
+
+  // Deliberately asymmetric: a claimant that fails while CONSUMING a stanza is
+  // a real error, and swallowing it would hide a broken feature.
+  it('lets a throwing claimant propagate', () => {
+    expect(() => routeStanza(xml('message'), [
+      { claims: [{ kind: 'message' }], handle: () => { throw new Error('boom') } },
+    ])).toThrow('boom')
+  })
+
+  it('runs every matching observer', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    routeStanza(xml('presence'), [], [
+      { observes: [{ kind: 'presence' }], observe: a },
+      { observes: [{ kind: 'presence' }], observe: b },
+    ])
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op when nothing claims or observes the stanza', () => {
+    const other = claimant([{ kind: 'iq' }])
+    expect(() => routeStanza(xml('presence'), [other], [])).not.toThrow()
+    expect(other.seen).toHaveLength(0)
+  })
+
+  it('never offers a stanza to a claimant that declares no claims', () => {
+    const silent = claimant([])
+    routeStanza(xml('message'), [silent])
+    expect(silent.seen).toHaveLength(0)
+  })
+
+  it('ignores stanza kinds nothing can claim', () => {
+    const all = claimant([{ kind: 'message' }, { kind: 'presence' }, { kind: 'iq' }])
+    routeStanza(xml('features'), [all])
+    expect(all.seen).toHaveLength(0)
+  })
+
+  it('does not run an observer whose claim does not match', () => {
+    const observe = vi.fn()
+    routeStanza(xml('presence', { type: 'unavailable' }), [], [
+      { observes: [{ kind: 'presence', type: null }], observe },
+    ])
+    expect(observe).not.toHaveBeenCalled()
+  })
+})
+
+describe('findAmbiguousClaims', () => {
+  it('reports two modules naming the same shape at the same priority', () => {
+    const found = findAmbiguousClaims([
+      { name: 'A', claims: [{ kind: 'iq', type: 'set' }] },
+      { name: 'B', claims: [{ kind: 'iq', type: 'set' }] },
+    ])
+    expect(found).toHaveLength(1)
+    expect(found[0]).toMatchObject({ a: 'A', b: 'B' })
+  })
+
+  it('accepts the same shape once a priority separates them', () => {
+    expect(findAmbiguousClaims([
+      { name: 'A', claims: [{ kind: 'iq', type: 'set' }] },
+      { name: 'B', claims: [{ kind: 'iq', type: 'set', priority: 1 }] },
+    ])).toEqual([])
+  })
+
+  it('reports every conflicting pair across more than two modules', () => {
+    const found = findAmbiguousClaims([
+      { name: 'A', claims: [{ kind: 'iq', type: 'set' }] },
+      { name: 'B', claims: [{ kind: 'iq', type: 'set' }] },
+      { name: 'C', claims: [{ kind: 'iq', type: 'set' }] },
+    ])
+    expect(found.map((f) => `${f.a}/${f.b}`)).toEqual(['A/B', 'A/C', 'B/C'])
+  })
+
+  it('separates claims that differ only by child namespace', () => {
+    expect(findAmbiguousClaims([
+      { name: 'A', claims: [{ kind: 'iq', child: { name: 'query', ns: 'urn:a' } }] },
+      { name: 'B', claims: [{ kind: 'iq', child: { name: 'query', ns: 'urn:b' } }] },
+    ])).toEqual([])
+  })
+
+  it('does not report claims of different specificity, which is the mechanism working', () => {
+    expect(findAmbiguousClaims([
+      { name: 'Chat', claims: [{ kind: 'message' }] },
+      { name: 'PubSub', claims: [{ kind: 'message', child: { name: 'event', ns: NS_PUBSUB_EVENT } }] },
+    ])).toEqual([])
+  })
+})
+
+/**
+ * The guard the hand-ordered array could not provide: the real modules' claims,
+ * checked for an overlap that only declaration order would settle.
+ */
+describe('the routed modules', () => {
+  // The modules' own claim constants, not a copy: a module that changes what
+  // it claims changes this guard with it.
+  const REAL_CLAIMS = [
+    { name: 'PubSub', claims: PUBSUB_CLAIMS },
+    { name: 'Blocking', claims: BLOCKING_CLAIMS },
+    { name: 'Poll', claims: POLL_CLAIMS },
+    { name: 'Chat', claims: CHAT_CLAIMS },
+    { name: 'MUC', claims: MUC_CLAIMS },
+    { name: 'Roster', claims: ROSTER_CLAIMS },
+  ]
+
+  it('leave no overlap that only declaration order would settle', () => {
+    expect(findAmbiguousClaims(REAL_CLAIMS)).toEqual([])
+  })
+
+  it('order MUC ahead of Roster for room presence and for error presence', () => {
+    const order = (stanza: Element) =>
+      selectClaimants(stanza, REAL_CLAIMS.map((m) => ({ ...m, handle: () => false })))
+        .map((m) => (m as { name: string }).name)
+
+    expect(order(xml('presence', {}, xml('x', { xmlns: NS_MUC_USER })))).toEqual(['MUC', 'Roster'])
+    expect(order(xml('presence', { type: 'error' }))).toEqual(['MUC', 'Roster'])
+    // Ordinary contact presence is Roster's alone.
+    expect(order(xml('presence', { from: 'a@b/c' }))).toEqual(['Roster'])
+  })
+
+  it('order PubSub ahead of Chat for event payloads only', () => {
+    const order = (stanza: Element) =>
+      selectClaimants(stanza, REAL_CLAIMS.map((m) => ({ ...m, handle: () => false })))
+        .map((m) => (m as { name: string }).name)
+
+    expect(order(xml('message', {}, xml('event', { xmlns: NS_PUBSUB_EVENT })))).toEqual(['PubSub', 'Chat'])
+    expect(order(xml('message', {}, xml('body', {}, 'hi')))).toEqual(['Chat'])
+  })
+})

--- a/packages/fluux-sdk/src/core/stanzaRouting.ts
+++ b/packages/fluux-sdk/src/core/stanzaRouting.ts
@@ -1,0 +1,185 @@
+/**
+ * Declarative stanza routing.
+ *
+ * Each module states the stanza SHAPES it may handle. The router matches an
+ * incoming stanza against those claims and offers it to the matching modules
+ * most-specific first; the first one whose `handle()` returns true consumes it.
+ *
+ * `handle()` is still the decider, because some claims cannot be expressed
+ * statically — MUC only wants an error presence when it has a join or nick
+ * change in flight for that room. A claim narrows the candidates and fixes the
+ * order; it does not promise to consume.
+ *
+ * The order used to be the position of a module in a hand-written array, with a
+ * comment explaining why MUC had to precede Roster. Specificity now derives it:
+ * a claim naming a child element outranks one naming only a stanza type, which
+ * outranks a bare kind. Two modules claiming the SAME shape is the one case
+ * specificity cannot settle, so it is a declared conflict — see
+ * {@link findAmbiguousClaims}, which the routing test asserts is empty.
+ *
+ * @module Core/StanzaRouting
+ */
+import type { Element } from '@xmpp/client'
+
+/** A stanza shape a module may handle. */
+export interface StanzaClaim {
+  kind: 'message' | 'presence' | 'iq'
+  /** Only stanzas carrying this child element match. */
+  child?: { name: string; ns?: string }
+  /**
+   * Only stanzas with this `type` attribute match. `null` matches a stanza with
+   * no `type` at all, which is how available presence is expressed.
+   */
+  type?: string | null
+  /**
+   * Tie-break for two claims of equal specificity. Higher is offered first.
+   * Needed only for a genuine overlap; {@link findAmbiguousClaims} reports any
+   * overlap left undeclared.
+   */
+  priority?: number
+}
+
+/** A module that participates in routing. */
+export interface StanzaClaimant {
+  readonly claims: readonly StanzaClaim[]
+  /** Return true to consume the stanza and stop the walk. */
+  handle(stanza: Element): boolean | void
+}
+
+/**
+ * A module that sees stanzas but never consumes them.
+ *
+ * Kept separate from claimants because an observer must not depend on whether
+ * some other module happened to claim first. An observer that sits at the end
+ * of a consume-chain silently stops running the moment anything ahead of it
+ * widens its claim.
+ */
+export interface StanzaObserver {
+  readonly observes: readonly StanzaClaim[]
+  observe(stanza: Element): void
+}
+
+/** Does this stanza have the shape the claim describes? */
+export function claimMatches(claim: StanzaClaim, stanza: Element): boolean {
+  if (!stanza.is(claim.kind)) return false
+  if (claim.type !== undefined) {
+    const type = stanza.attrs.type
+    if (claim.type === null ? type !== undefined && type !== '' : type !== claim.type) return false
+  }
+  if (claim.child && !stanza.getChild(claim.child.name, claim.child.ns)) return false
+  return true
+}
+
+/**
+ * How narrowly a claim describes a stanza. Higher wins, so a module asking for
+ * one child element is offered the stanza before one asking for a whole kind.
+ */
+export function claimSpecificity(claim: StanzaClaim): number {
+  return (claim.child ? 2 : 0) + (claim.type !== undefined ? 1 : 0)
+}
+
+interface Candidate<T> {
+  claimant: T
+  specificity: number
+  priority: number
+}
+
+/**
+ * The claimants that want this stanza, most specific first. Stable within a
+ * (specificity, priority) tier, so declaration order remains the last resort
+ * rather than the primary mechanism.
+ */
+export function selectClaimants<T extends StanzaClaimant>(stanza: Element, claimants: readonly T[]): T[] {
+  const candidates: Candidate<T>[] = []
+  for (const claimant of claimants) {
+    let best: Candidate<T> | null = null
+    for (const claim of claimant.claims) {
+      if (!claimMatches(claim, stanza)) continue
+      const specificity = claimSpecificity(claim)
+      const priority = claim.priority ?? 0
+      // A module may hold several claims; it is offered the stanza once, at its
+      // strongest matching claim.
+      if (!best || specificity > best.specificity || (specificity === best.specificity && priority > best.priority)) {
+        best = { claimant, specificity, priority }
+      }
+    }
+    if (best) candidates.push(best)
+  }
+  return candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((a, b) =>
+      b.candidate.specificity - a.candidate.specificity ||
+      b.candidate.priority - a.candidate.priority ||
+      a.index - b.index)
+    .map(({ candidate }) => candidate.claimant)
+}
+
+/**
+ * Offer the stanza to every matching claimant until one consumes it, then run
+ * every matching observer regardless of the outcome.
+ *
+ * Observers are firewalled from each other and from the stanza loop: they run
+ * for every matching stanza, so a throw in one would otherwise stop the others
+ * and escape into the transport's stanza handler. Claimants are deliberately
+ * NOT firewalled — a module that fails while consuming a stanza is a real
+ * error, and swallowing it would hide a broken feature behind a silent drop.
+ */
+export function routeStanza(
+  stanza: Element,
+  claimants: readonly StanzaClaimant[],
+  observers: readonly StanzaObserver[] = [],
+): void {
+  for (const claimant of selectClaimants(stanza, claimants)) {
+    if (claimant.handle(stanza)) break
+  }
+  for (const observer of observers) {
+    if (!observer.observes.some((claim) => claimMatches(claim, stanza))) continue
+    try {
+      observer.observe(stanza)
+    } catch {
+      // See above: an observer never affects routing, failure included.
+    }
+  }
+}
+
+/** A pair of claims that describe the same shape without saying who goes first. */
+export interface AmbiguousClaim {
+  a: string
+  b: string
+  claim: StanzaClaim
+}
+
+/**
+ * Overlaps that specificity cannot settle: two claimants naming the same shape
+ * at the same specificity and the same priority. Whichever is declared first
+ * would win, which is exactly the implicit ordering this module exists to
+ * remove, so the routing test requires this to be empty.
+ *
+ * Claims of DIFFERENT specificity are not reported: that is the mechanism
+ * working, and it is what lets Chat claim every message while PubSub takes the
+ * ones carrying an event payload.
+ */
+export function findAmbiguousClaims(
+  claimants: readonly { name: string; claims: readonly StanzaClaim[] }[],
+): AmbiguousClaim[] {
+  const found: AmbiguousClaim[] = []
+  for (let i = 0; i < claimants.length; i++) {
+    for (let j = i + 1; j < claimants.length; j++) {
+      for (const a of claimants[i].claims) {
+        for (const b of claimants[j].claims) {
+          if (!sameShape(a, b)) continue
+          if ((a.priority ?? 0) !== (b.priority ?? 0)) continue
+          found.push({ a: claimants[i].name, b: claimants[j].name, claim: a })
+        }
+      }
+    }
+  }
+  return found
+}
+
+function sameShape(a: StanzaClaim, b: StanzaClaim): boolean {
+  return a.kind === b.kind
+    && a.type === b.type
+    && a.child?.name === b.child?.name
+    && a.child?.ns === b.child?.ns
+}


### PR DESCRIPTION
Two commits, separable: a routing refactor, and a behaviour fix it uncovered.

## `15e3a5d3` — routing order from declared claims

Modules stated no routing intent. The order came from their position in a hand-written array in
`XMPPClient`, with a twelve-line comment explaining why MUC had to precede Roster. Each module now
declares the stanza shapes it may handle:

```ts
readonly claims = MUC_CLAIMS  // presence carrying muc#user, plus error presence
```

and the router derives the order from how narrowly a claim is written: a child element outranks a
type, which outranks a bare kind. A test asserts the resulting order is identical whichever way the
modules are listed.

`handle()` still decides. Some claims cannot be static — MUC only wants an error presence when it
has a join or nick change in flight for that room — so a claim narrows the candidates and fixes the
order without promising to consume. MUC's error claim is deliberately wider than what it takes, and
Roster picks up what it declines.

`findAmbiguousClaims` reports the one case specificity cannot settle: two modules naming the same
shape at the same priority, where declaration order would decide. The test asserts the real modules
produce none, importing their claim constants rather than a copy that could drift.

Routing is opt-in now: `BaseModule.handle` is no longer abstract, and the no-op handlers in
Discovery and Profile are gone.

## `88f574c5` — behaviour change, reviewable on its own

`LastActivity` invalidated a contact's cached last-seen when they came back online, and that
invalidation has been unreachable. Roster claims essentially all presence and consumed it first;
`LastActivity` sat after Roster in the array. A contact returning online kept a stale "last seen X
ago" for the rest of the session.

It never consumed a stanza, so it is an observer rather than a claimant, and the router runs
observers regardless of who claimed. That is the distinction the ordered array could not express,
and why the bug was invisible: a module ahead of it widened its claim and switched it off silently.

Observers are firewalled from each other and from the stanza loop, since they now run on every
available presence. Claimants stay unprotected deliberately — a module failing while consuming a
stanza it claimed is a real error, and that matches the previous behaviour.

The regression test routes a real presence through the real Roster and asserts both that Roster
claims it and that the cache is invalidated anyway. The test that existed called the method
directly, so it passed against the broken code.

Revert this commit alone to keep the refactor without the behaviour change.
