### PR TITLE
refactor(sdk): give the two stores one definition of four map edits

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -69,6 +69,7 @@ import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, n
 // Sliding-window bound (messages kept resident per conversation; rest live in IndexedDB + MAM).
 // Read via getResidentWindowSize() so a DEV/DEMO/TEST caller can shrink it — see shared/residentWindow.ts.
 import { getResidentWindowSize } from './shared/residentWindow'
+import { clearMarker, lastMessageTimestamp, clearCoverageEntry, clearGapAnchor } from './shared/keyedMapEdits'
 
 const STORAGE_KEY_BASE = 'xmpp-chat-storage'
 
@@ -1956,10 +1957,8 @@ export const chatStore = createStore<ChatState>()(
 
       clearFirstNewMessageId: (conversationId) => {
         set((state) => {
-          if (!state.firstNewMessageMarkers.has(conversationId)) return state
-          const newMarkers = new Map(state.firstNewMessageMarkers)
-          newMarkers.delete(conversationId)
-          return { firstNewMessageMarkers: newMarkers }
+          const next = clearMarker(state.firstNewMessageMarkers, conversationId)
+          return next ? { firstNewMessageMarkers: next } : state
         })
       },
 
@@ -2461,12 +2460,7 @@ export const chatStore = createStore<ChatState>()(
 
       getConversationLastTimestamp: (conversationId) => {
         const state = get()
-        // Prefer conversationMeta (frequently-updated); fall back to the combined
-        // conversations map for backward compat with persist/tests.
-        const lastMessage =
-          state.conversationMeta.get(conversationId)?.lastMessage ??
-          state.conversations.get(conversationId)?.lastMessage
-        return lastMessage?.timestamp?.getTime()
+        return lastMessageTimestamp(state.conversationMeta, state.conversations, conversationId)
       },
 
       removeMessage: (conversationId, messageId) => {
@@ -3110,12 +3104,8 @@ export const chatStore = createStore<ChatState>()(
 
       clearConversationGapAnchor: (conversationId, purgedStartId) => {
         set((state) => {
-          const gap = state.conversationGaps.get(conversationId)
-          if (!gap || gap.startId !== purgedStartId) return state
-          const newGaps = new Map(state.conversationGaps)
-          const { startId: _purged, ...withoutAnchor } = gap
-          newGaps.set(conversationId, withoutAnchor)
-          return { conversationGaps: newGaps }
+          const next = clearGapAnchor(state.conversationGaps, conversationId, purgedStartId)
+          return next ? { conversationGaps: next } : state
         })
       },
 
@@ -3123,12 +3113,8 @@ export const chatStore = createStore<ChatState>()(
 
       clearConversationCoverage: (conversationId, ifBottomId) => {
         set((state) => {
-          const existing = state.conversationCoverage.get(conversationId)
-          if (!existing) return state
-          if (ifBottomId !== undefined && existing.bottomId !== ifBottomId) return state
-          const next = new Map(state.conversationCoverage)
-          next.delete(conversationId)
-          return { conversationCoverage: next }
+          const next = clearCoverageEntry(state.conversationCoverage, conversationId, ifBottomId)
+          return next ? { conversationCoverage: next } : state
         })
       },
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -83,6 +83,7 @@ import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, n
 // Sliding-window bound (messages kept resident per room; rest live in IndexedDB + MAM). Read via
 // getResidentWindowSize() so a DEV/DEMO/TEST caller can shrink it — see shared/residentWindow.ts.
 import { getResidentWindowSize } from './shared/residentWindow'
+import { clearMarker, lastMessageTimestamp, clearCoverageEntry, clearGapAnchor } from './shared/keyedMapEdits'
 
 /**
  * Carry a previously-resolved avatar across a presence update.
@@ -2564,12 +2565,7 @@ export const roomStore = createStore<RoomState>()(
 
   getRoomLastTimestamp: (roomJid) => {
     const state = get()
-    // Prefer roomMeta (frequently-updated); fall back to the combined rooms map
-    // for backward compat with persist/tests.
-    const lastMessage =
-      state.roomMeta.get(roomJid)?.lastMessage ??
-      state.rooms.get(roomJid)?.lastMessage
-    return lastMessage?.timestamp?.getTime()
+    return lastMessageTimestamp(state.roomMeta, state.rooms, roomJid)
   },
 
   markAsRead: (roomJid) => {
@@ -2918,10 +2914,8 @@ export const roomStore = createStore<RoomState>()(
 
   clearFirstNewMessageId: (roomJid) => {
     set((state) => {
-      if (!state.firstNewMessageMarkers.has(roomJid)) return state
-      const newMarkers = new Map(state.firstNewMessageMarkers)
-      newMarkers.delete(roomJid)
-      return { firstNewMessageMarkers: newMarkers }
+      const next = clearMarker(state.firstNewMessageMarkers, roomJid)
+      return next ? { firstNewMessageMarkers: next } : state
     })
   },
 
@@ -4107,13 +4101,10 @@ export const roomStore = createStore<RoomState>()(
 
   clearRoomGapAnchor: (roomJid, purgedStartId) => {
     set((state) => {
-      const gap = state.roomGaps.get(roomJid)
-      if (!gap || gap.startId !== purgedStartId) return state
-      const newGaps = new Map(state.roomGaps)
-      const { startId: _purged, ...withoutAnchor } = gap
-      newGaps.set(roomJid, withoutAnchor)
-      saveGapsToStorage(newGaps)
-      return { roomGaps: newGaps }
+      const next = clearGapAnchor(state.roomGaps, roomJid, purgedStartId)
+      if (!next) return state
+      saveGapsToStorage(next)
+      return { roomGaps: next }
     })
   },
 
@@ -4121,11 +4112,9 @@ export const roomStore = createStore<RoomState>()(
 
   clearRoomCoverage: (roomJid, ifBottomId) => {
     set((state) => {
-      const existing = state.roomCoverage.get(roomJid)
-      if (!existing) return state
-      if (ifBottomId !== undefined && existing.bottomId !== ifBottomId) return state
-      const next = new Map(state.roomCoverage)
-      next.delete(roomJid)
+      const next = clearCoverageEntry(state.roomCoverage, roomJid, ifBottomId)
+      if (!next) return state
+      // roomStore has no persist middleware: it writes this map itself.
       saveCoverageToStorage(next)
       return { roomCoverage: next }
     })

--- a/packages/fluux-sdk/src/stores/shared/keyedMapEdits.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/keyedMapEdits.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clearMarker,
+  lastMessageTimestamp,
+  clearCoverageEntry,
+  clearGapAnchor,
+} from './keyedMapEdits'
+import type { CoverageRecord } from '../../core/types'
+import type { GapInterval } from './mamGap'
+
+/**
+ * The `null` return is the contract these share: it is what lets a Zustand
+ * `set` hand back the same state object and skip the re-render, so a no-op that
+ * returned a fresh map would be a render-loop defect, not a style question.
+ */
+describe('clearMarker', () => {
+  it('returns null when the entity has no marker, leaving the map identical', () => {
+    const markers = new Map([['a@x', 'm1']])
+    expect(clearMarker(markers, 'b@x')).toBeNull()
+  })
+
+  it('removes only the named entity, in a fresh map', () => {
+    const markers = new Map([['a@x', 'm1'], ['b@x', 'm2']])
+    const next = clearMarker(markers, 'a@x')!
+    expect(next).not.toBe(markers)
+    expect([...next.keys()]).toEqual(['b@x'])
+    expect(markers.has('a@x')).toBe(true)
+  })
+})
+
+describe('lastMessageTimestamp', () => {
+  const at = (ms: number) => ({ lastMessage: { timestamp: new Date(ms) } })
+
+  it('prefers metadata, which is the map kept current', () => {
+    expect(lastMessageTimestamp(new Map([['a', at(200)]]), new Map([['a', at(100)]]), 'a')).toBe(200)
+  })
+
+  it('falls back to the compat map, which persisted state can populate alone', () => {
+    expect(lastMessageTimestamp(new Map(), new Map([['a', at(100)]]), 'a')).toBe(100)
+  })
+
+  it('is undefined for an unknown entity, and for one with no last message', () => {
+    expect(lastMessageTimestamp(new Map(), new Map(), 'a')).toBeUndefined()
+    expect(lastMessageTimestamp(new Map([['a', {}]]), new Map(), 'a')).toBeUndefined()
+  })
+})
+
+describe('clearCoverageEntry', () => {
+  const coverage = (): Map<string, CoverageRecord> => new Map([['a', { bottomId: 'b1' }]])
+
+  it('returns null when there is no record', () => {
+    expect(clearCoverageEntry(new Map(), 'a', 'b1')).toBeNull()
+  })
+
+  it('deletes unconditionally when no guard is given', () => {
+    expect(clearCoverageEntry(coverage(), 'a')!.has('a')).toBe(false)
+  })
+
+  it('deletes when the guard matches the record it was observed on', () => {
+    expect(clearCoverageEntry(coverage(), 'a', 'b1')!.has('a')).toBe(false)
+  })
+
+  it('leaves a record another path has since replaced', () => {
+    expect(clearCoverageEntry(coverage(), 'a', 'stale')).toBeNull()
+  })
+})
+
+describe('clearGapAnchor', () => {
+  const gaps = (): Map<string, GapInterval> =>
+    new Map([['a', { start: 10, startId: 'g1', endId: 'g9' } as GapInterval]])
+
+  it('returns null when there is no gap for the entity', () => {
+    expect(clearGapAnchor(new Map(), 'a', 'g1')).toBeNull()
+  })
+
+  it('returns null when the anchor has moved since it was observed', () => {
+    expect(clearGapAnchor(gaps(), 'a', 'stale')).toBeNull()
+  })
+
+  it('drops the anchor and KEEPS the gap — the hole is still real', () => {
+    const next = clearGapAnchor(gaps(), 'a', 'g1')!
+    const gap = next.get('a')!
+    expect(gap).toBeDefined()
+    expect('startId' in gap).toBe(false)
+    expect(gap.start).toBe(10)
+    expect(gap.endId).toBe('g9')
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/keyedMapEdits.ts
+++ b/packages/fluux-sdk/src/stores/shared/keyedMapEdits.ts
@@ -1,0 +1,101 @@
+/**
+ * Copy-on-write edits to the per-entity maps both stores keep.
+ *
+ * `chatStore` and `roomStore` hold the same four maps under different names —
+ * new-message markers, archive coverage, forward-gap intervals, and the
+ * entity/metadata pair a preview timestamp is read from. The edits here were
+ * written twice, once per store, and had already drifted in shape if not yet in
+ * behaviour.
+ *
+ * Every function returns `null` when nothing changed, and a fresh map
+ * otherwise. That is what keeps them usable from both stores despite their
+ * different persistence: a Zustand `set` returning the same reference skips the
+ * re-render, and the caller — not this module — decides whether a change also
+ * has to reach disk. `roomStore` persists these maps by hand; `chatStore` rides
+ * its `persist` middleware.
+ *
+ * These are deliberately the edits that touch ONE map. The methods that patch
+ * an entity across several maps are not here: the two stores project their
+ * entities differently (`Conversation` is entity + metadata, `Room` is entity +
+ * metadata + runtime), so a shared writer for those would have to encode both
+ * models before it encoded any behaviour.
+ *
+ * @packageDocumentation
+ * @module Stores/Shared
+ */
+
+import type { CoverageRecord } from '../../core/types'
+import type { GapInterval } from './mamGap'
+
+/**
+ * Drop one entity's new-message marker.
+ *
+ * @returns the new map, or `null` when the entity had no marker.
+ */
+export function clearMarker<T>(markers: Map<string, T>, key: string): Map<string, T> | null {
+  if (!markers.has(key)) return null
+  const next = new Map(markers)
+  next.delete(key)
+  return next
+}
+
+/**
+ * The timestamp of an entity's last message, in epoch ms.
+ *
+ * Reads the metadata map first — it is the one kept current — and falls back to
+ * the combined compat map, which persisted state and older tests still populate
+ * on its own.
+ */
+export function lastMessageTimestamp(
+  meta: Map<string, { lastMessage?: { timestamp?: Date } } | undefined>,
+  compat: Map<string, { lastMessage?: { timestamp?: Date } } | undefined>,
+  key: string
+): number | undefined {
+  const lastMessage = meta.get(key)?.lastMessage ?? compat.get(key)?.lastMessage
+  return lastMessage?.timestamp?.getTime()
+}
+
+/**
+ * Drop an entity's contiguous-with-live coverage record.
+ *
+ * `ifBottomId` makes the removal conditional: a caller that observed a purged
+ * anchor passes the id it saw, so a record another path has since replaced is
+ * left alone rather than deleted on stale evidence.
+ *
+ * @returns the new map, or `null` when there was no record or the guard failed.
+ */
+export function clearCoverageEntry(
+  coverage: Map<string, CoverageRecord>,
+  key: string,
+  ifBottomId?: string
+): Map<string, CoverageRecord> | null {
+  const existing = coverage.get(key)
+  if (!existing) return null
+  if (ifBottomId !== undefined && existing.bottomId !== ifBottomId) return null
+  const next = new Map(coverage)
+  next.delete(key)
+  return next
+}
+
+/**
+ * Drop a forward gap's resume anchor while keeping the gap itself.
+ *
+ * The anchor is an archive id the server has since purged (`item-not-found`);
+ * the hole it marks is still real, so the interval stays and only the cursor
+ * goes. Guarded on `purgedStartId` for the same reason as coverage: another
+ * path may have re-anchored the gap in the meantime.
+ *
+ * @returns the new map, or `null` when there is no such gap or the anchor moved.
+ */
+export function clearGapAnchor(
+  gaps: Map<string, GapInterval>,
+  key: string,
+  purgedStartId: string
+): Map<string, GapInterval> | null {
+  const gap = gaps.get(key)
+  if (!gap || gap.startId !== purgedStartId) return null
+  const next = new Map(gaps)
+  const { startId: _purged, ...withoutAnchor } = gap
+  next.set(key, withoutAnchor)
+  return next
+}


### PR DESCRIPTION
First slice of the chat/room duality, chosen after measuring rather than from the naive reading.

## What the measurement said first

Of **32 twin implementations** across `chatStore` and `roomStore`, only **11 are ≥55% line-identical**. `markAsRead` is at 53%, `advanceReadPointer` 43%, `setTyping` 41% — merging those would be a behaviour change, not a refactor. The "42 identically-named members" reading is true of the *names*, not the *bodies*.

## What this PR extracts

Four edits that were written twice and touch **one map** each:

| | |
|---|---|
| `clearFirstNewMessageId` | 100% identical |
| `get{Conversation,Room}LastTimestamp` | 100% identical |
| `clear{Conversation,Room}Coverage` | 91% — room also persists |
| `clear{Conversation,Room}GapAnchor` | 91% — room also persists |

They become pure functions in `shared/keyedMapEdits.ts` returning **`null` when nothing changed**. That return is the contract that lets both stores use them despite different persistence: a `set` handing back the same state skips the re-render, and the *caller* decides whether a change also reaches disk — `roomStore` writes these maps by hand, `chatStore` rides its `persist` middleware.

## What is deliberately not extracted

**`recordPendingRetraction`** looks like a fifth (56%) but is not. Rooms carry an `actorOccupantId` and decide authorship through `roomRetractionAuthor` (XEP-0421); chats compare `target.from`. The shared part is already `addPendingRetraction`. Forcing it would mean an authorship predicate parameter and two persistence callbacks for ~8 lines.

**The six methods that carry the real value** — `recomputeUnread` (92 l), `applyRemoteDisplayed` (51 l), `activate` (43 l), `resyncDivider`, `switchAccount`, `loadMessagesAroundFromCache` — patch an entity across several maps, and are blocked on a model decision rather than on effort:

```ts
Conversation extends ConversationEntity, ConversationMetadata          // 2 sources
Room         extends RoomEntity, RoomMetadata, RoomRuntime             // 3 sources
```

`shared/conversationMaps.ts` rests on the invariant that the compat entry is a *total* reconstruction of entity + metadata, which is why it is only ever derived, never patched. That invariant is **false for rooms**: `RoomRuntime` holds live Maps (occupants, nick caches, messages). Generalising the module as-is would break the projection.

The two stores in fact solved that same hazard independently and differently — `chatStore` with `draftConversationMaps` (structural: 21 writes through the draft, 0 hand-rolled), `roomStore` with exhaustive `ROOM_*_FIELDS` lists checked by `satisfies Record<keyof X, true>`. Neither is a copy of the other.

## Verification

Full suite (SDK 227 files / 5927 tests, app 451 / 5979), typecheck, lint, comment provenance, and `npm run test:scroll` 96/96 — the coverage and gap edits are on the pagination path.

12 focused tests on the extracted functions, including the `null`-means-unchanged contract and the rule that dropping a purged anchor **keeps** the gap, since the hole is still real.