### PR TITLE
refactor(scroll): make the last two ambient re-pin decisions testable

### DIFF
--- a/apps/fluux/src/components/conversation/mdsSettleDecision.test.ts
+++ b/apps/fluux/src/components/conversation/mdsSettleDecision.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { decideMdsSettle, type MdsSettleFacts } from './mdsSettleDecision'
+
+/** A divider that has just been cleared by a late read-sync, with nothing else in the way. */
+const settling: MdsSettleFacts = {
+  staticMode: false,
+  sameConversation: true,
+  previousDivider: 'msg-42',
+  currentDivider: undefined,
+  hasGenuineInput: false,
+}
+
+describe('decideMdsSettle', () => {
+  it('settles when the divider was cleared under a reader who has not moved', () => {
+    expect(decideMdsSettle(settling)).toBe('settle')
+  })
+
+  it('skips in static mode, which has no positioning owner', () => {
+    expect(decideMdsSettle({ ...settling, staticMode: true })).toBe('skip')
+  })
+
+  // The divider that vanished belonged to the conversation being left. Settling the newly-entered
+  // one to its bottom would override the entry position it just chose.
+  it('skips across a conversation switch', () => {
+    expect(decideMdsSettle({ ...settling, sameConversation: false })).toBe('skip')
+  })
+
+  it('skips when there was no divider to clear', () => {
+    expect(decideMdsSettle({ ...settling, previousDivider: undefined })).toBe('skip')
+  })
+
+  it('skips while a divider is still showing', () => {
+    expect(decideMdsSettle({ ...settling, currentDivider: 'msg-42' })).toBe('skip')
+  })
+
+  it('skips when the divider merely moved rather than cleared', () => {
+    expect(decideMdsSettle({ ...settling, currentDivider: 'msg-99' })).toBe('skip')
+  })
+
+  // A marker arriving from another device must not pull the reader off a position they chose.
+  it('skips when the reader has moved the list themselves', () => {
+    expect(decideMdsSettle({ ...settling, hasGenuineInput: true })).toBe('skip')
+  })
+
+  it('needs every condition at once', () => {
+    const broken: Partial<MdsSettleFacts>[] = [
+      { staticMode: true },
+      { sameConversation: false },
+      { previousDivider: undefined },
+      { currentDivider: 'msg-7' },
+      { hasGenuineInput: true },
+    ]
+    for (const override of broken) {
+      expect(decideMdsSettle({ ...settling, ...override })).toBe('skip')
+    }
+  })
+})

--- a/apps/fluux/src/components/conversation/mdsSettleDecision.ts
+++ b/apps/fluux/src/components/conversation/mdsSettleDecision.ts
@@ -1,0 +1,50 @@
+/**
+ * What to do when the unread divider disappears while the conversation is open.
+ *
+ * XEP-0490 read positions arrive from other devices after the conversation has already been
+ * rendered. When one lands past the divider, the store clears it: the boundary the reader was
+ * looking at no longer exists, and the list is left holding a position that was chosen to show it.
+ * Settling to the live edge is the only position that still means anything.
+ *
+ * This is ambient — the reader did not ask for it — so it must not run when they have moved the
+ * list themselves, and it must not fire on a conversation switch, where the previous conversation's
+ * divider says nothing about this one.
+ */
+export type MdsSettleDecision = 'settle' | 'skip'
+
+export interface MdsSettleFacts {
+  /** The list is rendered without a positioning owner (previews, selection surfaces). */
+  staticMode: boolean
+  /** The previous render was the SAME conversation, so its divider is comparable. */
+  sameConversation: boolean
+  /** Divider at the previous render. */
+  previousDivider: string | undefined
+  /** Divider now. */
+  currentDivider: string | undefined
+  /**
+   * The reader has scrolled, wheeled or keyed this conversation themselves.
+   *
+   * Genuine input, not any scroll event: the list's own corrections produce scroll events too, and
+   * treating those as the reader would make an ambient settle cancel itself.
+   */
+  hasGenuineInput: boolean
+}
+
+export function decideMdsSettle(facts: MdsSettleFacts): MdsSettleDecision {
+  if (facts.staticMode) return 'skip'
+
+  // A conversation switch rebaselines. The divider that vanished belonged to the conversation being
+  // left, and settling the newly-entered one to its bottom would override its own entry position.
+  if (!facts.sameConversation) return 'skip'
+
+  // The edge is present -> absent. No divider before means nothing was cleared; a divider still
+  // present means the read-sync has not superseded it, and the position showing it is still right.
+  if (facts.previousDivider === undefined) return 'skip'
+  if (facts.currentDivider !== undefined) return 'skip'
+
+  // The reader has taken the list somewhere. A late marker from another device is not a reason to
+  // pull them away from it.
+  if (facts.hasGenuineInput) return 'skip'
+
+  return 'settle'
+}

--- a/apps/fluux/src/components/conversation/typingIndicatorDecision.test.ts
+++ b/apps/fluux/src/components/conversation/typingIndicatorDecision.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { decideTypingIndicator, type TypingIndicatorFacts } from './typingIndicatorDecision'
+
+/** The indicator has just appeared under a reader glued to the bottom. */
+const appearing: TypingIndicatorFacts = {
+  staticMode: false,
+  sameConversation: true,
+  hasTypingIndicator: true,
+  hadTypingIndicator: false,
+  distanceFromBottom: 0,
+  atBottomThreshold: 100,
+}
+
+describe('decideTypingIndicator', () => {
+  it('pins when the band appears under a reader at the bottom', () => {
+    expect(decideTypingIndicator(appearing)).toBe('pin')
+  })
+
+  it('skips in static mode, which has no positioning owner', () => {
+    expect(decideTypingIndicator({ ...appearing, staticMode: true })).toBe('skip')
+  })
+
+  it('skips across a conversation switch', () => {
+    expect(decideTypingIndicator({ ...appearing, sameConversation: false })).toBe('skip')
+  })
+
+  // Only the off -> on edge shrinks the scrollport. Typing stopping grows it back and the browser
+  // clamps scrollTop itself, so there is nothing to correct.
+  it('skips when the indicator was already showing', () => {
+    expect(decideTypingIndicator({ ...appearing, hadTypingIndicator: true })).toBe('skip')
+  })
+
+  it('skips when the indicator turned off', () => {
+    expect(decideTypingIndicator({
+      ...appearing, hasTypingIndicator: false, hadTypingIndicator: true,
+    })).toBe('skip')
+  })
+
+  it('skips when the reader is scrolled away from the bottom', () => {
+    expect(decideTypingIndicator({ ...appearing, distanceFromBottom: 500 })).toBe('skip')
+  })
+
+  it('treats the threshold as exclusive, matching row growth', () => {
+    expect(decideTypingIndicator({ ...appearing, distanceFromBottom: 99 })).toBe('pin')
+    expect(decideTypingIndicator({ ...appearing, distanceFromBottom: 100 })).toBe('skip')
+  })
+
+  // The call site reports an absent scroller as infinitely far from the bottom.
+  it('skips when there is no geometry to judge', () => {
+    expect(decideTypingIndicator({
+      ...appearing, distanceFromBottom: Number.POSITIVE_INFINITY,
+    })).toBe('skip')
+  })
+})

--- a/apps/fluux/src/components/conversation/typingIndicatorDecision.ts
+++ b/apps/fluux/src/components/conversation/typingIndicatorDecision.ts
@@ -1,0 +1,49 @@
+/**
+ * What to do when the typing indicator appears.
+ *
+ * The indicator is a band BELOW the scrollport, so showing it shrinks the scroller by the band's
+ * height and leaves a reader who was glued to the bottom that many pixels short of it. The
+ * scroller's own ResizeObserver catches this too, but a frame later; deciding here, in the commit
+ * that mounts the band, avoids that frame of visible drift.
+ *
+ * The twin of {@link decideRowGrowth}: both are ambient re-pins triggered by content changing size
+ * under a reader who did not ask for it.
+ */
+export type TypingIndicatorDecision = 'pin' | 'skip'
+
+export interface TypingIndicatorFacts {
+  /** The list is rendered without a positioning owner (previews, selection surfaces). */
+  staticMode: boolean
+  /** The previous render was the SAME conversation, so its indicator state is comparable. */
+  sameConversation: boolean
+  /** The indicator is showing now. */
+  hasTypingIndicator: boolean
+  /** The indicator was showing at the previous render. */
+  hadTypingIndicator: boolean
+  /**
+   * Live distance from the bottom, measured now.
+   *
+   * Deliberately live geometry rather than a latched at-bottom flag: the flag can outlive the
+   * reader leaving the bottom, and re-pinning someone who has scrolled up is the harmful direction.
+   */
+  distanceFromBottom: number
+  /** Distance within which the list counts as "following the bottom". */
+  atBottomThreshold: number
+}
+
+export function decideTypingIndicator(facts: TypingIndicatorFacts): TypingIndicatorDecision {
+  if (facts.staticMode) return 'skip'
+
+  // A conversation switch rebaselines: the indicator state carried over from the conversation being
+  // left is not evidence about this one.
+  if (!facts.sameConversation) return 'skip'
+
+  // Only the off -> on edge shrinks the scrollport. Typing STOPPING grows it back, and the browser
+  // clamps scrollTop for that on its own — the same reason a measured shrink skips in row growth.
+  if (!facts.hasTypingIndicator) return 'skip'
+  if (facts.hadTypingIndicator) return 'skip'
+
+  if (facts.distanceFromBottom >= facts.atBottomThreshold) return 'skip'
+
+  return 'pin'
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -40,6 +40,8 @@ import {
 import { findBottomAnchor } from './bottomAnchor'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
+import { decideMdsSettle } from './mdsSettleDecision'
+import { decideTypingIndicator } from './typingIndicatorDecision'
 import { signalAnomaly } from '@/utils/anomalySignal'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
@@ -1406,12 +1408,14 @@ export function useMessageListScroll({
   useLayoutEffect(() => {
     const prev = prevSettleRef.current
     prevSettleRef.current = { conv: conversationId, divider: firstNewMessageId }
-    if (staticMode) return
-    if (prev.conv !== conversationId) return
-    if (prev.divider === undefined || firstNewMessageId !== undefined) return
-    if (viewportSessionRef.current?.hasGenuineInput(conversationId)) {
-      return
-    }
+    const decision = decideMdsSettle({
+      staticMode,
+      sameConversation: prev.conv === conversationId,
+      previousDivider: prev.divider,
+      currentDivider: firstNewMessageId,
+      hasGenuineInput: viewportSessionRef.current?.hasGenuineInput(conversationId) ?? false,
+    })
+    if (decision === 'skip') return
     debugLog('MDS SETTLE: divider cleared by late read-sync → settle to bottom', {
       conversationId,
       prevMarker: prev.divider,
@@ -1944,13 +1948,19 @@ export function useMessageListScroll({
     typingConvRef.current = conversationId
     const prevHasTyping = prevHasTypingRef.current
     prevHasTypingRef.current = hasTypingIndicator
-    if (!sameConversation) return // conversation switch → rebaseline, never nudge
-    if (!hasTypingIndicator || prevHasTyping) return // only the off→on edge shrinks the scrollport
 
     const scroller = scrollerRef.current
-    if (!scroller || staticMode) return
-    // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
-    if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
+    const decision = decideTypingIndicator({
+      staticMode,
+      sameConversation,
+      hasTypingIndicator,
+      hadTypingIndicator: prevHasTyping,
+      // No scroller is no geometry: report a distance nothing can be at the bottom of, so the
+      // decision skips for the same reason a scrolled-up reader does.
+      distanceFromBottom: scroller ? getDistanceFromBottom(scroller) : Number.POSITIVE_INFINITY,
+      atBottomThreshold: AT_BOTTOM_THRESHOLD,
+    })
+    if (decision === 'skip') return
 
     reconcileLiveEdge('typing')
   }, [hasTypingIndicator, conversationId, reconcileLiveEdge, staticMode])

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,9 +1,10 @@
 # Message-list scroll positioning contract
 
-Status: core migration, ownership hardening, and dead-owner cleanup complete. Saved-position
-restoration, unread-marker positioning, explicit message targets, live-edge pinning, fixed-anchor
-layout preservation, directional history preservation, and resident-top navigation are
-authoritative controller slices.
+Status: migration complete. Saved-position restoration, unread-marker positioning, explicit message
+targets, live-edge pinning, fixed-anchor layout preservation, directional history preservation, and
+resident-top navigation are authoritative controller slices, and the orchestration hook holds no
+positioning frame loop of its own. Every branch decision that a test could not otherwise reach is a
+pure function with paired controls.
 
 ## Purpose
 
@@ -504,7 +505,8 @@ kinetic scrolling and stale-paint behavior.
 
 ## Incremental migration after this contract
 
-1. Introduce one generation-aware reconciliation controller without changing existing positioning.
+1. [x] Introduce one generation-aware reconciliation controller without changing existing
+   positioning.
 2. [x] Migrate saved-anchor restoration: delete the legacy restore dispatcher, pending ref, and
    around-load status map; retain the measurement loop only as a generation/operation-leased
    reconciler.
@@ -561,6 +563,10 @@ kinetic scrolling and stale-paint behavior.
        `entryArbitration`, leaving a thin effect that applies its verdict. The five-condition
        synced-live-edge predicate and its late-resolving twin are now separately testable, including
        the empty-conversation case where a bare pointer comparison would discard a saved position.
+     - [x] Express the two remaining ambient re-pins as pure decisions: `mdsSettleDecision` for a
+       divider cleared by a late XEP-0490 read-sync, and `typingIndicatorDecision` for the band that
+       shrinks the scrollport, the twin of `rowGrowthDecision`. The detectors that remain in the
+       hook carry a single condition each, where a decision layer would be ceremony.
 
 Each migration must preserve observable behavior, add a falsifiable regression control, and remove
 one previous source of scroll authority.


### PR DESCRIPTION
Finishes the pattern #1234 established: where a slice carried real branch logic, that logic becomes
a pure function with paired controls. Two ambient re-pins were still deciding inline, and both are
in the part of the hook a test could not reach.

**`mdsSettleDecision`** — a divider cleared by a late XEP-0490 read-sync from another device. The
boundary the reader was looking at stops existing, so the list settles to the live edge. Four
conditions at once, and the conversation-switch guard is the one worth a control: a marker arriving
for the conversation just LEFT clears its divider, and without the guard the settle lands on the one
just entered, overriding the entry position it had already chosen.

**`typingIndicatorDecision`** — the band that shrinks the scrollport when someone starts typing. The
twin of `rowGrowthDecision`, and it now reads like it, including why only the off-to-on edge
matters: typing stopping grows the scroller back and the browser clamps `scrollTop` on its own.

At the typing call site an absent scroller is reported as an infinite distance from the bottom
rather than a nullable, so "no geometry" skips for the same reason a scrolled-up reader does.

The detectors still inline — `prevIsLoadingOlderRef`, `prevFirstNewMessageIdRef` — carry a single
condition each, where a decision layer would be ceremony rather than reach. That is the same call
#1234 made for the directional slice.

`docs/2026-07-23-scroll-positioning-contract.md` records the migration as complete, ticks the step
that was done but never marked, and says why the remaining detectors stay where they are.

Behaviour is unchanged.
