### PR TITLE
refactor(sdk): separate the client's public events from its own signals

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -6,6 +6,8 @@ import type {
   ConnectOptions,
   StoreBindings,
   XMPPClientEvents,
+  InternalClientEvents,
+  ClientEvents,
   SDKEvents,
   SDKEventHandler,
   StorageAdapter,
@@ -356,7 +358,7 @@ export class XMPPClient {
   public connectionActor!: ConnectionActor
 
   private stores: StoreBindings | null = null
-  private eventHandlers: Map<keyof XMPPClientEvents, Set<XMPPClientEvents[keyof XMPPClientEvents]>> = new Map()
+  private eventHandlers: Map<keyof ClientEvents, Set<ClientEvents[keyof ClientEvents]>> = new Map()
 
   /**
    * New SDK event handlers with object payloads.
@@ -654,7 +656,7 @@ export class XMPPClient {
       sendStanza: (stanza: Element) => this.sendStanza(stanza),
       sendIQ: (iq: Element, timeoutMs?: number) => this.sendIQ(iq, timeoutMs),
       getCurrentJid: () => this.currentJid,
-      emit: <K extends keyof XMPPClientEvents>(event: K, ...args: Parameters<XMPPClientEvents[K]>) => this.emit(event, ...args),
+      emit: <K extends keyof ClientEvents>(event: K, ...args: Parameters<ClientEvents[K]>) => this.emit(event, ...args),
       emitSDK: <K extends keyof SDKEvents>(event: K, payload: SDKEvents[K]) => this.emitSDK(event, payload),
       getXmpp: () => this.getXmpp(),
       storageAdapter: this.storageAdapter,
@@ -740,7 +742,7 @@ export class XMPPClient {
     // Only set up event listeners once
     if (!this.modulesInitialized) {
       // Listen for MUC join events to fetch room avatars and preview
-      this.on('mucJoined', (roomJid) => {
+      this.onInternal('mucJoined', (roomJid) => {
         const room = this.stores?.room.getRoom(roomJid)
         if (room && !room.avatar && !room.avatarFromPresence) {
           this.profile.fetchRoomAvatar(roomJid).catch(() => {})
@@ -756,13 +758,13 @@ export class XMPPClient {
       })
 
       // Listen for room avatar updates from presence
-      this.on('roomAvatarUpdate', (roomJid, photoHash) => {
+      this.onInternal('roomAvatarUpdate', (roomJid, photoHash) => {
         this.profile.fetchRoomAvatar(roomJid, photoHash).catch(() => {})
       })
 
       // Listen for MUC occupant avatar updates (XEP-0398)
       // Emitted by MUC module when an occupant's presence contains vcard-temp:x:update
-      this.on('occupantAvatarUpdate', (roomJid, nick, hash, realJid, occupantId) => {
+      this.onInternal('occupantAvatarUpdate', (roomJid, nick, hash, realJid, occupantId) => {
         // Only fetch if the avatar hash changed to avoid re-downloading on every presence
         const room = this.stores?.room.getRoom(roomJid)
         const occupant = room?.occupants.get(nick)
@@ -781,7 +783,7 @@ export class XMPPClient {
 
       // Listen for avatar metadata updates (XEP-0084)
       // Emitted by PubSub module for real events or Roster for vcard-temp:x:update
-      this.on('avatarMetadataUpdate', (jid, hash) => {
+      this.onInternal('avatarMetadataUpdate', (jid, hash) => {
         if (hash) {
           // Skip if contact already has this avatar hash with a loaded avatar
           const contact = this.stores?.roster.getContact(jid)
@@ -797,7 +799,7 @@ export class XMPPClient {
 
       // Listen for contacts missing XEP-0153 avatar (empty <photo/> in presence)
       // These contacts may use XEP-0084 (PEP) avatars instead (like Conversations)
-      this.on('contactMissingXep0153Avatar', (jid) => {
+      this.onInternal('contactMissingXep0153Avatar', (jid) => {
         // Only fetch if:
         // 1. Contact doesn't already have an avatar
         // 2. We haven't already checked this contact this session (prevents overfetching)
@@ -809,7 +811,7 @@ export class XMPPClient {
       })
 
       // Restore cached avatar hashes for offline contacts when roster loads
-      this.on('rosterLoaded', () => {
+      this.onInternal('rosterLoaded', () => {
         this.profile.restoreAllContactAvatarHashes().catch(() => {})
       })
 
@@ -855,6 +857,26 @@ export class XMPPClient {
     event: K,
     handler: XMPPClientEvents[K]
   ): () => void {
+    // `ClientEvents` is the intersection, so for a public K the two handler
+    // types are the same; TypeScript cannot see that through the generic.
+    return this.subscribeToBus(event, handler as ClientEvents[K])
+  }
+
+  /**
+   * Subscribe to a signal the client raises for itself. Separate from {@link on}
+   * so the internal events stay off the public surface.
+   */
+  private onInternal<K extends keyof InternalClientEvents>(
+    event: K,
+    handler: InternalClientEvents[K]
+  ): () => void {
+    return this.subscribeToBus(event, handler as ClientEvents[K])
+  }
+
+  private subscribeToBus<K extends keyof ClientEvents>(
+    event: K,
+    handler: ClientEvents[K]
+  ): () => void {
     if (!this.eventHandlers.has(event)) {
       this.eventHandlers.set(event, new Set())
     }
@@ -862,14 +884,14 @@ export class XMPPClient {
     return () => this.eventHandlers.get(event)?.delete(handler)
   }
 
-  private emit<K extends keyof XMPPClientEvents>(
+  private emit<K extends keyof ClientEvents>(
     event: K,
-    ...args: Parameters<XMPPClientEvents[K]>
+    ...args: Parameters<ClientEvents[K]>
   ): void {
     this.eventHandlers.get(event)?.forEach((handler) => {
       // Type assertion needed because the Map stores handlers as a union type
       // but we know at runtime that handlers for this event accept these args
-      ;(handler as (...args: Parameters<XMPPClientEvents[K]>) => void)(...args)
+      ;(handler as (...args: Parameters<ClientEvents[K]>) => void)(...args)
     })
   }
 

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -1,5 +1,5 @@
 import type { Client, Element } from '@xmpp/client'
-import type { StoreBindings, XMPPClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
+import type { StoreBindings, ClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
 import type { E2EEManager } from '../e2ee'
 import type { PresenceReader } from '../presenceReader'
 
@@ -22,9 +22,9 @@ export interface ModuleDependencies {
   sendStanza: (stanza: Element) => Promise<void>
   sendIQ: (iq: Element, timeoutMs?: number) => Promise<Element>
   getCurrentJid: () => string | null
-  emit: <K extends keyof XMPPClientEvents>(
+  emit: <K extends keyof ClientEvents>(
     event: K,
-    ...args: Parameters<XMPPClientEvents[K]>
+    ...args: Parameters<ClientEvents[K]>
   ) => void
   /**
    * Emit SDK events for store bindings.

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -678,7 +678,13 @@ describe('XMPPClient Own Avatar', () => {
 
       // Track emitted events
       const emittedEvents: Array<{ jid: string; hash: string | null }> = []
-      xmppClient.on('avatarMetadataUpdate', (jid, hash) => {
+      // `avatarMetadataUpdate` is an internal signal, deliberately absent from
+      // the public `on` surface. Reaching the bus directly is the point here:
+      // this asserts what the module emits, not what a consumer can subscribe to.
+      const onInternal = xmppClient as unknown as {
+        on: (event: 'avatarMetadataUpdate', handler: (jid: string, hash: string | null) => void) => () => void
+      }
+      onInternal.on('avatarMetadataUpdate', (jid, hash) => {
         emittedEvents.push({ jid, hash })
       })
 

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -33,9 +33,12 @@ export type {
 // ============================================================================
 
 /**
- * Events emitted by XMPPClient.
+ * The client's public event surface, and a compatibility contract.
  *
- * Use `client.on(event, handler)` to subscribe to these events.
+ * `@fluux/sdk/core` is consumed directly by bots and CLIs, for which these
+ * events are the API: removing or changing one breaks them. Anything the SDK
+ * emits purely to talk to itself belongs in {@link InternalClientEvents}
+ * instead, so the two are not mistaken for each other.
  *
  * @example
  * ```typescript
@@ -65,6 +68,23 @@ export interface XMPPClientEvents {
   reconnecting: (attempt: number, delayMs: number) => void
   /** Error occurred */
   error: (error: Error) => void
+}
+
+/**
+ * Signals a module raises for the client itself, not for consumers.
+ *
+ * Every one of these exists so a module can report something without reaching
+ * into `Profile` directly; `XMPPClient` is the only subscriber, and each
+ * handler turns the signal into an avatar or roster fetch. They are deliberately
+ * absent from {@link XMPPClientEvents}: `client.on` does not accept them, so
+ * they carry no promise to anyone outside the SDK and can change freely.
+ *
+ * This is not an unfinished migration to the {@link SDKEvents} bus. That bus
+ * carries state for the store bindings, and nothing binds these to a store.
+ *
+ * @internal
+ */
+export interface InternalClientEvents {
   /** Avatar metadata update received (XEP-0084) - hash is null when avatar removed */
   avatarMetadataUpdate: (jid: string, hash: string | null) => void
   /** Contact presence has empty XEP-0153 photo - may use XEP-0084 instead */
@@ -78,6 +98,14 @@ export interface XMPPClientEvents {
   /** Roster (contact list) fully loaded from server */
   rosterLoaded: () => void
 }
+
+/**
+ * Everything the client's legacy bus can carry. Modules emit against this;
+ * only {@link XMPPClientEvents} is reachable through the public `on`.
+ *
+ * @internal
+ */
+export type ClientEvents = XMPPClientEvents & InternalClientEvents
 
 /**
  * Options for integrating an external presence state machine.

--- a/packages/fluux-sdk/src/core/types/clientEvents.test.ts
+++ b/packages/fluux-sdk/src/core/types/clientEvents.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Guards the boundary between the client's public event surface and the signals
+ * it raises for itself.
+ *
+ * These are compile-time assertions: `npm run typecheck` fails if the boundary
+ * moves, which is the only way a type-level contract can be enforced. The
+ * runtime expectations exist so the file is a test rather than a stray module.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ClientEvents, InternalClientEvents, XMPPClientEvents } from './index'
+
+type PublicEventName = keyof XMPPClientEvents
+type InternalEventName = keyof InternalClientEvents
+
+describe('the client event surface', () => {
+  it('keeps internal signals out of the public surface', () => {
+    // Each `@ts-expect-error` fails the build if the name becomes publicly
+    // assignable, which is what would happen if someone moved one back.
+    // @ts-expect-error `mucJoined` is internal plumbing, not a consumer contract
+    const a: PublicEventName = 'mucJoined'
+    // @ts-expect-error `rosterLoaded` is internal plumbing
+    const b: PublicEventName = 'rosterLoaded'
+    // @ts-expect-error `avatarMetadataUpdate` is internal plumbing
+    const c: PublicEventName = 'avatarMetadataUpdate'
+    // @ts-expect-error `roomAvatarUpdate` is internal plumbing
+    const d: PublicEventName = 'roomAvatarUpdate'
+    // @ts-expect-error `occupantAvatarUpdate` is internal plumbing
+    const e: PublicEventName = 'occupantAvatarUpdate'
+    // @ts-expect-error `contactMissingXep0153Avatar` is internal plumbing
+    const f: PublicEventName = 'contactMissingXep0153Avatar'
+    expect([a, b, c, d, e, f]).toHaveLength(6)
+  })
+
+  // Removing one of these breaks every bot built on `@fluux/sdk/core`, so the
+  // build should say so rather than a consumer's runtime.
+  it('keeps the documented bot-facing events public', () => {
+    const documented: PublicEventName[] = [
+      'stanza', 'message', 'presence', 'roster',
+      'online', 'offline', 'resumed', 'reconnecting', 'error',
+    ]
+    expect(documented).toHaveLength(9)
+  })
+
+  it('carries both halves on the bus modules emit against', () => {
+    const fromPublic: keyof ClientEvents = 'message' satisfies PublicEventName
+    const fromInternal: keyof ClientEvents = 'mucJoined' satisfies InternalEventName
+    expect([fromPublic, fromInternal]).toEqual(['message', 'mucJoined'])
+  })
+
+  it('overlaps in no name, so the intersection loses nothing', () => {
+    // A name in both would silently take the intersection of its two handler
+    // types, which is neither signature.
+    type Overlap = PublicEventName & InternalEventName
+    const overlap: Overlap[] = []
+    expect(overlap).toEqual([])
+  })
+})

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -148,6 +148,8 @@ export type {
 export type {
   StoreBindings,
   XMPPClientEvents,
+  InternalClientEvents,
+  ClientEvents,
   PresenceOptions,
   PrivacyOptions,
 } from './client'


### PR DESCRIPTION
`XMPPClientEvents` mixed two unrelated things behind one mechanism, which is why the pair of event
buses reads as one unfinished migration.

**Nine are the public API.** `@fluux/sdk/core` is advertised for bots and CLIs, and
`client.on('online', ...)` appears in `docs/MARKETING_PAGE_DRAFT.md`. Removing one breaks consumers.

**Six are internal dispatch.** `mucJoined`, `rosterLoaded`, `avatarMetadataUpdate`,
`roomAvatarUpdate`, `occupantAvatarUpdate` and `contactMissingXep0153Avatar` exist so a module can
report something without reaching into `Profile` directly. `XMPPClient` is their only subscriber,
and nothing outside the SDK listens to any of them.

Nothing in the code said which was which. The six move to `InternalClientEvents`, modules emit
against the `ClientEvents` intersection, and the public `on` accepts only the public nine; internal
subscriptions go through a private `onInternal`.

## Not a step toward the SDKEvents bus

That bus carries state for the store bindings, and nothing binds these six to a store. They are
internal dispatch that happens to use an event shape. Moving them there would misfile them a second
time, so the type now says so.

## The boundary is enforced, not documented

`clientEvents.test.ts` puts a `@ts-expect-error` on each internal name, so `npm run typecheck` fails
the moment one becomes publicly assignable. Verified by moving `mucJoined` back to the public
interface and watching the build break with `Unused '@ts-expect-error' directive`.

## One test changed

`Profile.avatar.test.ts` subscribed to `avatarMetadataUpdate` through the public `on` — exactly the
confusion this separates. It now reaches the bus explicitly, with a comment saying why, rather than
the public surface widening to accommodate a test.

## Still open

`Profile`'s ten hand-rolled avatar PEP sites, the remaining half of the same finding. They are
entangled with `markPepForbiddenDomain`, a cross-cutting state `PepNode` knows nothing about, so
that is a separate change rather than a finishing touch.
