### PR TITLE
fix(sdk): count wire offsets in code points per XEP-0426

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8646,9 +8646,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "dev": true,
       "funding": [
         {
@@ -15323,6 +15323,7 @@
         "@xstate/react": "^6.0.0",
         "eslint": "^10.0.0",
         "fake-indexeddb": "^6.2.5",
+        "fast-check": "^4.9.0",
         "happy-dom": "^20.0.11",
         "jsdom": "^30.0.0",
         "react": "^19.2.0",

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -107,6 +107,7 @@
     "@xstate/react": "^6.0.0",
     "eslint": "^10.0.0",
     "fake-indexeddb": "^6.2.5",
+    "fast-check": "^4.9.0",
     "happy-dom": "^20.0.11",
     "jsdom": "^30.0.0",
     "react": "^19.2.0",

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -960,6 +960,218 @@ describe('XMPPClient Message', () => {
     })
   })
 
+  describe('wire offsets are code points (XEP-0426)', () => {
+    // An emoji in the quoted text makes the UTF-16 length exceed the code-point
+    // count, so these assertions only bite on supplementary-plane input.
+    const QUOTED = 'Nice 😀 work'
+    const FALLBACK = `> alice wrote:\n> ${QUOTED}\n`
+
+    it('should emit a reply fallback end counted in code points', async () => {
+      await connectClient()
+
+      await xmppClient.chat.sendMessage(
+        'alice@example.com',
+        'Thanks!',
+        'chat',
+        { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } },
+      )
+
+      const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
+      const fallbackEl = sentStanza.children.find((c: any) => c.name === 'fallback')
+      const range = fallbackEl.children.find((c: any) => c.name === 'body')
+
+      expect(range.attrs.end).toBe(String(Array.from(FALLBACK).length))
+      // The UTF-16 length is what the bug emitted; assert we no longer do.
+      expect(range.attrs.end).not.toBe(String(FALLBACK.length))
+    })
+
+    it('should emit mention reference offsets counted in code points', async () => {
+      await connectClient()
+
+      const body = '😀 hey @bob'
+      const begin = body.indexOf('@bob')
+
+      await xmppClient.chat.sendMessage(
+        'room@conference.example.com',
+        body,
+        'groupchat',
+        undefined,
+        [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
+      )
+
+      const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
+      const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
+
+      // One supplementary character precedes the mention, so every code-point
+      // offset trails its UTF-16 index by exactly one.
+      expect(refEl.attrs.begin).toBe(String(begin - 1))
+      expect(refEl.attrs.end).toBe(String(begin - 1 + '@bob'.length))
+    })
+
+    it('should shift mention offsets past a prepended reply quote', async () => {
+      await connectClient()
+
+      const typed = 'yes @bob'
+      const begin = typed.indexOf('@bob')
+
+      await xmppClient.chat.sendMessage(
+        'room@conference.example.com',
+        typed,
+        'groupchat',
+        { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } },
+        [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
+      )
+
+      const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
+      const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
+      const wireBody = sentStanza.children.find((c: any) => c.name === 'body').children[0]
+
+      // The reference must select the mention in the body actually sent, which
+      // begins with the quote block.
+      const from = Array.from(wireBody)
+      expect(from.slice(Number(refEl.attrs.begin), Number(refEl.attrs.end)).join('')).toBe('@bob')
+    })
+
+    it('should read inbound mention reference offsets as code points', async () => {
+      await connectClient()
+
+      mockStores.room.getRoom.mockReturnValue({
+        jid: 'room@conference.example.com',
+        name: 'room',
+        nickname: 'TestUser',
+        joined: true,
+        isBookmarked: false,
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set<string>(),
+        occupants: new Map(),
+        messages: [],
+      })
+
+      const body = '😀 hey @TestUser'
+      const utf16Begin = body.indexOf('@TestUser')
+      const codePointBegin = Array.from(body.slice(0, utf16Begin)).length
+
+      const messageStanza = createMockElement('message', {
+        from: 'room@conference.example.com/Alice',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'msg-mention-cp',
+      }, [
+        { name: 'body', text: body },
+        {
+          name: 'reference',
+          attrs: {
+            xmlns: 'urn:xmpp:reference:0',
+            type: 'mention',
+            begin: String(codePointBegin),
+            end: String(codePointBegin + '@TestUser'.length),
+            uri: 'xmpp:room@conference.example.com/TestUser',
+          },
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      // Consumers highlight by slicing the JS string, so offsets must come back
+      // as UTF-16 indices — one greater than the code-point offsets on the wire.
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
+        message: expect.objectContaining({
+          id: 'msg-mention-cp',
+          mentions: [expect.objectContaining({
+            begin: utf16Begin,
+            end: utf16Begin + '@TestUser'.length,
+            type: 'mention',
+          })],
+        })
+      }))
+      expect(body.slice(utf16Begin, utf16Begin + '@TestUser'.length)).toBe('@TestUser')
+    })
+
+    it('should drop a mention reference with malformed offsets', async () => {
+      await connectClient()
+
+      mockStores.room.getRoom.mockReturnValue({
+        jid: 'room@conference.example.com',
+        name: 'room',
+        nickname: 'TestUser',
+        joined: true,
+        isBookmarked: false,
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set<string>(),
+        occupants: new Map(),
+        messages: [],
+      })
+
+      const messageStanza = createMockElement('message', {
+        from: 'room@conference.example.com/Alice',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'msg-mention-bad',
+      }, [
+        { name: 'body', text: 'hey @TestUser' },
+        {
+          name: 'reference',
+          attrs: {
+            xmlns: 'urn:xmpp:reference:0',
+            type: 'mention',
+            begin: 'not-a-number',
+            end: '',
+            uri: 'xmpp:room@conference.example.com/TestUser',
+          },
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      const call = emitSDKSpy.mock.calls.find(
+        ([event, payload]: any[]) => event === 'room:message' && payload?.message?.id === 'msg-mention-bad',
+      )
+      expect(call).toBeDefined()
+      expect((call as any)[1].message.mentions).toBeUndefined()
+    })
+
+    it('should read inbound reply fallback offsets as code points', async () => {
+      await connectClient()
+
+      const body = `${FALLBACK}Thanks!`
+      const messageStanza = createMockElement('message', {
+        from: 'alice@example.com/res',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'msg-cp-1',
+      }, [
+        { name: 'body', text: body },
+        { name: 'reply', attrs: { xmlns: 'urn:xmpp:reply:0', id: 'orig-1', to: 'alice@example.com' } },
+        {
+          name: 'fallback',
+          attrs: { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+          children: [
+            {
+              name: 'body',
+              attrs: {
+                xmlns: 'urn:xmpp:fallback:0',
+                start: '0',
+                end: String(Array.from(FALLBACK).length),
+              },
+            },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
+        message: expect.objectContaining({
+          id: 'msg-cp-1',
+          body: 'Thanks!',
+          replyTo: expect.objectContaining({ fallbackBody: QUOTED }),
+        })
+      })
+    })
+  })
+
   describe('message replies with fallback (XEP-0461 + XEP-0428)', () => {
     it('should parse reply with fallback and preserve fallback body', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -4,6 +4,7 @@ import { BaseModule, type ModuleDependencies } from './BaseModule'
 import { getBareJid, getLocalPart, getResource, isQuickChatJid } from '../jid'
 import { isMucJid } from '../../utils/xmppUri'
 import { generateUUID, generateStableMessageId } from '../../utils/uuid'
+import { toCodePointOffset, fromCodePointOffset } from '../../utils/xep0426'
 import {
   NS_CHATSTATES,
   NS_CARBONS,
@@ -727,8 +728,8 @@ export class Chat extends BaseModule {
           'fallback',
           { xmlns: NS_FALLBACK, for: NS_OOB },
           xml('body', {
-            start: String(oobFallbackStart - fallbackEnd),
-            end: String(oobFallbackEnd - fallbackEnd),
+            start: String(toCodePointOffset(strippedBody, oobFallbackStart - fallbackEnd)),
+            end: String(toCodePointOffset(strippedBody, oobFallbackEnd - fallbackEnd)),
           }),
         )
       }
@@ -857,7 +858,7 @@ export class Chat extends BaseModule {
       if (replyTo.fallback) {
         children.push(
           xml('fallback', { xmlns: NS_FALLBACK, for: NS_REPLY },
-            xml('body', { start: '0', end: String(fallbackEnd) })
+            xml('body', { start: '0', end: String(toCodePointOffset(fullBody, fallbackEnd)) })
           )
         )
       }
@@ -866,10 +867,13 @@ export class Chat extends BaseModule {
     if (references && references.length > 0) {
       let hasMentionAll = false
       for (const ref of references) {
+        // Callers detect mentions in the text the user typed, but a reply
+        // prepends a quote block, so the wire body is `fallbackText + body`.
+        // Shift into that frame before converting to code points.
         children.push(xml('reference', {
           xmlns: NS_REFERENCE,
-          begin: ref.begin.toString(),
-          end: ref.end.toString(),
+          begin: String(toCodePointOffset(fullBody, fallbackEnd + ref.begin)),
+          end: String(toCodePointOffset(fullBody, fallbackEnd + ref.end)),
           type: ref.type,
           uri: ref.uri,
         }))
@@ -897,7 +901,10 @@ export class Chat extends BaseModule {
       children.push(xml('x', { xmlns: NS_OOB }, ...oobChildren))
       // Mark only the URL portion as fallback (preserves user text)
       children.push(xml('fallback', { xmlns: NS_FALLBACK, for: NS_OOB },
-        xml('body', { start: String(oobFallbackStart), end: String(oobFallbackEnd) })
+        xml('body', {
+          start: String(toCodePointOffset(fullBody, oobFallbackStart)),
+          end: String(toCodePointOffset(fullBody, oobFallbackEnd)),
+        })
       ))
 
       // XEP-0446: File Metadata Element (for original dimensions)
@@ -1101,7 +1108,10 @@ export class Chat extends BaseModule {
       }
       children.push(xml('x', { xmlns: NS_OOB }, ...oobChildren))
       children.push(xml('fallback', { xmlns: NS_FALLBACK, for: NS_OOB },
-        xml('body', { start: String(oobFallbackStart), end: String(oobFallbackEnd) })
+        xml('body', {
+          start: String(toCodePointOffset(fullBody, oobFallbackStart)),
+          end: String(toCodePointOffset(fullBody, oobFallbackEnd)),
+        })
       ))
     }
 
@@ -2446,12 +2456,22 @@ export class Chat extends BaseModule {
 
   private parseMentions(stanza: Element): MentionReference[] {
     const refs = stanza.getChildren('reference', NS_REFERENCE)
-    return refs.map(ref => ({
-      begin: parseInt(ref.attrs.begin, 10),
-      end: parseInt(ref.attrs.end, 10),
-      type: ref.attrs.type as 'mention',
-      uri: ref.attrs.uri,
-    })).filter(ref => ref.type === 'mention')
+    // XEP-0372 offsets index the body in code points (XEP-0426). Convert against
+    // the raw <body/>, not the fallback-stripped one: the sender counted the body
+    // as it appears on the wire, and consumers highlight against that same text.
+    const wireBody = stanza.getChildText('body') ?? ''
+    return refs.flatMap(ref => {
+      if (ref.attrs.type !== 'mention') return []
+      const begin = parseInt(ref.attrs.begin, 10)
+      const end = parseInt(ref.attrs.end, 10)
+      if (isNaN(begin) || isNaN(end)) return []
+      return [{
+        begin: fromCodePointOffset(wireBody, begin),
+        end: fromCodePointOffset(wireBody, end),
+        type: 'mention' as const,
+        uri: ref.attrs.uri,
+      }]
+    })
   }
 
   private checkForMentionAll(body: string, hasMentionAllElement: boolean): boolean {

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -24,6 +24,7 @@
  */
 
 import { XMPPClient } from '../core/XMPPClient'
+import { fromCodePointOffset } from '../utils/xep0426'
 import { connectionStore } from '../stores/connectionStore'
 import { chatStore } from '../stores/chatStore'
 import { roomStore } from '../stores/roomStore'
@@ -646,11 +647,13 @@ export class DemoClient extends XMPPClient {
     const fallbackEl = stanza.getChildren('fallback')?.find(
       (f: any) => f.attrs?.for?.includes('reply')
     )
+    // Fallback ranges are code-point offsets (XEP-0426), matching what the real
+    // send path emits; body.slice() indexes UTF-16 units.
     let processedBody = body
     if (fallbackEl) {
       const bodyRange = fallbackEl.getChild('body')
       if (bodyRange?.attrs?.end) {
-        processedBody = body.slice(Number(bodyRange.attrs.end))
+        processedBody = body.slice(fromCodePointOffset(body, Number(bodyRange.attrs.end)))
       }
     }
     // Also strip OOB fallback (URL appended at end)
@@ -660,7 +663,8 @@ export class DemoClient extends XMPPClient {
     if (oobFallbackEl) {
       const bodyRange = oobFallbackEl.getChild('body')
       if (bodyRange?.attrs?.start) {
-        processedBody = processedBody.slice(0, Number(bodyRange.attrs.start)).trimEnd()
+        const start = fromCodePointOffset(processedBody, Number(bodyRange.attrs.start))
+        processedBody = processedBody.slice(0, start).trimEnd()
       }
     }
 

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -671,6 +671,10 @@ export { generateUUID, generateStableMessageId } from './utils/uuid'
 export { processFallback, getFallbackElement } from './utils/fallbackUtils'
 export type { FallbackProcessingResult, FallbackProcessingOptions } from './utils/fallbackUtils'
 
+// XEP-0426 character counting: wire offsets are code points, JS indices are
+// UTF-16 units. Consumers building their own offset-bearing stanzas need these.
+export { codePointLength, toCodePointOffset, fromCodePointOffset } from './utils/xep0426'
+
 // RFC 6120: XMPP Stanza Error parsing
 export { parseXMPPError, formatXMPPError } from './utils/xmppError'
 export type { XMPPStanzaError, XMPPErrorType } from './utils/xmppError'

--- a/packages/fluux-sdk/src/utils/fallbackUtils.property.test.ts
+++ b/packages/fluux-sdk/src/utils/fallbackUtils.property.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Property tests for XEP-0428 fallback stripping.
+ *
+ * The oracle is a peer that follows the specification: it counts the fallback
+ * region in Unicode code points (XEP-0428 §4 → XEP-0426) using `Array.from`,
+ * independently of how the SDK indexes strings. A round-trip test against our
+ * own encoder cannot catch a wrong unit, because both ends would share the
+ * mistake; conformance against an external model can.
+ */
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { processFallback } from './fallbackUtils'
+import { createMockElement } from '../core/test-utils'
+import { NS_FALLBACK, NS_REPLY } from '../core/namespaces'
+
+const text = (maxLength: number) => fc.string({ unit: 'grapheme', maxLength })
+
+/** A conforming peer's reply stanza: offsets counted in code points. */
+function buildReplyStanza(author: string, quoted: string, reply: string) {
+  const quotedLines = quoted.split('\n').map((line) => `> ${line}`).join('\n')
+  const fallbackText = `> ${author} wrote:\n${quotedLines}\n`
+  const body = fallbackText + reply
+  return {
+    body,
+    reply,
+    stanza: createMockElement('message', {}, [
+      { name: 'body', text: body },
+      { name: 'reply', attrs: { xmlns: NS_REPLY, id: 'ref-1' } },
+      {
+        name: 'fallback',
+        attrs: { xmlns: NS_FALLBACK, for: NS_REPLY },
+        children: [
+          {
+            name: 'body',
+            attrs: {
+              xmlns: NS_FALLBACK,
+              start: '0',
+              // The unit that matters: code points, not UTF-16 code units.
+              end: String(Array.from(fallbackText).length),
+            },
+          },
+        ],
+      },
+    ]),
+  }
+}
+
+describe('processFallback (properties)', () => {
+  it('strips exactly the region a conforming peer marked', () => {
+    fc.assert(
+      fc.property(text(12), text(20), text(20), (author, quoted, reply) => {
+        const { stanza, body, reply: expected } = buildReplyStanza(author, quoted, reply)
+        const result = processFallback(stanza, body, { validTargets: [NS_REPLY] }, { id: 'ref-1' })
+        expect(result.processedBody).toBe(expected.trim())
+      }),
+    )
+  })
+
+  it('leaves the body untouched when the range is out of bounds or malformed', () => {
+    const attr = fc.oneof(
+      fc.string({ unit: 'binary', maxLength: 6 }),
+      fc.integer({ min: -50, max: 50 }).map(String),
+      fc.constantFrom('', 'NaN', 'Infinity', '1e400', '0x10'),
+    )
+    fc.assert(
+      fc.property(text(30), attr, attr, (body, start, end) => {
+        const stanza = createMockElement('message', {}, [
+          { name: 'body', text: body },
+          {
+            name: 'fallback',
+            attrs: { xmlns: NS_FALLBACK, for: NS_REPLY },
+            children: [{ name: 'body', attrs: { xmlns: NS_FALLBACK, start, end } }],
+          },
+        ])
+
+        const result = processFallback(stanza, body, { validTargets: [NS_REPLY] })
+        // Either the range was valid and a strict sub-region was removed, or it
+        // was rejected and the body survived. Never a crash, never longer.
+        expect(result.processedBody.length).toBeLessThanOrEqual(body.length)
+      }),
+    )
+  })
+
+  it('never strips a fallback aimed at a namespace the caller did not ask for', () => {
+    fc.assert(
+      fc.property(text(30), (body) => {
+        const stanza = createMockElement('message', {}, [
+          { name: 'body', text: body },
+          {
+            name: 'fallback',
+            attrs: { xmlns: NS_FALLBACK, for: 'urn:xmpp:some-other-feature:0' },
+            children: [{ name: 'body', attrs: { xmlns: NS_FALLBACK, start: '0', end: '1' } }],
+          },
+        ])
+        expect(processFallback(stanza, body, { validTargets: [NS_REPLY] }).processedBody).toBe(body)
+      }),
+    )
+  })
+})

--- a/packages/fluux-sdk/src/utils/fallbackUtils.ts
+++ b/packages/fluux-sdk/src/utils/fallbackUtils.ts
@@ -16,6 +16,7 @@
 
 import type { Element } from '@xmpp/client'
 import { NS_FALLBACK, NS_FALLBACK_LEGACY, NS_REPLY } from '../core/namespaces'
+import { codePointLength, fromCodePointOffset } from './xep0426'
 
 export interface FallbackProcessingResult {
   processedBody: string
@@ -146,6 +147,8 @@ export function processFallback(
   // Collect applicable ranges and check for entire-body fallbacks
   const ranges: Array<{ start: number; end: number; forNs: string }> = []
   let fallbackBody: string | undefined
+  // Wire offsets are code points (XEP-0426); `body` is indexed in UTF-16 units.
+  const bodyCodePoints = codePointLength(body)
 
   for (const { element, namespace } of fallbacks) {
     const fallbackFor = element.attrs.for
@@ -163,12 +166,21 @@ export function processFallback(
       return { processedBody: '' }
     }
 
-    const start = parseInt(startAttr, 10)
-    const end = parseInt(endAttr, 10)
+    const startCodePoints = parseInt(startAttr, 10)
+    const endCodePoints = parseInt(endAttr, 10)
 
-    if (isNaN(start) || isNaN(end) || start < 0 || end <= start || end > body.length) {
+    if (
+      isNaN(startCodePoints) ||
+      isNaN(endCodePoints) ||
+      startCodePoints < 0 ||
+      endCodePoints <= startCodePoints ||
+      endCodePoints > bodyCodePoints
+    ) {
       continue
     }
+
+    const start = fromCodePointOffset(body, startCodePoints)
+    const end = fromCodePointOffset(body, endCodePoints)
 
     // For replies, extract and save the quoted text (shown in the reply chip
     // when the referenced message isn't in the local store).

--- a/packages/fluux-sdk/src/utils/xep0426.property.test.ts
+++ b/packages/fluux-sdk/src/utils/xep0426.property.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Property tests for XEP-0426 character counting.
+ *
+ * The oracle is `Array.from(text)`, which iterates a string by code point and is
+ * therefore an independent model of what the XEP mandates — independent of the
+ * UTF-16 arithmetic under test. Example-based tests miss this class of bug
+ * because a hand-written case is almost always BMP-only, where the two counts
+ * coincide.
+ */
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { codePointLength, toCodePointOffset, fromCodePointOffset } from './xep0426'
+
+/** Strings that actually contain supplementary-plane characters. */
+const anyText = fc.string({ unit: 'grapheme', maxLength: 40 })
+/** Arbitrary UTF-16, including lone surrogates, for totality checks. */
+const anyUtf16 = fc.string({ unit: 'binary', maxLength: 40 })
+
+describe('XEP-0426 offsets (properties)', () => {
+  it('counts code points the way Array.from does', () => {
+    fc.assert(
+      fc.property(anyUtf16, (text) => {
+        expect(codePointLength(text)).toBe(Array.from(text).length)
+      }),
+    )
+  })
+
+  it('round-trips every code-point offset through UTF-16 and back', () => {
+    fc.assert(
+      fc.property(anyText, fc.nat(), (text, raw) => {
+        const offset = raw % (codePointLength(text) + 1)
+        expect(toCodePointOffset(text, fromCodePointOffset(text, offset))).toBe(offset)
+      }),
+    )
+  })
+
+  it('slices identically to the code-point model', () => {
+    // The property the wire format actually depends on: a peer that counted in
+    // code points and we who slice in UTF-16 must select the same characters.
+    fc.assert(
+      fc.property(anyText, fc.nat(), fc.nat(), (text, a, b) => {
+        const total = codePointLength(text)
+        const start = a % (total + 1)
+        const end = start + (b % (total - start + 1))
+
+        const sliced = text.slice(fromCodePointOffset(text, start), fromCodePointOffset(text, end))
+        const model = Array.from(text).slice(start, end).join('')
+        expect(sliced).toBe(model)
+      }),
+    )
+  })
+
+  it('maps the end of the string to the total code-point count', () => {
+    fc.assert(
+      fc.property(anyText, (text) => {
+        expect(toCodePointOffset(text, text.length)).toBe(codePointLength(text))
+        expect(fromCodePointOffset(text, codePointLength(text))).toBe(text.length)
+      }),
+    )
+  })
+
+  it('is monotonic in both directions', () => {
+    fc.assert(
+      fc.property(anyText, fc.nat(), fc.nat(), (text, a, b) => {
+        const lo = Math.min(a, b)
+        const hi = Math.max(a, b)
+        expect(fromCodePointOffset(text, lo)).toBeLessThanOrEqual(fromCodePointOffset(text, hi))
+        expect(toCodePointOffset(text, lo)).toBeLessThanOrEqual(toCodePointOffset(text, hi))
+      }),
+    )
+  })
+
+  it('stays in bounds for hostile offsets', () => {
+    const hostile = fc.oneof(
+      fc.integer({ min: -1000, max: 1000 }),
+      fc.constantFrom(NaN, Infinity, -Infinity, 0.5, -0),
+    )
+    fc.assert(
+      fc.property(anyUtf16, hostile, (text, offset) => {
+        const utf16 = fromCodePointOffset(text, offset)
+        expect(utf16).toBeGreaterThanOrEqual(0)
+        expect(utf16).toBeLessThanOrEqual(text.length)
+
+        const cp = toCodePointOffset(text, offset)
+        expect(cp).toBeGreaterThanOrEqual(0)
+        expect(cp).toBeLessThanOrEqual(codePointLength(text))
+      }),
+    )
+  })
+
+  it('never splits a surrogate pair', () => {
+    fc.assert(
+      fc.property(anyText, fc.nat(), (text, raw) => {
+        const index = fromCodePointOffset(text, raw % (codePointLength(text) + 1))
+        if (index > 0 && index < text.length) {
+          // A high surrogate at index-1 paired with a low surrogate at index
+          // would mean the boundary landed inside a character.
+          const before = text.charCodeAt(index - 1)
+          const after = text.charCodeAt(index)
+          const splits = before >= 0xd800 && before <= 0xdbff && after >= 0xdc00 && after <= 0xdfff
+          expect(splits).toBe(false)
+        }
+      }),
+    )
+  })
+})

--- a/packages/fluux-sdk/src/utils/xep0426.ts
+++ b/packages/fluux-sdk/src/utils/xep0426.ts
@@ -1,0 +1,73 @@
+/**
+ * XEP-0426: Character counting in message bodies.
+ *
+ * Offsets carried on the wire are counted in Unicode code points: "When counting
+ * characters in a body, they shall be counted by their number of Unicode code
+ * points." This governs every offset-bearing extension the SDK speaks, notably
+ * XEP-0372 references (`begin`/`end`) and XEP-0428 fallback ranges
+ * (`start`/`end`, via XEP-0428 §4).
+ *
+ * JavaScript string indices are UTF-16 code units, so the two counts diverge by
+ * one for every character outside the BMP — emoji, many CJK extension blocks,
+ * mathematical alphanumerics. A body containing a single emoji before an offset
+ * is enough to misplace it.
+ *
+ * In-memory offsets stay UTF-16. They index JS strings directly, and a
+ * textarea's `selectionStart`/`selectionEnd` are UTF-16 by definition, so
+ * converting the whole codebase to code points would push the conversion into
+ * every renderer and composer instead of removing it. Convert at the stanza
+ * boundary only: {@link toCodePointOffset} when writing an attribute,
+ * {@link fromCodePointOffset} when reading one.
+ */
+
+/** True when `code` is a UTF-16 code unit that starts a surrogate pair. */
+function isSupplementary(code: number | undefined): boolean {
+  return code !== undefined && code > 0xffff
+}
+
+/**
+ * Number of Unicode code points in `text`, per XEP-0426 §3.
+ *
+ * This is the value a conforming peer uses as the end-of-body offset, and the
+ * bound an inbound offset must be validated against.
+ */
+export function codePointLength(text: string): number {
+  let count = 0
+  for (let i = 0; i < text.length; count++) {
+    i += isSupplementary(text.codePointAt(i)) ? 2 : 1
+  }
+  return count
+}
+
+/**
+ * Convert a UTF-16 string index into the code-point offset to put on the wire.
+ *
+ * `utf16Index` is clamped to `[0, text.length]`. An index that falls between the
+ * two halves of a surrogate pair rounds up to the end of that pair, since a
+ * code-point offset cannot address the inside of a character.
+ */
+export function toCodePointOffset(text: string, utf16Index: number): number {
+  const limit = Math.max(0, Math.min(utf16Index, text.length))
+  let count = 0
+  for (let i = 0; i < limit; count++) {
+    i += isSupplementary(text.codePointAt(i)) ? 2 : 1
+  }
+  return count
+}
+
+/**
+ * Convert a code-point offset read off the wire into a UTF-16 string index.
+ *
+ * An offset past the end of `text` clamps to `text.length`; callers that must
+ * reject an out-of-range offset should compare it against
+ * {@link codePointLength} first rather than relying on the clamp.
+ */
+export function fromCodePointOffset(text: string, codePointOffset: number): number {
+  if (codePointOffset <= 0) return 0
+  let count = 0
+  for (let i = 0; i < text.length; count++) {
+    if (count === codePointOffset) return i
+    i += isSupplementary(text.codePointAt(i)) ? 2 : 1
+  }
+  return text.length
+}

--- a/packages/fluux-sdk/src/utils/xmppUri.property.test.ts
+++ b/packages/fluux-sdk/src/utils/xmppUri.property.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Property tests for the RFC 5122 `xmpp:` URI parser.
+ *
+ * Two oracles, neither derived from the implementation:
+ *  - totality — the documented contract is "returns null if the URI is
+ *    invalid", so no input may raise. These URIs arrive inside peer-controlled
+ *    message bodies, where a throw becomes a remotely triggered failure.
+ *  - round-trip — components encoded per RFC 5122 must parse back unchanged.
+ */
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { parseXmppUri } from './xmppUri'
+
+const jidPart = fc
+  .string({ unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789-'), minLength: 1, maxLength: 8 })
+
+const jid = fc.tuple(jidPart, jidPart, jidPart).map(([local, host, tld]) => `${local}@${host}.${tld}`)
+const action = fc.constantFrom('message', 'join', 'subscribe', 'roster', 'remove', 'disco')
+const params = fc.dictionary(
+  // '__proto__' is included deliberately: it is a legal parameter name a peer
+  // may send, and plain assignment would drop it.
+  fc.oneof(fc.string({ unit: 'grapheme', minLength: 1, maxLength: 8 }), fc.constant('__proto__')),
+  fc.string({ unit: 'grapheme', maxLength: 12 }),
+  { maxKeys: 4 },
+)
+
+describe('parseXmppUri (properties)', () => {
+  it('never throws, whatever it is handed', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary', maxLength: 60 }), (raw) => {
+        expect(() => parseXmppUri(raw)).not.toThrow()
+        expect(() => parseXmppUri(`xmpp:${raw}`)).not.toThrow()
+      }),
+    )
+  })
+
+  it('round-trips a well-formed URI', () => {
+    fc.assert(
+      fc.property(jid, action, params, (address, act, query) => {
+        const encoded = Object.entries(query)
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+          .join(';')
+        const uri = `xmpp:${address}?${act}${encoded ? `;${encoded}` : ''}`
+
+        const parsed = parseXmppUri(uri)
+        expect(parsed).not.toBeNull()
+        expect(parsed?.jid).toBe(address)
+        expect(parsed?.action).toBe(act)
+        expect(parsed?.params).toEqual(query)
+      }),
+    )
+  })
+
+  it('rejects rather than throws on a malformed percent-escape', () => {
+    const broken = fc.constantFrom('%', '%A', '%ZZ', '%E0%A4%A', '%C0', '%F8%A1')
+    fc.assert(
+      fc.property(jid, broken, (address, bad) => {
+        // In the JID, in the action, and in a parameter value.
+        expect(parseXmppUri(`xmpp:${address}${bad}`)).toBeNull()
+        expect(parseXmppUri(`xmpp:${address}?${bad}`)).toBeNull()
+        expect(parseXmppUri(`xmpp:${address}?message;body=${bad}`)).toBeNull()
+      }),
+    )
+  })
+})

--- a/packages/fluux-sdk/src/utils/xmppUri.ts
+++ b/packages/fluux-sdk/src/utils/xmppUri.ts
@@ -25,6 +25,21 @@ export interface XmppUri {
 }
 
 /**
+ * Percent-decode one URI component, yielding null on a malformed escape
+ * (`%`, `%A`, `%ZZ`) instead of throwing URIError.
+ *
+ * `xmpp:` URIs reach this parser from peer-controlled message bodies, so a bad
+ * escape is untrusted input to reject, not an exceptional condition.
+ */
+function safeDecode(value: string): string | null {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Parse an XMPP URI string into its components.
  * Returns null if the URI is invalid.
  *
@@ -70,7 +85,9 @@ export function parseXmppUri(uri: string): XmppUri | null {
   }
 
   // Decode the JID
-  jid = decodeURIComponent(jid)
+  const decodedJid = safeDecode(jid)
+  if (decodedJid === null) return null
+  jid = decodedJid
 
   // Validate JID has at least user@domain format
   if (!jid.includes('@')) {
@@ -79,7 +96,10 @@ export function parseXmppUri(uri: string): XmppUri | null {
 
   // Parse query string
   let action: string | undefined
-  const params: Record<string, string> = {}
+  // Collected as entries, not by assignment: `params['__proto__'] = v` mutates
+  // the prototype instead of creating an own property, silently dropping a
+  // parameter a peer is free to name. Object.fromEntries defines it properly.
+  const entries: Array<[string, string]> = []
 
   if (queryString) {
     // RFC 5122 uses semicolons as parameter separators
@@ -87,31 +107,29 @@ export function parseXmppUri(uri: string): XmppUri | null {
 
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i]
-      if (i === 0) {
+      if (i === 0 && !part.includes('=')) {
         // First part is the action (e.g., "message", "join")
-        if (part.includes('=')) {
-          // No action, just parameters
-          const [key, value] = part.split('=', 2)
-          params[decodeURIComponent(key)] = decodeURIComponent(value || '')
-        } else {
-          action = decodeURIComponent(part)
-        }
-      } else {
-        // Subsequent parts are parameters
-        const eqIndex = part.indexOf('=')
-        if (eqIndex !== -1) {
-          const key = decodeURIComponent(part.slice(0, eqIndex))
-          const value = decodeURIComponent(part.slice(eqIndex + 1))
-          params[key] = value
-        } else {
-          // Boolean parameter (presence means true)
-          params[decodeURIComponent(part)] = ''
-        }
+        const decodedAction = safeDecode(part)
+        if (decodedAction === null) return null
+        action = decodedAction
+        continue
       }
+
+      // Everything else is a parameter. A first part containing '=' means the
+      // URI carries parameters with no action.
+      const eqIndex = part.indexOf('=')
+      const rawKey = eqIndex === -1 ? part : part.slice(0, eqIndex)
+      // Boolean parameter (presence means true) when there is no '='
+      const rawValue = eqIndex === -1 ? '' : part.slice(eqIndex + 1)
+
+      const key = safeDecode(rawKey)
+      const value = safeDecode(rawValue)
+      if (key === null || value === null) return null
+      entries.push([key, value])
     }
   }
 
-  return { jid, action, params }
+  return { jid, action, params: Object.fromEntries(entries) }
 }
 
 /**


### PR DESCRIPTION
XEP-0426 requires offsets carried on the wire to be counted in Unicode code points. XEP-0372 references and XEP-0428 fallback ranges were both counted in UTF-16 code units, so every character outside the BMP shifted subsequent offsets by one. An emoji in a quoted message left the reply quote stripped one character short; the mirror image happened when a conforming peer parsed what we sent, cutting into real text and sometimes splitting a surrogate pair. Fluux-to-Fluux chat looked fine because both ends shared the same wrong unit.

Wire offsets now convert at the stanza boundary through a dedicated XEP-0426 helper. In-memory offsets stay UTF-16, which is what JS string indices and a textarea's `selectionStart` already are, so the conversion sits at the protocol edge rather than spreading into every renderer and composer.

Three further defects on the same paths:

- Replying while mentioning someone sent reference offsets relative to the typed text, while the wire body carried a prepended quote block.
- `parseXmppUri` threw `URIError` on a malformed percent-escape instead of returning `null` as documented. These URIs arrive in peer-controlled message bodies.
- An `xmpp:` URI parameter named `__proto__` was silently dropped, because plain assignment mutates the prototype instead of creating an own property.

Adds `fast-check` and a property-test suite covering offset conversion, fallback stripping against an independent code-point model, and URI parser totality. The conformance property is the one that matters here: a round-trip test stays green forever when both ends share a wrong unit, so the oracle has to come from the specification rather than from our own encoder.

Compatibility: messages from clients that share the old UTF-16 behaviour, including earlier Fluux versions, now differ by one character per supplementary-plane character in the fallback region. That surfaces as a stray character at the quote boundary, not lost content.
