### PR TITLE
refactor(sdk): move the raw XMPP vocabulary off the curated entries

### DIFF
--- a/apps/fluux/src/components/BrowseRoomsModal.test.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.test.tsx
@@ -74,6 +74,18 @@ vi.mock('@/hooks', () => ({
   }),
 }))
 
+/**
+ * Swap one export of a mocked module for the duration of a test.
+ *
+ * The stand-ins below are deliberately partial: the component reads a handful
+ * of fields, and spelling out every member of the real hook return would say
+ * nothing about what is under test. That partiality is what the cast covers,
+ * so restore the original in the same test rather than leaving it installed.
+ */
+function overrideMockedExport<M, K extends keyof M>(module: M, key: K, impl: unknown): void {
+  ;(module as Record<K, unknown>)[key] = impl
+}
+
 describe('BrowseRoomsModal', () => {
   const mockOnClose = vi.fn()
 
@@ -119,11 +131,11 @@ describe('BrowseRoomsModal', () => {
       // Override mock to include ownNickname
       const sdkModule = await import('@fluux/sdk')
       const originalUseConnection = sdkModule.useConnection
-      vi.mocked(sdkModule).useConnection = () => ({
+      overrideMockedExport(sdkModule, 'useConnection', () => ({
         ...originalUseConnection(),
         jid: 'testuser@example.com',
         ownNickname: 'My Display Name',
-      })
+      }))
 
       render(<BrowseRoomsModal onClose={mockOnClose} />)
       await act(async () => {})
@@ -132,7 +144,7 @@ describe('BrowseRoomsModal', () => {
       expect(nicknameInput).toHaveValue('My Display Name')
 
       // Restore original mock
-      vi.mocked(sdkModule).useConnection = originalUseConnection
+      overrideMockedExport(sdkModule, 'useConnection', originalUseConnection)
     })
 
     it('should render search input', async () => {
@@ -629,14 +641,14 @@ describe('BrowseRoomsModal', () => {
         ['general@conference.example.com', { jid: 'general@conference.example.com', joined: true }],
       ])
 
-      vi.mocked(await import('@fluux/sdk')).useRoom = () => ({
+      overrideMockedExport(await import('@fluux/sdk'), 'useRoom', () => ({
         browsePublicRooms: mockBrowsePublicRooms,
         joinRoom: mockJoinRoom,
         joinResult: mockJoinResult,
         getRoom: (jid: string) => mockRoomsMap.get(jid),
         setActiveRoom: mockSetActiveRoom,
         mucServiceJid: 'conference.example.com',
-      })
+      }))
 
       render(<BrowseRoomsModal onClose={mockOnClose} />)
 

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -17,13 +17,13 @@ import {
   isE2EEPluginError,
   parsePayloadEnvelope,
   serializePayloadEnvelope,
-  xml,
   type PEPItem,
   type PluginContext,
   type SecurityContextUpdate,
   type XMLElementData,
   type XMPPPrimitives,
 } from '@fluux/sdk'
+import { xml } from '@fluux/sdk/xmpp'
 
 // The cross-device verification-sync tests drive real openpgp.js work, so they
 // are CPU-bound and inflate several-fold under the contention of a full

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -17,12 +17,12 @@ import {
   createPluginStorage,
   parsePayloadEnvelope,
   serializePayloadEnvelope,
-  xml,
   type PEPItem,
   type PluginContext,
   type XMLElementData,
   type XMPPPrimitives,
 } from '@fluux/sdk'
+import { xml } from '@fluux/sdk/xmpp'
 import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
 import { clearSessionPassphrase, setSessionPassphrase } from './webPassphraseStore'
 import type { KeyBundle } from './OpenPGPPluginBase'

--- a/apps/fluux/src/e2ee/verificationSync.ts
+++ b/apps/fluux/src/e2ee/verificationSync.ts
@@ -34,7 +34,9 @@
  */
 
 import type { PluginContext, XMLElementData } from '@fluux/sdk'
-import { buildScopedStorageKey, NS_FLUUX_VERIFICATIONS } from '@fluux/sdk'
+import { buildScopedStorageKey } from '@fluux/sdk'
+// The PEP node id is a raw protocol name, so it comes from the escape hatch.
+import { NS_FLUUX_VERIFICATIONS } from '@fluux/sdk/xmpp'
 import { fingerprintsEqual } from './fingerprintCompare'
 
 /** Encrypt `plaintext` to `recipientPublicArmored`. Returns armored ciphertext. */

--- a/apps/fluux/tsconfig.json
+++ b/apps/fluux/tsconfig.json
@@ -9,6 +9,7 @@
       "@fluux/sdk/core": ["../../packages/fluux-sdk/dist/core/index.d.ts"],
       "@fluux/sdk/stores": ["../../packages/fluux-sdk/dist/stores/index.d.ts"],
       "@fluux/sdk/cache": ["../../packages/fluux-sdk/dist/cache/index.d.ts"],
+      "@fluux/sdk/xmpp": ["../../packages/fluux-sdk/dist/xmpp/index.d.ts"],
       "@fluux/sdk/demo": ["../../packages/fluux-sdk/dist/demo/index.d.ts"]
     }
   },

--- a/packages/fluux-sdk/README.md
+++ b/packages/fluux-sdk/README.md
@@ -385,7 +385,6 @@ Low-level access for advanced use cases:
 const {
   client,        // XMPPClient instance
   sendRawXml,    // (xml: string) => void
-  xml,           // xml builder function
   setPresence,   // (show, status?) => void
 } = useXMPP()
 
@@ -393,10 +392,29 @@ const {
 const { sendRawXml } = useXMPP()
 sendRawXml('<iq type="get" id="ping1"><ping xmlns="urn:xmpp:ping"/></iq>')
 
-// Example: Build and send presence
-const { xml, client } = useXMPP()
+// Example: Build and send presence. The stanza builder is protocol
+// vocabulary, so it comes from the escape hatch below, not from the hook.
+import { xml } from '@fluux/sdk/xmpp'
+
+const { client } = useXMPP()
 const presence = xml('presence', {}, xml('show', {}, 'away'))
 client?.send(presence)
+```
+
+### `@fluux/sdk/xmpp` — raw protocol
+
+Namespace constants, the `xml` stanza builder, and the wire parsers (data
+forms, RSM, fallback indication, stanza errors). None of it is on the curated
+entries: the rest of the SDK is meant to be usable without reading a XEP.
+
+Reach for this only to speak a part of XMPP the SDK does not model yet. An
+import from here marks a gap in the high-level API rather than a normal way to
+use the SDK.
+
+```typescript
+import { xml, NS_PING } from '@fluux/sdk/xmpp'
+
+const ping = xml('iq', { type: 'get', to: 'example.com' }, xml('ping', { xmlns: NS_PING }))
 ```
 
 ## Types

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -65,6 +65,16 @@
         "types": "./dist/cache/index.d.cts",
         "default": "./dist/cache/index.cjs"
       }
+    },
+    "./xmpp": {
+      "import": {
+        "types": "./dist/xmpp/index.d.ts",
+        "default": "./dist/xmpp/index.js"
+      },
+      "require": {
+        "types": "./dist/xmpp/index.d.cts",
+        "default": "./dist/xmpp/index.cjs"
+      }
     }
   },
   "files": [

--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import * as main from './index'
+import * as core from './core/index'
+import * as xmpp from './xmpp/index'
+
+/**
+ * The curated entries do not speak XMPP, and the escape hatch does.
+ *
+ * The SDK's promise is that a developer builds a client or a bot without
+ * reading a XEP. A barrel is where that promise erodes: a namespace constant
+ * is the smallest possible import, it is always locally justified, and 73 of
+ * them arrived that way once already. So the boundary is asserted rather than
+ * described.
+ *
+ * A new protocol name belongs on `@fluux/sdk/xmpp`. If something here fails
+ * because a feature genuinely needs raw XMPP in an app, that is the finding:
+ * the high-level API is missing a verb, and adding it is the fix, not moving
+ * the constant back.
+ */
+describe('public API surface', () => {
+  const PROTOCOL_ONLY = ['xml', 'Element']
+
+  it('keeps namespace constants off the main entry', () => {
+    const leaked = Object.keys(main).filter((key) => key.startsWith('NS_'))
+    expect(leaked).toEqual([])
+  })
+
+  it('keeps the stanza builder and the ltx element type off the main entry', () => {
+    const leaked = Object.keys(main).filter((key) => PROTOCOL_ONLY.includes(key))
+    expect(leaked).toEqual([])
+  })
+
+  it('keeps both off the bot/CLI entry, which most has to read as XMPP-free', () => {
+    const leaked = Object.keys(core).filter(
+      (key) => key.startsWith('NS_') || PROTOCOL_ONLY.includes(key),
+    )
+    expect(leaked).toEqual([])
+  })
+
+  it('keeps the wire parsers off the main entry', () => {
+    // Each takes or returns a raw element. `formatXMPPError` is deliberately
+    // absent from this list: it renders a value already carried by a message.
+    const wireParsers = [
+      'parseDataForm',
+      'getFormFieldValue',
+      'getFormFieldValues',
+      'buildDataFormSubmit',
+      'parseRSMResponse',
+      'buildRSMElement',
+      'processFallback',
+      'getFallbackElement',
+      'parseXMPPError',
+    ]
+    const leaked = Object.keys(main).filter((key) => wireParsers.includes(key))
+    expect(leaked).toEqual([])
+  })
+
+  it('offers all of it on the escape hatch, so the boundary is a move and not a loss', () => {
+    const keys = new Set(Object.keys(xmpp))
+    expect(keys.has('xml')).toBe(true)
+    expect([...keys].filter((key) => key.startsWith('NS_')).length).toBeGreaterThan(50)
+    for (const parser of ['parseDataForm', 'buildRSMElement', 'processFallback', 'parseXMPPError']) {
+      expect(keys.has(parser)).toBe(true)
+    }
+  })
+
+  it('still exposes what an app needs to render a delivery error', () => {
+    expect(Object.keys(main)).toContain('formatXMPPError')
+  })
+
+  it('does not hand the stanza builder back through a hook', () => {
+    // A named export is not the only door: `useXMPP` used to return `xml`,
+    // which would have made every assertion above true and meaningless. The
+    // hook needs a live provider, so read its shape from the source instead of
+    // rendering it.
+    const source = readFileSync(resolve(process.cwd(), 'src/hooks/useXMPP.ts'), 'utf8')
+    const returnBlock = source.slice(source.lastIndexOf('return {'))
+    expect(returnBlock).not.toMatch(/^\s*xml,\s*$/m)
+  })
+})

--- a/packages/fluux-sdk/src/core/e2ee/types.ts
+++ b/packages/fluux-sdk/src/core/e2ee/types.ts
@@ -10,6 +10,8 @@
  * (Rust via Tauri commands, WASM).
  */
 
+import type { XMLElementData } from '../types/stanza'
+
 /** Bare JID (`local@domain`, no resource). */
 export type BareJID = string
 
@@ -19,18 +21,9 @@ export interface DeviceIdentifier {
   deviceId: string
 }
 
-/**
- * Minimal structural form of an XMPP element that is JSON-serializable.
- *
- * Plugins emit this shape; the host converts it into an `@xmpp/client`
- * Element before sending. Using a structural form keeps the trait uniform
- * across TS plugins and native plugins bridged over Tauri.
- */
-export interface XMLElementData {
-  name: string
-  attrs: Record<string, string>
-  children: Array<XMLElementData | string>
-}
+// The element shape plugins emit is the SDK-wide one, not an E2EE dialect: the
+// host converts it to an `@xmpp/client` Element before sending.
+export type { XMLElementData }
 
 /** Features a plugin can advertise. Used for strategy selection and UI. */
 export interface ProtocolFeatures {

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -4,9 +4,9 @@ export { XMPPClient } from './XMPPClient'
 // Default store bindings for headless usage
 export { createDefaultStoreBindings } from './defaultStoreBindings'
 
-// Re-export xml builder from @xmpp/client for raw stanza construction
-export { xml } from '@xmpp/client'
-export type { Element } from '@xmpp/client'
+// This is the bot/CLI bundle, so it is the one that most has to read as
+// "XMPP without the XMPP". The stanza builder and the ltx `Element` type are
+// therefore not here either; they live on `@fluux/sdk/xmpp`.
 
 // Client construction options (carries the store bundle, so it lives outside
 // the leaf type layer).

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -8,6 +8,9 @@
  * @module Types
  */
 
+// The SDK's library-independent element shape (see ./stanza)
+export type { XMLElementData } from './stanza'
+
 // Connection types
 export type { ConnectionStatus, ConnectionMethod, ConnectOptions, SystemState } from './connection'
 

--- a/packages/fluux-sdk/src/core/types/stanza.ts
+++ b/packages/fluux-sdk/src/core/types/stanza.ts
@@ -1,0 +1,24 @@
+/**
+ * The SDK's own element shape, independent of any XML library.
+ *
+ * @module Core/Types/Stanza
+ */
+
+/**
+ * Minimal structural form of an XMPP element, JSON-serializable by
+ * construction.
+ *
+ * This is the one element shape the SDK exposes. It exists so that no consumer
+ * has to type against ltx: the host converts to and from an `@xmpp/client`
+ * Element at the boundary, and the raw type stays on `@fluux/sdk/xmpp`.
+ * Being plain data is also what lets the same contract be implemented in
+ * TypeScript or fronted by a native runtime (Rust over Tauri, WASM), where an
+ * ltx object could not cross the bridge.
+ *
+ * @category Core
+ */
+export interface XMLElementData {
+  name: string
+  attrs: Record<string, string>
+  children: Array<XMLElementData | string>
+}

--- a/packages/fluux-sdk/src/hooks/useXMPP.ts
+++ b/packages/fluux-sdk/src/hooks/useXMPP.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { useXMPPContext } from '../provider'
-import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 
 /**
@@ -19,8 +18,10 @@ import type { Element } from '@xmpp/client'
  *
  * @example Sending a raw IQ stanza
  * ```tsx
+ * import { xml } from '@fluux/sdk/xmpp'
+ *
  * function CustomIQ() {
- *   const { sendRawXml, xml } = useXMPP()
+ *   const { sendRawXml } = useXMPP()
  *
  *   const sendPing = async () => {
  *     const iq = xml('iq', { type: 'get', to: 'server.com', id: 'ping1' },
@@ -67,8 +68,12 @@ import type { Element } from '@xmpp/client'
  *
  * @example Building stanzas with the xml helper
  * ```tsx
+ * // The builder is protocol vocabulary, so it comes from the escape hatch
+ * // rather than from the hook.
+ * import { xml } from '@fluux/sdk/xmpp'
+ *
  * function MessageBuilder() {
- *   const { xml, sendRawXml } = useXMPP()
+ *   const { sendRawXml } = useXMPP()
  *
  *   const sendCustomMessage = async (to: string) => {
  *     const msg = xml('message', { to, type: 'chat' },
@@ -142,11 +147,6 @@ export function useXMPP() {
      * Set presence status
      */
     setPresence,
-
-    /**
-     * XML builder for constructing stanzas
-     */
-    xml,
 
     /**
      * Check if connected

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -18,6 +18,11 @@
  * - **`@fluux/sdk/core`** - Core-only: XMPPClient, types (for bots/CLI/other frameworks)
  * - **`@fluux/sdk/stores`** - Direct Zustand store access
  *
+ * None of those describes XMPP on the wire: conversations, rooms, contacts and
+ * presence are the vocabulary, and no XEP has to be read to use them. Raw
+ * namespaces, the stanza builder and the wire parsers are the escape hatch on
+ * **`@fluux/sdk/xmpp`**, for speaking a protocol the SDK does not model yet.
+ *
  * ## Quick Start (React)
  *
  * ```tsx
@@ -389,9 +394,10 @@ export type {
 // Message type guards
 export { isChatMessage, isRoomMessage } from './core/types'
 
-// Re-export xml builder for stanza construction
-export { xml } from '@xmpp/client'
-export type { Element } from '@xmpp/client'
+// The stanza builder (`xml`) and the ltx `Element` type are NOT exported here.
+// Typing consumer code against ltx would couple every app to an internal
+// dependency the SDK wants to keep replaceable. They live on the
+// `@fluux/sdk/xmpp` escape hatch, with the namespaces and the wire parsers.
 
 // =============================================================================
 // E2EE PLUGIN ARCHITECTURE
@@ -558,125 +564,28 @@ export type { WellKnownMucServer } from './core/config'
 // XMPP NAMESPACE CONSTANTS
 // =============================================================================
 
-export {
-  // XEP-0030: Service Discovery
-  NS_DISCO_INFO,
-  NS_DISCO_ITEMS,
-  // XEP-0363: HTTP File Upload
-  NS_HTTP_UPLOAD,
-  // XEP-0066: Out of Band Data
-  NS_OOB,
-  // XEP-0264: Jingle Content Thumbnails
-  NS_THUMBS,
-  // XEP-0085: Chat State Notifications
-  NS_CHATSTATES,
-  // XEP-0115: Entity Capabilities
-  NS_CAPS,
-  // XEP-0054: vcard-temp
-  NS_VCARD_TEMP,
-  // XEP-0153: vCard-Based Avatars
-  NS_VCARD_UPDATE,
-  // XEP-0280: Message Carbons
-  NS_CARBONS,
-  // XEP-0297: Stanza Forwarding
-  NS_FORWARD,
-  // XEP-0393: Message Styling
-  NS_STYLING,
-  // XEP-0428: Fallback Indication
-  NS_FALLBACK,
-  NS_FALLBACK_LEGACY,
-  // XEP-0444: Message Reactions
-  NS_REACTIONS,
-  // XEP-0461: Message Replies
-  NS_REPLY,
-  // XEP-0308: Last Message Correction
-  NS_CORRECTION,
-  // XEP-0424: Message Retraction
-  NS_RETRACT,
-  // XEP-0425: Message Moderation
-  NS_MESSAGE_MODERATE,
-  // XEP-0319: Last User Interaction in Presence
-  NS_IDLE,
-  // PubSub namespaces
-  NS_PUBSUB,
-  NS_PUBSUB_EVENT,
-  // XEP-0084: User Avatar (PEP)
-  NS_AVATAR_DATA,
-  NS_AVATAR_METADATA,
-  NS_AVATAR_METADATA_NOTIFY,
-  // XEP-0172: User Nickname
-  NS_NICK,
-  // XEP-0045: Multi-User Chat (MUC)
-  NS_MUC,
-  NS_MUC_USER,
-  NS_MUC_OWNER,
-  // XEP-0249: Direct MUC Invitations
-  NS_CONFERENCE,
-  // XEP-0402: PEP Native Bookmarks
-  NS_BOOKMARKS,
-  NS_BOOKMARKS_NOTIFY,
-  // XEP-0203: Delayed Delivery
-  NS_DELAY,
-  // XEP-0359: Unique and Stable Stanza IDs
-  NS_STANZA_ID,
-  // XEP-0372: References
-  NS_REFERENCE,
-  // XEP-0334: Message Processing Hints
-  NS_HINTS,
-  // XEP-0422: Message Fastening
-  NS_FASTEN,
-  // XEP-0050: Ad-Hoc Commands
-  NS_COMMANDS,
-  // XEP-0133: Service Administration
-  NS_ADMIN,
-  // XEP-0004: Data Forms
-  NS_DATA_FORMS,
-  // XEP-0059: Result Set Management
-  NS_RSM,
-  // XEP-0313: Message Archive Management
-  NS_MAM,
-  // XEP-0077: In-Band Registration
-  NS_REGISTER,
-  // XEP-0317: Hats
-  NS_HATS,
-  // XEP-0199: XMPP Ping
-  NS_PING,
-  // XEP-0202: Entity Time
-  NS_TIME,
-  // XEP-0191: Blocking Command
-  NS_BLOCKING,
-  // p1:push: ejabberd Push Notifications
-  NS_P1_PUSH,
-  NS_P1_PUSH_WEBPUSH,
-  // Custom: Fluux conversation list sync
-  NS_CONVERSATIONS,
-  // Custom: Fluux cross-device peer-verification sync (PEP node id)
-  NS_FLUUX_VERIFICATIONS,
-} from './core/namespaces'
+// The 73 `NS_*` protocol namespaces are NOT exported here. A consumer that
+// needs one is writing XMPP by hand, which the curated entry does not ask
+// anyone to do; they live on the `@fluux/sdk/xmpp` escape hatch.
 
 // =============================================================================
 // XMPP PROTOCOL UTILITIES
 // =============================================================================
 
-// XEP-0004: Data Form utilities
-export { parseDataForm, getFormFieldValue, getFormFieldValues, buildDataFormSubmit } from './utils/dataForm'
-
-// XEP-0059: Result Set Management utilities
-export { parseRSMResponse, buildRSMElement } from './utils/rsm'
-
 // UUID generation utility
 export { generateUUID, generateStableMessageId } from './utils/uuid'
 
-// XEP-0428: Fallback Indication utilities
-export { processFallback, getFallbackElement } from './utils/fallbackUtils'
-export type { FallbackProcessingResult, FallbackProcessingOptions } from './utils/fallbackUtils'
-
 // XEP-0426 character counting: wire offsets are code points, JS indices are
-// UTF-16 units. Consumers building their own offset-bearing stanzas need these.
+// UTF-16 units. These convert between the two and touch no stanza, so they
+// stay here rather than on the escape hatch.
 export { codePointLength, toCodePointOffset, fromCodePointOffset } from './utils/xep0426'
 
-// RFC 6120: XMPP Stanza Error parsing
-export { parseXMPPError, formatXMPPError } from './utils/xmppError'
+// A stanza delivery error, as carried by `BaseMessage.deliveryError`, and the
+// human-readable rendering of one. Formatting is a product concern: by the time
+// an app holds this value it is an ordinary field of a message. PARSING one out
+// of a stanza is not, and lives on `@fluux/sdk/xmpp` with the other wire
+// parsers (data forms, RSM, fallback indication).
+export { formatXMPPError } from './utils/xmppError'
 export type { XMPPStanzaError, XMPPErrorType } from './utils/xmppError'
 
 // The per-key latest-wins coalescing buffer (keyedCoalescer) is a generic,

--- a/packages/fluux-sdk/src/xmpp/index.ts
+++ b/packages/fluux-sdk/src/xmpp/index.ts
@@ -1,0 +1,49 @@
+/**
+ * # Fluux SDK — raw XMPP vocabulary (escape hatch)
+ *
+ * Protocol namespaces, the stanza builder, and the wire parsers. Import from
+ * `@fluux/sdk/xmpp`.
+ *
+ * The rest of the SDK is designed so that a developer never has to read a XEP:
+ * conversations, rooms, contacts and presence are described in domain terms,
+ * and the curated `@fluux/sdk` entry deliberately contains no namespace, no
+ * stanza builder and no `Element`. This entry is where that promise stops.
+ *
+ * Reach for it only to speak a part of XMPP the SDK does not model yet — a
+ * custom extension, an experimental XEP, a server-specific ad-hoc payload.
+ * Everything here traffics in raw stanzas and assumes you know the protocol.
+ *
+ * An import of this module is a signal, not a defect: it marks a place where
+ * the high-level API is missing something. Prefer raising that gap over
+ * building on the escape hatch permanently.
+ *
+ * @packageDocumentation
+ * @module XMPP
+ */
+
+// Stanza construction and the underlying element type (ltx, via @xmpp/client).
+export { xml } from '@xmpp/client'
+export type { Element } from '@xmpp/client'
+
+// Protocol namespace constants for every XEP the SDK speaks, plus the two
+// Fluux-specific nodes (NS_CONVERSATIONS, NS_FLUUX_VERIFICATIONS).
+export * from '../core/namespaces'
+
+// XEP-0004: Data Forms — read and submit a form carried in a stanza.
+// The `DataForm` shapes themselves stay on the main entry: an app renders
+// admin forms without ever touching the wire.
+export { parseDataForm, getFormFieldValue, getFormFieldValues, buildDataFormSubmit } from '../utils/dataForm'
+
+// XEP-0059: Result Set Management — pagination on the wire. The `RSMRequest`
+// and `RSMResponse` shapes stay on the main entry for the same reason.
+export { parseRSMResponse, buildRSMElement } from '../utils/rsm'
+
+// XEP-0428: Fallback Indication — strip the fallback text a sending client
+// wrote for clients that cannot render the real payload.
+export { processFallback, getFallbackElement } from '../utils/fallbackUtils'
+export type { FallbackProcessingResult, FallbackProcessingOptions } from '../utils/fallbackUtils'
+
+// RFC 6120: parse a stanza `<error/>` into a structured value. Formatting one
+// for a human (`formatXMPPError`) stays on the main entry — by then the error
+// is an ordinary field of a message, not a piece of XML.
+export { parseXMPPError } from '../utils/xmppError'

--- a/packages/fluux-sdk/tsup.config.ts
+++ b/packages/fluux-sdk/tsup.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     'demo/index': 'src/demo/index.ts',
     // Cache bundle (low-level IndexedDB escape hatch)
     'cache/index': 'src/cache/index.ts',
+    // Raw XMPP bundle (namespaces, stanza builder, wire parsers — escape hatch)
+    'xmpp/index': 'src/xmpp/index.ts',
   },
   format: ['cjs', 'esm'],
   dts: {

--- a/packages/fluux-sdk/typedoc.json
+++ b/packages/fluux-sdk/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["./src/index.ts"],
+  "entryPoints": ["./src/index.ts", "./src/xmpp/index.ts"],
   "tsconfig": "./tsconfig.docs.json",
   "out": "./docs",
   "name": "Fluux SDK",


### PR DESCRIPTION
The SDK aims to let a developer build a client or a bot without reading a XEP, but the main entry opened with 73 `NS_*` constants, the ltx `xml` builder and `Element` type, and the wire parsers (data forms, RSM, fallback indication). Typing consumer code against ltx also pins an internal dependency the SDK wants to keep replaceable.

All of it moves to a new `@fluux/sdk/xmpp` subpath, modelled on the existing `@fluux/sdk/cache` escape hatch. It stays available for speaking a protocol the SDK does not model yet, but an import from there now marks a gap in the high-level API rather than a normal way to use the SDK. The bot/CLI entry drops the builder too, and `useXMPP()` no longer returns it, which was the same leak through another door.

Two boundary calls worth noting:

- `formatXMPPError` and `XMPPStanzaError` stay on the main entry, because `BaseMessage.deliveryError` already carries that value. Parsing the wire is protocol; formatting something the domain model holds is not. `parseXMPPError` moves.
- `XMLElementData` becomes the SDK-wide element shape in `core/types/stanza.ts` instead of an E2EE-local one, which is where a library-independent stanza type belongs.

`barrelSurface.test.ts` asserts the boundary, including the hook path, so a namespace cannot drift back one convenient import at a time.

The app consumed almost none of this: four import sites, two of them in tests.