### PR TITLE
refactor(sdk): let Chat decide whether it is addressing a room or a person

### DIFF
--- a/apps/fluux/src/hooks/useLinkPreview.ts
+++ b/apps/fluux/src/hooks/useLinkPreview.ts
@@ -30,13 +30,11 @@ export function useLinkPreview() {
    * @param messageId - The ID of the sent message
    * @param body - The message body to scan for URLs
    * @param to - The conversation JID
-   * @param type - Message type ('chat' or 'groupchat')
    */
   const processMessageForLinkPreview = useCallback(async (
     messageId: string,
     body: string,
     to: string,
-    type: 'chat' | 'groupchat'
   ): Promise<void> => {
     // Extract first URL from message
     const url = extractFirstUrl(body)
@@ -65,7 +63,7 @@ export function useLinkPreview() {
       }
 
       // Send the fastening with link preview
-      await client.chat.sendLinkPreview(to, messageId, preview, type)
+      await client.chat.sendLinkPreview(to, messageId, preview)
 
       setState({ isFetching: false, error: null })
     } catch (err) {

--- a/apps/fluux/src/utils/mcpTools.test.ts
+++ b/apps/fluux/src/utils/mcpTools.test.ts
@@ -213,18 +213,18 @@ describe('mcpTools', () => {
       __resetSendRateLimitForTests()
     })
 
-    it('sends to a known chat conversation as type chat', async () => {
+    it('forwards a known chat conversation to the SDK, which decides the wire type', async () => {
       chatStore.setState({ conversations: new Map([['alice@example.com', { id: 'alice@example.com' } as Conversation]]) })
       const sendMessage = vi.fn().mockResolvedValue('msg-123')
       const client = { chat: { sendMessage } } as unknown as XMPPClient
 
       const result = await sendMessageTool(client, 'alice@example.com', 'hi')
 
-      expect(sendMessage).toHaveBeenCalledWith('alice@example.com', 'hi', 'chat')
+      expect(sendMessage).toHaveBeenCalledWith('alice@example.com', 'hi')
       expect(result).toEqual({ messageId: 'msg-123' })
     })
 
-    it('sends to a joined room as type groupchat', async () => {
+    it('forwards a joined room the same way, without classifying it', async () => {
       roomStore.setState({
         rooms: new Map([['room@conference.example.com', { jid: 'room@conference.example.com', joined: true } as Room]]),
       })
@@ -233,7 +233,7 @@ describe('mcpTools', () => {
 
       await sendMessageTool(client, 'room@conference.example.com', 'hi room')
 
-      expect(sendMessage).toHaveBeenCalledWith('room@conference.example.com', 'hi room', 'groupchat')
+      expect(sendMessage).toHaveBeenCalledWith('room@conference.example.com', 'hi room')
     })
 
     it('rejects sending to a known room the user is not joined to', async () => {

--- a/apps/fluux/src/utils/mcpTools.ts
+++ b/apps/fluux/src/utils/mcpTools.ts
@@ -151,8 +151,6 @@ export async function sendMessageTool(
   if (room && !room.joined) {
     throw new Error(`Not joined to room: ${conversationId}`)
   }
-  const isRoom = room !== undefined
-
-  const messageId = await client.chat.sendMessage(conversationId, body, isRoom ? 'groupchat' : 'chat')
+  const messageId = await client.chat.sendMessage(conversationId, body)
   return { messageId }
 }

--- a/packages/fluux-sdk/examples/assistant.ts
+++ b/packages/fluux-sdk/examples/assistant.ts
@@ -23,11 +23,6 @@ import { loadConfig, routeSdkLogsToStderr } from './config'
 interface Question {
   /** Who to address the answer to: the room, or the person. */
   to: string
-  /**
-   * Room or one-to-one. The SDK needs this on every call below even though it
-   * already knows what `to` is, so the bot has to carry it around.
-   */
-  kind: 'chat' | 'groupchat'
   /** The message being answered, for the acknowledgement and the reply. */
   messageId: string
   text: string
@@ -51,30 +46,22 @@ async function answer(question: string): Promise<string> {
  */
 async function respond(client: XMPPClient, question: Question): Promise<void> {
   // Tell the asker it landed, before anything slow starts.
-  await client.chat.sendReaction(question.to, question.messageId, ['👀'], question.kind)
-  await client.chat.sendChatState(question.to, 'composing', question.kind)
+  await client.chat.sendReaction(question.to, question.messageId, ['👀'])
+  await client.chat.sendChatState(question.to, 'composing')
 
-  const placeholderId = await client.chat.sendMessage(
-    question.to,
-    'Working on it…',
-    question.kind,
-    { id: question.messageId },
-  )
+  const placeholderId = await client.chat.sendMessage(question.to, 'Working on it…', {
+    id: question.messageId,
+  })
 
   try {
     const text = await answer(question.text)
-    await client.chat.sendCorrection(question.to, placeholderId, text, question.kind)
+    await client.chat.sendCorrection(question.to, placeholderId, text)
   } catch (error) {
     // The placeholder is already on everyone's screen, so a failure has to
     // replace it. Leaving it saying "Working on it…" forever is worse than
     // saying the work failed.
     const reason = error instanceof Error ? error.message : String(error)
-    await client.chat.sendCorrection(
-      question.to,
-      placeholderId,
-      `Sorry, that failed: ${reason}`,
-      question.kind,
-    )
+    await client.chat.sendCorrection(question.to, placeholderId, `Sorry, that failed: ${reason}`)
   }
 }
 
@@ -91,7 +78,6 @@ function questionFromChat(message: Message): Question | null {
 
   return {
     to: getBareJid(message.from),
-    kind: 'chat',
     messageId: message.id,
     text: message.body,
   }
@@ -112,7 +98,6 @@ function questionFromRoom(message: RoomMessage, nickname: string): Question | nu
 
   return {
     to: message.roomJid,
-    kind: 'groupchat',
     messageId: message.id,
     text: message.body,
   }

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -136,11 +136,26 @@ function makeDeps(options: {
   jid: string
   manager: E2EEManager
   captureStanza: (el: Element) => void
+  /**
+   * Rooms the client is in. Chat asks the room store whether a target JID is a
+   * room, so a test exercising groupchat has to declare it here.
+   */
+  rooms?: string[]
 }): { deps: ModuleDependencies; emitted: unknown[]; sdkEmitted: unknown[] } {
   const emitted: unknown[] = []
   const sdkEmitted: unknown[] = []
+  const rooms = new Set(options.rooms ?? [])
   const deps: ModuleDependencies = {
-    stores: null,
+    stores: rooms.size
+      ? ({
+          room: {
+            getRoom: (jid: string) => (rooms.has(jid) ? { jid } : undefined),
+            // Reaction, correction and retraction all check whether the target
+            // message was a whisper before addressing the room.
+            getMessage: () => undefined,
+          },
+        } as unknown as ModuleDependencies['stores'])
+      : null,
     presence: createPresenceReader(),
     sendStanza: async (stanza) => {
       options.captureStanza(stanza)
@@ -236,7 +251,14 @@ describe('Chat E2EE wiring', () => {
     })
 
     it('sends plaintext for groupchat messages (MUC encryption is a later phase)', async () => {
-      await chat.sendMessage('room@muc.example.com', 'hi room', 'groupchat')
+      // Chat reads the room store to know it is addressing a room.
+      const roomBuilt = makeDeps({
+        jid: 'me@example.com',
+        manager,
+        captureStanza: (el) => captured.push(el),
+        rooms: ['room@muc.example.com'],
+      })
+      await new Chat(roomBuilt.deps, stubMAM()).sendMessage('room@muc.example.com', 'hi room')
 
       const sent = captured[0]
       expect(sent.getChild('body')?.text()).toBe('hi room')
@@ -247,7 +269,7 @@ describe('Chat E2EE wiring', () => {
       // Regression: <fallback for="jabber:x:oob"> in the unencrypted stanza root
       // reveals to the XMPP server that an attachment was sent and its URL length.
       // It must be stripped after the OOB element is moved inside the encrypted payload.
-      await chat.sendMessage('bob@example.com', 'Check this file', 'chat', undefined, undefined, {
+      await chat.sendMessage('bob@example.com', 'Check this file', undefined, undefined, {
         url: 'https://upload.example.com/file.bin',
         name: 'photo.jpg',
         mediaType: 'image/jpeg',
@@ -277,7 +299,6 @@ describe('Chat E2EE wiring', () => {
       await chat.sendMessage(
         'bob@example.com',
         'Nice photo!',
-        'chat',
         { id: 'orig-msg-id', to: 'bob@example.com', fallback: { author: 'Bob', body: 'seen this?' } },
         undefined,
         {
@@ -322,7 +343,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'Check this', 'chat', undefined, undefined, {
+      await plainChat.sendMessage('bob@example.com', 'Check this', undefined, undefined, {
         url: 'https://upload.example.com/plain.jpg',
         name: 'plain.jpg',
         mediaType: 'image/jpeg',
@@ -408,7 +429,7 @@ describe('Chat E2EE wiring', () => {
       const guardedChat = new Chat(deps, stubMAM())
 
       await expect(
-        guardedChat.sendMessage('bob@example.com', 'secret photo', 'chat', undefined, undefined, {
+        guardedChat.sendMessage('bob@example.com', 'secret photo', undefined, undefined, {
           url: 'https://upload.example.com/photo.bin',
           name: 'photo.jpg',
           mediaType: 'image/jpeg',
@@ -437,7 +458,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'here is the file', 'chat', undefined, undefined, {
+      await plainChat.sendMessage('bob@example.com', 'here is the file', undefined, undefined, {
         url: 'https://upload.example.com/plain.jpg',
         name: 'plain.jpg',
         mediaType: 'image/jpeg',
@@ -1419,7 +1440,7 @@ describe('Chat E2EE wiring', () => {
       const guardedChat = new Chat(deps, stubMAM())
 
       await expect(
-        guardedChat.sendCorrection('bob@example.com', 'orig-id', 'updated caption', 'chat', {
+        guardedChat.sendCorrection('bob@example.com', 'orig-id', 'updated caption', {
           url: 'https://upload.example.com/edit.bin',
           name: 'edit.jpg',
           mediaType: 'image/jpeg',
@@ -1435,7 +1456,7 @@ describe('Chat E2EE wiring', () => {
     })
 
     it('strips the OOB fallback when encrypting a correction with attachment', async () => {
-      await chat.sendCorrection('bob@example.com', 'orig-id', 'new caption', 'chat', {
+      await chat.sendCorrection('bob@example.com', 'orig-id', 'new caption', {
         url: 'https://upload.example.com/photo.bin',
         name: 'photo.jpg',
         mediaType: 'image/jpeg',
@@ -1460,7 +1481,13 @@ describe('Chat E2EE wiring', () => {
     })
 
     it('groupchat correction sends plaintext (MUC E2EE not supported in this phase)', async () => {
-      await chat.sendCorrection('room@conf.example.com', 'orig-id', 'fixed text', 'groupchat')
+      const roomBuilt = makeDeps({
+        jid: 'me@example.com',
+        manager,
+        captureStanza: (el) => captured.push(el),
+        rooms: ['room@conf.example.com'],
+      })
+      await new Chat(roomBuilt.deps, stubMAM()).sendCorrection('room@conf.example.com', 'orig-id', 'fixed text')
 
       expect(captured).toHaveLength(1)
       const sent = captured[0]
@@ -1502,6 +1529,9 @@ describe('Chat E2EE wiring', () => {
             body: options.originalBody,
           } as unknown as import('../types').Message),
         },
+        // Chat asks the room store whether the target is a room. Here it is a
+        // person, so the lookup finds nothing.
+        room: { getRoom: () => undefined },
       } as unknown as import('../types').StoreBindings
       return { deps: built.deps, capturedStanzas, sdkEmitted: built.sdkEmitted }
     }
@@ -1702,6 +1732,9 @@ describe('Chat E2EE wiring', () => {
             body: 'will be retracted',
           } as unknown as import('../types').Message),
         },
+        // Chat asks the room store whether the target is a room. Here it is a
+        // person, so the lookup finds nothing.
+        room: { getRoom: () => undefined },
       } as unknown as import('../types').StoreBindings
       const rxChat = new Chat(rxBuilt.deps, stubMAM())
       rxChat.handle(inbound)
@@ -1835,7 +1868,7 @@ describe('Chat E2EE wiring', () => {
 
     // Build a Chat with no E2EE plugin so the fastening goes out in cleartext and
     // its wire format is directly inspectable.
-    const makePlainChat = () => {
+    const makePlainChat = (rooms?: string[]) => {
       const emptyManager = new E2EEManager({
         storage: new InMemoryStorageBackend(),
         xmpp: stubXmppPrimitives(async () => {}),
@@ -1846,6 +1879,7 @@ describe('Chat E2EE wiring', () => {
         jid: 'me@example.com',
         manager: emptyManager,
         captureStanza: (el) => localCaptured.push(el),
+        rooms,
       })
       return { chat: new Chat(deps, stubMAM()), captured: localCaptured }
     }
@@ -1889,9 +1923,9 @@ describe('Chat E2EE wiring', () => {
     })
 
     it('sends a groupchat preview in cleartext with the interop wire format (no encryption)', async () => {
-      const { chat: plainChat, captured: local } = makePlainChat()
+      const { chat: plainChat, captured: local } = makePlainChat(['room@muc.example.com'])
 
-      await plainChat.sendLinkPreview('room@muc.example.com', 'muc-orig', preview, 'groupchat')
+      await plainChat.sendLinkPreview('room@muc.example.com', 'muc-orig', preview)
 
       const sent = local[0]
       expect(sent.attrs.to).toBe('room@muc.example.com')
@@ -2012,7 +2046,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+      await plainChat.sendMessage('bob@example.com', 'sure thing', encryptedReply)
 
       const sent = captured[0]
       const body = sent.getChild('body')?.text() ?? ''
@@ -2035,7 +2069,7 @@ describe('Chat E2EE wiring', () => {
 
     it('keeps the quote INSIDE the encrypted payload when the reply is encrypted', async () => {
       // `chat` uses the DummyPlaintextPlugin (registered in beforeEach) → encrypts.
-      await chat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+      await chat.sendMessage('bob@example.com', 'sure thing', encryptedReply)
 
       const sent = captured[0]
       // Outer body is the generic fallback, never the quote.
@@ -2068,7 +2102,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', {
+      await plainChat.sendMessage('bob@example.com', 'sure thing', {
         id: 'orig',
         to: 'bob@example.com',
         fallback: { author: 'Bob', body: 'hello there' }, // fromEncrypted omitted → false
@@ -2102,7 +2136,6 @@ describe('Chat E2EE wiring', () => {
       await plainChat.sendMessage(
         'bob@example.com',
         'sure thing',
-        'chat',
         { id: 'orig', to: 'bob@example.com', fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true } },
         undefined,
         { url: attachmentUrl, name: 'file.bin', mediaType: 'application/octet-stream' }, // unencrypted attachment → cleartext send
@@ -2136,7 +2169,7 @@ describe('Chat E2EE wiring', () => {
 
   describe('outbound encryption — sendEasterEgg', () => {
     it('moves the easter-egg element inside the encrypted payload and keeps no-store', async () => {
-      await chat.sendEasterEgg('bob@example.com', 'chat', 'confetti')
+      await chat.sendEasterEgg('bob@example.com', 'confetti')
 
       expect(captured).toHaveLength(1)
       const sent = captured[0]
@@ -2150,7 +2183,7 @@ describe('Chat E2EE wiring', () => {
     })
 
     it('round-trips an encrypted easter egg back to a chat:animation event', async () => {
-      await chat.sendEasterEgg('bob@example.com', 'chat', 'confetti')
+      await chat.sendEasterEgg('bob@example.com', 'confetti')
       const outgoing = captured[0]
 
       const inbound = xml(
@@ -2185,7 +2218,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendEasterEgg('bob@example.com', 'chat', 'confetti')
+      await plainChat.sendEasterEgg('bob@example.com', 'confetti')
 
       const sent = captured[0]
       expect(sent.getChild('easter-egg', 'urn:fluux:easter-egg:0')).toBeDefined()

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -49,6 +49,9 @@ describe('XMPPClient Message', () => {
     vi.mocked(xmppClientFactory).mockReturnValue(mockXmppClientInstance as any)
 
     mockStores = createMockStores()
+    // Chat asks the room store whether a JID is a room, so the room these
+    // tests address has to exist, exactly as a join would make it.
+    mockStores.room.getRoom = vi.fn((jid: string) => (jid === 'room@conference.example.com' ? { jid: 'room@conference.example.com', nickname: 'me' } : undefined)) as typeof mockStores.room.getRoom
     xmppClient = new XMPPClient({ debug: false })
     xmppClient.bindStores(mockStores)
     emitSDKSpy = vi.spyOn(xmppClient, 'emitSDK')
@@ -636,7 +639,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('offline@example.com', 'composing', 'chat')
+      await xmppClient.chat.sendChatState('offline@example.com', 'composing')
 
       // Should NOT have sent any stanza
       expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
@@ -653,7 +656,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('online@example.com', 'composing', 'chat')
+      await xmppClient.chat.sendChatState('online@example.com', 'composing')
 
       // Should have sent the chat state
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -670,7 +673,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('away@example.com', 'composing', 'chat')
+      await xmppClient.chat.sendChatState('away@example.com', 'composing')
 
       // Should have sent the chat state (away users can still receive)
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -680,7 +683,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // For groupchat, we don't check individual presence
-      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing', 'groupchat')
+      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing')
 
       // Should have sent the chat state
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -696,8 +699,8 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('online@example.com', 'composing', 'chat')
-      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing', 'groupchat')
+      await xmppClient.chat.sendChatState('online@example.com', 'composing')
+      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
       for (const [sentStanza] of mockXmppClientInstance.send.mock.calls) {
@@ -972,7 +975,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'alice@example.com',
         'Thanks!',
-        'chat',
         { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } },
       )
 
@@ -994,7 +996,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'room@conference.example.com',
         body,
-        'groupchat',
         undefined,
         [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
       )
@@ -1017,7 +1018,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'room@conference.example.com',
         typed,
-        'groupchat',
         { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } },
         [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
       )
@@ -1547,7 +1547,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍', '❤️'], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍', '❤️'])
 
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
 
@@ -1582,7 +1582,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // getMessage returns undefined (default mock behavior)
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -1611,7 +1611,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', [], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', [])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1625,7 +1625,7 @@ describe('XMPPClient Message', () => {
     it('should update local store after sending reaction', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'])
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:reactions', {
         isLive: true,
@@ -1640,7 +1640,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // Send with full JID - should be stripped to bare JID
-      await xmppClient.chat.sendReaction('alice@example.com/mobile', 'msg-123', ['👍'], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com/mobile', 'msg-123', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sentStanza.attrs.to).toBe('alice@example.com')
@@ -1658,7 +1658,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1677,7 +1677,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1690,7 +1690,7 @@ describe('XMPPClient Message', () => {
       mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: 'room@conference.example.com', nickname: 'me' })
       // getMessage returns undefined (default mock behavior)
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'unknown-msg-id', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction('room@conference.example.com', 'unknown-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1709,7 +1709,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['🎉'], 'groupchat')
+      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['🎉'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -1744,7 +1744,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'room@conference.example.com',
         'My reply',
-        'groupchat',
         { id: 'client-msg-id', to: 'room@conference.example.com/alice', fallback: { author: 'alice', body: 'Original message' } }
       )
 
@@ -1768,7 +1767,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'room@conference.example.com',
         'My reply',
-        'groupchat',
         { id: 'client-msg-id', to: 'room@conference.example.com/alice' }
       )
 
@@ -1795,7 +1793,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'alice@example.com',
         'My reply',
-        'chat',
         { id: 'client-msg-id', to: 'alice@example.com' }
       )
 
@@ -1826,7 +1823,6 @@ describe('XMPPClient Message', () => {
       await xmppClient.chat.sendMessage(
         'bob@example.com',
         'Nice!',
-        'chat',
         { id: 'a1b2c3d4-uuid-style-id', to: 'bob@example.com', fallback: { author: 'bob', body: 'Check this out' } }
       )
 
@@ -1850,7 +1846,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'client-msg-id', ['👍'], 'chat')
+      await xmppClient.chat.sendReaction('alice@example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1870,7 +1866,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1892,7 +1888,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo', 'chat')
+      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1916,7 +1912,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo', 'chat')
+      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1941,7 +1937,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo', 'groupchat')
+      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1965,7 +1961,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo', 'groupchat')
+      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1985,7 +1981,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2010,7 +2006,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2034,7 +2030,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2056,7 +2052,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', url, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', url, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2085,7 +2081,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
 
       // Body should be empty because the URL is fallback text for OOB
       // (our client understands OOB, so we strip the fallback)
@@ -2117,7 +2113,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', userText, 'chat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', userText, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2149,7 +2145,7 @@ describe('XMPPClient Message', () => {
     it('should not include fallback when no attachment', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendMessage('alice@example.com', 'Hello, world!', 'chat')
+      await xmppClient.chat.sendMessage('alice@example.com', 'Hello, world!')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2159,6 +2155,44 @@ describe('XMPPClient Message', () => {
 
       expect(fallbackEl).toBeUndefined()
       expect(oobEl).toBeUndefined()
+    })
+
+    describe('addressing a room versus a person', () => {
+      // Callers no longer say which one they mean. The room store is the SDK's
+      // record of the rooms it is in, and XEP-0045 requires being in a room
+      // before sending to it, so a JID it knows is a room.
+
+      it('sends groupchat to a JID the room store knows', async () => {
+        await connectClient()
+
+        await xmppClient.chat.sendMessage('room@conference.example.com', 'hello room')
+
+        expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('groupchat')
+      })
+
+      it('sends chat to any other JID', async () => {
+        await connectClient()
+
+        await xmppClient.chat.sendMessage('alice@example.com', 'hello alice')
+
+        expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('chat')
+      })
+
+      it('resolves from the bare JID, so a full occupant JID still reads as its room', async () => {
+        await connectClient()
+
+        await xmppClient.chat.sendReaction('room@conference.example.com/bob', 'msg-1', ['\u{1F44D}'])
+
+        expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('groupchat')
+      })
+
+      it('treats a room it has not joined as a person, which is what the server would enforce', async () => {
+        await connectClient()
+
+        await xmppClient.chat.sendMessage('other@conference.example.com', 'hello')
+
+        expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('chat')
+      })
     })
 
     it('should work with groupchat type', async () => {
@@ -2171,7 +2205,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', attachment.url, 'groupchat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('room@conference.example.com', attachment.url, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -2200,7 +2234,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', userText, 'groupchat', undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('room@conference.example.com', userText, undefined, undefined, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2223,7 +2257,7 @@ describe('XMPPClient Message', () => {
   describe('sendCorrection (XEP-0308)', () => {
     it('should throw error if not connected', async () => {
       await expect(
-        xmppClient.chat.sendCorrection('contact@example.com', 'msg-123', 'Fixed message', 'chat')
+        xmppClient.chat.sendCorrection('contact@example.com', 'msg-123', 'Fixed message')
       ).rejects.toThrow('Not connected')
     })
 
@@ -2238,7 +2272,7 @@ describe('XMPPClient Message', () => {
         from: 'me@example.com',
       })
 
-      await xmppClient.chat.sendCorrection('contact@example.com/resource', 'original-msg-123', 'Fixed message', 'chat')
+      await xmppClient.chat.sendCorrection('contact@example.com/resource', 'original-msg-123', 'Fixed message')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2284,7 +2318,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated caption', 'chat', attachment)
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated caption', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2316,7 +2350,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', 'chat', attachment)
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2344,7 +2378,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', 'chat', attachment)
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobFallbackEl = sentStanza.children.find(
@@ -2366,7 +2400,7 @@ describe('XMPPClient Message', () => {
       })
 
       // No attachment passed = attachment removed
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Message without attachment', 'chat')
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Message without attachment')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2398,7 +2432,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', userText, 'chat', attachment)
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', userText, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2445,7 +2479,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated', 'chat', attachment)
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated', attachment)
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2469,7 +2503,7 @@ describe('XMPPClient Message', () => {
         attachment: { url: 'https://upload.example.com/old.jpg' },
       })
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Now just text', 'chat')
+      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Now just text')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2500,7 +2534,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'original-msg-123', 'Fixed', 'groupchat', attachment)
+      await xmppClient.chat.sendCorrection('room@conference.example.com', 'original-msg-123', 'Fixed', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -2534,7 +2568,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Fixed', 'groupchat')
+      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Fixed')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -2767,14 +2801,14 @@ describe('XMPPClient Message', () => {
   describe('sendRetraction (XEP-0424)', () => {
     it('should throw error if not connected', async () => {
       await expect(
-        xmppClient.chat.sendRetraction('contact@example.com', 'msg-123', 'chat')
+        xmppClient.chat.sendRetraction('contact@example.com', 'msg-123')
       ).rejects.toThrow('Not connected')
     })
 
     it('should send retraction stanza with correct structure for chat', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendRetraction('contact@example.com/resource', 'original-msg-123', 'chat')
+      await xmppClient.chat.sendRetraction('contact@example.com/resource', 'original-msg-123')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2807,7 +2841,7 @@ describe('XMPPClient Message', () => {
     it('should send retraction stanza with full JID for groupchat', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-msg-456', 'groupchat')
+      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-msg-456')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2838,7 +2872,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'original-msg-123', 'chat')
+      await xmppClient.chat.sendRetraction('contact@example.com', 'original-msg-123')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2865,7 +2899,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-room-msg-456', 'groupchat')
+      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-room-msg-456')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', {
         roomJid: 'room@conference.example.com',
@@ -2883,7 +2917,7 @@ describe('XMPPClient Message', () => {
       // Mock that the message doesn't exist
       vi.mocked(mockStores.chat.getMessage).mockReturnValue(undefined)
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'non-existent-msg', 'chat')
+      await xmppClient.chat.sendRetraction('contact@example.com', 'non-existent-msg')
 
       // Should still send the stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -2897,7 +2931,7 @@ describe('XMPPClient Message', () => {
       // Mock that the message doesn't exist
       vi.mocked(mockStores.room.getMessage).mockReturnValue(undefined)
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'non-existent-msg', 'groupchat')
+      await xmppClient.chat.sendRetraction('room@conference.example.com', 'non-existent-msg')
 
       // Should still send the stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -2929,7 +2963,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'client-msg-id', 'groupchat')
+      await xmppClient.chat.sendRetraction('room@conference.example.com', 'client-msg-id')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const retractEl = sentStanza.children.find(
@@ -3252,7 +3286,7 @@ describe('XMPPClient Message', () => {
     it('should include origin-id element in outgoing sendMessage stanza', async () => {
       await connectClient()
 
-      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello', 'chat')
+      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3266,7 +3300,7 @@ describe('XMPPClient Message', () => {
     it('should set originId on local message object for outgoing sendMessage', async () => {
       await connectClient()
 
-      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello', 'chat')
+      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
         message: expect.objectContaining({
@@ -4264,7 +4298,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
 
     // Should not throw — opportunistic + unverified = silent plaintext fallback.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 
@@ -4273,7 +4307,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = makeE2EEManager({ isVerified: true }) as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow(E2EEEncryptionRequiredError)
   })
 
@@ -4282,7 +4316,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = makeE2EEManager({ policy: 'strict', isVerified: false }) as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow(E2EEEncryptionRequiredError)
   })
 
@@ -4293,7 +4327,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     // A selected plugin failing to encrypt must never fall back to plaintext;
     // the original plugin error propagates so the UI can surface it.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow('plugin boom')
   })
 
@@ -4304,7 +4338,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     // Core downgrade-protection fix: even opportunistic + unverified must NOT
     // silently send plaintext when a selected plugin fails to encrypt.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow('plugin boom')
   })
 
@@ -4317,7 +4351,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = mgr as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 
@@ -4329,7 +4363,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = mgr as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello', 'chat'),
+      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -86,12 +86,12 @@ import type { StanzaClaim } from '../stanzaRouting'
  * await client.chat.sendMessage('user@example.com', 'Hello!')
  *
  * // Send a group chat message
- * await client.chat.sendMessage('room@conference.example.com', 'Hello room!', 'groupchat')
+ * await client.chat.sendMessage('room@conference.example.com', 'Hello room!')
  * ```
  *
  * @example Sending a reply
  * ```typescript
- * await client.chat.sendMessage('user@example.com', 'I agree!', 'chat', {
+ * await client.chat.sendMessage('user@example.com', 'I agree!', {
  *   id: 'original-message-id',
  *   to: 'user@example.com',
  *   fallback: { author: 'User', body: 'What do you think?' }
@@ -784,7 +784,6 @@ export class Chat extends BaseModule {
    *
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param body - Message text content
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    * @param replyTo - Optional reply information for threaded replies (XEP-0461)
    * @param references - Optional mention references (XEP-0372)
    * @param attachment - Optional file attachment (XEP-0066, XEP-0264)
@@ -797,7 +796,7 @@ export class Chat extends BaseModule {
    *
    * @example Message with attachment
    * ```typescript
-   * const msgId = await client.chat.sendMessage('user@example.com', 'Check this out', 'chat', undefined, undefined, {
+   * const msgId = await client.chat.sendMessage('user@example.com', 'Check this out', undefined, undefined, {
    *   url: 'https://example.com/file.pdf',
    *   name: 'document.pdf',
    *   size: 12345,
@@ -808,11 +807,11 @@ export class Chat extends BaseModule {
   async sendMessage(
     to: string,
     body: string,
-    type: 'chat' | 'groupchat' = 'chat',
     replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } },
     references?: MentionReference[],
     attachment?: FileAttachment
   ): Promise<string> {
+    const type = this.conversationKind(to)
     const id = generateUUID()
     const recipient = type === 'chat' ? getBareJid(to) : to
 
@@ -1143,7 +1142,6 @@ export class Chat extends BaseModule {
    *
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param state - The chat state to send
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    *
    * @example
    * ```typescript
@@ -1162,7 +1160,8 @@ export class Chat extends BaseModule {
    * - Common states: 'composing' (typing), 'paused' (stopped typing),
    *   'active' (focused), 'inactive' (not focused), 'gone' (left)
    */
-  async sendChatState(to: string, state: ChatStateNotification, type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
+  async sendChatState(to: string, state: ChatStateNotification): Promise<void> {
+    const type = this.conversationKind(to)
     const recipient = type === 'chat' ? getBareJid(to) : to
 
     if (type === 'chat') {
@@ -1181,7 +1180,7 @@ export class Chat extends BaseModule {
 
   /**
    * Send a chat state (XEP-0085) privately to a single room occupant — the typing
-   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState('groupchat'),
+   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState on the room,
    * which broadcasts to the room, this addresses room/nick with the muc#user marker
    * and a no-store hint, so the room never sees that you are whispering.
    */
@@ -1204,7 +1203,6 @@ export class Chat extends BaseModule {
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param messageId - The ID of the message to react to
    * @param emojis - Array of emoji characters (empty array removes reactions)
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    *
    * @example
    * ```typescript
@@ -1215,10 +1213,11 @@ export class Chat extends BaseModule {
    * await client.chat.sendReaction('user@example.com', 'msg-123', [])
    *
    * // React in a MUC room
-   * await client.chat.sendReaction('room@conference.example.com', 'msg-456', ['🎉'], 'groupchat')
+   * await client.chat.sendReaction('room@conference.example.com', 'msg-456', ['🎉'])
    * ```
    */
-  async sendReaction(to: string, messageId: string, emojis: string[], type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
+  async sendReaction(to: string, messageId: string, emojis: string[]): Promise<void> {
+    const type = this.conversationKind(to)
     // XEP-0045 §7.5: a reaction on a whisper is addressed privately to the one
     // occupant; whispers are <no-store> so the reference is the origin-id.
     const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, messageId) : null
@@ -1301,7 +1300,6 @@ export class Chat extends BaseModule {
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param originalMessageId - The ID of the message to correct
    * @param newBody - The corrected message text
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    * @param attachment - Optional replacement file attachment
    *
    * @example
@@ -1310,7 +1308,7 @@ export class Chat extends BaseModule {
    * await client.chat.sendCorrection('user@example.com', 'msg-123', 'Fixed the typo')
    *
    * // Correct a message in a MUC room
-   * await client.chat.sendCorrection('room@conference.example.com', 'msg-456', 'Updated content', 'groupchat')
+   * await client.chat.sendCorrection('room@conference.example.com', 'msg-456', 'Updated content')
    * ```
    *
    * @remarks
@@ -1318,7 +1316,8 @@ export class Chat extends BaseModule {
    * - The original body is preserved in `originalBody` for display
    * - Corrected messages are marked with `isEdited: true`
    */
-  async sendCorrection(to: string, originalMessageId: string, newBody: string, type: 'chat' | 'groupchat' = 'chat', attachment?: FileAttachment): Promise<void> {
+  async sendCorrection(to: string, originalMessageId: string, newBody: string, attachment?: FileAttachment): Promise<void> {
+    const type = this.conversationKind(to)
     // XEP-0045 §7.5: if the target is a whisper, address the correction privately
     // to the one occupant (type=chat to room/nick + muc#user + no-store) instead of
     // broadcasting to the room. Throws WhisperCounterpartGoneError if they have left.
@@ -1443,7 +1442,6 @@ export class Chat extends BaseModule {
    *
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param originalMessageId - The ID of the message to retract
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    *
    * @example
    * ```typescript
@@ -1451,7 +1449,7 @@ export class Chat extends BaseModule {
    * await client.chat.sendRetraction('user@example.com', 'msg-123')
    *
    * // Retract a message in a MUC room
-   * await client.chat.sendRetraction('room@conference.example.com', 'msg-456', 'groupchat')
+   * await client.chat.sendRetraction('room@conference.example.com', 'msg-456')
    * ```
    *
    * @remarks
@@ -1459,7 +1457,8 @@ export class Chat extends BaseModule {
    * - Retracted messages are marked with `isRetracted: true` and `retractedAt`
    * - A fallback message is included for clients that don't support XEP-0424
    */
-  async sendRetraction(to: string, originalMessageId: string, type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
+  async sendRetraction(to: string, originalMessageId: string): Promise<void> {
+    const type = this.conversationKind(to)
     // XEP-0045 §7.5: a retraction of a whisper is addressed privately to the one
     // occupant; whispers are <no-store> so the reference is the origin-id.
     const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, originalMessageId) : null
@@ -1526,23 +1525,23 @@ export class Chat extends BaseModule {
    * These are ephemeral and not stored in message history.
    *
    * @param to - Recipient JID (user for chat, room for groupchat)
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    * @param animation - The animation identifier (e.g., 'confetti', 'fireworks')
    *
    * @example
    * ```typescript
    * // Send confetti animation
-   * await client.chat.sendEasterEgg('user@example.com', 'chat', 'confetti')
+   * await client.chat.sendEasterEgg('user@example.com', 'confetti')
    *
    * // Send fireworks in a room
-   * await client.chat.sendEasterEgg('room@conference.example.com', 'groupchat', 'fireworks')
+   * await client.chat.sendEasterEgg('room@conference.example.com', 'fireworks')
    * ```
    *
    * @remarks
    * - Messages are sent with no-store hint (not archived)
    * - The animation is triggered locally immediately
    */
-  async sendEasterEgg(to: string, type: 'chat' | 'groupchat', animation: string): Promise<void> {
+  async sendEasterEgg(to: string, animation: string): Promise<void> {
+    const type = this.conversationKind(to)
     const recipient = type === 'chat' ? getBareJid(to) : to
     const children: Element[] = [
       xml('no-store', { xmlns: NS_HINTS }),
@@ -1586,7 +1585,6 @@ export class Chat extends BaseModule {
    * @param preview.description - The page description
    * @param preview.image - URL to the preview image
    * @param preview.siteName - The site name
-   * @param type - Message type: 'chat' for 1:1, 'groupchat' for MUC
    *
    * @example
    * ```typescript
@@ -1603,7 +1601,8 @@ export class Chat extends BaseModule {
    * - Sent with no-store hint (not archived separately)
    * - Updates the local message with the preview immediately
    */
-  async sendLinkPreview(to: string, originalId: string, preview: any, type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
+  async sendLinkPreview(to: string, originalId: string, preview: any): Promise<void> {
+    const type = this.conversationKind(to)
     const recipient = type === 'chat' ? getBareJid(to) : to
     const metaElements: Element[] = [
       xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:url', content: preview.url })
@@ -1814,6 +1813,18 @@ export class Chat extends BaseModule {
    * (occupant-id gone, or nick gone in rooms without occupant-id), it throws
    * WhisperCounterpartGoneError — it must NEVER fall back to the room-broadcast path.
    */
+  /**
+   * Whether a message addressed to `to` is a room message or a one-to-one one.
+   *
+   * This is a fact about the session, not a guess. XEP-0045 §7.4 requires
+   * presence in a room before sending to it, and `MUC.joinRoom` records the
+   * room before it sends that presence, so a JID the room store knows is a
+   * room we are addressing as one, and any other JID is a person.
+   */
+  private conversationKind(to: string): 'chat' | 'groupchat' {
+    return this.deps.stores?.room.getRoom(getBareJid(to)) ? 'groupchat' : 'chat'
+  }
+
   private resolveWhisperRouting(
     roomJid: string,
     messageId: string,

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -289,7 +289,7 @@ describe('MUC Whispers', () => {
       // Pass the message-id (w-msg-1) to the operation; assert that the protocol
       // reference is the origin-id (w-1). If the code used message-id, this would
       // be 'w-msg-1' and the test would fail — proving origin-id is used.
-      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed secret', 'groupchat')
+      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed secret')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -310,7 +310,7 @@ describe('MUC Whispers', () => {
         nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'm-1', 'hi fixed', 'groupchat')
+      await xmppClient.chat.sendCorrection(ROOM, 'm-1', 'hi fixed')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)
@@ -324,7 +324,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       await expect(
-        xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'x', 'groupchat'),
+        xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'x'),
       ).rejects.toThrow(WhisperCounterpartGoneError)
       expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
     })
@@ -336,7 +336,7 @@ describe('MUC Whispers', () => {
       ])))
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed', 'groupchat')
+      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed')
 
       expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
     })
@@ -347,7 +347,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
-      await xmppClient.chat.sendReaction(ROOM, 'w-msg-1', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction(ROOM, 'w-msg-1', ['👍'])
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -367,7 +367,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
-      await xmppClient.chat.sendRetraction(ROOM, 'w-msg-1', 'groupchat')
+      await xmppClient.chat.sendRetraction(ROOM, 'w-msg-1')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -388,7 +388,7 @@ describe('MUC Whispers', () => {
         from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendReaction(ROOM, 'm-1', ['👍'], 'groupchat')
+      await xmppClient.chat.sendReaction(ROOM, 'm-1', ['👍'])
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)
@@ -406,7 +406,7 @@ describe('MUC Whispers', () => {
         from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendRetraction(ROOM, 'm-1', 'groupchat')
+      await xmppClient.chat.sendRetraction(ROOM, 'm-1')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)

--- a/packages/fluux-sdk/src/core/modules/Poll.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Poll.test.ts
@@ -237,7 +237,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '2️⃣', [], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', ['2️⃣'], 'groupchat',
+        'room@conf.example.com', 'msg-1', ['2️⃣'],
       )
     })
 
@@ -257,7 +257,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '2️⃣', ['1️⃣'], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', ['2️⃣'], 'groupchat',
+        'room@conf.example.com', 'msg-1', ['2️⃣'],
       )
     })
 
@@ -277,7 +277,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '2️⃣', ['👍', '1️⃣'], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', ['👍', '2️⃣'], 'groupchat',
+        'room@conf.example.com', 'msg-1', ['👍', '2️⃣'],
       )
     })
 
@@ -297,7 +297,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '1️⃣', ['1️⃣'], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', [], 'groupchat',
+        'room@conf.example.com', 'msg-1', [],
       )
     })
 
@@ -318,7 +318,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '2️⃣', ['1️⃣'], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', ['1️⃣', '2️⃣'], 'groupchat',
+        'room@conf.example.com', 'msg-1', ['1️⃣', '2️⃣'],
       )
     })
 
@@ -338,7 +338,7 @@ describe('Poll module', () => {
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '1️⃣', ['1️⃣', '2️⃣'], poll)
 
       expect(sendReactionSpy).toHaveBeenCalledWith(
-        'room@conf.example.com', 'msg-1', ['2️⃣'], 'groupchat',
+        'room@conf.example.com', 'msg-1', ['2️⃣'],
       )
     })
   })

--- a/packages/fluux-sdk/src/core/modules/Poll.ts
+++ b/packages/fluux-sdk/src/core/modules/Poll.ts
@@ -202,7 +202,7 @@ export class Poll extends BaseModule {
       newReactions = enforceSingleVote(currentMyReactions, optionEmoji, pollEmojis)
     }
 
-    await this.chat.sendReaction(roomJid, messageId, newReactions, 'groupchat')
+    await this.chat.sendReaction(roomJid, messageId, newReactions)
 
     // Persist vote acknowledgement locally for banner dismissal across page reloads
     if (newReactions.length > 0) {

--- a/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
@@ -41,7 +41,7 @@ describe('useChatActions.sendMessage (options object)', () => {
     })
 
     expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
-      'bob@example.com', 'hi', 'chat', undefined, undefined, undefined
+      'bob@example.com', 'hi', undefined, undefined, undefined
     )
   })
 
@@ -55,7 +55,7 @@ describe('useChatActions.sendMessage (options object)', () => {
     })
 
     expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
-      'bob@example.com', 'see this', 'chat', replyTo, undefined, attachment
+      'bob@example.com', 'see this', replyTo, undefined, attachment
     )
   })
 })

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -34,7 +34,7 @@ export function useChatActions() {
       }
     ): Promise<string> => {
       // 1:1 chat hook: always a 'chat'-type message (rooms use useRoomActions).
-      return await client.chat.sendMessage(to, body, 'chat', options?.replyTo, undefined, options?.attachment)
+      return await client.chat.sendMessage(to, body, options?.replyTo, undefined, options?.attachment)
     },
     [client]
   )
@@ -73,36 +73,36 @@ export function useChatActions() {
   }, [])
 
   const sendChatState = useCallback(
-    async (to: string, state: ChatStateNotification, type: 'chat' | 'groupchat' = 'chat') => {
-      await client.chat.sendChatState(to, state, type)
+    async (to: string, state: ChatStateNotification) => {
+      await client.chat.sendChatState(to, state)
     },
     [client]
   )
 
   const sendReaction = useCallback(
-    async (to: string, messageId: string, emojis: string[], type: 'chat' | 'groupchat' = 'chat') => {
-      await client.chat.sendReaction(to, messageId, emojis, type)
+    async (to: string, messageId: string, emojis: string[]) => {
+      await client.chat.sendReaction(to, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (conversationId: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(conversationId, messageId, newBody, 'chat', attachment)
+      await client.chat.sendCorrection(conversationId, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (conversationId: string, messageId: string) => {
-      await client.chat.sendRetraction(conversationId, messageId, 'chat')
+      await client.chat.sendRetraction(conversationId, messageId)
     },
     [client]
   )
 
   const sendEasterEgg = useCallback(
-    async (to: string, type: 'chat' | 'groupchat', animation: string) => {
-      await client.chat.sendEasterEgg(to, type, animation)
+    async (to: string, animation: string) => {
+      await client.chat.sendEasterEgg(to, animation)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useConnection.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useConnection.test.tsx
@@ -458,7 +458,6 @@ describe('useConnection hook', () => {
           'alice@example.com',
           'msg-123',
           preview,
-          'chat'
         )
       })
 
@@ -466,7 +465,6 @@ describe('useConnection hook', () => {
         'alice@example.com',
         'msg-123',
         preview,
-        'chat'
       )
     })
 
@@ -485,7 +483,6 @@ describe('useConnection hook', () => {
           'room@conference.example.com',
           'msg-456',
           preview,
-          'groupchat'
         )
       })
 
@@ -493,7 +490,6 @@ describe('useConnection hook', () => {
         'room@conference.example.com',
         'msg-456',
         preview,
-        'groupchat'
       )
     })
   })

--- a/packages/fluux-sdk/src/hooks/useConnectionActions.ts
+++ b/packages/fluux-sdk/src/hooks/useConnectionActions.ts
@@ -122,10 +122,9 @@ export function useConnectionActions() {
     async (
       to: string,
       originalMessageId: string,
-      preview: LinkPreview,
-      type: 'chat' | 'groupchat' = 'chat'
+      preview: LinkPreview
     ) => {
-      await client.chat.sendLinkPreview(to, originalMessageId, preview, type)
+      await client.chat.sendLinkPreview(to, originalMessageId, preview)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -139,35 +139,35 @@ export function useRoomActions() {
         attachment?: FileAttachment
       }
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, 'groupchat', options?.replyTo, options?.references, options?.attachment)
+      return await client.chat.sendMessage(roomJid, body, options?.replyTo, options?.references, options?.attachment)
     },
     [client]
   )
 
   const sendReaction = useCallback(
     async (roomJid: string, messageId: string, emojis: string[]) => {
-      await client.chat.sendReaction(roomJid, messageId, emojis, 'groupchat')
+      await client.chat.sendReaction(roomJid, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(roomJid, messageId, newBody, 'groupchat', attachment)
+      await client.chat.sendCorrection(roomJid, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (roomJid: string, messageId: string) => {
-      await client.chat.sendRetraction(roomJid, messageId, 'groupchat')
+      await client.chat.sendRetraction(roomJid, messageId)
     },
     [client]
   )
 
   const sendChatState = useCallback(
     async (roomJid: string, state: ChatStateNotification) => {
-      await client.chat.sendChatState(roomJid, state, 'groupchat')
+      await client.chat.sendChatState(roomJid, state)
     },
     [client]
   )
@@ -181,7 +181,7 @@ export function useRoomActions() {
 
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
-      await client.chat.sendEasterEgg(roomJid, 'groupchat', animation)
+      await client.chat.sendEasterEgg(roomJid, animation)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -225,7 +225,7 @@ export function useRoomActive() {
         attachment?: FileAttachment
       }
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, 'groupchat', options?.replyTo, options?.references, options?.attachment)
+      return await client.chat.sendMessage(roomJid, body, options?.replyTo, options?.references, options?.attachment)
     },
     [client]
   )
@@ -239,28 +239,28 @@ export function useRoomActive() {
 
   const sendReaction = useCallback(
     async (roomJid: string, messageId: string, emojis: string[]) => {
-      await client.chat.sendReaction(roomJid, messageId, emojis, 'groupchat')
+      await client.chat.sendReaction(roomJid, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(roomJid, messageId, newBody, 'groupchat', attachment)
+      await client.chat.sendCorrection(roomJid, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (roomJid: string, messageId: string) => {
-      await client.chat.sendRetraction(roomJid, messageId, 'groupchat')
+      await client.chat.sendRetraction(roomJid, messageId)
     },
     [client]
   )
 
   const sendChatState = useCallback(
     async (roomJid: string, state: ChatStateNotification) => {
-      await client.chat.sendChatState(roomJid, state, 'groupchat')
+      await client.chat.sendChatState(roomJid, state)
     },
     [client]
   )
@@ -274,7 +274,7 @@ export function useRoomActive() {
 
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
-      await client.chat.sendEasterEgg(roomJid, 'groupchat', animation)
+      await client.chat.sendEasterEgg(roomJid, animation)
     },
     [client]
   )


### PR DESCRIPTION
Every send method asked the caller for a `type: 'chat' | 'groupchat'`. That is the one piece of XMPP a caller could least avoid learning: you had to know a room message is a different stanza type, and repeat it on every reaction, correction, retraction and chat state.

The SDK already knows. XEP-0045 §7.4 requires presence in a room before sending to it, and `MUC.joinRoom` records the room before it sends that presence, so a JID the room store knows is a room we are in, and any other JID is a person. `Chat.conversationKind` reads that once, and the seven send methods lose the parameter, as do the hooks that were forwarding it.

Two consumers show what the parameter cost:

- `mcpTools` already looked the room up in the store and then turned that fact back into a flag for the SDK to act on. That derivation is gone.
- The assistant example loses a field of its own model: replying no longer depends on knowing what it is replying to.

The boundaries are covered by tests asserting the wire type: a known room, a person, a full occupant JID that must resolve through its bare form, and a room that was never joined, which reads as a person because that is what the server would enforce anyway.

Validated interactively in demo mode, which runs the real `Chat` and only intercepts at the stanza layer: a one-to-one goes out as `chat`, a room message and a room reaction as `groupchat`, the room echo arrives, a one-to-one correction applies, and whisper rendering is unchanged.

Still open, deliberately not bundled here: `sendMessage` keeps five positional parameters, and moving to an options object is a separate change.