### PR TITLE
test(sdk): pin the MAM coverage and gap invariants with properties

### DIFF
--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.property.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.property.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Property tests for the contiguous-with-live coverage record.
+ *
+ * The `CoverageTransition` this module returns is not a description — it is the
+ * persistence layer's durability input, and only `replaced` force-flushes.
+ * The module states the stakes itself: every safe transition errs SHALLOW,
+ * costing a re-walk, and only `replaced` can leave disk asserting coverage that
+ * does not exist. So the property that matters is LABEL FIDELITY: a run that
+ * overwrites a recorded bottom without proving contiguity must say so, because
+ * a mislabel means disk keeps a record this very walk disproved and the next
+ * session seeds its backward walk from it — skipping real history.
+ *
+ * Archive ids are non-sequential (see `mamGap`), so nothing downstream can
+ * recompute this by comparing two ids. The label is the only signal.
+ */
+import { describe, expect, it } from 'vitest'
+import 'fake-indexeddb/auto'
+import fc from 'fast-check'
+import {
+  deserializeCoverage,
+  isCaughtUpForCounting,
+  serializeCoverage,
+  syncCoverageAfterArchiveMerge,
+  type ArchiveMergeCoverageInput,
+  type CoverageRecord,
+} from './mamCoverage'
+
+const IDS = ['a@b', 'c@d'] as const
+/** Archive ids drawn from a tiny pool so cursors coincide with recorded edges. */
+const ARCHIVE_IDS = ['x1', 'x2', 'x3'] as const
+const maybeArchiveId = fc.option(fc.constantFrom(...ARCHIVE_IDS), { nil: undefined })
+
+const recordArb: fc.Arbitrary<CoverageRecord> = fc.record({
+  bottomId: fc.constantFrom(...ARCHIVE_IDS),
+  topId: maybeArchiveId,
+})
+
+const coverageArb = fc
+  .array(fc.tuple(fc.constantFrom(...IDS), recordArb), { maxLength: 2 })
+  .map((entries) => new Map<string, CoverageRecord>(entries))
+
+const inputArb: fc.Arbitrary<ArchiveMergeCoverageInput> = fc.record({
+  coverage: coverageArb,
+  id: fc.constantFrom(...IDS),
+  direction: fc.constantFrom<'backward' | 'forward'>('backward', 'forward'),
+  isFetchLatest: fc.boolean(),
+  complete: fc.option(fc.boolean(), { nil: undefined }),
+  initialAfter: maybeArchiveId,
+  preserveGapMarker: fc.boolean(),
+  rsmFirst: maybeArchiveId,
+  fetchLatestTopId: maybeArchiveId,
+  initialBefore: maybeArchiveId,
+  sawCoverageTop: fc.boolean(),
+  walkCarriedModifications: fc.boolean(),
+})
+
+describe('coverage transition labels are faithful', () => {
+  it('signals every overwrite of a recorded bottom', () => {
+    // The safety property. A bottom that moves without the walk having resumed
+    // id-exactly from it is an unproven claim, and the persistence layer only
+    // learns that from the label.
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const before = input.coverage.get(input.id)
+        const { coverage, transition } = syncCoverageAfterArchiveMerge(input)
+        const after = coverage.get(input.id)
+        if (!before || !after) return
+        if (after.bottomId === before.bottomId) return
+
+        expect(['deepened', 'replaced']).toContain(transition)
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('only calls it deepened when the walk resumed id-exactly from the recorded bottom', () => {
+    // `deepened` is the label that lets the write ride the throttle. It is only
+    // safe because losing it leaves the shallower bottom, which is still true —
+    // and that holds only when the new bottom extends the SAME contiguous run.
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const before = input.coverage.get(input.id)
+        const { transition } = syncCoverageAfterArchiveMerge(input)
+        if (transition !== 'deepened') return
+
+        expect(before).toBeDefined()
+        expect(input.initialBefore).toBe(before!.bottomId)
+        expect(input.direction).toBe('backward')
+        expect(input.isFetchLatest).toBe(false)
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('reserves replaced for an unproven overwrite of an existing record', () => {
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const before = input.coverage.get(input.id)
+        const { transition } = syncCoverageAfterArchiveMerge(input)
+        if (transition !== 'replaced') return
+
+        expect(before).toBeDefined()
+        expect(input.isFetchLatest).toBe(true)
+        // Having SEEN the record's top entry is the proof that would have kept
+        // the deeper bottom; `replaced` means that proof was absent.
+        expect(input.sawCoverageTop).toBe(false)
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('creates only where there was nothing, and refreshes only the top', () => {
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const before = input.coverage.get(input.id)
+        const { coverage, transition } = syncCoverageAfterArchiveMerge(input)
+        const after = coverage.get(input.id)
+
+        if (transition === 'created') {
+          expect(before).toBeUndefined()
+          expect(after).toBeDefined()
+        }
+        if (transition === 'topRefreshed') {
+          expect(before).toBeDefined()
+          expect(after!.bottomId).toBe(before!.bottomId)
+          expect(after!.topId).not.toBe(before!.topId)
+        }
+      }),
+      { numRuns: 5000 },
+    )
+  })
+})
+
+describe('coverage map discipline', () => {
+  it('is copy-on-write: the same reference exactly when the label says none', () => {
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const { coverage, transition } = syncCoverageAfterArchiveMerge(input)
+        expect(coverage === input.coverage).toBe(transition === 'none')
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('never drops a record, and never touches another entity', () => {
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        const { coverage } = syncCoverageAfterArchiveMerge(input)
+        for (const [key, value] of input.coverage) {
+          expect(coverage.has(key)).toBe(true)
+          if (key !== input.id) expect(coverage.get(key)).toBe(value)
+        }
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('certifies nothing when the walk proves nothing', () => {
+    // A bounded windowed query proves nothing about live contiguity, and a walk
+    // whose modifications were written fire-and-forget is not durably confirmed.
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        if (!input.preserveGapMarker && !input.walkCarriedModifications) return
+        const { coverage, transition } = syncCoverageAfterArchiveMerge(input)
+        expect(transition).toBe('none')
+        expect(coverage).toBe(input.coverage)
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('round-trips through serialisation, and never throws on hostile input', () => {
+    fc.assert(
+      fc.property(coverageArb, (map) => {
+        expect(deserializeCoverage(serializeCoverage(map))).toEqual(map)
+      }),
+      { numRuns: 2000 },
+    )
+    fc.assert(
+      fc.property(fc.string(), (raw) => {
+        expect(() => deserializeCoverage(raw)).not.toThrow()
+      }),
+      { numRuns: 2000 },
+    )
+  })
+})
+
+describe('the counting gate', () => {
+  it('never consults hasQueried', () => {
+    // A restored entity carries persisted coverage while `hasQueried` is false,
+    // because that flag is session-scoped. Counting on it would under-count at
+    // cold start and overwrite a correct persisted value — the unsafe direction.
+    fc.assert(
+      fc.property(fc.boolean(), fc.boolean(), (isLoading, isCaughtUpToLive) => {
+        expect(isCaughtUpForCounting({ hasQueried: true, isLoading, isCaughtUpToLive })).toBe(
+          isCaughtUpForCounting({ hasQueried: false, isLoading, isCaughtUpToLive }),
+        )
+      }),
+    )
+  })
+
+  it('requires both settled loading and proven live contiguity', () => {
+    fc.assert(
+      fc.property(fc.boolean(), fc.boolean(), fc.boolean(), (hasQueried, isLoading, isCaughtUpToLive) => {
+        expect(isCaughtUpForCounting({ hasQueried, isLoading, isCaughtUpToLive })).toBe(
+          !isLoading && isCaughtUpToLive,
+        )
+      }),
+    )
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/mamGap.property.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.property.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Property tests for room history-gap interval algebra.
+ *
+ * A `GapInterval` is a KNOWN hole: messages are held below `start` and, when
+ * `end` is set, above it. Two laws follow from that reading and hold across
+ * every transition here:
+ *
+ *  - a gap is well formed, `end > start`. An inverted or empty interval is not a
+ *    hole, and anything downstream that renders "Load missing messages" from it
+ *    would be offering to fetch nothing.
+ *  - reconciling a gap against a page only ever SHRINKS or CLEARS it. A gap that
+ *    could widen would keep re-opening ground already fetched.
+ *
+ * The detection side has the opposite bias, and it is the safety-critical one:
+ * a seam is planted only on structural proof of disconnection, never on a
+ * heuristic, because a false seam shows the user a hole that is not there.
+ */
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+import {
+  closeGapWithBackwardPage,
+  computeGapEnd,
+  detectFetchLatestSeam,
+  messagePageExtent,
+  newestMessageStanzaId,
+  oldestMessageStanzaId,
+  serializeGaps,
+  deserializeGaps,
+  syncGap,
+  type GapInterval,
+} from './mamGap'
+
+/** Timestamps from a tiny pool so pages overlap, abut and interleave. */
+const TS = fc.integer({ min: 0, max: 6 })
+const JIDS = ['room-a@conf', 'room-b@conf'] as const
+
+const messageArb = fc.record({
+  timestamp: fc.option(TS, { nil: undefined }).map((t) => (t === undefined ? undefined : new Date(t))),
+  stanzaId: fc.option(fc.constantFrom('s1', 's2', 's3'), { nil: undefined }),
+})
+const pageArb = fc.array(messageArb, { maxLength: 6 })
+
+/** A well-formed gap, as every producer in this module yields. */
+const gapArb: fc.Arbitrary<GapInterval> = fc
+  .tuple(TS, fc.option(TS, { nil: undefined }))
+  .map(([start, rawEnd]) => ({
+    start,
+    ...(rawEnd !== undefined && rawEnd > start ? { end: rawEnd } : {}),
+  }))
+
+const wellFormed = (gap: GapInterval | undefined) => {
+  if (!gap) return
+  if (gap.end !== undefined) expect(gap.end).toBeGreaterThan(gap.start)
+}
+
+describe('gap intervals stay well formed', () => {
+  it('detectFetchLatestSeam never plants an inverted or empty gap', () => {
+    fc.assert(
+      fc.property(pageArb, fc.nat(6), fc.nat(3), fc.option(TS, { nil: undefined }), (page, newCount, patched, heldBelow) => {
+        wellFormed(detectFetchLatestSeam(page, newCount, patched, heldBelow))
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('closeGapWithBackwardPage never yields an inverted or empty gap', () => {
+    fc.assert(
+      fc.property(gapArb, pageArb, fc.boolean(), (gap, page, complete) => {
+        wellFormed(closeGapWithBackwardPage(gap, messagePageExtent(page), complete))
+      }),
+      { numRuns: 3000 },
+    )
+  })
+})
+
+describe('reconciling a gap only shrinks it', () => {
+  it('never moves the start, and never widens the end', () => {
+    fc.assert(
+      fc.property(gapArb, pageArb, fc.boolean(), (gap, page, complete) => {
+        const next = closeGapWithBackwardPage(gap, messagePageExtent(page), complete)
+        if (next === undefined) return // cleared, which is the strongest shrink
+
+        // The lower edge is held history below the hole; a backward page cannot
+        // move it, only the region above can close in.
+        expect(next.start).toBe(gap.start)
+
+        if (gap.end === undefined) return // was open to live: any end is a shrink
+        expect(next.end).toBeDefined()
+        expect(next.end!).toBeLessThanOrEqual(gap.end)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('is idempotent: re-applying the same page changes nothing further', () => {
+    fc.assert(
+      fc.property(gapArb, pageArb, fc.boolean(), (gap, page, complete) => {
+        const extent = messagePageExtent(page)
+        const once = closeGapWithBackwardPage(gap, extent, complete)
+        if (once === undefined) return
+        expect(closeGapWithBackwardPage(once, extent, complete)).toEqual(once)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('leaves the gap alone for a page that sits entirely below it', () => {
+    // Older-region pagination says nothing about a hole above it — not even a
+    // `complete` page, whose completeness is about the archive start.
+    fc.assert(
+      fc.property(gapArb, pageArb, fc.boolean(), (gap, page, complete) => {
+        const extent = messagePageExtent(page)
+        if (extent.newestTs === undefined || extent.newestTs > gap.start) return
+        expect(closeGapWithBackwardPage(gap, extent, complete)).toBe(gap)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+})
+
+describe('seam detection stays conservative', () => {
+  it('refuses to plant a seam on any evidence of connection', () => {
+    // A dedupe hit or an archive-id backfill both prove the page touches held
+    // history, so there is no disconnection to record.
+    fc.assert(
+      fc.property(
+        pageArb.filter((p) => p.length > 0),
+        fc.nat(6),
+        fc.nat(3),
+        fc.option(TS, { nil: undefined }),
+        (page, newCount, patched, heldBelow) => {
+          const connected = newCount < page.length || patched > 0
+          if (!connected) return
+          expect(detectFetchLatestSeam(page, newCount, patched, heldBelow)).toBeUndefined()
+        },
+      ),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('refuses to plant a seam with nothing held below, or on an interleaving page', () => {
+    fc.assert(
+      fc.property(pageArb, fc.option(TS, { nil: undefined }), (page, heldBelow) => {
+        const seam = detectFetchLatestSeam(page, page.length, 0, heldBelow)
+        if (heldBelow === undefined) {
+          expect(seam).toBeUndefined()
+          return
+        }
+        const { oldestTs } = messagePageExtent(page)
+        if (oldestTs !== undefined && oldestTs <= heldBelow) expect(seam).toBeUndefined()
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('anchors a planted seam on the two proven boundaries', () => {
+    fc.assert(
+      fc.property(pageArb, fc.option(TS, { nil: undefined }), (page, heldBelow) => {
+        const seam = detectFetchLatestSeam(page, page.length, 0, heldBelow)
+        if (!seam) return
+        expect(seam.start).toBe(heldBelow)
+        expect(seam.end).toBe(messagePageExtent(page).oldestTs)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+})
+
+describe('page extent and cursor helpers', () => {
+  it('messagePageExtent brackets exactly the timestamps present', () => {
+    fc.assert(
+      fc.property(pageArb, (page) => {
+        const stamps = page.map((m) => m.timestamp?.getTime()).filter((t): t is number => t !== undefined)
+        const { oldestTs, newestTs } = messagePageExtent(page)
+        if (stamps.length === 0) {
+          expect(oldestTs).toBeUndefined()
+          expect(newestTs).toBeUndefined()
+          return
+        }
+        expect(oldestTs).toBe(Math.min(...stamps))
+        expect(newestTs).toBe(Math.max(...stamps))
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('computeGapEnd is the least timestamp strictly above the start', () => {
+    fc.assert(
+      fc.property(pageArb, TS, (page, start) => {
+        const above = page
+          .map((m) => m.timestamp?.getTime())
+          .filter((t): t is number => t !== undefined && t > start)
+        const end = computeGapEnd(page, start)
+        if (above.length === 0) {
+          expect(end).toBeUndefined()
+          return
+        }
+        expect(end).toBe(Math.min(...above))
+        expect(end!).toBeGreaterThan(start)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('newestMessageStanzaId skips id-less messages, oldestMessageStanzaId does not', () => {
+    // The asymmetry is deliberate on the newest side, which must not degrade to
+    // undefined because an unreflected own-send sits at the top. The oldest side
+    // takes whatever the oldest row carries, so an id-less oldest row yields no
+    // cursor even when a slightly newer one has an id.
+    fc.assert(
+      fc.property(pageArb, (page) => {
+        const withIds = page.filter((m) => m.stanzaId && m.timestamp)
+        const newest = newestMessageStanzaId(page)
+        if (withIds.length === 0) {
+          expect(newest).toBeUndefined()
+        } else {
+          const best = withIds.reduce((a, b) => (b.timestamp!.getTime() > a.timestamp!.getTime() ? b : a))
+          expect(newest).toBe(best.stanzaId)
+        }
+
+        const timed = page.filter((m) => m.timestamp)
+        const oldestRow = timed.length
+          ? timed.reduce((a, b) => (b.timestamp!.getTime() < a.timestamp!.getTime() ? b : a))
+          : undefined
+        expect(oldestMessageStanzaId(page)).toBe(oldestRow?.stanzaId)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+})
+
+describe('syncGap map transitions', () => {
+  const mapArb = fc.array(fc.tuple(fc.constantFrom(...JIDS), gapArb), { maxLength: 2 }).map(
+    (entries) => new Map<string, GapInterval>(entries),
+  )
+
+  it('is copy-on-write: the same reference exactly when nothing changed', () => {
+    fc.assert(
+      fc.property(mapArb, fc.constantFrom(...JIDS), gapArb, (gaps, jid, gap) => {
+        const next = syncGap(gaps, jid, gap.start, gap.end, gap.startId, gap.endId)
+        const before = gaps.get(jid)
+        const same = next === gaps
+        const equal =
+          before?.start === gap.start &&
+          before?.end === gap.end &&
+          before?.startId === gap.startId &&
+          before?.endId === gap.endId
+        expect(same).toBe(equal)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('only ever touches the addressed entry', () => {
+    fc.assert(
+      fc.property(mapArb, fc.constantFrom(...JIDS), fc.option(gapArb, { nil: undefined }), (gaps, jid, gap) => {
+        const next = syncGap(gaps, jid, gap?.start, gap?.end, gap?.startId, gap?.endId)
+        for (const [key, value] of gaps) {
+          if (key === jid) continue
+          expect(next.get(key)).toBe(value)
+        }
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('clears the entry exactly when no start is given', () => {
+    fc.assert(
+      fc.property(mapArb, fc.constantFrom(...JIDS), (gaps, jid) => {
+        expect(syncGap(gaps, jid, undefined, undefined).has(jid)).toBe(false)
+      }),
+      { numRuns: 3000 },
+    )
+  })
+
+  it('round-trips through serialisation, and never throws on hostile input', () => {
+    fc.assert(
+      fc.property(mapArb, (gaps) => {
+        expect(deserializeGaps(serializeGaps(gaps))).toEqual(gaps)
+      }),
+      { numRuns: 3000 },
+    )
+    fc.assert(
+      fc.property(fc.string(), (raw) => {
+        expect(() => deserializeGaps(raw)).not.toThrow()
+      }),
+      { numRuns: 3000 },
+    )
+  })
+})


### PR DESCRIPTION
Both modules encode a safety direction in prose, and neither had a test that could fail if that direction inverted. These suites make the direction executable.

**Coverage.** The returned `CoverageTransition` is not a description — it is the persistence layer's durability input, and only `replaced` force-flushes. Archive ids are non-sequential, so nothing downstream can recompute the classification by comparing two `bottomId`s; the label is the only signal. The properties pin its fidelity:

- any overwrite of a recorded bottom is signalled as `deepened` or `replaced`, never as a quiet `none`/`topRefreshed`;
- `deepened` is reserved for a walk that resumed **id-exactly** from the recorded bottom, which is what makes losing the write harmless — the shallower bottom is still true;
- `replaced` is reserved for an unproven overwrite of an existing record.

Mislabelling the second as the first is precisely the failure the module's own table calls out: disk keeps the record whose contiguity the walk just disproved, and the next session seeds its backward walk from it, skipping the disconnected interval.

**Gaps.** A `GapInterval` is a known hole, so two laws follow: `end > start` always, and reconciling a gap against a backward page only ever shrinks or clears it — never widens it, never moves its lower edge. Seam detection carries the opposite bias and is checked for it: no seam is planted without structural proof of disconnection, because a false seam offers the user history that is not missing.

Also covered on both: copy-on-write discipline (same map reference exactly when nothing changed), map locality (no other entity touched), serialisation round-trip and parser totality on arbitrary input, and that the counting gate never consults the session-scoped `hasQueried`.

**No defect found** — both modules hold every property. The suites were validated by mutation instead: sixteen deliberate inversions across the two modules, each one caught, including relabelling an unproven overwrite as `deepened`, dropping the `preserveGapMarker` and `walkCarriedModifications` guards, letting a gap widen, and restoring the never-queried shortcut in the counting gate.
