### PR TITLE
refactor(sdk): give sendMessage an options object

### DIFF
--- a/packages/fluux-sdk/examples/assistant.ts
+++ b/packages/fluux-sdk/examples/assistant.ts
@@ -50,7 +50,7 @@ async function respond(client: XMPPClient, question: Question): Promise<void> {
   await client.chat.sendChatState(question.to, 'composing')
 
   const placeholderId = await client.chat.sendMessage(question.to, 'Working on it…', {
-    id: question.messageId,
+    replyTo: { id: question.messageId },
   })
 
   try {

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -22,6 +22,8 @@ export type {
   ConnectionMethod,
   Message,
   RoomMessage,
+  SendMessageOptions,
+  ReplyTarget,
   AnyMessage,
   MentionReference,
   ReplyInfo,

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -269,7 +269,7 @@ describe('Chat E2EE wiring', () => {
       // Regression: <fallback for="jabber:x:oob"> in the unencrypted stanza root
       // reveals to the XMPP server that an attachment was sent and its URL length.
       // It must be stripped after the OOB element is moved inside the encrypted payload.
-      await chat.sendMessage('bob@example.com', 'Check this file', undefined, undefined, {
+      await chat.sendMessage('bob@example.com', 'Check this file', { attachment: {
         url: 'https://upload.example.com/file.bin',
         name: 'photo.jpg',
         mediaType: 'image/jpeg',
@@ -278,7 +278,7 @@ describe('Chat E2EE wiring', () => {
           key: new Uint8Array(32).fill(1),
           iv: new Uint8Array(12).fill(2),
         },
-      })
+      } })
 
       expect(captured).toHaveLength(1)
       const sent = captured[0]
@@ -296,12 +296,7 @@ describe('Chat E2EE wiring', () => {
     it('preserves <fallback for="urn:xmpp:reply:0"> when OOB fallback is removed', async () => {
       // Removing the OOB fallback must be surgical — unrelated fallbacks (e.g. reply
       // quote for legacy clients) must not be collateral damage.
-      await chat.sendMessage(
-        'bob@example.com',
-        'Nice photo!',
-        { id: 'orig-msg-id', to: 'bob@example.com', fallback: { author: 'Bob', body: 'seen this?' } },
-        undefined,
-        {
+      await chat.sendMessage('bob@example.com', 'Nice photo!', { replyTo: { id: 'orig-msg-id', to: 'bob@example.com', fallback: { author: 'Bob', body: 'seen this?' } }, attachment: {
           url: 'https://upload.example.com/reply.bin',
           name: 'reply.jpg',
           mediaType: 'image/jpeg',
@@ -310,8 +305,7 @@ describe('Chat E2EE wiring', () => {
             key: new Uint8Array(32).fill(3),
             iv: new Uint8Array(12).fill(4),
           },
-        },
-      )
+        } })
 
       const sent = captured[0]
 
@@ -343,11 +337,11 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'Check this', undefined, undefined, {
+      await plainChat.sendMessage('bob@example.com', 'Check this', { attachment: {
         url: 'https://upload.example.com/plain.jpg',
         name: 'plain.jpg',
         mediaType: 'image/jpeg',
-      })
+      } })
 
       const sent = captured[0]
 
@@ -429,7 +423,7 @@ describe('Chat E2EE wiring', () => {
       const guardedChat = new Chat(deps, stubMAM())
 
       await expect(
-        guardedChat.sendMessage('bob@example.com', 'secret photo', undefined, undefined, {
+        guardedChat.sendMessage('bob@example.com', 'secret photo', { attachment: {
           url: 'https://upload.example.com/photo.bin',
           name: 'photo.jpg',
           mediaType: 'image/jpeg',
@@ -438,7 +432,7 @@ describe('Chat E2EE wiring', () => {
             key: new Uint8Array(32).fill(1),
             iv: new Uint8Array(12).fill(2),
           },
-        }),
+        } }),
       ).rejects.toBeInstanceOf(E2EEEncryptionRequiredError)
 
       expect(captured).toHaveLength(0)
@@ -458,11 +452,11 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'here is the file', undefined, undefined, {
+      await plainChat.sendMessage('bob@example.com', 'here is the file', { attachment: {
         url: 'https://upload.example.com/plain.jpg',
         name: 'plain.jpg',
         mediaType: 'image/jpeg',
-      })
+      } })
 
       expect(captured).toHaveLength(1)
       expect(captured[0].getChild('x', 'jabber:x:oob')).toBeDefined()
@@ -2046,7 +2040,7 @@ describe('Chat E2EE wiring', () => {
       })
       const plainChat = new Chat(deps, stubMAM())
 
-      await plainChat.sendMessage('bob@example.com', 'sure thing', encryptedReply)
+      await plainChat.sendMessage('bob@example.com', 'sure thing', { replyTo: encryptedReply })
 
       const sent = captured[0]
       const body = sent.getChild('body')?.text() ?? ''
@@ -2069,7 +2063,7 @@ describe('Chat E2EE wiring', () => {
 
     it('keeps the quote INSIDE the encrypted payload when the reply is encrypted', async () => {
       // `chat` uses the DummyPlaintextPlugin (registered in beforeEach) → encrypts.
-      await chat.sendMessage('bob@example.com', 'sure thing', encryptedReply)
+      await chat.sendMessage('bob@example.com', 'sure thing', { replyTo: encryptedReply })
 
       const sent = captured[0]
       // Outer body is the generic fallback, never the quote.
@@ -2103,9 +2097,11 @@ describe('Chat E2EE wiring', () => {
       const plainChat = new Chat(deps, stubMAM())
 
       await plainChat.sendMessage('bob@example.com', 'sure thing', {
-        id: 'orig',
-        to: 'bob@example.com',
-        fallback: { author: 'Bob', body: 'hello there' }, // fromEncrypted omitted → false
+        replyTo: {
+          id: 'orig',
+          to: 'bob@example.com',
+          fallback: { author: 'Bob', body: 'hello there' }, // fromEncrypted omitted → false
+        },
       })
 
       const sent = captured[0]
@@ -2133,13 +2129,7 @@ describe('Chat E2EE wiring', () => {
       const plainChat = new Chat(deps, stubMAM())
 
       const attachmentUrl = 'https://upload.example.com/file.bin'
-      await plainChat.sendMessage(
-        'bob@example.com',
-        'sure thing',
-        { id: 'orig', to: 'bob@example.com', fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true } },
-        undefined,
-        { url: attachmentUrl, name: 'file.bin', mediaType: 'application/octet-stream' }, // unencrypted attachment → cleartext send
-      )
+      await plainChat.sendMessage('bob@example.com', 'sure thing', { replyTo: { id: 'orig', to: 'bob@example.com', fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true } }, attachment: { url: attachmentUrl, name: 'file.bin', mediaType: 'application/octet-stream' } })
 
       const sent = captured[0]
       const body = sent.getChild('body')?.text() ?? ''

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -972,11 +972,7 @@ describe('XMPPClient Message', () => {
     it('should emit a reply fallback end counted in code points', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendMessage(
-        'alice@example.com',
-        'Thanks!',
-        { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } },
-      )
+      await xmppClient.chat.sendMessage('alice@example.com', 'Thanks!', { replyTo: { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find((c: any) => c.name === 'fallback')
@@ -993,12 +989,7 @@ describe('XMPPClient Message', () => {
       const body = '😀 hey @bob'
       const begin = body.indexOf('@bob')
 
-      await xmppClient.chat.sendMessage(
-        'room@conference.example.com',
-        body,
-        undefined,
-        [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
-      )
+      await xmppClient.chat.sendMessage('room@conference.example.com', body, { references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
@@ -1015,12 +1006,7 @@ describe('XMPPClient Message', () => {
       const typed = 'yes @bob'
       const begin = typed.indexOf('@bob')
 
-      await xmppClient.chat.sendMessage(
-        'room@conference.example.com',
-        typed,
-        { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } },
-        [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }],
-      )
+      await xmppClient.chat.sendMessage('room@conference.example.com', typed, { replyTo: { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } }, references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
@@ -1741,11 +1727,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendMessage(
-        'room@conference.example.com',
-        'My reply',
-        { id: 'client-msg-id', to: 'room@conference.example.com/alice', fallback: { author: 'alice', body: 'Original message' } }
-      )
+      await xmppClient.chat.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice', fallback: { author: 'alice', body: 'Original message' } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1764,11 +1746,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendMessage(
-        'room@conference.example.com',
-        'My reply',
-        { id: 'client-msg-id', to: 'room@conference.example.com/alice' }
-      )
+      await xmppClient.chat.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice' } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1790,11 +1768,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: false,
       })
 
-      await xmppClient.chat.sendMessage(
-        'alice@example.com',
-        'My reply',
-        { id: 'client-msg-id', to: 'alice@example.com' }
-      )
+      await xmppClient.chat.sendMessage('alice@example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'alice@example.com' } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1820,11 +1794,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: false,
       })
 
-      await xmppClient.chat.sendMessage(
-        'bob@example.com',
-        'Nice!',
-        { id: 'a1b2c3d4-uuid-style-id', to: 'bob@example.com', fallback: { author: 'bob', body: 'Check this out' } }
-      )
+      await xmppClient.chat.sendMessage('bob@example.com', 'Nice!', { replyTo: { id: 'a1b2c3d4-uuid-style-id', to: 'bob@example.com', fallback: { author: 'bob', body: 'Check this out' } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1981,7 +1951,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2006,7 +1976,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2030,7 +2000,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2052,7 +2022,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2081,7 +2051,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       // Body should be empty because the URL is fallback text for OOB
       // (our client understands OOB, so we strip the fallback)
@@ -2113,7 +2083,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', userText, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('alice@example.com', userText, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2205,7 +2175,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', attachment.url, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('room@conference.example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -2234,7 +2204,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', userText, undefined, undefined, attachment)
+      await xmppClient.chat.sendMessage('room@conference.example.com', userText, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -52,6 +52,7 @@ import type {
   Message,
   MentionReference,
   FileAttachment,
+  SendMessageOptions,
   ChatStateNotification,
   MAMQueryOptions,
   MAMResult,
@@ -92,9 +93,11 @@ import type { StanzaClaim } from '../stanzaRouting'
  * @example Sending a reply
  * ```typescript
  * await client.chat.sendMessage('user@example.com', 'I agree!', {
- *   id: 'original-message-id',
- *   to: 'user@example.com',
- *   fallback: { author: 'User', body: 'What do you think?' }
+ *   replyTo: {
+ *     id: 'original-message-id',
+ *     to: 'user@example.com',
+ *     fallback: { author: 'User', body: 'What do you think?' }
+ *   }
  * })
  * ```
  *
@@ -784,9 +787,7 @@ export class Chat extends BaseModule {
    *
    * @param to - Recipient JID (user for chat, room for groupchat)
    * @param body - Message text content
-   * @param replyTo - Optional reply information for threaded replies (XEP-0461)
-   * @param references - Optional mention references (XEP-0372)
-   * @param attachment - Optional file attachment (XEP-0066, XEP-0264)
+   * @param options - Reply, mentions and attachment. See {@link SendMessageOptions}.
    * @returns The message ID
    *
    * @example Simple message
@@ -796,21 +797,18 @@ export class Chat extends BaseModule {
    *
    * @example Message with attachment
    * ```typescript
-   * const msgId = await client.chat.sendMessage('user@example.com', 'Check this out', undefined, undefined, {
-   *   url: 'https://example.com/file.pdf',
-   *   name: 'document.pdf',
-   *   size: 12345,
-   *   mimeType: 'application/pdf'
+   * const msgId = await client.chat.sendMessage('user@example.com', 'Check this out', {
+   *   attachment: {
+   *     url: 'https://example.com/file.pdf',
+   *     name: 'document.pdf',
+   *     size: 12345,
+   *     mimeType: 'application/pdf'
+   *   }
    * })
    * ```
    */
-  async sendMessage(
-    to: string,
-    body: string,
-    replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } },
-    references?: MentionReference[],
-    attachment?: FileAttachment
-  ): Promise<string> {
+  async sendMessage(to: string, body: string, options?: SendMessageOptions): Promise<string> {
+    const { replyTo, references, attachment } = options ?? {}
     const type = this.conversationKind(to)
     const id = generateUUID()
     const recipient = type === 'chat' ? getBareJid(to) : to

--- a/packages/fluux-sdk/src/core/types/chat.ts
+++ b/packages/fluux-sdk/src/core/types/chat.ts
@@ -7,6 +7,7 @@
 
 import type { BaseMessage } from './message-base'
 import type { ReadPointer } from './readState'
+import type { FileAttachment } from './upload'
 
 /**
  * Chat state notification types (XEP-0085).
@@ -56,6 +57,41 @@ export interface MentionReference {
   type: 'mention'
   /** XMPP URI: 'xmpp:room@conf/nick' for user, 'xmpp:room@conf' for \@all */
   uri: string
+}
+
+/**
+ * The message an outgoing one replies to (XEP-0461).
+ *
+ * Distinct from {@link ReplyInfo}, which records a reply that already exists:
+ * this is what the SDK needs in order to build one.
+ *
+ * @category Chat
+ */
+export interface ReplyTarget {
+  /** Id of the message being replied to. */
+  id: string
+  /** Author of that message, when the reply has to address them (MUC). */
+  to?: string
+  /**
+   * Text to quote for clients that cannot render a reply. The SDK puts it above
+   * the body and marks the range per XEP-0428, so clients that can render the
+   * reply strip the quote instead of showing it twice.
+   */
+  fallback?: { author: string; body: string; fromEncrypted?: boolean }
+}
+
+/**
+ * Everything optional about an outgoing message.
+ *
+ * @category Chat
+ */
+export interface SendMessageOptions {
+  /** Reply to an earlier message (XEP-0461). */
+  replyTo?: ReplyTarget
+  /** Mentions to mark in the body (XEP-0372). */
+  references?: MentionReference[]
+  /** File to attach (XEP-0066, XEP-0363). */
+  attachment?: FileAttachment
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -21,6 +21,8 @@ export type { BaseMessage, MessageSecurityContext, UnsupportedEncryptionInfo, Po
 export type {
   ChatStateNotification,
   ReplyInfo,
+  ReplyTarget,
+  SendMessageOptions,
   MentionReference,
   Message,
   ConversationEntity,

--- a/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
@@ -33,19 +33,17 @@ describe('useChatActions.sendMessage (options object)', () => {
     mockClient.chat.sendMessage.mockResolvedValue('msg-id-1')
   })
 
-  it('sends a plain message as type "chat" with no reply/attachment', async () => {
+  it('sends a plain message with no options at all', async () => {
     const { result } = renderHook(() => useChatActions(), { wrapper })
 
     await act(async () => {
       await result.current.sendMessage('bob@example.com', 'hi')
     })
 
-    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
-      'bob@example.com', 'hi', undefined, undefined, undefined
-    )
+    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith('bob@example.com', 'hi', undefined)
   })
 
-  it('forwards replyTo and attachment from the options object', async () => {
+  it('passes the options object straight through to the SDK', async () => {
     const { result } = renderHook(() => useChatActions(), { wrapper })
 
     const replyTo = { id: 'm1', to: 'bob@example.com', fallback: { author: 'Bob', body: 'earlier' } }
@@ -54,8 +52,9 @@ describe('useChatActions.sendMessage (options object)', () => {
       await result.current.sendMessage('bob@example.com', 'see this', { replyTo, attachment })
     })
 
-    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
-      'bob@example.com', 'see this', replyTo, undefined, attachment
-    )
+    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith('bob@example.com', 'see this', {
+      replyTo,
+      attachment,
+    })
   })
 })

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { useXMPPContext } from '../provider'
-import type { Conversation, ChatStateNotification, FileAttachment } from '../core'
+import type { Conversation, ChatStateNotification, FileAttachment, SendMessageOptions } from '../core'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
@@ -28,13 +28,10 @@ export function useChatActions() {
     async (
       to: string,
       body: string,
-      options?: {
-        replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } }
-        attachment?: FileAttachment
-      }
+      // A 1:1 message carries no mentions: those address room occupants.
+      options?: Omit<SendMessageOptions, 'references'>
     ): Promise<string> => {
-      // 1:1 chat hook: always a 'chat'-type message (rooms use useRoomActions).
-      return await client.chat.sendMessage(to, body, options?.replyTo, undefined, options?.attachment)
+      return await client.chat.sendMessage(to, body, options)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -2,15 +2,21 @@ import { useCallback, useMemo } from 'react'
 import { roomStore } from '../stores/roomStore'
 import { useXMPPContext } from '../provider'
 import type {
-  MentionReference,
   ChatStateNotification,
   FileAttachment,
   RoomFeatures,
+  SendMessageOptions,
+  ReplyTarget,
 } from '../core/types'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 import { usePolls } from './usePolls'
 import { useRoomModeration } from './useRoomModeration'
 import { useRoomManagement } from './useRoomManagement'
+
+/** {@link SendMessageOptions} with the room reply rule applied. */
+type RoomSendMessageOptions = Omit<SendMessageOptions, 'replyTo'> & {
+  replyTo?: ReplyTarget & { to: string }
+}
 
 /**
  * Action-only counterpart to `useRoom()`.
@@ -133,13 +139,11 @@ export function useRoomActions() {
     async (
       roomJid: string,
       body: string,
-      options?: {
-        replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }
-        references?: MentionReference[]
-        attachment?: FileAttachment
-      }
+      // XEP-0461 §4: a reply in a room names the occupant it answers, so `to`
+      // is required here even though the protocol leaves it optional.
+      options?: RoomSendMessageOptions
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, options?.replyTo, options?.references, options?.attachment)
+      return await client.chat.sendMessage(roomJid, body, options)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -3,7 +3,7 @@ import { roomStore } from '../stores/roomStore'
 import { roomSelectors } from '../stores/roomSelectors'
 import { useRoomStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
-import type { Room, RoomMessage, MentionReference, ChatStateNotification, FileAttachment, MAMQueryState, RoomFeatures } from '../core/types'
+import type { Room, RoomMessage, ChatStateNotification, FileAttachment, MAMQueryState, RoomFeatures, SendMessageOptions, ReplyTarget } from '../core/types'
 import { createFetchOlderHistory, createContinueCatchUp, pickOldestArchiveId } from './shared'
 import { usePolls } from './usePolls'
 import { useRoomModeration } from './useRoomModeration'
@@ -14,6 +14,11 @@ import { useRoomManagement } from './useRoomManagement'
  */
 const EMPTY_MESSAGE_ARRAY: RoomMessage[] = []
 const EMPTY_TYPING_ARRAY: string[] = []
+
+/** {@link SendMessageOptions} with the room reply rule applied. */
+type RoomSendMessageOptions = Omit<SendMessageOptions, 'replyTo'> & {
+  replyTo?: ReplyTarget & { to: string }
+}
 
 /**
  * Lightweight hook for components that display the active room.
@@ -219,13 +224,11 @@ export function useRoomActive() {
     async (
       roomJid: string,
       body: string,
-      options?: {
-        replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }
-        references?: MentionReference[]
-        attachment?: FileAttachment
-      }
+      // XEP-0461 §4: a reply in a room names the occupant it answers, so `to`
+      // is required here even though the protocol leaves it optional.
+      options?: RoomSendMessageOptions
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, options?.replyTo, options?.references, options?.attachment)
+      return await client.chat.sendMessage(roomJid, body, options)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -261,6 +261,8 @@ export type {
   Message,
   Conversation,
   ReplyInfo,
+  ReplyTarget,
+  SendMessageOptions,
   ChatStateNotification,
 
   // Roster types


### PR DESCRIPTION
`sendMessage(to, body, replyTo?, references?, attachment?)` made a caller count commas: sending an attachment meant passing two `undefined` first, and adding an argument later would have meant another one.

The three optionals become `SendMessageOptions`, and the shape a reply needs gets a name of its own, `ReplyTarget`. That name was missing: `ReplyInfo` records a reply that already exists, while this is what the SDK needs in order to build one, and the difference had been living inside an anonymous inline type. Both are exported from `@fluux/sdk` and `@fluux/sdk/core`, so a bot can build a reply without reconstructing the shape by hand.

The hooks already took an options object, each with its own hand-written copy of that shape. They now share the named one and forward it untouched instead of unpacking it into positional arguments. The room hooks keep a rule their local copies encoded and the shared type does not: XEP-0461 §4 wants a reply in a room to name the occupant it answers, so `replyTo.to` stays required there.

No application file changed — the hooks had already absorbed this shape, which is a good sign for that boundary.

Validated in demo mode on the path that moved most. At the stanza level the `<reply>` element is present and references the original, the XEP-0428 marker is there, and the quote is in the body for clients without reply support. On screen the reply renders with its quoted card and no duplicated quote in the text.