### PR TITLE
fix(scroll): mark the target adapters' scroll writes as programmatic

### DIFF
--- a/apps/fluux/src/components/conversation/explicitTargetBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/explicitTargetBrowserAdapter.ts
@@ -35,6 +35,12 @@ export interface ExplicitTargetBrowserAdapterOptions {
   setMeasuredAtBottom: (atLiveEdge: boolean) => void
   markNotAtBottom: () => void
   consumeStoreTarget: () => void
+  /**
+   * Opens the settle window after a scrollTop write. Without it the measurement settle that lands
+   * once the re-assert loop has ended reads as a scrollbar drag: height unchanged, no loop running.
+   * See scrollGate.
+   */
+  recordProgrammaticWrite: (conversationId: string) => void
   log?: (action: string, data?: Record<string, unknown>) => void
 }
 
@@ -188,6 +194,7 @@ export class ExplicitTargetBrowserAdapter {
     this.options.setMeasuredAtBottom(
       distanceFromBottom < AT_BOTTOM_THRESHOLD,
     )
+    this.options.recordProgrammaticWrite(request.conversationId)
     this.options.log?.('TARGET MESSAGE: controller positioned frame', {
       conversationId: request.conversationId,
       generation: request.generation,

--- a/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
@@ -159,6 +159,7 @@ describe('UnreadMarkerBrowserAdapter', () => {
       getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
       beginLoop,
       setMeasuredAtBottom: vi.fn(),
+      recordProgrammaticWrite: vi.fn(),
     }).createExecutor(liveEdge)
 
     expect(executor.liveEdge).toBe(liveEdge)
@@ -181,6 +182,7 @@ describe('UnreadMarkerBrowserAdapter', () => {
       getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
       beginLoop: loopHarness().beginLoop,
       setMeasuredAtBottom: vi.fn(),
+      recordProgrammaticWrite: vi.fn(),
     }).createExecutor({} as LiveEdgeExecutor)
 
     expect(executor.reachability(unreadRequest().desired)).toEqual({
@@ -210,6 +212,7 @@ describe('UnreadMarkerBrowserAdapter', () => {
       }),
       beginLoop: loopHarness().beginLoop,
       setMeasuredAtBottom: vi.fn(),
+      recordProgrammaticWrite: vi.fn(),
     })
     const executor = adapter.createExecutor({} as LiveEdgeExecutor)
 
@@ -232,6 +235,7 @@ describe('UnreadMarkerBrowserAdapter', () => {
       getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
       beginLoop: loopHarness().beginLoop,
       setMeasuredAtBottom: measured,
+      recordProgrammaticWrite: vi.fn(),
     }).createExecutor({} as LiveEdgeExecutor)
 
     expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'unavailable' })
@@ -249,6 +253,38 @@ describe('UnreadMarkerBrowserAdapter', () => {
     expect(measured).toHaveBeenLastCalledWith(true)
   })
 
+  it('opens the settle window whenever it moves scrollTop, and only then', () => {
+    // Every executor that writes scrollTop must mark it, or the measurement settle arriving after
+    // the re-assert loop ends is indistinguishable from a scrollbar drag: it opens the save gate on
+    // a drifted position and arms user takeover against the positioning that produced it.
+    const viewport = scrollerHarness({ clientHeight: 600 })
+    const nearTop = virtualizerHarness(viewport.scroller, { offset: 200 }).virtualizer
+    let virtualizer = nearTop
+    const recordWrite = vi.fn()
+    const executor = new UnreadMarkerBrowserAdapter({
+      getScroller: () => viewport.scroller,
+      getVirtualizer: () => virtualizer,
+      getWindowFacts: () => ({ hasRows: true, windowAtLiveEdge: true }),
+      getPassiveContext: () => ({ conversationId: 'room-a', virtualizer }),
+      beginLoop: loopHarness().beginLoop,
+      setMeasuredAtBottom: vi.fn(),
+      recordProgrammaticWrite: recordWrite,
+    }).createExecutor({} as LiveEdgeExecutor)
+
+    // A rejected near-top marker writes nothing, so it must not open the window either.
+    expect(executor.positionFrame(unreadRequest(), lease())).toEqual({ kind: 'unavailable' })
+    expect(recordWrite).not.toHaveBeenCalled()
+
+    virtualizer = virtualizerHarness(viewport.scroller, {
+      offset: 900,
+      landedTop: 1_395,
+    }).virtualizer
+    expect(executor.positionFrame(unreadRequest('start'), lease())).toMatchObject({
+      kind: 'positioned',
+    })
+    expect(recordWrite).toHaveBeenCalledWith('room-a')
+  })
+
   it('applies top-third placement without a virtualizer and never writes under a stale lease', () => {
     const viewport = scrollerHarness({ clientHeight: 600 })
     appendMessage(viewport.scroller, { offsetTop: 800 })
@@ -259,6 +295,7 @@ describe('UnreadMarkerBrowserAdapter', () => {
       getPassiveContext: () => ({ conversationId: 'room-a', virtualizer: undefined }),
       beginLoop: loopHarness().beginLoop,
       setMeasuredAtBottom: vi.fn(),
+      recordProgrammaticWrite: vi.fn(),
     }).createExecutor({} as LiveEdgeExecutor)
 
     expect(executor.positionFrame(unreadRequest(), lease())).toMatchObject({
@@ -288,6 +325,7 @@ describe('ExplicitTargetBrowserAdapter', () => {
     const measured = vi.fn()
     const markNotAtBottom = vi.fn()
     const consumeStoreTarget = vi.fn()
+    const recordWrite = vi.fn()
     const adapter = new ExplicitTargetBrowserAdapter({
       getScroller: () => scroller,
       getVirtualizer: () => input.virtualizer,
@@ -305,6 +343,7 @@ describe('ExplicitTargetBrowserAdapter', () => {
       setMeasuredAtBottom: measured,
       markNotAtBottom,
       consumeStoreTarget,
+      recordProgrammaticWrite: recordWrite,
     })
     return {
       adapter,
@@ -315,6 +354,7 @@ describe('ExplicitTargetBrowserAdapter', () => {
       measured,
       markNotAtBottom,
       consumeStoreTarget,
+      recordWrite,
     }
   }
 
@@ -402,12 +442,17 @@ describe('ExplicitTargetBrowserAdapter', () => {
     })
     expect(scrollToIndex).toHaveBeenCalledWith(5, { align: 'center' })
     expect(result.measured).toHaveBeenCalledWith(false)
+    // The centring write must open the settle window; see the equivalent unread-marker test.
+    expect(result.recordWrite).toHaveBeenCalledWith('room-a')
 
     viewport.scroller.scrollTop = 123
+    result.recordWrite.mockClear()
     expect(executor.positionFrame(explicitRequest(), lease(() => false))).toEqual({
       kind: 'unavailable',
     })
     expect(viewport.scrollTop).toBe(123)
+    // A stale lease writes nothing, so it must not open the window either.
+    expect(result.recordWrite).not.toHaveBeenCalled()
   })
 
   it('falls back to the scoped mounted element when no virtual index exists', () => {

--- a/apps/fluux/src/components/conversation/unreadMarkerBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/unreadMarkerBrowserAdapter.ts
@@ -25,6 +25,12 @@ export interface UnreadMarkerBrowserAdapterOptions {
   getPassiveContext: () => UnreadMarkerPassiveContext
   beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
   setMeasuredAtBottom: (atLiveEdge: boolean) => void
+  /**
+   * Opens the settle window after a scrollTop write. Without it the measurement settle that lands
+   * once the re-assert loop has ended reads as a scrollbar drag: height unchanged, no loop running.
+   * See scrollGate.
+   */
+  recordProgrammaticWrite: (conversationId: string) => void
   log?: (action: string, data?: Record<string, unknown>) => void
 }
 
@@ -113,6 +119,7 @@ export class UnreadMarkerBrowserAdapter {
       scroller.scrollHeight - scrollTop - scroller.clientHeight
     const atLiveEdge = distanceFromBottom < AT_BOTTOM_THRESHOLD
     this.options.setMeasuredAtBottom(atLiveEdge)
+    this.options.recordProgrammaticWrite(request.conversationId)
     this.options.log?.('UNREAD MARKER: controller positioned frame', {
       conversationId: request.conversationId,
       generation: request.generation,

--- a/apps/fluux/src/components/conversation/useScrollExecutors.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.ts
@@ -466,6 +466,8 @@ export function useScrollExecutors({
       getPassiveContext: () => portsRef.current.getPassiveContext(),
       beginLoop: (lease) => beginControllerFrameLoop('marker', lease),
       setMeasuredAtBottom,
+      recordProgrammaticWrite: (id) =>
+        portsRef.current.recordProgrammaticWrite(id, Date.now()),
       log: (action, data) => portsRef.current.log(action, data),
     })
     return browser.createExecutor(createLiveEdgeExecutor('marker-fallback'))
@@ -498,6 +500,8 @@ export function useScrollExecutors({
       setMeasuredAtBottom,
       markNotAtBottom: () => { isAtBottomRef.current = false },
       consumeStoreTarget: () => portsRef.current.consumeStoreTarget(),
+      recordProgrammaticWrite: (id) =>
+        portsRef.current.recordProgrammaticWrite(id, Date.now()),
       log: (action, data) => portsRef.current.log(action, data),
     })
     return browser.createExecutor({

--- a/apps/fluux/src/components/conversation/viewportSession.test.ts
+++ b/apps/fluux/src/components/conversation/viewportSession.test.ts
@@ -166,4 +166,68 @@ describe('ViewportSession', () => {
     expect(session.hasTravelledAway('room-a', 'top')).toBe(false)
     expect(session.hasTravelledAway('room-a', 'bottom')).toBe(true)
   })
+
+  describe('post-write settle window', () => {
+    /**
+     * Replays the sequence every positioning executor produces: it writes scrollTop while its
+     * re-assert loop owns the pixels, the loop ends, and a few frames later the virtualizer's
+     * measurement settle fires one more scroll event at an unchanged height.
+     *
+     * `marksWrite` is the only difference between executors. Those whose adapter or completion
+     * calls recordProgrammaticWrite keep the settle inside the programmatic window; the rest leave
+     * it looking exactly like a scrollbar drag.
+     */
+    function replayPositioningThenSettle(marksWrite: boolean): boolean {
+      const session = new ViewportSession('room-a')
+      const height = 4_000
+      const writeAt = 10_000
+
+      // Baseline: one observation before the write, so previousScrollHeight is known.
+      session.observeScroll({
+        conversationId: 'room-a',
+        geometry: geometry(1_200, height),
+        bottomAnchor: null,
+        controllerOwnsPixels: false,
+        now: writeAt - 500,
+      })
+
+      if (marksWrite) session.recordProgrammaticWrite('room-a', writeAt)
+
+      // The positioning frame itself, while the loop still owns the pixels.
+      session.observeScroll({
+        conversationId: 'room-a',
+        geometry: geometry(800, height),
+        bottomAnchor: null,
+        controllerOwnsPixels: true,
+        now: writeAt,
+      })
+
+      // The loop has ended. The measurement settle lands two frames later, height unchanged.
+      session.observeScroll({
+        conversationId: 'room-a',
+        geometry: geometry(800, height),
+        bottomAnchor: null,
+        controllerOwnsPixels: false,
+        now: writeAt + 32,
+      })
+
+      return session.hasGenuineInput('room-a')
+    }
+
+    it('keeps the settle programmatic when the write was recorded', () => {
+      // The live-edge and anchor-preservation adapters, saved position and directional history all
+      // mark the write, so their settle is correctly not user input.
+      expect(replayPositioningThenSettle(true)).toBe(false)
+    })
+
+    it('cannot tell an unrecorded programmatic settle from a scrollbar drag', () => {
+      // The session has no other evidence to go on: loop finished, height unchanged, no recorded
+      // write. This is why marking the write is mandatory for every executor that moves scrollTop,
+      // and it is what makes an unmarked writer a defect rather than a style difference.
+      //
+      // A genuine-input verdict opens the save gate on a drifted settle position and arms user
+      // takeover against the positioning that produced it.
+      expect(replayPositioningThenSettle(false)).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
The unread-marker and explicit-target adapters moved `scrollTop` without opening the settle window that tells the scroll gate the write was ours. The measurement settle landing once the re-assert loop has ended then has nothing to distinguish it from a scrollbar drag: no loop running, height unchanged.

`scrollGate` documents what follows from that — the save gate opens on a drifted settle position, which is persisted and restored on the next visit, and user takeover is armed against the very positioning that produced the settle.

## Where it came from

Both adapters were extracted in #1222, four days after `recordProgrammaticWrite` landed in #1188 and a week before #1228 wired it into the live-edge, fixed-anchor and resident-top adapters. They are the only two writers never retrofitted. That is also why `UnreadMarkerExecutor` has no completion callback while the other six executors do: there was no terminal hook where the marking could have been added.

## The change

Marking happens in `positionFrame`, next to `setMeasuredAtBottom`, matching the live-edge and anchor-preservation adapters. No new port member is needed, so `UnreadMarkerExecutor` keeps its current shape.

Covered from both sides: a positioning write opens the window, while a rejected near-top marker and a stale lease write nothing and must not open it. Removing either call turns both regression tests red.

A characterisation test on `ViewportSession` replays the sequence every executor produces — write under the loop, loop ends, settle two frames later at unchanged height — and pins the contrast: with the write recorded the settle is not user input, without it the session has no evidence left to tell them apart. It records why marking is mandatory rather than stylistic.

## Scope of the evidence

The mechanism is demonstrated and its cause removed. The user-visible occurrence was not reproduced end to end: none of the 96 scroll invariants covers the marker-positioning → loop-end → settle sequence, so they show the absence of regression rather than the presence of the defect beforehand. A dedicated invariant would be the honest complement if this class recurs.
