### PR TITLE
build(sdk): compile the JSDoc examples, and fix what that found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      # After the type check, because it compiles the doc examples against the
+      # same sources: a broken signature should be reported once, from the code,
+      # before it is reported again from the prose that documents it.
+      - name: Doc examples compile against the API they document
+        run: npm run check:examples
+
       - name: Lint SDK
         run: npm run lint --workspace=@fluux/sdk
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ CLAUDE.md
 
 # Benchmark output (regenerated; the numbers that matter live in the design doc)
 packages/fluux-sdk/bench/results/
+
+# Scratch project written by scripts/check-jsdoc-examples.mjs; removed on exit,
+# but a killed run must not leave it staged.
+packages/fluux-sdk/.jsdoc-examples-*

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prebuild:app": "npm run guard:sdk-link",
     "build:app": "npm run build -w @xmpp/fluux",
     "check:comments": "node --test scripts/check-comment-provenance.test.mjs && node scripts/check-comment-provenance.mjs",
+    "check:examples": "node --test scripts/check-jsdoc-examples.test.mjs && node scripts/check-jsdoc-examples.mjs",
     "check:anomaly:prod": "npm run build:app && node scripts/check-anomaly-elimination.mjs",
     "check:anomaly:dev": "FLUUX_ANOMALY=1 npm run build:app && FLUUX_ANOMALY=1 node scripts/check-anomaly-elimination.mjs",
     "build:e2e": "npm run build:sdk && node scripts/build-e2e.mjs",

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -71,11 +71,9 @@ export type UnsubscribeBindings = () => void
  *
  * @example
  * ```typescript
- * const unsubscribe = createStoreBindings(client, () => ({
- *   connection: useConnectionStore.getState(),
- *   chat: useChatStore.getState(),
- *   // ... other stores
- * }))
+ * declare const stores: StoreRefs
+ *
+ * const unsubscribe = createStoreBindings(client, () => stores)
  *
  * // Clean up on unmount
  * unsubscribe()

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -132,40 +132,46 @@ import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, d
  * }
  *
  * function Chat() {
- *   const client = useXMPP()
+ *   const { client } = useXMPP()
  *   const { connect, status } = useConnection()
  *
  *   const handleConnect = () => {
- *     connect({ jid: 'user@example.com', password: 'secret', server: 'example.com' })
+ *     connect({ jid: 'user@example.com', password: 'secret', server: 'wss://example.com:5443/ws' })
  *   }
  *
  *   const sendMessage = () => {
  *     client.chat.sendMessage('friend@example.com', 'Hello!')
  *   }
+ *
+ *   if (status !== 'online') return <button onClick={handleConnect}>Connect</button>
+ *   return <button onClick={sendMessage}>Say hello</button>
  * }
  * ```
  *
  * @example Namespace-based module API
  * ```typescript
- * // Chat operations
- * client.chat.sendMessage(to, body)
- * client.chat.sendReaction(to, messageId, emoji)
+ * declare const imageData: string
+ *
+ * // Chat operations. A room is addressed the same way: `chat` reads the room
+ * // store to decide whether it is talking to a room or to a person.
+ * client.chat.sendMessage('bob@example.com', 'Hello!')
+ * client.chat.sendReaction('bob@example.com', 'msg-1', ['\u{1F44D}'])
  *
  * // MUC (Multi-User Chat) operations
- * client.muc.joinRoom(roomJid, nickname)
- * client.muc.sendRoomMessage(roomJid, body)
+ * client.muc.joinRoom('room@conference.example.com', 'alice')
+ * client.chat.sendMessage('room@conference.example.com', 'Hello room!')
  *
  * // Roster operations
- * client.roster.add(jid, name)
- * client.roster.remove(jid)
+ * client.roster.addContact('bob@example.com', 'Bob')
+ * client.roster.removeContact('bob@example.com')
  *
  * // Profile operations
- * client.profile.publishOwnAvatar(base64Data, mimeType)
- * client.profile.setNickname(nickname)
+ * client.profile.publishOwnAvatar(imageData, 'image/png', 64, 64)
+ * client.profile.publishOwnNickname('alice')
  *
  * // Admin operations (XEP-0133)
  * client.admin.discoverAdminCommands()
- * client.admin.executeCommand(node)
+ * client.admin.executeAdminCommand('http://jabber.org/protocol/admin#add-user')
  *
  * // Service discovery
  * client.discovery.fetchServerInfo()
@@ -432,7 +438,7 @@ export class XMPPClient {
    * @example Simple bot
    * ```typescript
    * const client = new XMPPClient()
-   * await client.connect({ jid: 'bot@example.com', password: 'secret' })
+   * await client.connect({ jid: 'bot@example.com', password: 'secret', server: 'wss://example.com:5443/ws' })
    *
    * client.subscribe('chat:message', ({ message }) => {
    *   console.log(`${message.from}: ${message.body}`)
@@ -922,6 +928,8 @@ export class XMPPClient {
    *
    * @example Wiring to custom state management
    * ```typescript
+   * declare const myStore: { setContacts(contacts: Contact[]): void }
+   *
    * client.subscribe('roster:loaded', ({ contacts }) => {
    *   myStore.setContacts(contacts)
    * })
@@ -1032,8 +1040,8 @@ export class XMPPClient {
    * await client.connect({
    *   jid: 'user@example.com',
    *   password: 'secret',
-   *   server: 'example.com',
-   *   smState // Resume previous session
+   *   server: 'wss://example.com:5443/ws',
+   *   smState: smState ?? undefined // Resume the previous session when there is one
    * })
    * ```
    */
@@ -1193,6 +1201,8 @@ export class XMPPClient {
    *
    * @example
    * ```typescript
+   * declare const sleepGapMs: number
+   *
    * // App detects wake from sleep with duration (e.g., via time-gap detection)
    * client.notifySystemState('awake', sleepGapMs)
    *
@@ -1316,6 +1326,12 @@ export class XMPPClient {
    *
    * @example
    * ```typescript
+   * class MyCustomHook extends EventHook {
+   *   readonly id = 'my-hook'
+   *   readonly name = 'My Custom Hook'
+   *   onload() {}
+   * }
+   *
    * const hook = new MyCustomHook(client)
    * client.registerHook(hook)
    * ```
@@ -1487,8 +1503,10 @@ export class XMPPClient {
    * sessionStorage.setItem('sm', JSON.stringify(smState))
    *
    * // Restore on reconnect
-   * const saved = JSON.parse(sessionStorage.getItem('sm'))
-   * await client.connect({ ...options, smState: saved })
+   * declare const options: ConnectOptions
+   *
+   * const stored = sessionStorage.getItem('sm')
+   * await client.connect({ ...options, smState: stored ? JSON.parse(stored) : undefined })
    * ```
    */
   getStreamManagementState(): { id: string; inbound: number; outbound: number } | null {

--- a/packages/fluux-sdk/src/core/clientConfig.ts
+++ b/packages/fluux-sdk/src/core/clientConfig.ts
@@ -62,7 +62,7 @@ export interface XMPPClientConfig {
    * Desktop apps can provide a custom adapter using OS keychain.
    *
    * @example
-   * ```tsx
+   * ```tsx fragment
    * // Web app - uses default sessionStorageAdapter
    * <XMPPProvider>
    *   <App />
@@ -85,7 +85,7 @@ export interface XMPPClientConfig {
    * for each connection. When not provided, connections use WebSocket directly.
    *
    * @example
-   * ```tsx
+   * ```tsx fragment
    * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
    *   <App />
    * </XMPPProvider>

--- a/packages/fluux-sdk/src/core/jid.ts
+++ b/packages/fluux-sdk/src/core/jid.ts
@@ -152,6 +152,8 @@ export function isQuickChatJid(roomJid: string): boolean {
  *
  * @example
  * ```typescript
+ * declare const room: Room
+ *
  * const count = getUniqueOccupantCount(room.occupants.values())
  * // 2 connections from alice@example.com + 1 from bob@example.com = 2
  * ```

--- a/packages/fluux-sdk/src/core/logger.ts
+++ b/packages/fluux-sdk/src/core/logger.ts
@@ -46,6 +46,8 @@ let sink: LogSink | null = null
  * its own output.
  *
  * ```typescript
+ * import { setLogSink } from '@fluux/sdk/core'
+ *
  * setLogSink((level, message) => {
  *   if (level === 'warn' || level === 'error') console.error(`[sdk] ${message}`)
  * })

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -87,6 +87,9 @@ export interface ModuleDependencies {
  *
  * @example Creating a custom module
  * ```typescript
+ * import type { Element } from '@fluux/sdk/xmpp'
+ * import { BaseModule } from './BaseModule'
+ *
  * class CustomModule extends BaseModule {
  *   handle(stanza: Element): boolean {
  *     if (stanza.is('message') && stanza.getChild('custom', 'urn:example:custom')) {

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -802,7 +802,7 @@ export class Chat extends BaseModule {
    *     url: 'https://example.com/file.pdf',
    *     name: 'document.pdf',
    *     size: 12345,
-   *     mimeType: 'application/pdf'
+   *     mediaType: 'application/pdf'
    *   }
    * })
    * ```

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1264,6 +1264,8 @@ export class Connection extends BaseModule {
    * @example
    * ```typescript
    * // App detects wake from sleep with duration
+   * declare const sleepGapMs: number
+   *
    * client.notifySystemState('awake', sleepGapMs)
    *
    * // App visibility changed

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -1359,7 +1359,7 @@ export class MUC extends BaseModule {
    * ])
    *
    * // Create a solo quick chat (invite others later)
-   * const roomJid = await client.muc.createQuickChat('Me', 'Notes')
+   * const soloRoomJid = await client.muc.createQuickChat('Me', 'Notes')
    * ```
    *
    * @remarks

--- a/packages/fluux-sdk/src/core/modules/Poll.ts
+++ b/packages/fluux-sdk/src/core/modules/Poll.ts
@@ -52,6 +52,8 @@ interface LocalPollEntry {
  * await client.poll.sendPoll('room@conference.example.com', 'What for lunch?', ['Pizza', 'Sushi', 'Tacos'])
  *
  * // Vote on a poll (single-vote mode)
+ * declare const pollData: PollData
+ *
  * await client.poll.vote('room@conference.example.com', 'msg-123', '2️⃣', ['1️⃣'], pollData)
  * ```
  *

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -50,6 +50,8 @@ import {
  *
  * @example
  * ```typescript
+ * declare const base64Data: string
+ *
  * // Access via XMPPClient
  * client.profile.publishOwnAvatar(base64Data, 'image/png', 256, 256)
  * client.profile.publishOwnNickname('My Nickname')

--- a/packages/fluux-sdk/src/core/modules/WebPush.ts
+++ b/packages/fluux-sdk/src/core/modules/WebPush.ts
@@ -22,6 +22,11 @@ import type { WebPushService } from '../types'
  *
  * @example
  * ```typescript
+ * declare const endpoint: string
+ * declare const p256dh: string
+ * declare const auth: string
+ * declare const appId: string
+ *
  * // Query available push services
  * const services = await client.webPush.queryServices()
  *

--- a/packages/fluux-sdk/src/core/sideEffects.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.ts
@@ -35,6 +35,8 @@ export { setupMdsSideEffects } from './mdsSideEffects'
  *
  * @example
  * ```typescript
+ * import { setupStoreSideEffects } from '@fluux/sdk/core'
+ *
  * const client = new XMPPClient()
  * const cleanup = setupStoreSideEffects(client)
  *

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -854,6 +854,8 @@ export interface MockSDKClient {
  *
  * @example
  * ```typescript
+ * import { createMockClientWithSDKEvents, createMockStoreRefs } from './test-utils'
+ *
  * const mockClient = createMockClientWithSDKEvents()
  * const stores = createMockStoreRefs()
  *
@@ -863,7 +865,16 @@ export interface MockSDKClient {
  * mockClient.emit('connection:status', { status: 'connecting' })
  * expect(stores.connection.setStatus).toHaveBeenCalledWith('connecting')
  *
- * mockClient.emit('chat:message', { message: { id: '1', body: 'Hello' } })
+ * const message: Message = {
+ *   type: 'chat',
+ *   id: '1',
+ *   conversationId: 'bob@example.com',
+ *   from: 'bob@example.com',
+ *   body: 'Hello',
+ *   timestamp: new Date(),
+ *   isOutgoing: false,
+ * }
+ * mockClient.emit('chat:message', { message })
  * expect(stores.chat.addMessage).toHaveBeenCalled()
  * ```
  */
@@ -904,6 +915,9 @@ export type MockStoreRefs = {
  *
  * @example
  * ```typescript
+ * import { createMockClientWithSDKEvents, createMockStoreRefs } from './test-utils'
+ *
+ * const mockClient = createMockClientWithSDKEvents()
  * const stores = createMockStoreRefs()
  *
  * // Use with createStoreBindings

--- a/packages/fluux-sdk/src/core/types/connection.ts
+++ b/packages/fluux-sdk/src/core/types/connection.ts
@@ -46,6 +46,8 @@ export type ConnectionMethod = 'proxy' | 'websocket'
  *
  * @example
  * ```typescript
+ * const { notifySystemState } = client
+ *
  * // App detects wake from sleep
  * notifySystemState('awake')
  *

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -236,6 +236,8 @@ export type AnyMessage = Message | RoomMessage
  *
  * @example
  * ```typescript
+ * declare const msg: AnyMessage
+ *
  * if (isChatMessage(msg)) {
  *   console.log('Conversation:', msg.conversationId)
  * }
@@ -255,6 +257,8 @@ export function isChatMessage(msg: AnyMessage): msg is Message {
  *
  * @example
  * ```typescript
+ * declare const msg: AnyMessage
+ *
  * if (isRoomMessage(msg)) {
  *   console.log('Room:', msg.roomJid, 'Nick:', msg.nick)
  * }

--- a/packages/fluux-sdk/src/core/types/proxy.ts
+++ b/packages/fluux-sdk/src/core/types/proxy.ts
@@ -32,7 +32,7 @@ export interface ProxyStartResult {
  * const tauriProxyAdapter: ProxyAdapter = {
  *   async startProxy(server) {
  *     const { invoke } = await import('@tauri-apps/api/core')
- *     const result = await invoke('start_xmpp_proxy', { server })
+ *     const result = await invoke<{ url: string; connection_method: ConnectionMethod }>('start_xmpp_proxy', { server })
  *     return { url: result.url, connectionMethod: result.connection_method }
  *   },
  *   async stopProxy() {

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -752,13 +752,13 @@ export interface StanzaEvents {
  * @example
  * ```typescript
  * // Bot listening to messages
- * client.on('chat:message', ({ message }) => {
+ * client.subscribe('chat:message', ({ message }) => {
  *   console.log(`${message.from}: ${message.body}`)
  * })
  *
  * // React-SDK wiring events to stores
- * client.on('chat:message', ({ message }) => {
- *   useChatStore.getState().addMessage(message)
+ * client.subscribe('chat:message', ({ message }) => {
+ *   chatStore.getState().addMessage(message)
  * })
  * ```
  */

--- a/packages/fluux-sdk/src/core/types/storage.ts
+++ b/packages/fluux-sdk/src/core/types/storage.ts
@@ -80,14 +80,14 @@ export interface StoredCredentials {
  * for web apps that uses browser sessionStorage.
  *
  * @example Web app (uses default)
- * ```tsx
+ * ```tsx fragment
  * <XMPPProvider>
  *   <App />
  * </XMPPProvider>
  * ```
  *
  * @example Desktop app with OS keychain
- * ```tsx
+ * ```tsx fragment
  * import { tauriStorageAdapter } from './utils/tauriStorageAdapter'
  *
  * <XMPPProvider storageAdapter={tauriStorageAdapter}>

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -6,7 +6,7 @@
  * screen recordings, and marketing demos.
  *
  * @example
- * ```tsx
+ * ```tsx fragment
  * import { DemoClient, XMPPProvider } from '@fluux/sdk'
  * import { buildDemoData, buildDemoAnimation } from './demoData'
  *

--- a/packages/fluux-sdk/src/hooks/useAdmin.ts
+++ b/packages/fluux-sdk/src/hooks/useAdmin.ts
@@ -17,6 +17,9 @@ import { USER_COMMANDS } from './adminCommands'
  *
  * @example Checking admin status
  * ```tsx
+ * import type { ReactElement } from 'react'
+ * declare function AdminDashboard(): ReactElement
+ *
  * function AdminPanel() {
  *   const { isAdmin, hasCommands } = useAdmin()
  *
@@ -78,10 +81,11 @@ import { USER_COMMANDS } from './adminCommands'
  *   }
  *
  *   return (
- *     <form onSubmit={...}>
+ *     <form>
  *       {currentSession.form.fields.map(field => (
- *         <FormField key={field.var} field={field} />
+ *         <div key={field.var}>{field.label}</div>
  *       ))}
+ *       <button type="button" onClick={() => handleSubmit({ nick: 'alice' })}>Send</button>
  *       {canGoBack && <button type="button" onClick={previousStep}>Back</button>}
  *       <button type="submit">Submit</button>
  *       <button type="button" onClick={cancelCommand}>Cancel</button>

--- a/packages/fluux-sdk/src/hooks/useBlocking.ts
+++ b/packages/fluux-sdk/src/hooks/useBlocking.ts
@@ -49,7 +49,7 @@ import { useXMPPContext } from '../provider'
  *   const { fetchBlocklist } = useBlocking()
  *
  *   useEffect(() => {
- *     if (status === 'connected') {
+ *     if (status === 'online') {
  *       fetchBlocklist()
  *     }
  *   }, [status, fetchBlocklist])

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -49,7 +49,7 @@ const EMPTY_TYPING_ARRAY: string[] = []
  *     setText('')
  *   }
  *
- *   return <input value={text} onChange={e => setText(e.target.value)} onKeyDown={...} />
+ *   return <input value={text} onChange={e => setText(e.target.value)} onBlur={handleSend} />
  * }
  * ```
  *
@@ -59,18 +59,20 @@ const EMPTY_TYPING_ARRAY: string[] = []
  *   const { sendChatState, activeConversationId } = useChat()
  *
  *   const handleTyping = () => {
- *     sendChatState(activeConversationId, 'composing')
+ *     if (activeConversationId) sendChatState(activeConversationId, 'composing')
  *   }
  *
  *   const handleStopTyping = () => {
- *     sendChatState(activeConversationId, 'paused')
+ *     if (activeConversationId) sendChatState(activeConversationId, 'paused')
  *   }
+ *
+ *   return <input onFocus={handleTyping} onBlur={handleStopTyping} />
  * }
  * ```
  *
  * @example Message reactions
  * ```tsx
- * function MessageReaction({ messageId, conversationId }) {
+ * function MessageReaction({ messageId, conversationId }: { messageId: string; conversationId: string }) {
  *   const { sendReaction } = useChat()
  *
  *   const handleReact = (emoji: string) => {

--- a/packages/fluux-sdk/src/hooks/useConnection.ts
+++ b/packages/fluux-sdk/src/hooks/useConnection.ts
@@ -27,7 +27,7 @@ import { useConnectionActions } from './useConnectionActions'
  *
  *   const handleLogin = async () => {
  *     try {
- *       await connect('user@example.com', 'password', 'example.com')
+ *       await connect({ jid: 'user@example.com', password: 'password', server: 'wss://example.com:5443/ws' })
  *     } catch (err) {
  *       console.error('Login failed:', err)
  *     }
@@ -86,7 +86,7 @@ import { useConnectionActions } from './useConnectionActions'
  *   const handleReconnect = async () => {
  *     const saved = sessionStorage.getItem('sm')
  *     const smState = saved ? JSON.parse(saved) : undefined
- *     await connect('user@example.com', 'pass', 'example.com', smState)
+ *     await connect({ jid: 'user@example.com', password: 'pass', server: 'wss://example.com:5443/ws', smState })
  *   }
  * }
  * ```

--- a/packages/fluux-sdk/src/hooks/useConsole.ts
+++ b/packages/fluux-sdk/src/hooks/useConsole.ts
@@ -35,9 +35,9 @@ import { useConsoleStore } from '../react/storeHooks'
  *       <button onClick={clearEntries}>Clear</button>
  *       <ul>
  *         {entries.map((entry, i) => (
- *           <li key={i} className={entry.direction}>
- *             <span>{entry.direction === 'in' ? '←' : '→'}</span>
- *             <pre>{entry.xml}</pre>
+ *           <li key={i} className={entry.type}>
+ *             <span>{entry.type === 'incoming' ? '←' : '→'}</span>
+ *             <pre>{entry.content}</pre>
  *             <time>{entry.timestamp.toISOString()}</time>
  *           </li>
  *         ))}
@@ -52,14 +52,13 @@ import { useConsoleStore } from '../react/storeHooks'
  * function ResizableConsole() {
  *   const { height, setHeight } = useConsole()
  *
- *   const handleDrag = (e: MouseEvent) => {
+ *   const handleDrag = (e: { clientY: number }) => {
  *     setHeight(window.innerHeight - e.clientY)
  *   }
  *
  *   return (
  *     <div style={{ height }}>
- *       <div className="resize-handle" onMouseDown={...} />
- *       <ConsoleContent />
+ *       <div className="resize-handle" onMouseDown={handleDrag} />
  *     </div>
  *   )
  * }

--- a/packages/fluux-sdk/src/hooks/useContactIdentities.ts
+++ b/packages/fluux-sdk/src/hooks/useContactIdentities.ts
@@ -36,9 +36,10 @@ const EMPTY_MAP: Map<string, ContactIdentity> = new Map()
  *
  * @example
  * ```tsx
- * function ChatView() {
+ * function ChatView({ message }: { message: Message }) {
  *   const contactIdentities = useContactIdentities()
  *   const senderName = contactIdentities.get(message.from)?.name ?? message.from
+ *   return <p>{senderName}</p>
  * }
  * ```
  *

--- a/packages/fluux-sdk/src/hooks/useEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useEvents.ts
@@ -55,12 +55,12 @@ import type { Conversation } from '../core'
  *     <ul>
  *       {mucInvitations.map(inv => (
  *         <li key={inv.roomJid}>
- *           {inv.from} invited you to {inv.roomName || inv.roomJid}
+ *           {inv.from} invited you to {inv.roomJid}
  *           {inv.reason && <p>{inv.reason}</p>}
  *           // Rejects with a RoomJoinError when the server refuses the join
  *           // (password required, members-only, …). The invitation is kept, so
  *           // the user can retry — e.g. after supplying a password.
- *           <button onClick={() => acceptInvitation(inv.roomJid).catch(showError)}>Join</button>
+ *           <button onClick={() => acceptInvitation(inv.roomJid).catch(console.error)}>Join</button>
  *           <button onClick={() => declineInvitation(inv.roomJid)}>Decline</button>
  *         </li>
  *       ))}

--- a/packages/fluux-sdk/src/hooks/useIgnore.ts
+++ b/packages/fluux-sdk/src/hooks/useIgnore.ts
@@ -15,7 +15,7 @@ import { useIgnoreStore } from '../react/storeHooks'
  *
  * @example Ignoring an occupant in a room
  * ```tsx
- * function OccupantActions({ roomJid, occupant }: Props) {
+ * function OccupantActions({ roomJid, occupant }: { roomJid: string; occupant: RoomOccupant }) {
  *   const { isIgnored, addIgnored, removeIgnored } = useIgnore()
  *   const identifier = occupant.occupantId || occupant.jid || occupant.nick
  *   const ignored = isIgnored(roomJid, identifier)

--- a/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.ts
+++ b/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.ts
@@ -220,6 +220,9 @@ export function useRoomMetadata(roomJid: string): RoomMetadata | undefined {
  *
  * @example
  * ```tsx
+ * import type { ReactElement } from 'react'
+ * declare function OccupantList(props: { occupants?: Map<string, RoomOccupant> }): ReactElement
+ *
  * function OccupantPanel({ jid }: { jid: string }) {
  *   const runtime = useRoomRuntime(jid)
  *   // Only re-renders when occupants or messages change

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -75,7 +75,7 @@ interface PrevRoomState {
  * @example Desktop notifications
  * ```tsx
  * function NotificationHandler() {
- *   const handlers = useMemo(() => ({
+ *   const handlers: NotificationEventHandlers = useMemo(() => ({
  *     onConversationMessage: (conv, msg) => {
  *       new Notification(conv.name, { body: msg.body })
  *     },

--- a/packages/fluux-sdk/src/hooks/usePresence.ts
+++ b/packages/fluux-sdk/src/hooks/usePresence.ts
@@ -99,6 +99,8 @@ export interface UsePresenceReturn {
  *
  * @example Auto-away integration
  * ```tsx
+ * declare function getIdleTime(): number
+ *
  * function AutoAwayManager() {
  *   const { idleDetected, activityDetected, isAutoAway } = usePresence()
  *

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -58,11 +58,11 @@ const EMPTY_TYPING_ARRAY: string[] = []
  *
  * @example Managing bookmarks
  * ```tsx
- * function RoomSettings({ roomJid }) {
+ * function RoomSettings({ roomJid }: { roomJid: string }) {
  *   const { setBookmark, removeBookmark } = useRoom()
  *
  *   const handleBookmark = () => {
- *     setBookmark(roomJid, 'Room Name', 'mynick', true) // autojoin=true
+ *     setBookmark(roomJid, { name: 'Room Name', nick: 'mynick', autojoin: true })
  *   }
  *
  *   const handleRemove = () => {
@@ -73,7 +73,7 @@ const EMPTY_TYPING_ARRAY: string[] = []
  *
  * @example Inviting users
  * ```tsx
- * function InviteUser({ roomJid }) {
+ * function InviteUser({ roomJid }: { roomJid: string }) {
  *   const { inviteToRoom } = useRoom()
  *
  *   const handleInvite = (userJid: string) => {

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -39,7 +39,7 @@ type RoomSendMessageOptions = Omit<SendMessageOptions, 'replyTo'> & {
  *
  * @example
  * ```tsx
- * function InviteModal({ room }) {
+ * function InviteModal({ room }: { room: Room }) {
  *   const { inviteMultipleToRoom } = useRoomActions()
  *   // No re-render when other rooms update during sync
  * }

--- a/packages/fluux-sdk/src/hooks/useRoster.ts
+++ b/packages/fluux-sdk/src/hooks/useRoster.ts
@@ -23,7 +23,7 @@ import type { Contact } from '../core'
  *       {sortedContacts.map(contact => (
  *         <li key={contact.jid}>
  *           {contact.name || contact.jid}
- *           <span>{contact.show || 'offline'}</span>
+ *           <span>{contact.presence}</span>
  *         </li>
  *       ))}
  *     </ul>
@@ -54,12 +54,11 @@ import type { Contact } from '../core'
  * @example Handling subscription requests
  * ```tsx
  * function SubscriptionRequests() {
- *   const { acceptSubscription, rejectSubscription } = useRoster()
- *   const { pendingSubscriptions } = useEvents()
+ *   const { acceptSubscription, rejectSubscription, subscriptionRequests } = useEvents()
  *
  *   return (
  *     <ul>
- *       {pendingSubscriptions.map(req => (
+ *       {subscriptionRequests.map(req => (
  *         <li key={req.from}>
  *           {req.from} wants to add you
  *           <button onClick={() => acceptSubscription(req.from)}>Accept</button>

--- a/packages/fluux-sdk/src/hooks/useRosterActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRosterActions.ts
@@ -17,6 +17,8 @@ import type { Contact } from '../core'
  *
  * @example Removing a contact from a modal
  * ```tsx
+ * declare const onClose: () => void
+ *
  * function ContactProfileModal({ jid }: { jid: string }) {
  *   const { removeContact, renameContact } = useRosterActions()
  *

--- a/packages/fluux-sdk/src/hooks/useSearch.ts
+++ b/packages/fluux-sdk/src/hooks/useSearch.ts
@@ -5,6 +5,10 @@
  *
  * @example
  * ```tsx
+ * import type { ReactElement } from 'react'
+ * declare function Spinner(): ReactElement
+ * declare function SearchResultItem(props: { result: SearchResult }): ReactElement
+ *
  * function SearchPanel() {
  *   const { query, results, mamResults, isSearching, search, searchMAM } = useSearch()
  *

--- a/packages/fluux-sdk/src/hooks/useSystemState.ts
+++ b/packages/fluux-sdk/src/hooks/useSystemState.ts
@@ -98,19 +98,22 @@ export interface UseSystemStateReturn {
  *
  * @example Basic usage
  * ```tsx
+ * declare function listen(event: string, handler: () => void): Promise<() => void>
+ * declare function invoke<T>(command: string): Promise<T>
+ *
  * function PlatformIntegration() {
  *   const { notifyIdle, notifyActive, notifyWake, notifySleep } = useSystemState()
  *
  *   useEffect(() => {
  *     // Tauri: listen for system wake
  *     const unlisten = listen('system-did-wake', () => notifyWake())
- *     return () => unlisten.then(fn => fn())
+ *     return () => { void unlisten.then(fn => fn()) }
  *   }, [notifyWake])
  *
  *   useEffect(() => {
  *     // Check OS idle time periodically
  *     const interval = setInterval(async () => {
- *       const idleSeconds = await invoke('get_idle_time')
+ *       const idleSeconds = await invoke<number>('get_idle_time')
  *       if (idleSeconds > 300) {
  *         notifyIdle(new Date(Date.now() - idleSeconds * 1000))
  *       }

--- a/packages/fluux-sdk/src/hooks/useXMPP.ts
+++ b/packages/fluux-sdk/src/hooks/useXMPP.ts
@@ -56,8 +56,8 @@ import type { Element } from '@xmpp/client'
  *   const { on } = useXMPP()
  *
  *   useEffect(() => {
- *     const unsubscribe = on('status', (status) => {
- *       console.log('Connection status:', status)
+ *     const unsubscribe = on('online', () => {
+ *       console.log('Connected')
  *     })
  *     return unsubscribe
  *   }, [on])

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -38,9 +38,11 @@
  * }
  *
  * function Chat() {
- *   const { connect, isConnected } = useConnection()
- *   const { conversations, sendMessage } = useChat()
- *   // ...
+ *   const { isConnected } = useConnection()
+ *   const { conversations } = useChat()
+ *
+ *   if (!isConnected) return <p>Connecting…</p>
+ *   return <p>{conversations.length} conversations</p>
  * }
  * ```
  *

--- a/packages/fluux-sdk/src/provider/XMPPProvider.tsx
+++ b/packages/fluux-sdk/src/provider/XMPPProvider.tsx
@@ -42,7 +42,7 @@ export interface XMPPProviderProps {
    * @default sessionStorageAdapter (browser sessionStorage)
    *
    * @example Desktop app with OS keychain
-   * ```tsx
+   * ```tsx fragment
    * <XMPPProvider storageAdapter={tauriStorageAdapter}>
    *   <App />
    * </XMPPProvider>
@@ -56,7 +56,7 @@ export interface XMPPProviderProps {
    * connections to XMPP servers instead of WebSocket.
    *
    * @example Desktop app with TCP proxy
-   * ```tsx
+   * ```tsx fragment
    * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
    *   <App />
    * </XMPPProvider>
@@ -70,7 +70,7 @@ export interface XMPPProviderProps {
    * should be injected into the provider.
    *
    * @example Demo mode with pre-populated data
-   * ```tsx
+   * ```tsx fragment
    * const demoClient = new DemoClient()
    * demoClient.populateDemo()
    *
@@ -99,7 +99,7 @@ export interface XMPPProviderProps {
  * @returns Provider component wrapping children
  *
  * @example Basic usage
- * ```tsx
+ * ```tsx fragment
  * import { XMPPProvider } from '@fluux/sdk'
  *
  * function App() {
@@ -112,7 +112,7 @@ export interface XMPPProviderProps {
  * ```
  *
  * @example With debug mode
- * ```tsx
+ * ```tsx fragment
  * function App() {
  *   return (
  *     <XMPPProvider debug={process.env.NODE_ENV === 'development'}>
@@ -123,7 +123,7 @@ export interface XMPPProviderProps {
  * ```
  *
  * @example Desktop app with custom storage adapter
- * ```tsx
+ * ```tsx fragment
  * import { tauriStorageAdapter } from './utils/tauriStorageAdapter'
  *
  * function App() {

--- a/packages/fluux-sdk/src/react/index.ts
+++ b/packages/fluux-sdk/src/react/index.ts
@@ -18,9 +18,11 @@
  * }
  *
  * function Chat() {
- *   const { connect, status } = useConnection()
- *   const { conversations, sendMessage } = useChat()
- *   // ...
+ *   const { status } = useConnection()
+ *   const { conversations } = useChat()
+ *
+ *   if (status !== 'online') return <p>{status}</p>
+ *   return <p>{conversations.length} conversations</p>
  * }
  * ```
  *

--- a/packages/fluux-sdk/src/stores/adminStore.ts
+++ b/packages/fluux-sdk/src/stores/adminStore.ts
@@ -48,23 +48,20 @@ const initialEntityListState = <T>(): EntityListState<T> => ({
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useAdminStore } from '@fluux/sdk'
+ * import { adminStore } from '@fluux/sdk'
  *
  * // Check if current user is admin
- * const isAdmin = useAdminStore.getState().isAdmin
+ * const isAdmin = adminStore.getState().isAdmin
  *
  * // Get available commands
- * const commands = useAdminStore.getState().commands
+ * const commands = adminStore.getState().commands
  *
  * // Subscribe to command execution state
- * useAdminStore.subscribe(
- *   (state) => state.currentSession,
- *   (session) => {
- *     if (session?.status === 'completed') {
- *       console.log('Command completed:', session.notes)
- *     }
+ * adminStore.subscribe((state) => {
+ *   if (state.currentSession?.status === 'completed') {
+ *     console.log('Command completed:', state.currentSession.note)
  *   }
- * )
+ * })
  * ```
  *
  * @category Stores

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -6,11 +6,11 @@
  *
  * @example
  * ```tsx
- * import { useChatStore, chatSelectors } from '@fluux/sdk'
- * import { shallow } from 'zustand/shallow'
+ * import { chatSelectors } from '@fluux/sdk'
+ * import { useChatStore } from '@fluux/sdk/react'
  *
  * // Only re-renders when conversation IDs change (not when messages/content change)
- * const conversationIds = useChatStore(chatSelectors.conversationIds, shallow)
+ * const conversationIds = useChatStore(chatSelectors.conversationIds)
  *
  * // Only re-renders when this specific conversation changes
  * const conversation = useChatStore(chatSelectors.conversationById('user@example.com'))

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -246,15 +246,15 @@ function chatTimelineConfig(): timeline.TimelineConfig<Message> {
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useChatStore } from '@fluux/sdk'
+ * import { chatStore } from '@fluux/sdk'
  *
  * // Get all conversations (combined entity + metadata)
- * const conversations = useChatStore.getState().conversations
+ * const conversations = chatStore.getState().conversations
  *
  * // Subscribe to metadata only (sidebar optimization)
- * useChatStore.subscribe(
+ * chatStore.subscribe(
  *   (state) => state.conversationMeta,
- *   (meta) => console.log('Metadata changed')
+ *   () => console.log('Metadata changed')
  * )
  * ```
  *

--- a/packages/fluux-sdk/src/stores/connectionStore.ts
+++ b/packages/fluux-sdk/src/stores/connectionStore.ts
@@ -30,12 +30,12 @@ export type { ServerInfo, ServerIdentity, HttpUploadService, WebPushService, Web
  * const { jid, serverInfo } = connectionStore.getState()
  *
  * // Update state
- * connectionStore.getState().setStatus('connected')
+ * connectionStore.getState().setStatus('online')
  * ```
  *
  * @example React usage
  * ```tsx
- * import { useConnectionStore } from '@fluux/sdk'
+ * import { useConnectionStore } from '@fluux/sdk/react'
  *
  * function Component() {
  *   const status = useConnectionStore((state) => state.status)

--- a/packages/fluux-sdk/src/stores/consoleStore.ts
+++ b/packages/fluux-sdk/src/stores/consoleStore.ts
@@ -23,19 +23,18 @@ const BATCH_INTERVAL_MS = 100
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useConsoleStore } from '@fluux/sdk'
+ * import { consoleStore } from '@fluux/sdk'
  *
  * // Toggle console visibility
- * useConsoleStore.getState().toggle()
+ * consoleStore.getState().toggle()
  *
  * // Add a packet entry (typically called by the SDK internals)
- * useConsoleStore.getState().addPacket('outgoing', '<message>...</message>')
+ * consoleStore.getState().addPacket('outgoing', '<message>...</message>')
  *
  * // Subscribe to new entries
- * useConsoleStore.subscribe(
- *   (state) => state.entries,
- *   (entries) => console.log('New entry:', entries[entries.length - 1])
- * )
+ * consoleStore.subscribe((state) => {
+ *   console.log('New entry:', state.entries[state.entries.length - 1])
+ * })
  * ```
  *
  * @category Stores

--- a/packages/fluux-sdk/src/stores/eventsStore.ts
+++ b/packages/fluux-sdk/src/stores/eventsStore.ts
@@ -16,19 +16,18 @@ import { generateUUID } from '../utils/uuid'
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useEventsStore } from '@fluux/sdk'
+ * import { eventsStore } from '@fluux/sdk'
  *
  * // Get pending subscription requests
- * const requests = useEventsStore.getState().subscriptionRequests
+ * const requests = eventsStore.getState().subscriptionRequests
  *
  * // Add a subscription request (typically called by the SDK internals)
- * useEventsStore.getState().addSubscriptionRequest('user@example.com')
+ * eventsStore.getState().addSubscriptionRequest('user@example.com')
  *
  * // Subscribe to invitation changes
- * useEventsStore.subscribe(
- *   (state) => state.mucInvitations,
- *   (invitations) => console.log('New invitations:', invitations.length)
- * )
+ * eventsStore.subscribe((state) => {
+ *   console.log('New invitations:', state.mucInvitations.length)
+ * })
  * ```
  *
  * @category Stores

--- a/packages/fluux-sdk/src/stores/index.ts
+++ b/packages/fluux-sdk/src/stores/index.ts
@@ -16,17 +16,17 @@
  * const status = connectionStore.getState().status
  *
  * // Update state
- * connectionStore.getState().setStatus('connected')
+ * connectionStore.getState().setStatus('online')
  * ```
  *
  * ### React Applications
  * ```tsx
- * import { useConnectionStore, useChatStore } from '@fluux/sdk'
- * // Or: import { useConnectionStore, useChatStore } from '@fluux/sdk/react'
+ * import { useConnectionStore, useChatStore } from '@fluux/sdk/react'
  *
  * function Component() {
  *   const status = useConnectionStore((state) => state.status)
  *   const conversations = useChatStore((state) => state.conversations)
+ *   return <p>{status}: {conversations.size} conversations</p>
  * }
  * ```
  *

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -6,11 +6,11 @@
  *
  * @example
  * ```tsx
- * import { useRoomStore, roomSelectors } from '@fluux/sdk'
- * import { shallow } from 'zustand/shallow'
+ * import { roomSelectors } from '@fluux/sdk'
+ * import { useRoomStore } from '@fluux/sdk/react'
  *
  * // Only re-renders when room JIDs change (not when occupants/messages change)
- * const roomJids = useRoomStore(roomSelectors.bookmarkedRoomJids, shallow)
+ * const roomJids = useRoomStore(roomSelectors.bookmarkedRoomJids)
  *
  * // Only re-renders when this specific room changes
  * const room = useRoomStore(roomSelectors.roomById('room@conference.example.com'))

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -759,19 +759,19 @@ function mergeCachedRoomMessages(
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useRoomStore } from '@fluux/sdk'
+ * import { roomStore } from '@fluux/sdk'
  *
  * // Get all bookmarked rooms
- * const bookmarked = useRoomStore.getState().bookmarkedRooms()
+ * const bookmarked = roomStore.getState().bookmarkedRooms()
  *
  * // Subscribe to room updates
- * useRoomStore.subscribe(
+ * roomStore.subscribe(
  *   (state) => state.rooms,
  *   (rooms) => console.log('Rooms updated:', rooms.size)
  * )
  *
  * // Get total unread mentions
- * const mentions = useRoomStore.getState().totalMentionsCount()
+ * const mentions = roomStore.getState().totalMentionsCount()
  * ```
  *
  * @category Stores

--- a/packages/fluux-sdk/src/stores/rosterSelectors.ts
+++ b/packages/fluux-sdk/src/stores/rosterSelectors.ts
@@ -6,11 +6,11 @@
  *
  * @example
  * ```tsx
- * import { useRosterStore, rosterSelectors } from '@fluux/sdk'
- * import { shallow } from 'zustand/shallow'
+ * import { rosterSelectors } from '@fluux/sdk'
+ * import { useRosterStore } from '@fluux/sdk/react'
  *
  * // Only re-renders when contact JIDs change (not when presence/status changes)
- * const contactJids = useRosterStore(rosterSelectors.contactJids, shallow)
+ * const contactJids = useRosterStore(rosterSelectors.contactJids)
  *
  * // Only re-renders when this specific contact changes
  * const contact = useRosterStore(rosterSelectors.contactById('user@example.com'))

--- a/packages/fluux-sdk/src/stores/rosterStore.ts
+++ b/packages/fluux-sdk/src/stores/rosterStore.ts
@@ -53,19 +53,18 @@ let _cachedOnlineContactsSource: Map<string, Contact> | null = null
  *
  * @example Direct store access (advanced)
  * ```ts
- * import { useRosterStore } from '@fluux/sdk'
+ * import { rosterStore } from '@fluux/sdk'
  *
  * // Get sorted contacts (online first)
- * const contacts = useRosterStore.getState().sortedContacts()
+ * const contacts = rosterStore.getState().sortedContacts()
  *
  * // Subscribe to roster changes
- * useRosterStore.subscribe(
- *   (state) => state.contacts,
- *   (contacts) => console.log('Contacts updated:', contacts.size)
- * )
+ * rosterStore.subscribe((state) => {
+ *   console.log('Contacts updated:', state.contacts.size)
+ * })
  *
  * // Check if JID is a known contact
- * const isContact = useRosterStore.getState().hasContact('user@example.com')
+ * const isContact = rosterStore.getState().hasContact('user@example.com')
  * ```
  *
  * @category Stores

--- a/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
@@ -174,14 +174,22 @@ export function findLastPreviewableMessage<T extends PreviewableMessage>(
  *
  * @example
  * ```typescript
+ * import { shouldUpdateLastMessage } from './lastMessageUtils'
+ *
+ * declare const meta: { lastMessage?: Message }
+ * declare const room: Room
+ * declare const newMessage: Message
+ * declare const newRoomMessage: RoomMessage
+ *
  * // In chatStore.updateLastMessagePreview
- * if (!shouldUpdateLastMessage(meta.lastMessage, newMessage)) {
- *   return state // Keep existing, new message is older
+ * function updateChatPreview(state: unknown) {
+ *   // Keep the existing preview when the new message is older
+ *   if (!shouldUpdateLastMessage(meta.lastMessage, newMessage)) return state
  * }
  *
  * // In roomStore.updateLastMessagePreview
- * if (!shouldUpdateLastMessage(room.lastMessage, newMessage)) {
- *   return state
+ * function updateRoomPreview(state: unknown) {
+ *   if (!shouldUpdateLastMessage(room.lastMessage, newRoomMessage)) return state
  * }
  * ```
  */

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -32,15 +32,20 @@ export interface TimestampedMessage {
  *
  * @example
  * ```typescript
+ * import { deduplicateMessages } from './messageArrayUtils'
+ *
+ * declare const existingMessages: Message[]
+ * declare const mamMessages: Message[]
+ *
  * // Chat messages: dedupe by stanzaId or from+id combo
- * const newMsgs = deduplicateMessages(
+ * const chatMsgs = deduplicateMessages(
  *   existingMessages,
  *   mamMessages,
  *   (m) => m.stanzaId ? `stanzaId:${m.stanzaId}` : `from:${m.from}:id:${m.id}`
  * )
  *
  * // Room messages: dedupe by stanzaId or id
- * const newMsgs = deduplicateMessages(
+ * const roomMsgs = deduplicateMessages(
  *   existingMessages,
  *   mamMessages,
  *   (m) => m.stanzaId || m.id
@@ -71,6 +76,10 @@ export function deduplicateMessages<T>(
  *
  * @example
  * ```typescript
+ * import { buildMessageKeySet } from './messageArrayUtils'
+ *
+ * declare const existingMessages: Message[]
+ *
  * // Chat messages need to check both stanzaId and from+id
  * const existingIds = buildMessageKeySet(existingMessages, (m) => {
  *   const keys: string[] = []

--- a/packages/fluux-sdk/src/utils/concurrencyUtils.ts
+++ b/packages/fluux-sdk/src/utils/concurrencyUtils.ts
@@ -17,6 +17,13 @@
  *
  * @example
  * ```typescript
+ * import { executeWithConcurrency } from './concurrencyUtils'
+ *
+ * declare const conversationIds: string[]
+ * declare const roomJids: string[]
+ * declare function fetchPreviewForConversation(id: string): Promise<void>
+ * declare function fetchPreviewForRoom(jid: string): Promise<void>
+ *
  * // Refresh previews for multiple conversations
  * await executeWithConcurrency(
  *   conversationIds,

--- a/packages/fluux-sdk/src/utils/messagePreview.ts
+++ b/packages/fluux-sdk/src/utils/messagePreview.ts
@@ -24,7 +24,7 @@ export interface AttachmentDisplay {
  *
  * @example
  * ```typescript
- * getAttachmentEmoji({ mediaType: 'image/png', name: 'photo.png' })
+ * getAttachmentEmoji({ url: 'https://example.com/photo.png', mediaType: 'image/png', name: 'photo.png' })
  * // { emoji: '📷', label: 'Photo' }
  * ```
  */
@@ -257,7 +257,7 @@ export function stripReplyQuote(body: string): string {
  * formatMessagePreview({ body: 'Hello', attachment: undefined })
  * // 'Hello'
  *
- * formatMessagePreview({ body: '', attachment: { mediaType: 'image/png', name: 'photo.png' } })
+ * formatMessagePreview({ body: '', attachment: { url: 'https://example.com/photo.png', mediaType: 'image/png', name: 'photo.png' } })
  * // '📷 photo.png'
  *
  * // Reply with quote still in body (no XEP-0428)

--- a/packages/fluux-sdk/src/utils/presenceUtils.ts
+++ b/packages/fluux-sdk/src/utils/presenceUtils.ts
@@ -65,6 +65,10 @@ export function getBestPresenceShow(showValues: (PresenceShow | null | undefined
  *
  * @example
  * ```typescript
+ * import type { Element } from '@fluux/sdk/xmpp'
+ *
+ * declare const presence: Element
+ *
  * // From a presence stanza handler (after checking type !== 'unavailable')
  * const showElement = presence.getChildText('show')
  * const status = getPresenceFromShow(showElement as PresenceShow | null)

--- a/packages/fluux-sdk/src/utils/sessionStorageAdapter.ts
+++ b/packages/fluux-sdk/src/utils/sessionStorageAdapter.ts
@@ -101,7 +101,7 @@ function removeItem(key: string): void {
  * - NO credential storage (web apps should re-prompt for login)
  *
  * @example
- * ```tsx
+ * ```tsx fragment
  * import { XMPPProvider, sessionStorageAdapter } from '@fluux/sdk'
  *
  * // Uses sessionStorageAdapter by default

--- a/scripts/check-jsdoc-examples.mjs
+++ b/scripts/check-jsdoc-examples.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+//
+// Typecheck the code examples inside the SDK's JSDoc.
+//
+// An `@example` block is the first thing a reader copies, and it is the one
+// part of the API that no compiler looks at: `tsc` sees a comment. So when a
+// signature changes, the prose around it goes stale silently and keeps
+// teaching a call that no longer exists. This extracts every fenced TypeScript
+// block from the SDK's doc comments and compiles it against the real source.
+//
+// Two properties this file must keep:
+//
+//   1. One compiler pass. Every snippet becomes a file in one temporary
+//      project, typechecked in a single `tsc` invocation, so the gate stays
+//      cheap enough to sit inside `npm run typecheck`.
+//
+//   2. Errors reported at the doc comment, not at the generated file. A
+//      failure has to point the author at the line they can edit.
+//
+// Snippets are compiled as modules against `PRELUDE` below. A snippet that
+// needs more context than the prelude offers should declare it inline: that
+// makes the example self-contained for a reader too, which is the point.
+//
+// Usage:
+//   node scripts/check-jsdoc-examples.mjs [--list]
+//
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const SDK_ROOT = join(REPO_ROOT, 'packages/fluux-sdk')
+const SCAN_ROOT = join(SDK_ROOT, 'src')
+
+const SKIP_DIRECTORIES = new Set(['node_modules', 'dist', 'build', 'coverage'])
+
+/** Fence languages that carry compilable TypeScript. */
+const CHECKED_LANGUAGES = new Set(['typescript', 'ts', 'tsx'])
+
+/**
+ * Fence modifier opting a snippet out of compilation: ```tsx fragment.
+ *
+ * For snippets that show where something goes rather than what runs — bare
+ * JSX placed inside an app that is not shown. Compiling those would mean
+ * wrapping them in a component and inventing the surrounding app, which buys
+ * a green check by making the documentation worse. Anything that is meant to
+ * be copied is not a fragment.
+ */
+const FRAGMENT_MODIFIER = 'fragment'
+
+/**
+ * What every snippet may assume is in scope.
+ *
+ * A doc example is read on the API page of the thing it documents, so it opens
+ * on the call rather than on an import block. To keep them that way while still
+ * compiling them, the package's own public exports are put in scope, read from
+ * the barrel so the list cannot drift from what is actually exported.
+ *
+ * `client` is declared because an example of a client method cannot show the
+ * method without one, and constructing and connecting a client would bury the
+ * line the example is about.
+ */
+function buildPrelude() {
+  const barrel = readFileSync(join(SDK_ROOT, 'src/index.ts'), 'utf8')
+  const values = new Set()
+  const types = new Set()
+  // The barrel is curated and explicit: every line names what it re-exports.
+  const clause = /export\s+(type\s+)?\{([^}]*)\}\s*from/g
+  let m
+  while ((m = clause.exec(barrel)) !== null) {
+    const typeOnlyClause = Boolean(m[1])
+    for (const raw of m[2].split(',')) {
+      // `export { flush as flushPersistentStorage }`: the alias is the name a
+      // consumer can import, so it is the one the prelude must use.
+      const aliased = raw.trim().match(/\s+as\s+([A-Za-z_$][\w$]*)$/)
+      const name = aliased ? aliased[1] : raw.trim()
+      if (!name) continue
+      const isType = typeOnlyClause || raw.trim().startsWith('type ')
+      const clean = name.replace(/^type\s+/, '')
+      if (isType) types.add(clean)
+      else values.add(clean)
+    }
+  }
+  return { values, types }
+}
+
+const { values: SDK_VALUES, types: SDK_TYPES } = buildPrelude()
+
+/** Names a snippet declares itself, which must not be shadowed by the prelude. */
+function declaredIn(code) {
+  const names = new Set()
+  for (const m of code.matchAll(/\b(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/g)) {
+    names.add(m[1])
+  }
+  for (const m of code.matchAll(/\bimport\s+(?:type\s+)?\{([^}]*)\}/g)) {
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().replace(/^type\s+/, '').replace(/\s+as\s+.*$/, '')
+      if (name) names.add(name)
+    }
+  }
+  return names
+}
+
+function preludeFor(code) {
+  const own = declaredIn(code)
+  const values = [...SDK_VALUES].filter((n) => !own.has(n))
+  const types = [...SDK_TYPES].filter((n) => !own.has(n))
+  const lines = []
+  if (values.length) lines.push(`import { ${values.join(', ')} } from '@fluux/sdk'`)
+  if (types.length) lines.push(`import type { ${types.join(', ')} } from '@fluux/sdk'`)
+  // React examples assume React, the way any reader of a hook page does.
+  const react = ['useState', 'useEffect', 'useCallback', 'useMemo', 'useRef'].filter((n) => !own.has(n))
+  if (react.length) lines.push(`import { ${react.join(', ')} } from 'react'`)
+  if (!own.has('XMPPClient')) lines.push("import { XMPPClient } from '@fluux/sdk/core'")
+  if (!own.has('client')) lines.push('declare const client: XMPPClient')
+  lines.push('export {}')
+  return lines.join('\n') + '\n'
+}
+
+/**
+ * Extract fenced code blocks from the JSDoc comments of one source file.
+ *
+ * @returns Blocks with the 1-based line of their opening fence.
+ */
+export function extractExamples(source) {
+  const blocks = []
+  const docComment = /\/\*\*[\s\S]*?\*\//g
+  let comment
+  while ((comment = docComment.exec(source)) !== null) {
+    const commentStart = comment.index
+    const lines = comment[0].split('\n')
+    let inFence = false
+    let language = ''
+    let modifier = ''
+    let body = []
+    let fenceLine = 0
+    for (let i = 0; i < lines.length; i++) {
+      // Doc comments carry a leading ` * `; the code is what follows it.
+      const text = lines[i].replace(/^\s*\*ᅟ?\s?/, '').replace(/^\s*\/\*\*\s?/, '')
+      const fence = text.match(/^```(\w*)(?:\s+(\w+))?\s*$/)
+      if (fence) {
+        if (!inFence) {
+          inFence = true
+          language = fence[1]
+          modifier = fence[2] ?? ''
+          body = []
+          fenceLine = source.slice(0, commentStart).split('\n').length + i
+        } else {
+          if (CHECKED_LANGUAGES.has(language)) {
+            blocks.push({
+              language,
+              code: body.join('\n'),
+              line: fenceLine,
+              fragment: modifier === FRAGMENT_MODIFIER,
+            })
+          }
+          inFence = false
+        }
+        continue
+      }
+      if (inFence) body.push(text)
+    }
+  }
+  return blocks
+}
+
+function sourceFiles(root) {
+  const found = []
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry)
+    if (statSync(full).isDirectory()) {
+      if (!SKIP_DIRECTORIES.has(entry)) found.push(...sourceFiles(full))
+      continue
+    }
+    if (!/\.tsx?$/.test(entry)) continue
+    if (/\.test\.tsx?$/.test(entry) || /\.testHelpers\.ts$/.test(entry)) continue
+    found.push(full)
+  }
+  return found
+}
+
+/**
+ * Rewrite a snippet's relative imports so they still point at what they named.
+ *
+ * `import { x } from './sibling'` in a doc comment means the sibling of the
+ * file being documented. The snippet is compiled elsewhere, so the harness
+ * re-anchors the specifier rather than asking authors to write paths that only
+ * make sense to the checker.
+ */
+function reanchorRelativeImports(code, sourceDir, generatedDir) {
+  const prefix = relative(generatedDir, sourceDir).split(sep).join('/')
+  return code.replace(/(\bfrom\s*['"])(\.\.?\/[^'"]*)(['"])/g, (_all, open, spec, close) => {
+    const resolved = `${prefix}/${spec}`.replace(/\/\.\//g, '/')
+    return open + resolved + close
+  })
+}
+
+function collect() {
+  const collected = []
+  for (const file of sourceFiles(SCAN_ROOT)) {
+    for (const block of extractExamples(readFileSync(file, 'utf8'))) {
+      collected.push({ ...block, file: relative(REPO_ROOT, file), sourceDir: dirname(file) })
+    }
+  }
+  return collected
+}
+
+function main() {
+  const blocks = collect()
+  if (process.argv.includes('--list')) {
+    for (const b of blocks) console.log(`${b.file}:${b.line}  (${b.language}${b.fragment ? ' fragment' : ''})`)
+    console.log(`\n${blocks.length} example(s)`)
+    return 0
+  }
+
+  const compiled = blocks.filter((b) => !b.fragment)
+  const fragments = blocks.length - compiled.length
+
+  // Generated inside the package, not in the system temp directory: module
+  // resolution has to reach `node_modules` for React and the Node types, and
+  // it only walks up from where the files actually live.
+  const dir = mkdtempSync(join(SDK_ROOT, '.jsdoc-examples-'))
+  try {
+    const index = new Map()
+    compiled.forEach((block, i) => {
+      const name = `example_${String(i).padStart(3, '0')}.${block.language === 'tsx' ? 'tsx' : 'ts'}`
+      const prelude = preludeFor(block.code)
+      index.set(name, { ...block, preludeLines: prelude.split('\n').length - 1 })
+      const code = reanchorRelativeImports(block.code, block.sourceDir, dir)
+      writeFileSync(join(dir, name), prelude + code + '\n')
+    })
+    writeFileSync(
+      join(dir, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          extends: join(SDK_ROOT, 'tsconfig.json'),
+          exclude: [],
+          // `types` and `typeRoots` are deliberately left to the inherited
+          // config: the generated project sits inside the package, so ordinary
+          // upward resolution finds the same type packages the package uses.
+          compilerOptions: {
+            noEmit: true,
+            // Wide enough to hold both the generated snippets and the sources
+            // they import; the inherited `./src` would exclude the snippets.
+            rootDir: '..',
+            baseUrl: '.',
+            // Snippets import the package the way a reader would; the paths
+            // resolve to source so the check runs without a build.
+            paths: {
+              '@fluux/sdk': [join(SDK_ROOT, 'src/index.ts')],
+              '@fluux/sdk/core': [join(SDK_ROOT, 'src/core/index.ts')],
+              '@fluux/sdk/xmpp': [join(SDK_ROOT, 'src/xmpp/index.ts')],
+              '@fluux/sdk/react': [join(SDK_ROOT, 'src/react/index.ts')],
+              '@fluux/sdk/stores': [join(SDK_ROOT, 'src/stores/index.ts')],
+            },
+          },
+          // The package's ambient module declarations (`@xmpp/client`, `ltx`)
+          // are not reachable from the snippets by import, so they are named.
+          include: ['*.ts', '*.tsx', '../src/**/*.d.ts'],
+        },
+        null,
+        2,
+      ),
+    )
+
+    // Resolved rather than pathed: npm hoists typescript to the workspace root,
+    // and which node_modules holds it is not this script's business.
+    const tscBin = createRequire(import.meta.url).resolve('typescript/bin/tsc')
+    // Run from the temporary project so diagnostics carry bare file names.
+    const tsc = spawnSync(process.execPath, [tscBin, '--noEmit', '-p', 'tsconfig.json'], {
+      encoding: 'utf8',
+      cwd: dir,
+    })
+    const output = `${tsc.stdout ?? ''}${tsc.stderr ?? ''}`
+    if (tsc.status === 0) {
+      console.log(`JSDoc examples: ${compiled.length} compiled, ${fragments} marked as fragments.`)
+      return 0
+    }
+
+    // Translate `example_007.ts(12,3): error ...` back to the doc comment.
+    const failures = new Map()
+    for (const line of output.split('\n')) {
+      const m = line.match(/^(example_\d+\.tsx?)\((\d+),(\d+)\): (.*)$/)
+      if (!m) continue
+      const block = index.get(m[1])
+      if (!block) continue
+      const inBlock = Number(m[2]) - block.preludeLines
+      const key = `${block.file}:${block.line}`
+      if (!failures.has(key)) failures.set(key, [])
+      failures.get(key).push(`      line ${inBlock} of the example: ${m[4]}`)
+    }
+
+    if (failures.size === 0) {
+      console.error('\nThe example project failed to compile as a whole:\n')
+      console.error(output)
+      return 1
+    }
+
+    console.error(`\nJSDoc examples: ${failures.size} of ${compiled.length} do not compile.\n`)
+    for (const [where, messages] of failures) {
+      console.error(`  ${where}`)
+      for (const message of messages) console.error(message)
+    }
+    console.error(
+      '\nAn example is API documentation. Fix the call, or make the snippet' +
+        '\nself-contained by declaring what it uses.\n',
+    )
+    return 1
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main())
+}

--- a/scripts/check-jsdoc-examples.test.mjs
+++ b/scripts/check-jsdoc-examples.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { extractExamples } from './check-jsdoc-examples.mjs'
+
+const doc = (body) => `/**\n${body}\n */\nexport const x = 1\n`
+
+test('extracts a fenced typescript block from a doc comment', () => {
+  const blocks = extractExamples(doc(' * ```typescript\n * const a = 1\n * ```'))
+  assert.equal(blocks.length, 1)
+  assert.equal(blocks[0].language, 'typescript')
+  assert.equal(blocks[0].code, 'const a = 1')
+  assert.equal(blocks[0].fragment, false)
+})
+
+test('reports the line of the opening fence, so a failure points at the source', () => {
+  const source = `const before = 1\n\n${doc(' * ```ts\n * const a = 1\n * ```')}`
+  const blocks = extractExamples(source)
+  assert.equal(blocks.length, 1)
+  // Line 3 is `/**`, line 4 is the fence.
+  assert.equal(blocks[0].line, 4)
+})
+
+test('ignores fences in languages that are not TypeScript', () => {
+  const blocks = extractExamples(doc(' * ```bash\n * npm install\n * ```\n * ```xml\n * <iq/>\n * ```'))
+  assert.deepEqual(blocks, [])
+})
+
+test('marks a block as a fragment when the fence says so', () => {
+  const blocks = extractExamples(doc(' * ```tsx fragment\n * <App />\n * ```'))
+  assert.equal(blocks.length, 1)
+  assert.equal(blocks[0].fragment, true)
+})
+
+test('an unknown modifier does not silently exempt a block', () => {
+  const blocks = extractExamples(doc(' * ```tsx skipme\n * <App />\n * ```'))
+  assert.equal(blocks.length, 1)
+  assert.equal(blocks[0].fragment, false)
+})
+
+test('keeps blank lines inside a block, so reported line numbers stay true', () => {
+  const blocks = extractExamples(doc(' * ```ts\n * const a = 1\n *\n * const b = 2\n * ```'))
+  assert.equal(blocks[0].code, 'const a = 1\n\nconst b = 2')
+})
+
+test('reads every block in a comment that carries several', () => {
+  const blocks = extractExamples(
+    doc(' * ```ts\n * const a = 1\n * ```\n * @example\n * ```ts\n * const b = 2\n * ```'),
+  )
+  assert.deepEqual(
+    blocks.map((b) => b.code),
+    ['const a = 1', 'const b = 2'],
+  )
+})
+
+test('leaves ordinary comments alone', () => {
+  const blocks = extractExamples('// ```ts\n// const a = 1\n// ```\nexport const x = 1\n')
+  assert.deepEqual(blocks, [])
+})


### PR DESCRIPTION
An `@example` block is the first thing a reader copies, and the one part of the API no compiler looks at: `tsc` sees a comment. Two signature changes in a row (#1259, #1262) left their examples teaching calls that no longer existed, and both times the drift was caught by hand.

`scripts/check-jsdoc-examples.mjs` extracts every fenced TypeScript block from the SDK's doc comments and compiles it, in one pass, against the real sources. Diagnostics are reported at the doc comment rather than at the generated file, so a failure points at the line the author can edit. It runs in CI next to `check:comments`, as `npm run check:examples`, and validates its own extractor first.

Snippets get the package's public exports in scope, read from the barrel so the list cannot drift from what is actually exported. A snippet needing more declares it inline, which is what makes it self-contained for a reader too. A fence marked ` ```tsx fragment ` opts out: twelve snippets show where JSX goes inside an app that is not shown, and compiling those would mean inventing the app around them.

## What turning it on found

79 of 194 examples did not compile. The substantive ones:

- The client's API overview documented **five methods that do not exist** (`muc.sendRoomMessage`, `roster.add`, `roster.remove`, `profile.setNickname`, `admin.executeCommand`) and a `connect` call missing the required `server`.
- Twelve examples imported the `use*Store` hooks from `@fluux/sdk`, which deliberately excludes them to avoid React initialisation issues in some webviews, instead of `@fluux/sdk/react`.
- Four documented `store.subscribe(selector, listener)` on stores that have no `subscribeWithSelector` middleware, where that subscription never fires as described.
- SDK events were shown on `client.on`, which carries the client's own signals; they arrive through `client.subscribe`.
- Wrong field names a reader would have copied: `XmppPacket.direction` and `.xml`, `MucInvitation.roomName`, `Contact.show`, `AdminSession.notes`, `FileAttachment.mimeType`, and `'connected'` for a `ConnectionStatus`.

Every change under `src` is inside a comment; no runtime code moves.