### PR TITLE
refactor(sdk): group the modules the SDK drives itself off the client

### DIFF
--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -131,9 +131,8 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
           const client = getSearchClient()
           if (client) {
             try {
-              const mamContext = await client.mam.fetchContext(
+              const mamContext = await client.chat.fetchContextAround(
                 previewResult.conversationId,
-                previewResult.isRoom,
                 targetDate.toISOString(),
                 CONTEXT_BATCH_SIZE
               )
@@ -142,9 +141,8 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
               after = []
 
               // Trigger background catch-up to fill the gap (non-blocking)
-              void client.mam.catchUpToTimestamp(
+              void client.chat.catchUpTo(
                 previewResult.conversationId,
-                previewResult.isRoom,
                 targetDate.toISOString(),
               )
             } catch {

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -330,7 +330,7 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
               onCatchUpAll={() => {
                 if (isCatchingUpRooms) return
                 setIsCatchingUpRooms(true)
-                void client.mam.forceCatchUpAllRooms().finally(() => setIsCatchingUpRooms(false))
+                void client.muc.resync().finally(() => setIsCatchingUpRooms(false))
               }}
               isCatchingUp={isCatchingUpRooms}
               onMarkAllRead={markAllRoomsRead}

--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest'
 import * as main from './index'
 import * as core from './core/index'
 import * as xmpp from './xmpp/index'
+import { XMPPClient } from './core/XMPPClient'
 
 /**
  * The curated entries do not speak XMPP, and the escape hatch does.
@@ -68,6 +69,21 @@ describe('public API surface', () => {
 
   it('still exposes what an app needs to render a delivery error', () => {
     expect(Object.keys(main)).toContain('formatXMPPError')
+  })
+
+  it('keeps the modules the SDK drives itself off the client', () => {
+    // A consumer names conversations and rooms, not MAM or MDS. These are
+    // grouped under `internal` so the protocol vocabulary stays where it
+    // belongs — inside — while the client reads as domain API.
+    const client = new XMPPClient()
+    try {
+      for (const name of ['mam', 'mds', 'conversationSync', 'entityTime', 'lastActivity']) {
+        expect(name in client).toBe(false)
+      }
+      expect(typeof client.internal.mam).toBe('object')
+    } finally {
+      client.destroy()
+    }
   })
 
   it('does not hand the stanza builder back through a hook', () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -93,7 +93,7 @@ describe('XMPPClient', () => {
       expect(client.admin).toBeDefined()
       expect(client.profile).toBeDefined()
       expect(client.discovery).toBeDefined()
-      expect(client.mam).toBeDefined()
+      expect(client.internal.mam).toBeDefined()
       expect(client.blocking).toBeDefined()
     })
 
@@ -2119,7 +2119,7 @@ describe('XMPPClient', () => {
       vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
       vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
-      const convSync = (xmppClient as any).conversationSync
+      const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
 
       // No previouslyJoinedRooms, no autojoin bookmarks
@@ -2146,7 +2146,7 @@ describe('XMPPClient', () => {
       vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
       vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
-      const convSync = (xmppClient as any).conversationSync
+      const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
 
       await (xmppClient as any).sessionLifecycle.runFreshSessionSetup(
@@ -2184,7 +2184,7 @@ describe('XMPPClient', () => {
       vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Mock conversation sync
-      const convSync = (xmppClient as any).conversationSync
+      const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) {
         vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
       }
@@ -2214,7 +2214,7 @@ describe('XMPPClient', () => {
         roomsToAutojoin: [{ jid: 'public@conf.example.com', nick: 'me' }],
         allRoomJids: ['public@conf.example.com'],
       })
-      const convSync = (xmppClient as any).conversationSync
+      const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
       vi.spyOn(xmppClient.muc, 'queryRoomFeatures').mockResolvedValue({
         supportsMAM: false, supportsReactions: true, supportsHats: false,

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -110,6 +110,19 @@ import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
 import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, deleteMessage as cacheDeleteMessage } from '../utils/messageCache'
 
 /**
+ * The protocol modules the SDK drives on the consumer's behalf.
+ *
+ * @internal
+ */
+export interface InternalModules {
+  mam: MAM
+  mds: Mds
+  conversationSync: ConversationSync
+  entityTime: EntityTime
+  lastActivity: LastActivity
+}
+
+/**
  * Core XMPP client with namespace-based module API.
  *
  * The XMPPClient provides a high-level interface for XMPP protocol operations,
@@ -276,17 +289,25 @@ export class XMPPClient {
    */
   public poll!: Poll
 
-  /**
-   * Conversation sync module.
-   * Persists 1:1 conversation lists (active + archived) via PEP (XEP-0223 private storage).
-   */
-  public conversationSync!: ConversationSync
+
 
   /**
-   * MDS module (XEP-0490: Message Displayed Synchronization).
-   * Publishes/fetches per-conversation last-displayed stanza-ids via PEP.
+   * Modules the SDK drives itself.
+   *
+   * These speak XMPP the way the protocol names it — MAM, MDS, XEP-0202
+   * entity time — because that is what they implement. They are here rather
+   * than on the client because a consumer never calls them: history catch-up,
+   * read-marker publication and conversation-list sync are driven by the SDK's
+   * own side effects, and what a consumer needs from them is already offered
+   * as a domain verb elsewhere (`useContactTime`, `useLastActivity`,
+   * `muc.resync`).
+   *
+   * NOT a compatibility surface. Reaching in means the domain API is missing
+   * something; say so rather than building on this.
+   *
+   * @internal
    */
-  public mds!: Mds
+  public internal!: InternalModules
 
   /**
    * Web Push module (p1:push).
@@ -294,23 +315,8 @@ export class XMPPClient {
    */
   public webPush!: WebPush
 
-  /**
-   * Entity Time module (XEP-0202).
-   * Queries contacts for their local time and caches timezone offsets.
-   */
-  public entityTime!: EntityTime
 
-  /**
-   * Last Activity module (XEP-0012).
-   * Queries the server for when an offline contact was last active.
-   */
-  public lastActivity!: LastActivity
 
-  /**
-   * Message Archive Management module (XEP-0313).
-   * Handles querying message history for 1:1 conversations and MUC rooms.
-   */
-  public mam!: MAM
 
   /**
    * XState presence actor managing user presence state.
@@ -676,21 +682,22 @@ export class XMPPClient {
     this.connection = new Connection(moduleDeps)
     this.connectionActor = this.connection.getConnectionActor()
     this.pubsub = new PubSub(moduleDeps)
-    this.mam = new MAM(moduleDeps)
-    this.chat = new Chat(moduleDeps, this.mam)
+    const mam = new MAM(moduleDeps)
+    this.chat = new Chat(moduleDeps, mam)
     this.poll = new Poll(moduleDeps, this.chat)
     this.roster = new Roster(moduleDeps)
-    this.muc = new MUC(moduleDeps)
+    this.muc = new MUC(moduleDeps, mam)
     this.admin = new Admin(moduleDeps)
     this.profile = new Profile(moduleDeps)
     this.discovery = new Discovery(moduleDeps)
     this.blocking = new Blocking(moduleDeps)
     this.ignore = new Ignore(moduleDeps)
-    this.conversationSync = new ConversationSync(moduleDeps)
-    this.mds = new Mds(moduleDeps)
+    const conversationSync = new ConversationSync(moduleDeps)
+    const mds = new Mds(moduleDeps)
     this.webPush = new WebPush(moduleDeps)
-    this.entityTime = new EntityTime(moduleDeps)
-    this.lastActivity = new LastActivity(moduleDeps)
+    const entityTime = new EntityTime(moduleDeps)
+    const lastActivity = new LastActivity(moduleDeps)
+    this.internal = { mam, mds, conversationSync, entityTime, lastActivity }
 
     // Post-connection orchestration. Drives the domain modules just built; the
     // churny bits (stores, JID, transport) are read through getters so a
@@ -702,7 +709,7 @@ export class XMPPClient {
       muc: this.muc,
       profile: this.profile,
       webPush: this.webPush,
-      conversationSync: this.conversationSync,
+      conversationSync: this.internal.conversationSync,
       getStores: () => this.stores,
       getCurrentJid: () => this.currentJid,
       getXmpp: () => this.getXmpp(),
@@ -741,7 +748,7 @@ export class XMPPClient {
       routeStanza(
         stanza,
         [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster],
-        [this.lastActivity],
+        [this.internal.lastActivity],
       )
     })
 
@@ -759,7 +766,7 @@ export class XMPPClient {
         // For non-MAM rooms, history is requested via <history maxstanzas="50"/> on join
         // Skip on SM resumption — server already replayed all undelivered stanzas
         if (room?.supportsMAM && !room.isQuickChat && !this.sessionLifecycle.isSmResumed()) {
-          this.mam.fetchPreviewForRoom(roomJid).catch(() => {})
+          this.internal.mam.fetchPreviewForRoom(roomJid).catch(() => {})
         }
       })
 
@@ -1103,8 +1110,8 @@ export class XMPPClient {
     this.currentJid = null
     // Clear session-scoped tracking data
     this.xep0084AvatarChecked.clear()
-    this.entityTime?.clearCache()
-    this.lastActivity?.clearCache()
+    this.internal?.entityTime?.clearCache()
+    this.internal?.lastActivity?.clearCache()
     return this.connection.disconnect(options)
   }
 

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -87,11 +87,11 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
       // Must pass sessionStartTime so the 1:1 forward cursor excludes live messages
       // that arrive during catch-up (parity with rooms / Bug A).
-      expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledWith(
         expect.objectContaining({ sessionStartTime: expect.any(Number) })
       )
     })
@@ -103,7 +103,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpAllConversations).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpAllConversations).not.toHaveBeenCalled()
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -112,7 +112,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -129,7 +129,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       connectionStore.getState().setServerInfo({
@@ -139,7 +139,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+      expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
     })
 
     it('should reset and re-trigger after disconnect/reconnect cycle', async () => {
@@ -154,14 +154,14 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       simulateFreshSession(mockClient)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       connectionStore.getState().setStatus('disconnected')
 
       simulateFreshSession(mockClient)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(2)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(2)
       })
     })
 
@@ -181,7 +181,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledWith(
           expect.objectContaining({ exclude: 'alice@example.com' })
         )
       })
@@ -203,10 +203,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
-      expect(mockClient.mam.refreshConversationPreviews).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.refreshConversationPreviews).not.toHaveBeenCalled()
     })
   })
 
@@ -224,7 +224,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.refreshArchivedConversationPreviews).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.refreshArchivedConversationPreviews).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -243,11 +243,11 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.refreshArchivedConversationPreviews).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.refreshArchivedConversationPreviews).not.toHaveBeenCalled()
     })
 
     it('should trigger archived check after 24h', async () => {
@@ -266,7 +266,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.refreshArchivedConversationPreviews).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.refreshArchivedConversationPreviews).toHaveBeenCalledTimes(1)
       })
     })
   })
@@ -285,7 +285,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -304,11 +304,11 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.discoverNewConversationsFromRoster).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.discoverNewConversationsFromRoster).not.toHaveBeenCalled()
     })
 
     it('should trigger roster discovery after 1h', async () => {
@@ -327,7 +327,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -344,7 +344,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.discoverNewConversationsFromRoster).toHaveBeenCalledTimes(1)
       })
 
       expect(localStorageMock.setItem).toHaveBeenCalledWith(ROSTER_DISCOVERY_KEY, expect.any(String))
@@ -377,12 +377,12 @@ describe('setupBackgroundSyncSideEffects', () => {
       mockClient._emitSDK('room:joined', { roomJid: jid, joined: true })
 
     const caughtUpRooms = () =>
-      (mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mock.calls
+      (mockClient.internal.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mock.calls
         .map(([jid]) => jid as string)
         .sort()
 
     it('should trigger catchUpAllConversations with concurrency 2', async () => {
-      ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+      ;(mockClient.internal.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -396,10 +396,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
-      expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledWith(
         expect.objectContaining({ concurrency: 2 })
       )
     })
@@ -438,7 +438,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       }
 
       await vi.advanceTimersByTimeAsync(1_000)
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(10_000)
 
@@ -450,7 +450,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       // Must pass the session-start time so the forward cursor excludes live
       // messages that arrive during the 10s catch-up window (silent-gap fix).
-      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         'a@conference.example.com',
         expect.any(Array),
         expect.objectContaining({
@@ -465,7 +465,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       // one-shot key-unlock retry already ran its snapshot — would otherwise stay
       // "could not be decrypted" until the next launch. Re-running retryPendingDecrypts
       // when catch-up settles decrypts it in the same session.
-      ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+      ;(mockClient.internal.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -479,7 +479,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
       await vi.waitFor(() => {
         expect(mockClient.retryPendingDecrypts).toHaveBeenCalled()
@@ -503,7 +503,7 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       // Conversation catch-up settles first and triggers its own retry.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
       await vi.waitFor(() => {
         expect(mockClient.retryPendingDecrypts).toHaveBeenCalled()
@@ -515,7 +515,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       // retry so room messages stashed during that later pass also self-heal in-session.
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       await vi.waitFor(() => {
         expect(
@@ -544,11 +544,11 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(10_000)
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should re-trigger catch-up on reconnect', async () => {
-      ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+      ;(mockClient.internal.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
       addRoom('room@conference.example.com')
 
       connectionStore.getState().setServerInfo({
@@ -563,12 +563,12 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
       confirmJoin('room@conference.example.com')
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       connectionStore.getState().setStatus('disconnected')
@@ -576,12 +576,12 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateFreshSession(mockClient)
       confirmJoin('room@conference.example.com')
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(2)
+        expect(mockClient.internal.mam.catchUpAllConversations).toHaveBeenCalledTimes(2)
       })
 
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(2)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(2)
       })
     })
 
@@ -647,7 +647,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().setActiveRoom('b@conference.example.com')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       roomStore.getState().reset()
     })
 
@@ -697,7 +697,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       await Promise.resolve()
       await Promise.resolve()
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       loadSpy.mockRestore()
       roomStore.getState().reset()
     })
@@ -734,7 +734,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       mockClient._emitSDK('room:joined', { roomJid, joined: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       roomStore.getState().reset()
     })
@@ -772,7 +772,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(10_000)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           roomJid,
           expect.any(Array),
           expect.objectContaining({ sessionStartTime: 1_754_000_000_000 }),
@@ -804,7 +804,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       const oldCatchUp = new Promise<void>((resolve) => {
         resolveOldCatchUp = resolve
       })
-      vi.mocked(mockClient.mam.catchUpRoomHistory)
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory)
         .mockReturnValueOnce(oldCatchUp)
         .mockResolvedValue(undefined)
       connectionStore.getState().setServerInfo({
@@ -820,7 +820,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       mockClient._emitSDK('room:joined', { roomJid: oldRoomJid, joined: true })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           oldRoomJid,
           expect.any(Array),
           expect.any(Object),
@@ -838,7 +838,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         joined: true,
       })
       await vi.advanceTimersByTimeAsync(0)
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
         replacementRoomJid,
         expect.any(Array),
         expect.any(Object),
@@ -846,7 +846,7 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           replacementRoomJid,
           expect.any(Array),
           expect.any(Object),
@@ -916,11 +916,11 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       resolveFirstCache([])
       await vi.advanceTimersByTimeAsync(0)
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       resolveReplacementCache([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       expect(loadSpy.mock.calls.filter(([jid]) => jid === roomJid)).toHaveLength(2)
       loadSpy.mockRestore()
@@ -983,14 +983,14 @@ describe('setupBackgroundSyncSideEffects', () => {
       await vi.waitFor(() => {
         expect(loadSpy.mock.calls.filter(([jid]) => jid === roomJid)).toHaveLength(2)
       })
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       expect(roomStore.getState().getRoomMAMQueryState(roomJid).isLoading).toBe(false)
 
       resolveBackgroundCache([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         roomJid,
         [],
         expect.objectContaining({ stitchReadPointer: true }),
@@ -1039,7 +1039,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       const blockingCatchUp = new Promise<void>((resolve) => {
         resolveBlockingCatchUp = resolve
       })
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (roomJid) => {
           if (roomJid === blockingRoomJid) {
             await blockingCatchUp
@@ -1067,7 +1067,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           blockingRoomJid,
           [],
           expect.objectContaining({ stitchReadPointer: true }),
@@ -1082,14 +1082,14 @@ describe('setupBackgroundSyncSideEffects', () => {
         ).toBe(false)
       })
       expect(
-        vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+        vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
           .filter(([jid]) => jid === handoffRoomJid),
       ).toHaveLength(0)
 
       resolveBlockingCatchUp()
       await vi.waitFor(() => {
         expect(
-          vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+          vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
             .filter(([jid]) => jid === handoffRoomJid),
         ).toHaveLength(1)
       })
@@ -1139,7 +1139,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         const blockingCatchUp = new Promise<void>((resolve) => {
           resolveBlockingCatchUp = resolve
         })
-        vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+        vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
           async (roomJid) => {
             if (roomJid === blockingRoomJid) {
               await blockingCatchUp
@@ -1169,7 +1169,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         }
         await vi.advanceTimersByTimeAsync(10_000)
         await vi.waitFor(() => {
-          expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+          expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
             blockingRoomJid,
             [],
             expect.objectContaining({ stitchReadPointer: true }),
@@ -1188,14 +1188,14 @@ describe('setupBackgroundSyncSideEffects', () => {
           })
         }
         expect(
-          vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+          vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
             .filter(([jid]) => jid === targetRoomJid),
         ).toHaveLength(0)
 
         resolveBlockingCatchUp()
         await vi.waitFor(() => {
           expect(
-            vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+            vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
               .filter(([jid]) => jid === targetRoomJid),
           ).toHaveLength(1)
         })
@@ -1232,7 +1232,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         resolveBlockingCatchUp = resolve
       })
       let foregroundCatchUpCount = 0
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (roomJid) => {
           if (roomJid === foregroundRoomJid) {
             foregroundCatchUpCount += 1
@@ -1264,7 +1264,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           blockingRoomJid,
           [],
           expect.objectContaining({ stitchReadPointer: true }),
@@ -1308,7 +1308,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       const blockingCatchUp = new Promise<void>((resolve) => {
         resolveBlockingCatchUp = resolve
       })
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (roomJid) => {
           if (roomJid === blockingRoomJid) {
             await blockingCatchUp
@@ -1331,14 +1331,14 @@ describe('setupBackgroundSyncSideEffects', () => {
       }
       await vi.waitFor(() => {
         expect(
-          vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+          vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
             .filter(([jid]) => jid === foregroundRoomJid),
         ).toHaveLength(1)
       })
       await vi.advanceTimersByTimeAsync(0)
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           blockingRoomJid,
           [],
           expect.objectContaining({ stitchReadPointer: true }),
@@ -1351,7 +1351,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
       })
       expect(
-        vi.mocked(mockClient.mam.catchUpRoomHistory).mock.calls
+        vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
           .filter(([jid]) => jid === foregroundRoomJid),
       ).toHaveLength(1)
       roomStore.getState().reset()
@@ -1379,7 +1379,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         rejectForegroundCatchUp = reject
       })
       let roomCatchUpCount = 0
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (caughtUpRoomJid) => {
           if (caughtUpRoomJid !== roomJid) return
           roomCatchUpCount += 1
@@ -1440,7 +1440,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         rejectForegroundCatchUp = reject
       })
       let roomCatchUpCount = 0
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (caughtUpRoomJid) => {
           if (caughtUpRoomJid !== roomJid) return
           roomCatchUpCount += 1
@@ -1508,7 +1508,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         rejectForegroundCatchUp = reject
       })
       let roomCatchUpCount = 0
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockImplementation(
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockImplementation(
         async (caughtUpRoomJid) => {
           if (caughtUpRoomJid !== roomJid) return
           roomCatchUpCount += 1
@@ -1583,13 +1583,13 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       // Initial 10s pass — room is not MAM-ready, so it's not covered and not retried yet.
       await vi.advanceTimersByTimeAsync(10_000)
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
 
       // Disco resolves AFTER the pass → late retry fires for this room.
       roomStore.getState().updateRoom('late@conference.example.com', { supportsMAM: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'late@conference.example.com',
           expect.any(Array),
           expect.objectContaining({
@@ -1612,7 +1612,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().updateRoom('active@conference.example.com', { supportsMAM: true })
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalledWith('active@conference.example.com', expect.anything())
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalledWith('active@conference.example.com', expect.anything())
     })
 
     it('does not retry before the initial pass (the pass will cover it)', async () => {
@@ -1627,7 +1627,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().updateRoom('early@conference.example.com', { supportsMAM: true })
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
   })
 
@@ -1676,10 +1676,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoom).toHaveBeenCalledTimes(1)
       })
       expect(
-        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+        (mockClient.internal.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
       ).toBe('unseeded@conference.example.com')
     })
 
@@ -1692,7 +1692,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
 
     it('catches up a previewed room that is not caught up to live (open gap)', async () => {
@@ -1706,10 +1706,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoom).toHaveBeenCalledTimes(1)
       })
       expect(
-        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+        (mockClient.internal.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
       ).toBe('gap@conference.example.com')
     })
 
@@ -1721,7 +1721,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
 
     it('does not catch up rooms that do not support MAM', async () => {
@@ -1732,7 +1732,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
 
     it('does not catch up the active room (handled by roomSideEffects)', async () => {
@@ -1744,7 +1744,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
       await vi.advanceTimersByTimeAsync(100)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalledWith(
         'active@conference.example.com',
         expect.anything(),
       )
@@ -1769,7 +1769,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       simulateSmResumption(mockClient)
       await vi.advanceTimersByTimeAsync(300)
       // Nothing was eligible at resume time — the room was still unjoined.
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
 
       roomStore.getState().setRoomJoined('late@conference.example.com', true)
       mockClient._emitSDK('room:joined', {
@@ -1777,10 +1777,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoom).toHaveBeenCalledTimes(1)
       })
       expect(
-        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+        (mockClient.internal.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
       ).toBe('late@conference.example.com')
     })
 
@@ -1801,15 +1801,15 @@ describe('setupBackgroundSyncSideEffects', () => {
         roomJid: 'latemam@conference.example.com', joined: true,
       })
       await vi.advanceTimersByTimeAsync(100)
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
 
       roomStore.getState().updateRoom('latemam@conference.example.com', { supportsMAM: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoom).toHaveBeenCalledTimes(1)
       })
       expect(
-        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+        (mockClient.internal.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
       ).toBe('latemam@conference.example.com')
     })
 
@@ -1833,7 +1833,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(1_000)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
 
     // Second discrimination axis: the seed must be scoped to RESUMED sessions.
@@ -1859,7 +1859,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(30_000)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
 
     // A room joining while the transport is DOWN must not seed either: the
@@ -1881,7 +1881,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(1_000)
 
-      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoom).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -150,7 +150,7 @@ export function setupBackgroundSyncSideEffects(
     if (!isFreshRoomCatchUpEligible(roomJid, generation, membershipEpoch)) {
       return false
     }
-    await client.mam.catchUpRoomHistory(
+    await client.internal.mam.catchUpRoomHistory(
       roomJid,
       messages,
       { sessionStartTime, stitchReadPointer: true },
@@ -305,7 +305,7 @@ export function setupBackgroundSyncSideEffects(
     resumeSeededRooms.add(roomJid)
     logInfo(`Background sync: SM resumption — catching up late-joined room ${roomJid}`)
     try {
-      await client.mam.catchUpRoom(roomJid, sessionStartTime)
+      await client.internal.mam.catchUpRoom(roomJid, sessionStartTime)
     } catch {
       // Best-effort, exactly like the resume pass this mirrors. The seed stays
       // recorded so a failing room can't be retried on every presence change;
@@ -423,19 +423,19 @@ export function setupBackgroundSyncSideEffects(
       try {
         // Stage 1: Conversation catch-up (skip active — handled by chatSideEffects)
         logInfo('Background sync: conversation catch-up')
-        await client.mam.catchUpAllConversations({ concurrency: 2, exclude: activeConversationId, sessionStartTime })
+        await client.internal.mam.catchUpAllConversations({ concurrency: 2, exclude: activeConversationId, sessionStartTime })
 
         // Stage 2: Roster discovery (hourly cooldown)
         if (shouldDiscoverRoster()) {
           logInfo('Background sync: roster discovery')
-          await client.mam.discoverNewConversationsFromRoster({ concurrency: 2 })
+          await client.internal.mam.discoverNewConversationsFromRoster({ concurrency: 2 })
           markRosterDiscovered()
         }
 
         // Stage 3: Daily archived conversation check
         if (shouldCheckArchived()) {
           logInfo('Background sync: checking archived conversations')
-          await client.mam.refreshArchivedConversationPreviews()
+          await client.internal.mam.refreshArchivedConversationPreviews()
           markArchivedChecked()
         }
       } catch {

--- a/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
@@ -84,7 +84,7 @@ function settle(ms = 50): Promise<void> {
 function simulateDisconnect(client: ReturnType<typeof createMockClient>, opts?: { clearMocks?: boolean }) {
   connectionStore.getState().setStatus('reconnecting')
   if (opts?.clearMocks) {
-    vi.mocked(client.mam.catchUpConversationHistory).mockClear()
+    vi.mocked(client.internal.mam.catchUpConversationHistory).mockClear()
   }
 }
 
@@ -116,7 +116,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       simulateSmResumption(client)
 
       await settle()
-      expect(client.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -134,7 +134,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       simulateFreshSession(client)
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -162,13 +162,13 @@ describe('Chat Network Scenario Journey Tests', () => {
       chatStore.getState().setActiveConversation('bob@example.com')
       await settle()
 
-      vi.mocked(client.mam.catchUpConversationHistory).mockClear()
+      vi.mocked(client.internal.mam.catchUpConversationHistory).mockClear()
 
       chatStore.getState().setActiveConversation('alice@example.com')
       await settle()
 
       // Alice was the active conversation during SM resume → fetchInitiated marks it
-      expect(client.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -188,19 +188,19 @@ describe('Chat Network Scenario Journey Tests', () => {
       simulateFreshSession(client)
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
         )
       })
-      vi.mocked(client.mam.catchUpConversationHistory).mockClear()
+      vi.mocked(client.internal.mam.catchUpConversationHistory).mockClear()
 
       // Switch to bob — should trigger MAM (not yet caught up)
       chatStore.getState().setActiveConversation('bob@example.com')
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'bob@example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -220,7 +220,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       cleanup = setupChatSideEffects(client)
 
       // Mock queryMAM to clear loading state (in production, the MAM module does this)
-      vi.mocked(client.mam.catchUpConversationHistory).mockImplementation(async () => {
+      vi.mocked(client.internal.mam.catchUpConversationHistory).mockImplementation(async () => {
         const activeId = chatStore.getState().activeConversationId
         if (activeId) chatStore.getState().setMAMLoading(activeId, false)
       })
@@ -228,7 +228,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       // Cycle 1: fresh session
       simulateFreshSession(client)
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalled()
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalled()
       })
 
       // Cycle 2: disconnect → SM resume
@@ -237,7 +237,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       await settle()
 
       // No MAM on SM resume
-      expect(client.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
 
       // Cycle 3: disconnect → fresh session
       simulateDisconnect(client)
@@ -245,7 +245,7 @@ describe('Chat Network Scenario Journey Tests', () => {
 
       // MAM should trigger again (fetchInitiated cleared by disconnect + online)
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -270,13 +270,13 @@ describe('Chat Network Scenario Journey Tests', () => {
       await settle()
 
       // No MAM yet — server features not discovered
-      expect(client.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
 
       // Server info arrives with MAM support
       enableMAM()
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -298,7 +298,7 @@ describe('Chat Network Scenario Journey Tests', () => {
       enableMAM()
       await settle()
 
-      expect(client.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -341,8 +341,8 @@ describe('Chat Network Scenario Journey Tests', () => {
       simulateFreshSession(client)
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledTimes(1)
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledTimes(1)
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -388,13 +388,13 @@ describe('Chat Network Scenario Journey Tests', () => {
 
       // Chat MAM starts immediately, while room MAM waits for a confirmed join.
       await vi.waitFor(() => {
-        expect(client.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'alice@example.com',
           expect.any(Array),
           expect.objectContaining({}),
         )
       })
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       rs.getState().markAllRoomsNotJoined()
       rs.getState().setRoomJoined('room@conference.example.com', true)
@@ -405,7 +405,7 @@ describe('Chat Network Scenario Journey Tests', () => {
 
       // The confirmed room join starts its independent MAM catch-up.
       await vi.waitFor(() => {
-        expect(client.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),

--- a/packages/fluux-sdk/src/core/chatSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.test.ts
@@ -119,7 +119,7 @@ describe('setupChatSideEffects', () => {
 
       // Wait a bit - no MAM query should happen yet (no MAM support)
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
 
       // Now set server info with MAM support
       connectionStore.getState().setServerInfo({
@@ -129,7 +129,7 @@ describe('setupChatSideEffects', () => {
       })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'contact@example.com',
           expect.any(Array),
           expect.objectContaining({}), // no stitchReadPointer for the active path
@@ -185,7 +185,7 @@ describe('setupChatSideEffects', () => {
       // Cursor-policy specifics (start vs after) are covered by the orchestrator
       // and mamCatchUpUtils tests; this asserts delegation with the cached message.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'contact@example.com',
           expect.arrayContaining([expect.objectContaining({ id: 'cached-msg-1' })]),
           expect.objectContaining({}),
@@ -220,7 +220,7 @@ describe('setupChatSideEffects', () => {
       // Empty cache → delegates with an empty messages array; the orchestrator
       // resolves the fetch-latest fallback (covered by orchestrator tests).
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'contact@example.com',
           [],
           expect.objectContaining({}),
@@ -283,7 +283,7 @@ describe('setupChatSideEffects', () => {
       // the forward-vs-backward cursor decision is covered by mamCatchUpUtils
       // (selectCatchUpQuery / findNewestMessage) and orchestrator tests.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
           'contact@example.com',
           expect.arrayContaining([expect.objectContaining({ id: 'delayed-msg-1' })]),
           expect.objectContaining({}),
@@ -319,7 +319,7 @@ describe('setupChatSideEffects', () => {
       simulateSmResumption(mockClient)
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
     })
 
     it('should NOT trigger MAM when serverInfo MAM support discovered during SM resumption', async () => {
@@ -346,7 +346,7 @@ describe('setupChatSideEffects', () => {
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpConversationHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpConversationHistory).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -104,7 +104,7 @@ export function setupChatSideEffects(
       // edge from the resident window; the activation machinery owns the active
       // deep-pointer UX. See MAM.catchUpConversationHistory.
       const cachedMessages = chatStore.getState().messages.get(conversationId) || []
-      await client.mam.catchUpConversationHistory(conversationId, cachedMessages, { sessionStartTime })
+      await client.internal.mam.catchUpConversationHistory(conversationId, cachedMessages, { sessionStartTime })
       logInfo('Chat: MAM sync complete')
     } catch (error) {
       // Allow retry on next conversation switch or reconnect

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
@@ -57,8 +57,8 @@ describe('setupConversationSyncSideEffects', () => {
     connectionStore.getState().reset()
     chatStore.getState().reset()
     mockClient = createMockClient()
-    // Add conversationSync mock to the client
-    ;(mockClient as any).conversationSync = {
+    // The module lives under the client's internal group, so the double does too.
+    ;(mockClient as any).internal.conversationSync = {
       fetchConversations: vi.fn().mockResolvedValue([]),
       publishConversations: vi.fn().mockResolvedValue(undefined),
     }
@@ -87,13 +87,13 @@ describe('setupConversationSyncSideEffects', () => {
       })
 
       // Should not publish immediately
-      expect((mockClient as any).conversationSync.publishConversations).not.toHaveBeenCalled()
+      expect((mockClient as any).internal.conversationSync.publishConversations).not.toHaveBeenCalled()
 
       // Advance past debounce (3 seconds)
       await vi.advanceTimersByTimeAsync(3_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledWith(
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ jid: 'alice@example.com', archived: false }),
         ])
@@ -121,8 +121,8 @@ describe('setupConversationSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(3_000)
 
       // Should have published once with all three conversations
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
-      const publishedList = (mockClient as any).conversationSync.publishConversations.mock.calls[0][0]
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      const publishedList = (mockClient as any).internal.conversationSync.publishConversations.mock.calls[0][0]
       expect(publishedList).toHaveLength(3)
     })
 
@@ -142,8 +142,8 @@ describe('setupConversationSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(3_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledWith(
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ jid: 'alice@example.com', archived: true }),
         ])
@@ -167,8 +167,8 @@ describe('setupConversationSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(3_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledWith(
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ jid: 'alice@example.com', archived: false }),
         ])
@@ -194,8 +194,8 @@ describe('setupConversationSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(3_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
-      const publishedList = (mockClient as any).conversationSync.publishConversations.mock.calls[0][0]
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      const publishedList = (mockClient as any).internal.conversationSync.publishConversations.mock.calls[0][0]
       expect(publishedList).toHaveLength(1)
       expect(publishedList[0].jid).toBe('bob@example.com')
     })
@@ -217,7 +217,7 @@ describe('setupConversationSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(5_000)
 
       // No publish because snapshot was taken on 'online' and nothing changed
-      expect((mockClient as any).conversationSync.publishConversations).not.toHaveBeenCalled()
+      expect((mockClient as any).internal.conversationSync.publishConversations).not.toHaveBeenCalled()
     })
   })
 
@@ -235,7 +235,7 @@ describe('setupConversationSyncSideEffects', () => {
 
       await vi.advanceTimersByTimeAsync(3_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).not.toHaveBeenCalled()
+      expect((mockClient as any).internal.conversationSync.publishConversations).not.toHaveBeenCalled()
     })
   })
 
@@ -259,7 +259,7 @@ describe('setupConversationSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(5_000)
 
       // Should not have published because disconnect cancelled the timer
-      expect((mockClient as any).conversationSync.publishConversations).not.toHaveBeenCalled()
+      expect((mockClient as any).internal.conversationSync.publishConversations).not.toHaveBeenCalled()
     })
 
     it('should not publish when disconnected even if timer fires', async () => {
@@ -278,7 +278,7 @@ describe('setupConversationSyncSideEffects', () => {
       // Advance past debounce
       await vi.advanceTimersByTimeAsync(5_000)
 
-      expect((mockClient as any).conversationSync.publishConversations).not.toHaveBeenCalled()
+      expect((mockClient as any).internal.conversationSync.publishConversations).not.toHaveBeenCalled()
     })
   })
 
@@ -295,7 +295,7 @@ describe('setupConversationSyncSideEffects', () => {
       })
 
       await vi.advanceTimersByTimeAsync(3_000)
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
 
       // Disconnect
       connectionStore.getState().setStatus('disconnected')
@@ -309,13 +309,13 @@ describe('setupConversationSyncSideEffects', () => {
       })
 
       await vi.advanceTimersByTimeAsync(3_000)
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(2)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('error handling', () => {
     it('should not crash if publish fails', async () => {
-      ;(mockClient as any).conversationSync.publishConversations.mockRejectedValue(
+      ;(mockClient as any).internal.conversationSync.publishConversations.mockRejectedValue(
         new Error('network error')
       )
 
@@ -331,7 +331,7 @@ describe('setupConversationSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(3_000)
 
       // Should not throw — error is silently caught
-      expect((mockClient as any).conversationSync.publishConversations).toHaveBeenCalledTimes(1)
+      expect((mockClient as any).internal.conversationSync.publishConversations).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
@@ -85,7 +85,7 @@ export function setupConversationSyncSideEffects(
     if (snapshot === lastPublishedSnapshot) return
 
     try {
-      await client.conversationSync.publishConversations(conversations)
+      await client.internal.conversationSync.publishConversations(conversations)
       lastPublishedSnapshot = snapshot
       logInfo('ConversationSync: published conversation list')
     } catch {

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -85,7 +85,7 @@ function makeClient() {
     _emit: (event: string, payload?: unknown) => {
       for (const handler of handlers[event] ?? []) handler(payload)
     },
-    mds,
+    internal: { mds },
   }
 }
 
@@ -169,7 +169,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.waitFor(() => {
-      expect(client.mds.fetchAllDisplayedResult).toHaveBeenCalledTimes(1)
+      expect(client.internal.mds.fetchAllDisplayedResult).toHaveBeenCalledTimes(1)
     })
 
     chatStore.setState((state) => {
@@ -193,9 +193,9 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
       return { roomMeta }
     })
 
-    await waitForPublishes(client.mds.publishDisplayed, 3)
+    await waitForPublishes(client.internal.mds.publishDisplayed, 3)
 
-    const calls = client.mds.publishDisplayed.mock.calls
+    const calls = client.internal.mds.publishDisplayed.mock.calls
     expect(calls).toContainEqual([EXACT_CHAT, 'exact-stanza-7', OWN_BARE])
     expect(calls).toContainEqual([FALLBACK_CHAT, 'fallback-stanza-3', OWN_BARE])
     expect(calls).not.toContainEqual([FALLBACK_CHAT, 'unread-stanza-5', OWN_BARE])

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -237,7 +237,7 @@ function makeClient() {
     on: register,
     subscribe: register,
     _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
-    mds,
+    internal: { mds },
   }
 }
 
@@ -302,7 +302,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
       before: new Date(timeFor('m7').getTime() + 1),
       limit: 50,
     })
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -318,7 +318,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: pointerAt('m2') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's2', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's2', OWN_BARE)
     expect(getMessage).not.toHaveBeenCalled()
     expect(getMessages).not.toHaveBeenCalled()
     cleanup()
@@ -338,7 +338,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: pointerAt('m4') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's3', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's3', OWN_BARE)
     cleanup()
   })
 
@@ -357,9 +357,9 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: pointerAt('m4') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's5', OWN_BARE)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's6', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's5', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's6', OWN_BARE)
     cleanup()
   })
 
@@ -371,7 +371,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: pointerAt('m4') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -399,8 +399,8 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -423,9 +423,9 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getMessages).toHaveBeenCalledTimes(2)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
     // The superseded position must never be published: the pointer moved.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -451,12 +451,12 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     // reached the node on its own, not merely been coalesced away.
     first.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     second.resolve([cachedMsg('m8', 's8')])
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
     cleanup()
   })
 
@@ -474,7 +474,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -491,7 +491,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -508,7 +508,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -531,7 +531,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -553,7 +553,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getMessages).toHaveBeenCalledTimes(2)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -566,7 +566,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await flushMicrotasks()
 
     expect(getMessages).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     connectionStore.setState({ status: 'disconnected' } as never)
     connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
@@ -574,7 +574,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getMessages).toHaveBeenCalledTimes(2)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -599,13 +599,13 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     expect(vi.getTimerCount()).toBe(idleTimers)
 
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // The position stayed UNHANDLED, so catch-up completing republishes it
     // without needing a further local read advance (#1142).
     setConvMamState({ hasQueried: true, isCaughtUpToLive: true })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })
 
@@ -630,7 +630,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     gate.resolve([cachedMsg('m7', 's7')])
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -655,7 +655,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     expect(vi.getTimerCount()).toBe(timersAfterTeardown)
 
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
   })
 
   // ==========================================================================
@@ -676,7 +676,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
 
     expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'r5', `${ROOM}/alice`)
     // Rooms publish under the room's own archive (XEP-0359 `by`).
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
     cleanup()
   })
 
@@ -700,8 +700,8 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'shared-id', alice)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
     cleanup()
   })
 
@@ -728,12 +728,12 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
 
     first.resolve(cachedRoomMsg('shared-id', 'alice-stanza', alice))
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     second.resolve(cachedRoomMsg('shared-id', 'bob-stanza', bob))
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
     cleanup()
   })
 
@@ -747,7 +747,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
 
     seedBackgroundedRoom('shared-id', alice)
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
 
     roomStore.setState((state) => {
       const roomMeta = new Map(state.roomMeta)
@@ -760,8 +760,8 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'shared-id', bob)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(2)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(2)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
     cleanup()
   })
 
@@ -781,7 +781,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getRoomMessage).not.toHaveBeenCalled()
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -800,7 +800,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
 
     // The deliberate asymmetry (#1189): MUC reflection supplies the exact
     // stanza-id shortly, so an approximation would degrade a working path.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
   // ==========================================================================
@@ -832,7 +832,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: addressablePointerAt('m7', 's7') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     // The whole #1175 apparatus is skipped: nothing touched the cache, and
     // nothing needed the resident slice either.
     expect(getMessages).not.toHaveBeenCalled()
@@ -852,7 +852,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
     expect(getRoomMessage).not.toHaveBeenCalled()
     cleanup()
   })
@@ -869,7 +869,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(getMessages).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
     cleanup()
   })
 })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -212,7 +212,7 @@ function makeClient() {
     // SDK events ('read:displayed-synced') use client.subscribe(...).
     subscribe: register,
     _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
-    mds,
+    internal: { mds },
   }
 }
 
@@ -295,12 +295,12 @@ describe('setupMdsSideEffects', () => {
     seedMeta(cid, 'm1')
     chatStore.getState().advanceReadPointer(cid, 'm2')
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled() // still debouncing
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled() // still debouncing
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     // 1:1 → by is our own bare JID (the archive that assigned the stanza-id).
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
@@ -317,7 +317,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm1')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -347,7 +347,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m2')
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     cleanup()
   })
 
@@ -366,7 +366,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -386,8 +386,8 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m2')
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
     cleanup()
   })
 
@@ -414,8 +414,8 @@ describe('setupMdsSideEffects', () => {
     expect(
       chatStore.getState().conversationMeta.get(cid)?.readPointer?.order
     ).toEqual({ role: 'exact', timestamp: timeFor('m2').getTime(), tiebreak: { kind: 'chat', id: 'm2' } })
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
     cleanup()
   })
 
@@ -436,8 +436,8 @@ describe('setupMdsSideEffects', () => {
     patchMeta(cid, { readPointer: { order: { role: 'floor', timestamp: new Date(timeFor('m2')).getTime() }, identity: { state: 'local', messageId: 'm4' } } })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
     cleanup()
   })
 
@@ -457,7 +457,7 @@ describe('setupMdsSideEffects', () => {
     patchMeta(cid, { readPointer: { order: { role: 'floor', timestamp: new Date(timeFor('m2')).getTime() }, identity: { state: 'local', messageId: 'evicted-m2' } } })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -473,7 +473,7 @@ describe('setupMdsSideEffects', () => {
     seedMeta(cid)
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
 
     // A further own send advances the pointer, but resolves to the same
     // fallback: the exact-equal skip must suppress a redundant publish.
@@ -481,7 +481,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm4')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -503,7 +503,7 @@ describe('setupMdsSideEffects', () => {
     // stanza-id — and it avoids degrading a path that already reports the true
     // position. A room that never injected stanza-ids would have nothing
     // resolvable at-or-behind either, so a fallback could not help it.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // The reflection lands and backfills the stanza-id; #1142's retry then
     // publishes the TRUE position rather than an approximation of it.
@@ -518,7 +518,7 @@ describe('setupMdsSideEffects', () => {
     })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(room, 'rs2', room)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(room, 'rs2', room)
     cleanup()
   })
 
@@ -536,7 +536,7 @@ describe('setupMdsSideEffects', () => {
     connectionStore.setState({ status: 'connecting' } as never) // disconnect
     await vi.advanceTimersByTimeAsync(5_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -548,7 +548,7 @@ describe('setupMdsSideEffects', () => {
     // Conversation already exists with a SETTLED local read position at m1: the
     // node holds that same position, so the seed has nothing left to publish for
     // it and the test isolates the echo of the s2 marker that follows.
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
@@ -570,7 +570,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     // The marker s2 is already on the node (it is the echo) → must NOT republish.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -582,7 +582,7 @@ describe('setupMdsSideEffects', () => {
     // Seed the room (rooms + roomRuntime + roomMeta) so isRoom()/routing works.
     // The node already holds the settled position m1/s1, so the only publish the
     // test can observe is the m2 advance below.
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's1' }])
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)], 'm1')
@@ -592,19 +592,19 @@ describe('setupMdsSideEffects', () => {
     await vi.runOnlyPendingTimersAsync() // let the async seed settle
 
     roomStore.getState().advanceReadPointer(ROOM, 'm2')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled() // still debouncing
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled() // still debouncing
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     // MUC → by is the room JID (the room's archive assigned the stanza-id).
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
     cleanup()
   })
 
   it('seeds a room marker from the node into roomStore', async () => {
     const ROOM = 'room@conference.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2' }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -626,7 +626,7 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     // The node holds a marker for a room that is NOT yet in roomStore.rooms at
     // seed time (bookmarks load after the online seed on a cold start).
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2' }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -651,7 +651,7 @@ describe('setupMdsSideEffects', () => {
     // And it must NOT cause an echo republish: lastKnownNodeStanzaId[ROOM] was
     // recorded during the seed, so consider() is echo-suppressed.
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -662,7 +662,7 @@ describe('setupMdsSideEffects', () => {
 
     // Known room with a SETTLED local read position at m1 — the node holds that
     // same position, so the seed has nothing left to publish for it.
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's1' }])
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)], 'm1')
@@ -681,7 +681,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     // s2 is already on the node (it is the echo) → must NOT republish.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -720,8 +720,8 @@ describe('setupMdsSideEffects', () => {
 
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's9', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's9', ROOM)
     cleanup()
   })
 
@@ -756,7 +756,7 @@ describe('setupMdsSideEffects', () => {
     // the dirty coalescer with the debounce still pending. Do NOT advance
     // fake timers yet — the publish must still be sitting unflushed.
     roomStore.getState().advanceReadPointer(ROOM, 'm9')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // Before the debounce fires, another device publishes the SAME position:
     // the read:displayed-synced subscription records
@@ -768,7 +768,7 @@ describe('setupMdsSideEffects', () => {
     // exact-equal skip against the just-recorded node value, and publishes
     // nothing.
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -791,18 +791,18 @@ describe('setupMdsSideEffects', () => {
 
     patchMeta(cid, { readPointer: pointerAt('m2') })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     chatStore.getState().mergeMAMMessages(cid, [msg('m2', 's2')], {}, true, 'forward')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
 
     // …and once handled it stays handled: further meta churn must not republish.
     patchMeta(cid, { unreadCount: 2 })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -827,7 +827,7 @@ describe('setupMdsSideEffects', () => {
       return { roomMeta: meta }
     })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     roomStore.getState().mergeRoomMAMMessages(
       ROOM,
@@ -838,8 +838,8 @@ describe('setupMdsSideEffects', () => {
     )
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
 
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
@@ -847,7 +847,7 @@ describe('setupMdsSideEffects', () => {
       return { roomMeta: meta }
     })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -865,7 +865,7 @@ describe('setupMdsSideEffects', () => {
 
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     connectionStore.setState({
       status: 'online',
@@ -874,8 +874,8 @@ describe('setupMdsSideEffects', () => {
     patchMeta(cid, { unreadCount: 1 })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(
       cid,
       's2',
       'romeo@montague.example'
@@ -883,7 +883,7 @@ describe('setupMdsSideEffects', () => {
 
     patchMeta(cid, { unreadCount: 2 })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -908,7 +908,7 @@ describe('setupMdsSideEffects', () => {
 
     patchMeta(cid, { readPointer: pointerAt('m2') })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(first.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(first.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     connectionStore.setState({ status: 'offline' } as never)
     stopFirst()
@@ -919,7 +919,7 @@ describe('setupMdsSideEffects', () => {
     // has ever been published — the seed must not treat that as "handled".
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
     const second = makeClient()
-    second.mds.fetchAllDisplayed = vi
+    second.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -930,8 +930,8 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     // No local read advance happened in session 2 — the seed itself must publish.
-    expect(second.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(second.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(second.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(second.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     stopSecond()
   })
 
@@ -945,7 +945,7 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     // The node is ahead at s9, whose message is NOT in the loaded slice → the seed
     // can only stash it as pendingRemoteDisplayedStanzaId.
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's9' }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -963,7 +963,7 @@ describe('setupMdsSideEffects', () => {
 
     // Publishing s1 here would walk every other device back from s9 to s1.
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // It is a HOLD, not a silence: once the merge brings s9 into the slice the
     // marker resolves, the pointer advances onto it, and there is nothing to send…
@@ -976,13 +976,13 @@ describe('setupMdsSideEffects', () => {
     )
     await vi.advanceTimersByTimeAsync(2_000)
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // …and a genuine advance past the node's position publishes normally.
     chatStore.getState().advanceReadPointer(cid, 'm10')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's10', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's10', 'romeo@montague.example')
     cleanup()
   })
 
@@ -1003,8 +1003,8 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     // The empty node learns our position m1/s1 from the seed sweep.
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
 
     // A peer device publishes s9, off-slice → the binding can only stash it.
     chatStore.getState().applyRemoteDisplayed(cid, 's9')
@@ -1015,7 +1015,7 @@ describe('setupMdsSideEffects', () => {
     // otherwise — publishing it would regress the peer.
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -1052,7 +1052,7 @@ describe('setupMdsSideEffects', () => {
     })
 
     // The node already holds the first two positions.
-    client.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
+    client.internal.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
       jids.slice(0, 2).map((cid) => ({ conversationJid: cid, stanzaId: `${cid}-s2` }))
     )
 
@@ -1061,13 +1061,13 @@ describe('setupMdsSideEffects', () => {
     await vi.runOnlyPendingTimersAsync()
     await vi.advanceTimersByTimeAsync(2_000)
 
-    const published = client.mds.publishDisplayed.mock.calls.map((c) => c[0])
+    const published = client.internal.mds.publishDisplayed.mock.calls.map((c) => c[0])
     expect(published.sort()).toEqual(jids.slice(2))
 
     // Second start against the now-complete node: nothing left to publish.
     cleanup()
-    client.mds.publishDisplayed.mockClear()
-    client.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
+    client.internal.mds.publishDisplayed.mockClear()
+    client.internal.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
       jids.map((cid) => ({ conversationJid: cid, stanzaId: `${cid}-s2` }))
     )
     const restarted = setupMdsSideEffects(client as never)
@@ -1075,14 +1075,14 @@ describe('setupMdsSideEffects', () => {
     await vi.runOnlyPendingTimersAsync()
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     restarted()
   })
 
   it('does not sweep local positions when the node fetch fails', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
+    client.internal.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     seedMessages(cid, [msg('m1', 's1')])
     seedMeta(cid, 'm1')
@@ -1091,7 +1091,7 @@ describe('setupMdsSideEffects', () => {
     client._emit('online')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -1108,10 +1108,10 @@ describe('setupMdsSideEffects', () => {
 
     chatStore.getState().advanceReadPointer(cid, 'm1')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
 
     connectionStore.setState({ status: 'offline' } as never)
-    client.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
+    client.internal.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     client._emit('online')
     await vi.advanceTimersByTimeAsync(0)
@@ -1119,7 +1119,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -1139,14 +1139,14 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
   it('publishes a local position removed from the node between fresh sessions', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValueOnce([{ conversationJid: cid, stanzaId: 's1' }])
       .mockResolvedValueOnce([])
@@ -1157,15 +1157,15 @@ describe('setupMdsSideEffects', () => {
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     connectionStore.setState({ status: 'offline' } as never)
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     client._emit('online')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     cleanup()
   })
 
@@ -1173,7 +1173,7 @@ describe('setupMdsSideEffects', () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
     let resolveFetch!: (markers: Array<{ conversationJid: string; stanzaId: string }>) => void
-    client.mds.fetchAllDisplayed = vi.fn().mockImplementation(
+    client.internal.mds.fetchAllDisplayed = vi.fn().mockImplementation(
       () => new Promise((resolve) => {
         resolveFetch = resolve
       })
@@ -1192,7 +1192,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -1210,7 +1210,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().deleteConversation(cid)
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(client.mds.retractDisplayed).toHaveBeenCalledWith(cid)
+    expect(client.internal.mds.retractDisplayed).toHaveBeenCalledWith(cid)
     cleanup()
   })
 
@@ -1228,14 +1228,14 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().reset() // mass clear
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(client.mds.retractDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.retractDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
   it('migrates a legacy-format 1:1 seed marker by republishing it in spec format', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1', legacy: true }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -1247,22 +1247,22 @@ describe('setupMdsSideEffects', () => {
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
 
     // Migration is one-shot: nothing further is pending or debounced.
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
   it('a failed legacy migration does not break the seed or later publishing', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1', legacy: true }])
     // The migration republish fails (e.g. transient IQ error)…
-    client.mds.publishDisplayed = vi.fn().mockRejectedValueOnce(new Error('timeout'))
+    client.internal.mds.publishDisplayed = vi.fn().mockRejectedValueOnce(new Error('timeout'))
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     addConversation(cid)
 
@@ -1270,23 +1270,23 @@ describe('setupMdsSideEffects', () => {
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1) // the failed migration
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1) // the failed migration
 
     // …and a later local read advance still publishes normally.
-    client.mds.publishDisplayed = vi.fn().mockResolvedValue(undefined)
+    client.internal.mds.publishDisplayed = vi.fn().mockResolvedValue(undefined)
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
     seedMeta(cid, 'm1')
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
   it('does NOT republish spec-format seed markers', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -1297,14 +1297,14 @@ describe('setupMdsSideEffects', () => {
     await vi.runOnlyPendingTimersAsync()
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
   it('migrates a legacy room marker when the room becomes known after the seed', async () => {
     const ROOM = 'room@conference.example'
     const client = makeClient()
-    client.mds.fetchAllDisplayed = vi
+    client.internal.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2', legacy: true }])
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
@@ -1315,19 +1315,19 @@ describe('setupMdsSideEffects', () => {
 
     // Unknown JID at seed time (bookmarks not loaded, no conversation entity):
     // cannot classify → no migration yet.
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     // The bookmark lands: the room appears, the stashed marker drains, and the
     // legacy marker is republished in spec format with by = room JID.
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)])
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
     expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('m2')
 
     // And no echo republish on top of the migration.
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -1342,7 +1342,7 @@ describe('setupMdsSideEffects', () => {
     chatStore.getState().deleteConversation(cid)
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(client.mds.retractDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.retractDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 })
@@ -1389,7 +1389,7 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -1400,7 +1400,7 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
     cleanup()
   })
 
@@ -1411,7 +1411,7 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
@@ -1428,13 +1428,13 @@ describe('setupMdsSideEffects catch-up gate', () => {
     // must refuse to speak from the now-partial archive.
     setConvMamState(cid, { isLoading: true, hasQueried: true })
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
@@ -1445,13 +1445,13 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    expect(client.internal.mds.publishDisplayed).not.toHaveBeenCalled()
 
     chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
@@ -1464,7 +1464,7 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    expect(client.internal.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -165,7 +165,7 @@ export function setupMdsSideEffects(
   function migrateLegacyMarker(jid: string, stanzaId: string): void {
     const by = stanzaIdBy(jid)
     if (!by) return
-    client.mds.publishDisplayed(jid, stanzaId, by).catch(() => {
+    client.internal.mds.publishDisplayed(jid, stanzaId, by).catch(() => {
       // Best-effort — an unconverted marker is republished on the next advance.
     })
   }
@@ -528,7 +528,7 @@ export function setupMdsSideEffects(
       }
       if (decision === 'skip') continue
       try {
-        await client.mds.publishDisplayed(jid, stanzaId, by)
+        await client.internal.mds.publishDisplayed(jid, stanzaId, by)
         recordKnownNodeStanzaId(jid, stanzaId)
       } catch {
         // Best-effort; keep the position handled as documented above.
@@ -733,7 +733,7 @@ export function setupMdsSideEffects(
     for (const jid of trackedJids) {
       if (!current.has(jid)) {
         evictJid(jid)
-        void client.mds.retractDisplayed(jid) // best-effort
+        void client.internal.mds.retractDisplayed(jid) // best-effort
       }
     }
     trackedJids = current
@@ -830,7 +830,7 @@ export function setupMdsSideEffects(
       const seedStartedAtRevision = nodeRevision
       let result: DisplayedMarkerFetchResult
       try {
-        result = await client.mds.fetchAllDisplayedResult()
+        result = await client.internal.mds.fetchAllDisplayedResult()
       } catch {
         result = { status: 'unknown' }
       }

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -3998,7 +3998,7 @@ describe('XMPPClient Message', () => {
         mockStores.room.getMessage = vi.fn().mockReturnValue(undefined)
 
         // MAM returns original poll confirming the creator
-        const fetchSpy = vi.spyOn(xmppClient.mam, 'fetchRoomMessageById').mockResolvedValue({
+        const fetchSpy = vi.spyOn(xmppClient.internal.mam, 'fetchRoomMessageById').mockResolvedValue({
           id: pollMsgId,
           nick: 'Creator',
           occupantId: 'occ-1',
@@ -4042,7 +4042,7 @@ describe('XMPPClient Message', () => {
         mockStores.room.getMessage = vi.fn().mockReturnValue(undefined)
 
         // MAM returns original poll with a different creator
-        vi.spyOn(xmppClient.mam, 'fetchRoomMessageById').mockResolvedValue({
+        vi.spyOn(xmppClient.internal.mam, 'fetchRoomMessageById').mockResolvedValue({
           id: pollMsgId,
           nick: 'RealCreator',
           occupantId: 'occ-real',
@@ -4075,7 +4075,7 @@ describe('XMPPClient Message', () => {
         mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
         mockStores.room.getMessage = vi.fn().mockReturnValue(undefined)
 
-        vi.spyOn(xmppClient.mam, 'fetchRoomMessageById').mockRejectedValue(new Error('timeout'))
+        vi.spyOn(xmppClient.internal.mam, 'fetchRoomMessageById').mockRejectedValue(new Error('timeout'))
 
         const stanza = buildPollClosedStanza('Creator', 'occ-1')
         mockXmppClientInstance._emit('stanza', stanza)

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1812,6 +1812,51 @@ export class Chat extends BaseModule {
    * WhisperCounterpartGoneError — it must NEVER fall back to the room-broadcast path.
    */
   /**
+   * Fetch the messages surrounding a point in time in a conversation.
+   *
+   * For opening a search result: the archive holds context the local cache may
+   * not. Whether the target is a room is read from the room store, the same
+   * way sending is.
+   *
+   * @param conversationId - The conversation or room JID.
+   * @param at - ISO timestamp to centre on.
+   * @param size - How many messages to ask for.
+   *
+   * @example
+   * ```typescript
+   * declare const at: string
+   *
+   * const { messages } = await client.chat.fetchContextAround('room@conference.example.com', at, 50)
+   * ```
+   */
+  async fetchContextAround(
+    conversationId: string,
+    at: string,
+    size = 50,
+  ): Promise<{ messages: (Message | RoomMessage)[] }> {
+    return this.mamModule.fetchContext(conversationId, this.conversationKind(conversationId) === 'groupchat', at, size)
+  }
+
+  /**
+   * Page the archive backwards until a point in time is covered.
+   *
+   * Closes the gap between what the cache holds and an older message the user
+   * jumped to. Best-effort and safe to leave unawaited.
+   *
+   * @param conversationId - The conversation or room JID.
+   * @param at - ISO timestamp to reach back to.
+   * @param oldestCached - Oldest timestamp already held locally, when known.
+   */
+  async catchUpTo(conversationId: string, at: string, oldestCached?: string): Promise<void> {
+    await this.mamModule.catchUpToTimestamp(
+      conversationId,
+      this.conversationKind(conversationId) === 'groupchat',
+      at,
+      oldestCached,
+    )
+  }
+
+  /**
    * Whether a message addressed to `to` is a room message or a one-to-one one.
    *
    * This is a fact about the session, not a guess. XEP-0045 §7.4 requires

--- a/packages/fluux-sdk/src/core/modules/ConversationSync.test.ts
+++ b/packages/fluux-sdk/src/core/modules/ConversationSync.test.ts
@@ -112,7 +112,7 @@ describe('ConversationSync', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const result = await xmppClient.conversationSync.fetchConversations()
+      const result = await xmppClient.internal.conversationSync.fetchConversations()
 
       expect(result).toEqual([
         { jid: 'alice@example.com', archived: false },
@@ -126,7 +126,7 @@ describe('ConversationSync', () => {
         new Error('item-not-found')
       )
 
-      const result = await xmppClient.conversationSync.fetchConversations()
+      const result = await xmppClient.internal.conversationSync.fetchConversations()
 
       expect(result).toEqual([])
     })
@@ -148,7 +148,7 @@ describe('ConversationSync', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResponse)
 
-      const result = await xmppClient.conversationSync.fetchConversations()
+      const result = await xmppClient.internal.conversationSync.fetchConversations()
 
       expect(result).toEqual([])
     })
@@ -186,7 +186,7 @@ describe('ConversationSync', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const result = await xmppClient.conversationSync.fetchConversations()
+      const result = await xmppClient.internal.conversationSync.fetchConversations()
 
       expect(result).toEqual([
         { jid: 'alice@example.com', archived: false },
@@ -197,7 +197,7 @@ describe('ConversationSync', () => {
     it('should return empty array when not connected', async () => {
       await xmppClient.disconnect()
 
-      const result = await xmppClient.conversationSync.fetchConversations()
+      const result = await xmppClient.internal.conversationSync.fetchConversations()
 
       expect(result).toEqual([])
     })
@@ -220,7 +220,7 @@ describe('ConversationSync', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.conversationSync.publishConversations([
+      await xmppClient.internal.conversationSync.publishConversations([
         { jid: 'alice@example.com', archived: false },
         { jid: 'bob@example.com', archived: true },
       ])
@@ -259,7 +259,7 @@ describe('ConversationSync', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.conversationSync.publishConversations([
+      await xmppClient.internal.conversationSync.publishConversations([
         { jid: 'alice@example.com', archived: false },
         { jid: 'bob@example.com', archived: true },
       ])
@@ -284,7 +284,7 @@ describe('ConversationSync', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.conversationSync.publishConversations([])
+      await xmppClient.internal.conversationSync.publishConversations([])
 
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalled()
     })
@@ -293,7 +293,7 @@ describe('ConversationSync', () => {
       await xmppClient.disconnect()
 
       await expect(
-        xmppClient.conversationSync.publishConversations([
+        xmppClient.internal.conversationSync.publishConversations([
           { jid: 'alice@example.com', archived: false },
         ])
       ).rejects.toThrow('Not connected')

--- a/packages/fluux-sdk/src/core/modules/EntityTime.ts
+++ b/packages/fluux-sdk/src/core/modules/EntityTime.ts
@@ -62,7 +62,7 @@ export function getBestResource(resources: Map<string, ResourcePresence>): strin
  *
  * @example
  * ```typescript
- * const result = await client.entityTime.queryTime('alice@example.com')
+ * const result = await client.internal.entityTime.queryTime('alice@example.com')
  * if (result?.supported) {
  *   console.log(`Alice's offset: ${result.offsetMinutes} minutes from UTC`)
  * }

--- a/packages/fluux-sdk/src/core/modules/LastActivity.ts
+++ b/packages/fluux-sdk/src/core/modules/LastActivity.ts
@@ -27,7 +27,7 @@ export type LastActivityCacheEntry =
  *
  * @example
  * ```typescript
- * const result = await client.lastActivity.queryLastActivity('alice@example.com')
+ * const result = await client.internal.lastActivity.queryLastActivity('alice@example.com')
  * if (result?.supported) {
  *   console.log(`Alice was last active ${result.seconds} seconds ago`)
  * }

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -107,7 +107,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([])
       mockXmppClientInstance.iqCaller.request.mockClear()
 
-      await xmppClient.mam.catchUpAllConversations()
+      await xmppClient.internal.mam.catchUpAllConversations()
 
       // Should not have emitted any console event
       expect(emitSDKSpy).not.toHaveBeenCalledWith(
@@ -140,7 +140,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -163,7 +163,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -198,7 +198,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(30, 100)
       await catchUpPromise
 
@@ -230,7 +230,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ concurrency: 2 })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ concurrency: 2 })
       await waitForAsyncOps(100, 100)
       await catchUpPromise
 
@@ -258,7 +258,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(30, 100)
       await expect(catchUpPromise).resolves.not.toThrow()
 
@@ -275,7 +275,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -306,7 +306,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ exclude: 'bob@example.com' })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ exclude: 'bob@example.com' })
       await waitForAsyncOps(30, 100)
       await catchUpPromise
 
@@ -324,7 +324,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ exclude: null })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ exclude: null })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -370,7 +370,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -412,7 +412,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations()
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -434,9 +434,9 @@ describe('MAM Background Catch-Up', () => {
       ]
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -459,9 +459,9 @@ describe('MAM Background Catch-Up', () => {
       ]
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ sessionStartTime })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -483,9 +483,9 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(gapStart.getTime())
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -501,9 +501,9 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(undefined)
       vi.mocked(mockStores.chat.getConversationLastTimestamp!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: false, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: false, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      const catchUpPromise = xmppClient.internal.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -521,13 +521,13 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupChat('mds-ptr')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async () => {
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async () => {
         // The fetch-latest merge resolved the pointer (its message was in the page).
         vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       expect(querySpy).toHaveBeenCalledTimes(1)
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ with: 'alice@example.com', before: '' }))
@@ -538,7 +538,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === 'page-1-first') {
           // Second backward page contained the pointer's message → resolved.
@@ -549,7 +549,7 @@ describe('MAM Background Catch-Up', () => {
         return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       expect(calls.map((c) => c.before)).toEqual(['', 'w-bottom', 'page-1-first'])
     })
@@ -559,13 +559,13 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
         return { messages: [], complete: true, rsm: { first: 'page-1-first' } } // archive start
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       expect(calls).toHaveLength(2)
     })
@@ -575,12 +575,12 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
 
       let n = 0
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async () => {
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async () => {
         n++
         return { messages: [], complete: false, rsm: { first: `page-${n}-first` } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       // 1 fetch-latest + MAM_POINTER_STITCH_MAX_PAGES backward pages
       expect(querySpy).toHaveBeenCalledTimes(1 + 10)
@@ -591,14 +591,14 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr') // the pending pointer never clears in this test
 
       const calls: any[] = []
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         // Every page — including the fetch-latest — returns the SAME cursor:
         // the archive has nothing further to offer this walk.
         return { messages: [], complete: false, rsm: { first: 'stuck' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       // Fetch-latest + exactly ONE backward page — the non-advancing-cursor
       // guard bails instead of looping MAM_POINTER_STITCH_MAX_PAGES times.
@@ -611,11 +611,11 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
       // Default loadMessagesFromCache mock resolves [] — the cache-bottom probe is unavailable.
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive')
         .mockResolvedValue({ messages: [], complete: false, rsm: {} })
 
       await expect(
-        xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+        xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
       ).resolves.not.toThrow()
 
       // Only the fetch-latest ran — with no windowBottom from Phase A, no seed
@@ -628,10 +628,10 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupChat('mds-ptr')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive')
         .mockResolvedValue({ messages: [], complete: false, rsm: { first: 'w-bottom' } })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [])
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [])
 
       expect(querySpy).toHaveBeenCalledTimes(1)
     })
@@ -640,11 +640,11 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupChat(undefined)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive')
         .mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(querySpy).toHaveBeenCalledTimes(1)
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -657,11 +657,11 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupChat(undefined)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive')
         .mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
         start: '2026-05-14T09:00:00.000Z',
@@ -674,14 +674,14 @@ describe('MAM Background Catch-Up', () => {
       setupChat(undefined)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start) return { messages: [], complete: false, rsm: { last: 'x' } }
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(calls).toHaveLength(2)
       expect(calls[0]).toMatchObject({ start: '2026-05-14T09:00:00.000Z' })
@@ -702,7 +702,7 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         // Phase A forward from the coverage edge completes in one page —
         // no fetch-latest, so windowBottom would stay unset.
@@ -719,7 +719,7 @@ describe('MAM Background Catch-Up', () => {
         { timestamp: new Date('2026-06-14T09:00:00Z'), stanzaId: 'old-1' },
         { timestamp: new Date('2026-06-14T10:00:00Z'), stanzaId: 'new-9' },
       ]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, {
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, {
         sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         stitchReadPointer: true,
       })
@@ -748,13 +748,13 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
         return { messages: [], complete: false, rsm: { first: 'p1' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com',
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com',
         [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'edge' }],
         { sessionStartTime: Date.now(), stitchReadPointer: true })
 
@@ -776,13 +776,13 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
         return { messages: [], complete: false, rsm: { first: 'p1' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com',
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com',
         [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'edge' }],
         { sessionStartTime: Date.now(), stitchReadPointer: true })
 
@@ -806,13 +806,13 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
         return { messages: [], complete: false, rsm: { first: 'p1' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com',
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com',
         [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'edge' }],
         { sessionStartTime: Date.now(), stitchReadPointer: true })
 
@@ -827,7 +827,7 @@ describe('MAM Background Catch-Up', () => {
       // Default loadMessagesFromCache mock resolves [] (cache unavailable).
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
         if (opts.before === 'old-1') {
@@ -841,7 +841,7 @@ describe('MAM Background Catch-Up', () => {
         { timestamp: new Date('2026-06-14T09:00:00Z'), stanzaId: 'old-1' },
         { timestamp: new Date('2026-06-14T10:00:00Z'), stanzaId: 'new-9' },
       ]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, {
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, {
         sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         stitchReadPointer: true,
       })
@@ -856,7 +856,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === 'w-bottom') {
           // The user opened the conversation while this backward page was in flight.
@@ -866,7 +866,7 @@ describe('MAM Background Catch-Up', () => {
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       // Fetch-latest + ONE backward page — the walk stops as soon as the
       // entity is active (backward pages would keep-oldest-evict the ACTIVE
@@ -880,9 +880,9 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
       vi.mocked(mockStores.chat.getConversationGapStartId!).mockReturnValue('gap-edge-7')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
 
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ after: 'gap-edge-7' }))
     })
@@ -904,7 +904,7 @@ describe('MAM Background Catch-Up', () => {
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'purged-42' }]
       await expect(
-        xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, {
+        xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, {
           sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         })
       ).resolves.not.toThrow()
@@ -918,7 +918,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr') // pending pointer set — exercises Phase B seeding too
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.after) {
           // Phase A's forward query already degraded internally (purged
@@ -932,7 +932,7 @@ describe('MAM Background Catch-Up', () => {
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', cached, {
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', cached, {
         sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         stitchReadPointer: true,
       })
@@ -949,13 +949,13 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr') // pending pointer never clears in this test
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         // Empty cache: Phase A's own query IS the fetch-latest (before: '').
         return { messages: [], complete: true, rsm: { first: 'w-bottom' } }
       })
 
-      await xmppClient.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
 
       // The fetch-latest exhausted the archive — nothing older exists, so a
       // still-pending pointer was purged, not merely deep. No backward page.
@@ -976,12 +976,12 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupRoom('mds-ptr')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async () => {
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async () => {
         vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
 
       expect(querySpy).toHaveBeenCalledTimes(1)
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ roomJid, before: '' }))
@@ -992,7 +992,7 @@ describe('MAM Background Catch-Up', () => {
       setupRoom('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === 'page-1-first') {
           vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
@@ -1002,7 +1002,7 @@ describe('MAM Background Catch-Up', () => {
         return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
 
       expect(calls.map((c) => c.before)).toEqual(['', 'w-bottom', 'page-1-first'])
     })
@@ -1012,14 +1012,14 @@ describe('MAM Background Catch-Up', () => {
       setupRoom(undefined)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start) return { messages: [], complete: false, rsm: { last: 'x' } }
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
-      await xmppClient.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(calls).toHaveLength(2)
       expect(calls[0]).toMatchObject({ start: '2026-05-14T09:00:00.000Z', maxAutoPages: 3 })
@@ -1040,7 +1040,7 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
         if (opts.before === 'bottom-1') {
@@ -1054,7 +1054,7 @@ describe('MAM Background Catch-Up', () => {
         { timestamp: new Date('2026-06-14T09:00:00Z'), stanzaId: 'old-1' },
         { timestamp: new Date('2026-06-14T10:00:00Z'), stanzaId: 'new-9' },
       ]
-      await xmppClient.mam.catchUpRoomHistory(roomJid, cached, {
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, cached, {
         sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         stitchReadPointer: true,
       })
@@ -1080,13 +1080,13 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
         return { messages: [], complete: false, rsm: { first: 'p1' } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid,
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid,
         [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'edge' }],
         { sessionStartTime: Date.now(), stitchReadPointer: true })
 
@@ -1105,13 +1105,13 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
         return { messages: [], complete: false, rsm: { first: 'p1' } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid,
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid,
         [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'edge' }],
         { sessionStartTime: Date.now(), stitchReadPointer: true })
 
@@ -1128,7 +1128,7 @@ describe('MAM Background Catch-Up', () => {
       // Default loadMessagesFromCache mock resolves [] (cache unavailable).
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
         if (opts.before === 'old-1') {
@@ -1142,7 +1142,7 @@ describe('MAM Background Catch-Up', () => {
         { timestamp: new Date('2026-06-14T09:00:00Z'), stanzaId: 'old-1' },
         { timestamp: new Date('2026-06-14T10:00:00Z'), stanzaId: 'new-9' },
       ]
-      await xmppClient.mam.catchUpRoomHistory(roomJid, cached, {
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, cached, {
         sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime(),
         stitchReadPointer: true,
       })
@@ -1157,7 +1157,7 @@ describe('MAM Background Catch-Up', () => {
       setupRoom('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === 'w-bottom') {
           // The user opened the room while this backward page was in flight.
@@ -1167,7 +1167,7 @@ describe('MAM Background Catch-Up', () => {
         return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
 
       expect(calls.map((c) => c.before)).toEqual(['', 'w-bottom'])
     })
@@ -1177,13 +1177,13 @@ describe('MAM Background Catch-Up', () => {
       setupRoom('mds-ptr')
 
       const calls: any[] = []
-      vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
+      vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
         return { messages: [], complete: true, rsm: { first: 'page-1-first' } } // archive start
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
 
       expect(calls).toHaveLength(2)
     })
@@ -1193,12 +1193,12 @@ describe('MAM Background Catch-Up', () => {
       setupRoom('mds-ptr')
 
       let n = 0
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockImplementation(async () => {
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockImplementation(async () => {
         n++
         return { messages: [], complete: false, rsm: { first: `page-${n}-first` } }
       })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
 
       // 1 fetch-latest + MAM_POINTER_STITCH_MAX_PAGES backward pages
       expect(querySpy).toHaveBeenCalledTimes(1 + 10)
@@ -1208,10 +1208,10 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupRoom('mds-ptr')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive')
         .mockResolvedValue({ messages: [], complete: false, rsm: { first: 'w-bottom' } })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [])
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [])
 
       expect(querySpy).toHaveBeenCalledTimes(1)
     })
@@ -1220,11 +1220,11 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupRoom(undefined)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive')
         .mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
-      await xmppClient.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(querySpy).toHaveBeenCalledTimes(1)
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -1237,11 +1237,11 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
       setupRoom(undefined)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive')
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive')
         .mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
-      await xmppClient.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
 
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
         start: '2026-05-14T09:00:00.000Z',
@@ -1255,9 +1255,9 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoomGapStart!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
       vi.mocked(mockStores.room.getRoomGapStartId!).mockReturnValue('gap-edge-7')
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      await xmppClient.mam.catchUpRoomHistory(roomJid, [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
+      await xmppClient.internal.mam.catchUpRoomHistory(roomJid, [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
 
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ after: 'gap-edge-7' }))
     })
@@ -1290,7 +1290,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
+      const catchUpPromise = xmppClient.internal.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1317,7 +1317,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
+      const catchUpPromise = xmppClient.internal.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1353,9 +1353,9 @@ describe('MAM Background Catch-Up', () => {
 
       // Cursor source = pure cache peek (catchUpRoom uses the return value).
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com', sessionStartTime)
+      const catchUpPromise = xmppClient.internal.mam.catchUpRoom('room1@conference.example.com', sessionStartTime)
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1378,9 +1378,9 @@ describe('MAM Background Catch-Up', () => {
 
       // Cursor source = pure cache peek (catchUpRoom uses the return value).
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
+      const catchUpPromise = xmppClient.internal.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1396,7 +1396,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.connection.getStatus).mockReturnValue('disconnected')
       mockXmppClientInstance.iqCaller.request.mockClear()
 
-      await xmppClient.mam.catchUpRoom('room1@conference.example.com')
+      await xmppClient.internal.mam.catchUpRoom('room1@conference.example.com')
 
       expect(mockStores.room.loadMessagesFromCache).not.toHaveBeenCalled()
       expect(mockXmppClientInstance.iqCaller.request).not.toHaveBeenCalled()
@@ -1410,7 +1410,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.joinedRooms).mockReturnValue([])
       mockXmppClientInstance.iqCaller.request.mockClear()
 
-      await xmppClient.mam.forceCatchUpAllRooms()
+      await xmppClient.internal.mam.forceCatchUpAllRooms()
 
       expect(emitSDKSpy).not.toHaveBeenCalledWith(
         'console:event',
@@ -1436,7 +1436,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(30, 100)
       await catchUpPromise
 
@@ -1466,7 +1466,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(30, 100)
       await catchUpPromise
 
@@ -1492,7 +1492,7 @@ describe('MAM Background Catch-Up', () => {
         return createFinResponse()
       })
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(30, 100)
       await expect(catchUpPromise).resolves.not.toThrow()
 
@@ -1509,7 +1509,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1527,9 +1527,9 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
 
-      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(xmppClient.internal.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1547,7 +1547,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms()
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1566,7 +1566,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms({ days: 3 })
+      const catchUpPromise = xmppClient.internal.mam.forceCatchUpAllRooms({ days: 3 })
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1584,7 +1584,7 @@ describe('MAM Background Catch-Up', () => {
       // complete=false, no rsm cursor → forward pagination stops with isComplete=false
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
 
-      const queryPromise = xmppClient.mam.queryArchive({
+      const queryPromise = xmppClient.internal.mam.queryArchive({
         with: 'alice@example.com',
         start: '2026-05-01T00:00:00.000Z',
         max: 100,
@@ -1608,7 +1608,7 @@ describe('MAM Background Catch-Up', () => {
       // complete=false, no rsm cursor → forward pagination stops with isComplete=false
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
 
-      const queryPromise = xmppClient.mam.queryRoomArchive({
+      const queryPromise = xmppClient.internal.mam.queryRoomArchive({
         roomJid: 'room1@conference.example.com',
         start: '2026-05-01T00:00:00.000Z',
         max: 100,
@@ -1628,7 +1628,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(true))
 
-      const queryPromise = xmppClient.mam.queryRoomArchive({
+      const queryPromise = xmppClient.internal.mam.queryRoomArchive({
         roomJid: 'room1@conference.example.com',
         start: '2026-05-01T00:00:00.000Z',
         max: 100,
@@ -1649,7 +1649,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.roster.sortedContacts).mockReturnValue([])
       mockXmppClientInstance.iqCaller.request.mockClear()
 
-      await xmppClient.mam.discoverNewConversationsFromRoster()
+      await xmppClient.internal.mam.discoverNewConversationsFromRoster()
 
       expect(emitSDKSpy).not.toHaveBeenCalledWith(
         'console:event',
@@ -1669,7 +1669,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.hasConversation).mockReturnValue(true)
       mockXmppClientInstance.iqCaller.request.mockClear()
 
-      await xmppClient.mam.discoverNewConversationsFromRoster()
+      await xmppClient.internal.mam.discoverNewConversationsFromRoster()
 
       // No MAM queries should have been made
       expect(mockXmppClientInstance.iqCaller.request).not.toHaveBeenCalled()
@@ -1690,7 +1690,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const discoverPromise = xmppClient.mam.discoverNewConversationsFromRoster()
+      const discoverPromise = xmppClient.internal.mam.discoverNewConversationsFromRoster()
       await waitForAsyncOps(20, 100)
       await discoverPromise
 
@@ -1714,7 +1714,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.hasConversation).mockReturnValue(false)
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const discoverPromise = xmppClient.mam.discoverNewConversationsFromRoster()
+      const discoverPromise = xmppClient.internal.mam.discoverNewConversationsFromRoster()
       await waitForAsyncOps(20, 100)
       await discoverPromise
 
@@ -1741,7 +1741,7 @@ describe('MAM Background Catch-Up', () => {
         .mockResolvedValue(createFinResponse())
 
       // Should not throw
-      const discoverPromise = xmppClient.mam.discoverNewConversationsFromRoster()
+      const discoverPromise = xmppClient.internal.mam.discoverNewConversationsFromRoster()
       await waitForAsyncOps(20, 100)
       await discoverPromise
     })
@@ -1757,13 +1757,13 @@ describe('MAM Background Catch-Up', () => {
 
       // Spy on queryArchive to return messages
       const fakeMessage = { id: 'msg-1', from: 'bob@example.com', body: 'Hello', timestamp: new Date() }
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({
         messages: [fakeMessage] as any,
         complete: true,
         rsm: {},
       })
 
-      await xmppClient.mam.discoverNewConversationsFromRoster()
+      await xmppClient.internal.mam.discoverNewConversationsFromRoster()
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:conversation', {
         conversation: expect.objectContaining({
@@ -1786,13 +1786,13 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.hasConversation).mockReturnValue(false)
 
       // queryArchive returns no messages
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({
         messages: [],
         complete: true,
         rsm: {},
       })
 
-      await xmppClient.mam.discoverNewConversationsFromRoster()
+      await xmppClient.internal.mam.discoverNewConversationsFromRoster()
 
       expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:conversation', expect.anything())
     })
@@ -1807,13 +1807,13 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.hasConversation).mockReturnValue(false)
 
       const fakeMessage = { id: 'msg-1', from: 'alice@example.com', body: 'Hi', timestamp: new Date() }
-      vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({
+      vi.spyOn(xmppClient.internal.mam, 'queryArchive').mockResolvedValue({
         messages: [fakeMessage] as any,
         complete: true,
         rsm: {},
       })
 
-      await xmppClient.mam.discoverNewConversationsFromRoster()
+      await xmppClient.internal.mam.discoverNewConversationsFromRoster()
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:conversation', {
         conversation: expect.objectContaining({

--- a/packages/fluux-sdk/src/core/modules/MAM.preview.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.preview.test.ts
@@ -97,7 +97,7 @@ describe('MAM Preview Refresh', () => {
       // Mock empty conversations
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([])
 
-      await xmppClient.mam.refreshConversationPreviews()
+      await xmppClient.internal.mam.refreshConversationPreviews()
 
       // Should not have logged anything about refreshing (early return)
       expect(mockStores.console.addEvent).not.toHaveBeenCalledWith(
@@ -132,7 +132,7 @@ describe('MAM Preview Refresh', () => {
       })
 
       // Start the refresh and advance timers
-      const refreshPromise = xmppClient.mam.refreshConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -215,7 +215,7 @@ describe('MAM Preview Refresh', () => {
       })
 
       // Start the refresh and advance timers
-      const refreshPromise = xmppClient.mam.refreshConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -252,7 +252,7 @@ describe('MAM Preview Refresh', () => {
       })
 
       // Start the refresh and advance timers - should not throw
-      const refreshPromise = xmppClient.mam.refreshConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshConversationPreviews()
       await waitForAsyncOps(30, 100)
       await expect(refreshPromise).resolves.not.toThrow()
 
@@ -274,7 +274,7 @@ describe('MAM Preview Refresh', () => {
       )
 
       // Start the refresh
-      const refreshPromise = xmppClient.mam.refreshConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -315,7 +315,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshConversationPreviews({ concurrency: 3 })
+      const refreshPromise = xmppClient.internal.mam.refreshConversationPreviews({ concurrency: 3 })
 
       // Process all async operations with lots of timer advances
       await waitForAsyncOps(100, 100)
@@ -334,7 +334,7 @@ describe('MAM Preview Refresh', () => {
       // Mock empty rooms
       vi.mocked(mockStores.room.joinedRooms).mockReturnValue([])
 
-      await xmppClient.mam.refreshRoomPreviews()
+      await xmppClient.internal.mam.refreshRoomPreviews()
 
       // Should not have logged anything about refreshing (early return)
       expect(emitSDKSpy).not.toHaveBeenCalledWith(
@@ -365,7 +365,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -389,7 +389,7 @@ describe('MAM Preview Refresh', () => {
         ])
       )
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -416,7 +416,7 @@ describe('MAM Preview Refresh', () => {
         { jid: 'non-mam-room@conference.example.com', name: 'Non-MAM Room', supportsMAM: false, isQuickChat: false, joined: true, nickname: 'me', lastMessage: existingMessage },
       ] as any)
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -444,7 +444,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -473,7 +473,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -562,7 +562,7 @@ describe('MAM Preview Refresh', () => {
       })
 
       // Start the refresh and advance timers
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -600,7 +600,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -639,7 +639,7 @@ describe('MAM Preview Refresh', () => {
       })
 
       // Start the refresh and advance timers - should not throw
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(30, 100)
       await expect(refreshPromise).resolves.not.toThrow()
 
@@ -666,7 +666,7 @@ describe('MAM Preview Refresh', () => {
       )
 
       // Start the refresh
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -716,7 +716,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshRoomPreviews({ concurrency: 3 })
+      const refreshPromise = xmppClient.internal.mam.refreshRoomPreviews({ concurrency: 3 })
 
       // Process all async operations with lots of timer advances
       await waitForAsyncOps(100, 100)
@@ -755,7 +755,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      await xmppClient.mam.fetchPreviewForRoom('room1@conference.example.com')
+      await xmppClient.internal.mam.fetchPreviewForRoom('room1@conference.example.com')
 
       // Should have tried the cache
       expect(mockStores.room.loadPreviewFromCache).toHaveBeenCalledWith('room1@conference.example.com')
@@ -784,7 +784,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      await xmppClient.mam.fetchPreviewForRoom('room1@conference.example.com')
+      await xmppClient.internal.mam.fetchPreviewForRoom('room1@conference.example.com')
 
       // Should have tried the cache first
       expect(mockStores.room.loadPreviewFromCache).toHaveBeenCalledWith('room1@conference.example.com')
@@ -799,7 +799,7 @@ describe('MAM Preview Refresh', () => {
 
       vi.mocked(mockStores.chat.getArchivedConversations!).mockReturnValue([])
 
-      await xmppClient.mam.refreshArchivedConversationPreviews()
+      await xmppClient.internal.mam.refreshArchivedConversationPreviews()
 
       // No MAM queries should have been sent
       expect(mockStores.console.addEvent).not.toHaveBeenCalledWith(
@@ -831,7 +831,7 @@ describe('MAM Preview Refresh', () => {
         ])
       })
 
-      const refreshPromise = xmppClient.mam.refreshArchivedConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshArchivedConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -910,7 +910,7 @@ describe('MAM Preview Refresh', () => {
         return createMockElement('iq', { type: 'result' }, [])
       })
 
-      const refreshPromise = xmppClient.mam.refreshArchivedConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshArchivedConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -937,7 +937,7 @@ describe('MAM Preview Refresh', () => {
         ])
       )
 
-      const refreshPromise = xmppClient.mam.refreshArchivedConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshArchivedConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 
@@ -1017,7 +1017,7 @@ describe('MAM Preview Refresh', () => {
         return createMockElement('iq', { type: 'result' }, [])
       })
 
-      const refreshPromise = xmppClient.mam.refreshArchivedConversationPreviews()
+      const refreshPromise = xmppClient.internal.mam.refreshArchivedConversationPreviews()
       await waitForAsyncOps(20, 100)
       await refreshPromise
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -145,7 +145,7 @@ interface UnresolvedModifications {
  *
  * @example Fetch recent 1:1 messages
  * ```typescript
- * const result = await client.mam.queryArchive({
+ * const result = await client.internal.mam.queryArchive({
  *   with: 'user@example.com',
  *   max: 50
  * })
@@ -155,14 +155,14 @@ interface UnresolvedModifications {
  * @example Fetch room messages with pagination
  * ```typescript
  * // Initial fetch
- * const initial = await client.mam.queryRoomArchive({
+ * const initial = await client.internal.mam.queryRoomArchive({
  *   roomJid: 'room@conference.example.com',
  *   max: 50
  * })
  *
  * // Load older messages
  * if (!initial.complete && initial.rsm?.first) {
- *   const older = await client.mam.queryRoomArchive({
+ *   const older = await client.internal.mam.queryRoomArchive({
  *     roomJid: 'room@conference.example.com',
  *     before: initial.rsm.first
  *   })

--- a/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
@@ -7,6 +7,7 @@
  * - Handle privacy options to disable fetching in anonymous rooms
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { MAM } from './MAM'
 import { MUC } from './MUC'
 import { Profile } from './Profile'
 import {
@@ -41,7 +42,7 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
       getXmpp: () => null,
     } as unknown as ModuleDependencies
 
-    muc = new MUC(deps)
+    muc = new MUC(deps, { forceCatchUpAllRooms: vi.fn() } as unknown as MAM)
   })
 
   describe('parsing occupant presence with avatar hash', () => {

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -5,6 +5,7 @@
  * including XEP-0402 bookmark parsing.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { MAM } from './MAM'
 import { MUC } from './MUC'
 import {
   createMockElement,
@@ -40,7 +41,7 @@ describe('MUC Module', () => {
       getCurrentJid: () => 'user@example.com/resource',
     } as unknown as ModuleDependencies
 
-    muc = new MUC(deps)
+    muc = new MUC(deps, { forceCatchUpAllRooms: vi.fn() } as unknown as MAM)
   })
 
   describe('fetchBookmarks', () => {

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -1,5 +1,6 @@
 import { xml, Element } from '@xmpp/client'
-import { BaseModule } from './BaseModule'
+import { BaseModule, type ModuleDependencies } from './BaseModule'
+import type { MAM } from './MAM'
 import { getBareJid, getLocalPart, getResource, getDomain } from '../jid'
 import { stripNickWhitespace, resolveDefaultMucNick } from '../nick'
 import { generateUUID } from '../../utils/uuid'
@@ -164,6 +165,18 @@ export class MUC extends BaseModule {
    * This reduces store updates from ~50 to ~1 for large rooms.
    */
   private pendingOccupants = new Map<string, RoomOccupant[]>()
+
+  /**
+   * The archive, for the one room concern that needs it: catching a room's
+   * history back up on demand. MUC owns the verb because a user asks to
+   * resync ROOMS; MAM owns how that is fetched.
+   */
+  private readonly mam: MAM
+
+  constructor(deps: ModuleDependencies, mam: MAM) {
+    super(deps)
+    this.mam = mam
+  }
 
   /**
    * Rooms whose affiliation lists the server refused to share (forbidden).
@@ -1547,6 +1560,24 @@ export class MUC extends BaseModule {
    * await client.muc.setSubject('room@conference.example.com', 'New topic for discussion')
    * ```
    */
+  /**
+   * Re-fetch recent history for every joined room that supports archiving.
+   *
+   * For when a user believes they are missing messages: it re-runs the
+   * catch-up the SDK does on connect, over a wider window.
+   *
+   * @param options - `days` of history to cover (default 45) and how many
+   *   rooms to query at once.
+   *
+   * @example
+   * ```typescript
+   * await client.muc.resync()
+   * ```
+   */
+  async resync(options: { days?: number; concurrency?: number } = {}): Promise<void> {
+    await this.mam.forceCatchUpAllRooms(options)
+  }
+
   async setSubject(roomJid: string, subject: string): Promise<void> {
     const msg = xml(
       'message',

--- a/packages/fluux-sdk/src/core/networkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/networkScenarios.test.ts
@@ -97,7 +97,7 @@ describe('Network Scenario Journey Tests', () => {
       )
 
       // No MAM on SM resume — replay covers any missed messages
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -124,7 +124,7 @@ describe('Network Scenario Journey Tests', () => {
       expect(room?.isJoining).toBeFalsy()
 
       // No MAM on SM resume
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -167,7 +167,7 @@ describe('Network Scenario Journey Tests', () => {
       )
 
       // No MAM for any room — SM replay covers message delivery
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -190,7 +190,7 @@ describe('Network Scenario Journey Tests', () => {
       ])
 
       // Neither room should trigger MAM — SM replay handles message delivery
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -209,7 +209,7 @@ describe('Network Scenario Journey Tests', () => {
       // Fresh session (SM failed) requires a new self-presence before MAM.
       simulateFreshSession(client)
       await settle()
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       roomStore.getState().markAllRoomsNotJoined()
       roomStore.getState().setRoomJoined('room@conference.example.com', true)
@@ -225,9 +225,9 @@ describe('Network Scenario Journey Tests', () => {
 
       // MAM starts after the confirmed join.
       await vi.waitFor(() => {
-        expect(client.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(client.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      expect(client.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(client.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         'room@conference.example.com',
         expect.any(Array),
         expect.objectContaining({}),
@@ -259,7 +259,7 @@ describe('Network Scenario Journey Tests', () => {
       expect(room?.isJoining).toBeFalsy()
 
       // No MAM on either SM resume
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -287,13 +287,13 @@ describe('Network Scenario Journey Tests', () => {
         'roomB@conference.example.com',
       ])
 
-      vi.mocked(client.mam.catchUpRoomHistory).mockClear()
+      vi.mocked(client.internal.mam.catchUpRoomHistory).mockClear()
 
       // Switch to room B (empty local archive) — must fetch its archive.
       roomStore.getState().setActiveRoom('roomB@conference.example.com')
       await settle()
 
-      expect(client.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(client.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         'roomB@conference.example.com',
         expect.any(Array),
         expect.objectContaining({}),
@@ -363,7 +363,7 @@ describe('Network Scenario Journey Tests', () => {
       expect(afterResume.get('roomC@conference.example.com')?.joined).toBe(true)
 
       // SM replay covers any diff — no MAM catch-up, no rejoin churn
-      expect(client.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(client.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should trigger MAM when switching to a room after fresh session', async () => {
@@ -381,13 +381,13 @@ describe('Network Scenario Journey Tests', () => {
         'roomB@conference.example.com',
       ])
 
-      vi.mocked(client.mam.catchUpRoomHistory).mockClear()
+      vi.mocked(client.internal.mam.catchUpRoomHistory).mockClear()
 
       // Switch to room B — should trigger MAM (fresh session only protected active room)
       roomStore.getState().setActiveRoom('roomB@conference.example.com')
 
       await vi.waitFor(() => {
-        expect(client.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(client.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         'roomB@conference.example.com',
         expect.any(Array),
         expect.objectContaining({}),

--- a/packages/fluux-sdk/src/core/roomSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.test.ts
@@ -102,7 +102,7 @@ describe('setupRoomSideEffects', () => {
 
       await vi.waitFor(() => {
         // Confirmed join sees MAM is unsupported, so it is skipped.
-        expect((mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
+        expect((mockClient.internal.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
       })
 
       // supportsMAM becomes true — triggers MAM fetch via supportsMAM watcher
@@ -111,7 +111,7 @@ describe('setupRoomSideEffects', () => {
       })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -142,17 +142,17 @@ describe('setupRoomSideEffects', () => {
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
-      ;(mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
+      ;(mockClient.internal.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
 
       roomStore.getState().updateRoom('room@conference.example.com', {
         name: 'Updated Room Name',
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should not trigger MAM fetch when supportsMAM becomes true on inactive room', async () => {
@@ -196,7 +196,7 @@ describe('setupRoomSideEffects', () => {
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should not trigger MAM fetch when no room is active', async () => {
@@ -224,7 +224,7 @@ describe('setupRoomSideEffects', () => {
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should not trigger MAM fetch for Quick Chat rooms even when supportsMAM becomes true', async () => {
@@ -255,7 +255,7 @@ describe('setupRoomSideEffects', () => {
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -350,7 +350,7 @@ describe('setupRoomSideEffects', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 50))
       expect(loadSpy).not.toHaveBeenCalledWith(ROOM, expect.anything())
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
         ROOM,
         expect.anything(),
         expect.anything(),
@@ -401,12 +401,12 @@ describe('setupRoomSideEffects', () => {
       staleCache.resolve([])
       await Promise.resolve()
       await Promise.resolve()
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(true)
 
       replacementCache.resolve([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       loadSpy.mockRestore()
     })
@@ -451,12 +451,12 @@ describe('setupRoomSideEffects', () => {
       await Promise.resolve()
       await Promise.resolve()
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(true)
 
       replacementCache.resolve([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       loadSpy.mockRestore()
@@ -495,14 +495,14 @@ describe('setupRoomSideEffects', () => {
       await vi.waitFor(() => {
         expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
       })
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       loadSpy.mockResolvedValue([])
       roomStore.getState().setRoomJoined(ROOM, true)
       mockClient._emitSDK('room:joined', { roomJid: ROOM, joined: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       loadSpy.mockRestore()
@@ -540,7 +540,7 @@ describe('setupRoomSideEffects', () => {
       await vi.waitFor(() => {
         expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
       })
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       loadSpy.mockRestore()
     })
@@ -592,7 +592,7 @@ describe('setupRoomSideEffects', () => {
       await vi.waitFor(() => {
         expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
       })
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalledWith(
         ROOM,
         expect.anything(),
         expect.anything(),
@@ -627,7 +627,7 @@ describe('setupRoomSideEffects', () => {
       )
         .mockReturnValueOnce(cacheA.promise)
         .mockReturnValueOnce(cacheB.promise)
-      vi.mocked(mockClient.mam.catchUpRoomHistory)
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory)
         .mockImplementation(async (roomJid: string) => {
           // Mirror the real MAM module's successful loading-state event.
           roomStore.getState().setRoomMAMLoading(roomJid, false)
@@ -650,12 +650,12 @@ describe('setupRoomSideEffects', () => {
       cacheA.resolve([])
       await cacheA.promise
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(true)
 
       cacheB.resolve([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
 
@@ -700,11 +700,11 @@ describe('setupRoomSideEffects', () => {
       await cacheA.promise.catch(() => {})
 
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(true)
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       cacheB.resolve([])
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       loadSpy.mockRestore()
@@ -733,15 +733,15 @@ describe('setupRoomSideEffects', () => {
       simulateFreshSession(mockClient)
       await new Promise(resolve => setTimeout(resolve, 50))
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       roomStore.getState().markAllRoomsNotJoined()
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         ROOM,
         expect.any(Array),
         expect.objectContaining({ sessionStartTime: expect.any(Number) }),
@@ -773,7 +773,7 @@ describe('setupRoomSideEffects', () => {
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -832,7 +832,7 @@ describe('setupRoomSideEffects', () => {
       // Cursor-policy specifics (start vs after) are covered by the orchestrator
       // and mamCatchUpUtils tests; this asserts delegation with the cached message.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.arrayContaining([expect.objectContaining({ id: 'cached-msg-1' })]),
           expect.objectContaining({}),
@@ -888,7 +888,7 @@ describe('setupRoomSideEffects', () => {
       // mamCatchUpUtils.test.ts / MAM.catchup.test.ts). This asserts the side
       // effect forwards BOTH cached messages and a concrete sessionStartTime.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.arrayContaining([
             expect.objectContaining({ id: 'old' }),
@@ -928,7 +928,7 @@ describe('setupRoomSideEffects', () => {
       // Empty cache → delegates with an empty messages array; the orchestrator
       // resolves the fetch-latest fallback (covered by orchestrator tests).
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           [],
           expect.objectContaining({}),
@@ -960,14 +960,14 @@ describe('setupRoomSideEffects', () => {
 
       // Room wasn't joined yet, so initial MAM fetch was skipped
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       // Self-presence arrives — room is now joined
       roomStore.getState().setRoomJoined('room@conference.example.com', true)
       mockClient._emitSDK('room:joined', { roomJid: 'room@conference.example.com', joined: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -1013,15 +1013,15 @@ describe('setupRoomSideEffects', () => {
 
       // Wait for confirmed active-room MAM fetch.
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      ;(mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
+      ;(mockClient.internal.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
 
       // Non-active room joins — should not trigger MAM
       confirmRoomJoin('other-room@conference.example.com')
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should NOT trigger MAM when room:joined fires with joined=false (leaving)', async () => {
@@ -1047,15 +1047,15 @@ describe('setupRoomSideEffects', () => {
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      ;(mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
+      ;(mockClient.internal.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mockClear()
 
       // Room leaves — should not trigger MAM
       mockClient._emitSDK('room:joined', { roomJid: 'room@conference.example.com', joined: false })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
   })
 
@@ -1084,7 +1084,7 @@ describe('setupRoomSideEffects', () => {
       simulateSmResumption(mockClient)
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('triggers MAM when supportsMAM becomes true after SM resumption for a never-fetched room', async () => {
@@ -1118,7 +1118,7 @@ describe('setupRoomSideEffects', () => {
       })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -1156,7 +1156,7 @@ describe('setupRoomSideEffects', () => {
       mockClient._emitSDK('room:joined', { roomJid: 'room@conference.example.com', joined: true })
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -1197,7 +1197,7 @@ describe('setupRoomSideEffects', () => {
       mockClient._emit('online')
 
       mockClient._emitSDK('room:joined', { roomJid: ROOM, joined: true })
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       connectionStore.getState().setStatus('reconnecting')
       simulateFreshSession(mockClient)
@@ -1205,7 +1205,7 @@ describe('setupRoomSideEffects', () => {
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -1242,9 +1242,9 @@ describe('setupRoomSideEffects', () => {
       cache.resolve([])
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
-      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
         ROOM,
         expect.any(Array),
         expect.objectContaining({ sessionStartTime: expect.any(Number) }),
@@ -1253,22 +1253,22 @@ describe('setupRoomSideEffects', () => {
       roomStore.getState().setRoomMAMLoading(ROOM, false)
       mockClient._emitSDK('room:joined', { roomJid: ROOM, joined: true })
       expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
-      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+      expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
 
       // A later fresh transport session must not inherit that confirmation.
       connectionStore.getState().setStatus('reconnecting')
       simulateFreshSession(mockClient)
-      vi.mocked(mockClient.mam.catchUpRoomHistory).mockClear()
+      vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mockClear()
 
       roomStore.getState().updateRoom(ROOM, { supportsMAM: false })
       roomStore.getState().updateRoom(ROOM, { supportsMAM: true })
       await Promise.resolve()
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       roomStore.getState().markAllRoomsNotJoined()
       confirmRoomJoin()
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       loadSpy.mockRestore()
@@ -1311,7 +1311,7 @@ describe('setupRoomSideEffects', () => {
       await Promise.resolve()
       await Promise.resolve()
 
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('retains the resume boundary when hydration finishes after synthetic online', async () => {
@@ -1344,7 +1344,7 @@ describe('setupRoomSideEffects', () => {
       cache.resolve([])
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           ROOM,
           expect.any(Array),
           expect.objectContaining({ sessionStartTime: 1_754_000_000_000 }),
@@ -1392,7 +1392,7 @@ describe('setupRoomSideEffects', () => {
       mockClient._emitSDK('room:joined', { roomJid: 'room@conference.example.com', joined: true })
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('does NOT trigger MAM on a post-resumption room:joined for a NON-ACTIVE room', async () => {
@@ -1439,7 +1439,7 @@ describe('setupRoomSideEffects', () => {
       await new Promise(resolve => setTimeout(resolve, 50))
 
       // room2 is not the active room, so no foreground catch-up is needed.
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should trigger MAM correctly after SM resume then fresh session', async () => {
@@ -1465,20 +1465,20 @@ describe('setupRoomSideEffects', () => {
       simulateSmResumption(mockClient)
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       // Then: disconnect and fresh session — wait for a confirmed room join.
       connectionStore.getState().setStatus('reconnecting')
       simulateFreshSession(mockClient)
 
       await new Promise(resolve => setTimeout(resolve, 50))
-      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
+      expect(mockClient.internal.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       roomStore.getState().markAllRoomsNotJoined()
       confirmRoomJoin()
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           'room@conference.example.com',
           expect.any(Array),
           expect.objectContaining({}),
@@ -1527,7 +1527,7 @@ describe('setupRoomSideEffects', () => {
       await roomStore.getState().activateRoom(ROOM)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           ROOM,
           [],
           expect.objectContaining({}),
@@ -1548,7 +1548,7 @@ describe('setupRoomSideEffects', () => {
       await roomStore.getState().activateRoom(ROOM)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        expect(mockClient.internal.mam.catchUpRoomHistory).toHaveBeenCalledWith(
           ROOM,
           [],
           expect.objectContaining({}),

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -111,7 +111,7 @@ export function setupRoomSideEffects(
   /**
    * Triggers MAM fetch for the active room if needed (catchup).
    * Delegates the actual query direction/cursor selection to the shared
-   * latest-first orchestrator (`client.mam.catchUpRoomHistory`) after
+   * latest-first orchestrator (`client.internal.mam.catchUpRoomHistory`) after
    * loading the IndexedDB cache.
    */
   async function fetchMAMForRoom(roomJid: string): Promise<void> {
@@ -213,7 +213,7 @@ export function setupRoomSideEffects(
 
       // Latest-first orchestrator — room twin, Phase A only (active entity).
       const roomMessages = roomStore.getState().rooms.get(roomJid)?.messages || []
-      await client.mam.catchUpRoomHistory(roomJid, roomMessages, { sessionStartTime })
+      await client.internal.mam.catchUpRoomHistory(roomJid, roomMessages, { sessionStartTime })
       if (!isRoomFetchOwnerCurrent(roomJid, fetchOwner)) {
         return
       }

--- a/packages/fluux-sdk/src/core/sideEffectHost.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHost.ts
@@ -108,9 +108,17 @@ export interface SideEffectHost extends SDKEventSource, ClientEventSource {
   retryPendingDecrypts(): Promise<number>
   /** Null until an identity is logged in — every caller must handle that. */
   readonly e2ee: E2EEWarmupHost | null
-  readonly mam: MamSideEffectHost
   readonly muc: MucSideEffectHost
-  readonly mds: MdsSideEffectHost
   readonly discovery: DiscoverySideEffectHost
-  readonly conversationSync: ConversationSyncSideEffectHost
+  /**
+   * The modules the SDK drives rather than offers. Grouped so the client can
+   * keep them off its public surface: a consumer has no reason to name MAM,
+   * MDS or conversation sync, and the domain verbs that do belong to them are
+   * exposed elsewhere.
+   */
+  readonly internal: {
+    readonly mam: MamSideEffectHost
+    readonly mds: MdsSideEffectHost
+    readonly conversationSync: ConversationSyncSideEffectHost
+  }
 }

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -41,14 +41,16 @@ export function createMockClient() {
       queryMAM: vi.fn().mockResolvedValue(undefined),
       queryRoomMAM: vi.fn().mockResolvedValue(undefined),
     },
-    mam: {
-      refreshConversationPreviews: vi.fn().mockResolvedValue(undefined),
-      refreshArchivedConversationPreviews: vi.fn().mockResolvedValue(undefined),
-      catchUpAllConversations: vi.fn().mockResolvedValue(undefined),
-      catchUpRoom: vi.fn().mockResolvedValue(undefined),
-      catchUpConversationHistory: vi.fn().mockResolvedValue(undefined),
-      catchUpRoomHistory: vi.fn().mockResolvedValue(undefined),
-      discoverNewConversationsFromRoster: vi.fn().mockResolvedValue(undefined),
+    internal: {
+      mam: {
+        refreshConversationPreviews: vi.fn().mockResolvedValue(undefined),
+        refreshArchivedConversationPreviews: vi.fn().mockResolvedValue(undefined),
+        catchUpAllConversations: vi.fn().mockResolvedValue(undefined),
+        catchUpRoom: vi.fn().mockResolvedValue(undefined),
+        catchUpConversationHistory: vi.fn().mockResolvedValue(undefined),
+        catchUpRoomHistory: vi.fn().mockResolvedValue(undefined),
+        discoverNewConversationsFromRoster: vi.fn().mockResolvedValue(undefined),
+      },
     },
     muc: {
       queryRoomMembers: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -774,9 +774,11 @@ export const createMockXMPPClientForHooks = () => ({
     queryMAM: vi.fn(),
     queryRoomMAM: vi.fn(),
   },
-  mam: {
-    catchUpConversationHistory: vi.fn(),
-    catchUpRoomHistory: vi.fn(),
+  internal: {
+    mam: {
+      catchUpConversationHistory: vi.fn(),
+      catchUpRoomHistory: vi.fn(),
+    },
   },
   muc: {
     joinRoom: vi.fn(),

--- a/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
@@ -1,7 +1,7 @@
 /**
  * Demo-mode XEP-0490 (MDS) simulation:
  * - DemoClient answers the MDS PEP-node IQs (publish / items / retract) from an
- *   in-memory node, so `client.mds.*` round-trips work without a server.
+ *   in-memory node, so `client.internal.mds.*` round-trips work without a server.
  * - simulateRemoteDisplayed() plays the "another device read up to X" +notify:
  *   it seeds the node AND emits `read:displayed-synced` like PubSub would.
  * - populateDemo defaults a stanza-id onto seeded messages (marker resolution
@@ -26,32 +26,32 @@ const ROOM_JID = 'team@conference.fluux.chat'
 describe('DemoClient MDS PEP node simulation', () => {
   it('publishDisplayed then fetchAllDisplayed round-trips the marker', async () => {
     const client = makeClient()
-    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+    await client.internal.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
 
-    const markers = await client.mds.fetchAllDisplayed()
+    const markers = await client.internal.mds.fetchAllDisplayed()
     expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-42' }])
   })
 
   it('a re-publish for the same conversation overwrites the item (current-value node)', async () => {
     const client = makeClient()
-    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
-    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-99', 'you@fluux.chat')
+    await client.internal.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+    await client.internal.mds.publishDisplayed('ava@fluux.chat', 'sid-99', 'you@fluux.chat')
 
-    const markers = await client.mds.fetchAllDisplayed()
+    const markers = await client.internal.mds.fetchAllDisplayed()
     expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-99' }])
   })
 
   it('retractDisplayed removes the item', async () => {
     const client = makeClient()
-    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
-    await client.mds.retractDisplayed('ava@fluux.chat')
+    await client.internal.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+    await client.internal.mds.retractDisplayed('ava@fluux.chat')
 
-    expect(await client.mds.fetchAllDisplayed()).toEqual([])
+    expect(await client.internal.mds.fetchAllDisplayed()).toEqual([])
   })
 
   it('fetchAllDisplayed returns [] when nothing was published', async () => {
     const client = makeClient()
-    expect(await client.mds.fetchAllDisplayed()).toEqual([])
+    expect(await client.internal.mds.fetchAllDisplayed()).toEqual([])
   })
 })
 
@@ -70,7 +70,7 @@ describe('DemoClient.simulateRemoteDisplayed', () => {
     const client = makeClient()
     client.simulateRemoteDisplayed('ava@fluux.chat', 'sid-7')
 
-    const markers = await client.mds.fetchAllDisplayed()
+    const markers = await client.internal.mds.fetchAllDisplayed()
     expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-7' }])
   })
 })

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -119,7 +119,7 @@ export class DemoClient extends XMPPClient {
   // Rooms the simulated MUC service protects with a password (XEP-0045 §7.2.6).
   private roomPasswords = new Map<string, string>()
   // Simulated XEP-0490 MDS PEP node: conversation bare JID → last-displayed
-  // marker. Backs the pubsub publish/items/retract IQs so client.mds.* and the
+  // marker. Backs the pubsub publish/items/retract IQs so client.internal.mds.* and the
   // fresh-session seed (fetchAllDisplayed) work in demo mode.
   private mdsNodeItems = new Map<string, { stanzaId: string; by: string }>()
 

--- a/packages/fluux-sdk/src/hooks/useChatActions.fetchHistory.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChatActions.fetchHistory.test.tsx
@@ -31,7 +31,7 @@ describe('fetchHistory stitchReadPointer active/non-active rule', () => {
   const OTHER = 'bob@example.com'
 
   beforeEach(() => {
-    vi.mocked(mockClient.mam.catchUpConversationHistory).mockReset().mockResolvedValue(undefined)
+    vi.mocked(mockClient.internal.mam.catchUpConversationHistory).mockReset().mockResolvedValue(undefined)
     chatStore.setState({
       conversations: new Map(),
       conversationEntities: new Map(),
@@ -63,7 +63,7 @@ describe('fetchHistory stitchReadPointer active/non-active rule', () => {
       await result.current.fetchHistory(ACTIVE)
     })
 
-    expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+    expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
       ACTIVE,
       expect.anything(),
       expect.objectContaining({ stitchReadPointer: false })
@@ -77,7 +77,7 @@ describe('fetchHistory stitchReadPointer active/non-active rule', () => {
       await result.current.fetchHistory()
     })
 
-    expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+    expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
       ACTIVE,
       expect.anything(),
       expect.objectContaining({ stitchReadPointer: false })
@@ -91,7 +91,7 @@ describe('fetchHistory stitchReadPointer active/non-active rule', () => {
       await result.current.fetchHistory(OTHER)
     })
 
-    expect(mockClient.mam.catchUpConversationHistory).toHaveBeenCalledWith(
+    expect(mockClient.internal.mam.catchUpConversationHistory).toHaveBeenCalledWith(
       OTHER,
       expect.anything(),
       expect.objectContaining({ stitchReadPointer: true })

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -162,7 +162,7 @@ export function useChatActions() {
         // the user isn't looking at) SHOULD stitch, so its unread region becomes
         // contiguous with the read pointer instead of leaving a gap.
         const isActive = targetId === chatStore.getState().activeConversationId
-        await client.mam.catchUpConversationHistory(conversation.id, cachedMessages ?? [], {
+        await client.internal.mam.catchUpConversationHistory(conversation.id, cachedMessages ?? [], {
           stitchReadPointer: !isActive,
         })
       } catch (error) {

--- a/packages/fluux-sdk/src/hooks/useContactTime.ts
+++ b/packages/fluux-sdk/src/hooks/useContactTime.ts
@@ -41,7 +41,7 @@ export function useContactTime(bareJid: string | null): string | null {
     }
 
     // Check cache first — queryTime handles cache + resource change detection
-    const cached = client.entityTime?.getCached(bareJid)
+    const cached = client.internal.entityTime?.getCached(bareJid)
     if (cached) {
       if (cached.supported) {
         setOffsetMinutes(cached.offsetMinutes)
@@ -59,7 +59,7 @@ export function useContactTime(bareJid: string | null): string | null {
     setTime(null)
     queriedJidRef.current = bareJid
 
-    client.entityTime?.queryTime(bareJid).then((result) => {
+    client.internal.entityTime?.queryTime(bareJid).then((result) => {
       // Only update if we're still looking at the same contact
       if (queriedJidRef.current !== bareJid) return
       if (result?.supported) {

--- a/packages/fluux-sdk/src/hooks/useLastActivity.ts
+++ b/packages/fluux-sdk/src/hooks/useLastActivity.ts
@@ -38,7 +38,7 @@ export function useLastActivity(bareJid: string | null): void {
     if (queriedJidRef.current === bareJid) return
 
     // Check cache — already queried this session
-    const cached = client.lastActivity?.getCached(bareJid)
+    const cached = client.internal.lastActivity?.getCached(bareJid)
     if (cached) {
       queriedJidRef.current = bareJid
       return
@@ -49,6 +49,6 @@ export function useLastActivity(bareJid: string | null): void {
     if (contact.lastSeen) return
 
     queriedJidRef.current = bareJid
-    client.lastActivity?.queryLastActivity(bareJid)
+    client.internal.lastActivity?.queryLastActivity(bareJid)
   }, [bareJid, client, contact?.presence, contact?.lastSeen])
 }

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -3,7 +3,7 @@
  * unread, coverage-gated, latest-wins, mentionsCount-preserving, divider-
  * rederiving.
  *
- * Unlike chatStore.test.ts / chatStore.mds.test.ts, this file does NOT fully
+ * Unlike chatStore.test.ts / chatStore.internal.mds.test.ts, this file does NOT fully
  * mock `../utils/messageCache` — `countUnreadInArchive` and
  * `resolveArchivePosition` run for REAL against fake-indexeddb (wrapped in
  * `vi.fn(actual)` only so the latest-wins test can control resolution order

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -322,7 +322,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     expect(chatStore.getState().conversations.get(cid)?.unreadCount).toBe(8)
   })
 
-  // NOTE (final-fix-3, consistency with roomStore.mds.test.ts's twin under
+  // NOTE (final-fix-3, consistency with roomStore.internal.mds.test.ts's twin under
   // final-fix-2): this test's title used to claim it isolated the
   // active-conversation guard ("skips the archive recount commit when the
   // conversation became active meanwhile"). It doesn't: this conversation has

--- a/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
@@ -102,7 +102,7 @@ function reportCurrent(conversationId: string, evidence: 'at-edge' | 'away'): vo
  * `onActivate` (there are no loaded messages in this lightweight test file,
  * so `onActivate` snaps straight to unreadCount 0), so a distinguishing
  * baseline has to be injected AFTER activation, not before — patching state
- * directly (as chatStore.mds.test.ts's `seedWithPointer` does) bypasses that
+ * directly (as chatStore.internal.mds.test.ts's `seedWithPointer` does) bypasses that
  * reset without touching the SDK's own activation code path under test.
  */
 function setPriorReadState(id: string, unreadCount: number, priorMessageId: string): void {

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -7,7 +7,7 @@
  * room-specific control: two messages sharing an `id` but sent by different
  * occupants (`from`) are two distinct cache positions, not one.
  *
- * Unlike roomStore.test.ts / roomStore.mds.test.ts, this file does NOT fully
+ * Unlike roomStore.test.ts / roomStore.internal.mds.test.ts, this file does NOT fully
  * mock `../utils/messageCache` — `countRoomUnreadInArchive` and
  * `resolveArchivePosition` run for REAL against fake-indexeddb (wrapped in
  * `vi.fn(actual)` only so the latest-wins test can control resolution order

--- a/packages/fluux-sdk/src/stores/searchStore.test.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.test.ts
@@ -612,7 +612,7 @@ describe('searchStore', () => {
       searchStore.getState().searchMAM()
       await vi.runAllTimersAsync()
 
-      expect(mockClient.mam.searchArchive).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockClient.internal.mam.searchArchive).toHaveBeenCalledWith(expect.objectContaining({
         query: 'hello',
         max: 20,
       }))
@@ -627,7 +627,7 @@ describe('searchStore', () => {
       searchStore.getState().searchMAM()
       await vi.runAllTimersAsync()
 
-      expect(mockClient.mam.searchArchive).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockClient.internal.mam.searchArchive).toHaveBeenCalledWith(expect.objectContaining({
         query: 'hello',
         with: 'alice@example.com',
       }))
@@ -642,7 +642,7 @@ describe('searchStore', () => {
       searchStore.getState().searchMAM()
       await vi.runAllTimersAsync()
 
-      expect(mockClient.mam.searchConversationByPaging).toHaveBeenCalledWith(
+      expect(mockClient.internal.mam.searchConversationByPaging).toHaveBeenCalledWith(
         expect.objectContaining({
           query: 'hello',
           with: 'alice@example.com',
@@ -679,7 +679,7 @@ describe('searchStore', () => {
 
     it('should handle MAM search errors gracefully', async () => {
       const mockClient = createMockMAMClient()
-      mockClient.mam.searchArchive.mockRejectedValueOnce(new Error('Server error'))
+      mockClient.internal.mam.searchArchive.mockRejectedValueOnce(new Error('Server error'))
       setSearchClient(mockClient as any)
       connectionStore.getState().setMAMFulltextSearch(true)
       searchStore.setState({ query: 'hello', searchScope: null })
@@ -990,30 +990,32 @@ function createMockMAMClient(opts?: {
 }) {
   const results = opts?.searchArchiveResults ?? []
   return {
+    internal: {
     mam: {
-      searchArchive: vi.fn().mockResolvedValue({
-        messages: results.map(r => ({
-          id: r.id,
-          conversationId: r.conversationId,
-          from: r.from,
-          body: r.body,
-          timestamp: r.timestamp,
-          isOutgoing: false,
-          isDelayed: true,
-        })),
-        complete: true,
-        rsm: {},
-      }),
-      searchRoomArchive: vi.fn().mockResolvedValue({
-        messages: [],
-        complete: true,
-        rsm: {},
-      }),
-      searchConversationByPaging: vi.fn().mockResolvedValue({
-        messages: [],
-        complete: true,
-        rsm: {},
-      }),
+        searchArchive: vi.fn().mockResolvedValue({
+          messages: results.map(r => ({
+            id: r.id,
+            conversationId: r.conversationId,
+            from: r.from,
+            body: r.body,
+            timestamp: r.timestamp,
+            isOutgoing: false,
+            isDelayed: true,
+          })),
+          complete: true,
+          rsm: {},
+        }),
+        searchRoomArchive: vi.fn().mockResolvedValue({
+          messages: [],
+          complete: true,
+          rsm: {},
+        }),
+        searchConversationByPaging: vi.fn().mockResolvedValue({
+          messages: [],
+          complete: true,
+          rsm: {},
+        }),
+      },
     },
   }
 }

--- a/packages/fluux-sdk/src/stores/searchStore.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.ts
@@ -424,7 +424,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
       if (supportsFulltext) {
         // Server fulltext search scoped to conversation
         if (isRoom) {
-          const result = await clientRef.mam.searchRoomArchive({
+          const result = await clientRef.internal.mam.searchRoomArchive({
             query,
             roomJid: scope,
             max: 20,
@@ -434,7 +434,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
           hasMore = !result.complete
           mamRsmCursor = result.rsm.first
         } else {
-          const result = await clientRef.mam.searchArchive({
+          const result = await clientRef.internal.mam.searchArchive({
             query,
             with: scope,
             max: 20,
@@ -447,7 +447,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
       } else if (!isRoom) {
         // Paging search (1:1 conversations only, no fulltext required)
         pagingAbortController = new AbortController()
-        const result = await clientRef.mam.searchConversationByPaging(
+        const result = await clientRef.internal.mam.searchConversationByPaging(
           { query, with: scope, maxPages: 20, maxResults: 50 },
           pagingAbortController.signal
         )
@@ -472,7 +472,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
         return
       }
 
-      const result = await clientRef.mam.searchArchive({
+      const result = await clientRef.internal.mam.searchArchive({
         query,
         max: 20,
         before: append ? mamRsmCursor : undefined,


### PR DESCRIPTION
First of the three steps agreed for the module-naming work: stop exposing what is internal, before renaming anything.

`client.mds` means nothing without XEP-0490, and neither do `mam`, `conversationSync`, `entityTime` or `lastActivity`. Counting their uses explains why: 155 for `mds`, none of them outside the SDK; `entityTime` and `lastActivity` are used only by their own hooks. They are wiring that happened to be public, so the answer is not a better name — it is not being on the client at all.

They move to `client.internal`, which says what it is. The class names and the vocabulary inside them stay protocol-accurate, because that is what they implement; only the boundary speaks domain. `SideEffectHost` groups them the same way, so the SDK's own side effects still reach them through a declared port.

## Three verbs that did belong to a consumer

Each was a domain action hidden behind a XEP name, and each is why the app was reaching into these modules at all:

- `mam.forceCatchUpAllRooms()` → `muc.resync()`
- `mam.fetchContext(id, isRoom, …)` → `chat.fetchContextAround(id, …)`
- `mam.catchUpToTimestamp(id, isRoom, …)` → `chat.catchUpTo(id, …)`

The last two no longer ask the caller whether the target is a room: the room store already answers that, the same way sending does since #1259.

`barrelSurface.test.ts` asserts the five are off the client, so they cannot drift back.

## Deliberately not in this PR

`client.pubsub` was in the plan, but its only consumer is the app's E2EE secret-key probe, and the primitive it wants (`queryPEP`) already exists on the plugin surface behind a private builder. Giving it a home is a decision of its own — expose the plugin primitives, or add a client-taking helper to `@fluux/sdk/xmpp` — and it does not belong inside a PR that renames nothing.