### PR TITLE
refactor(sdk): name the client's modules after the domain

### DIFF
--- a/apps/fluux/src/components/AdminView.test.tsx
+++ b/apps/fluux/src/components/AdminView.test.tsx
@@ -70,7 +70,7 @@ const destroyRoom = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@fluux/sdk', () => ({
   useAdmin: () => adminState,
-  useXMPP: () => ({ client: { muc: { destroyRoom } } }),
+  useXMPP: () => ({ client: { rooms: { destroyRoom } } }),
   adminStore: { getState: () => ({ setActiveCategory }) },
   getBareJid: (jid: string) => jid.split('/')[0],
 }))

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -263,7 +263,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
 
   const handleDestroyRoom = async (jid: string) => {
     try {
-      await client.muc.destroyRoom(jid)
+      await client.rooms.destroyRoom(jid)
       setSelectedRoom(null)
       resetRoomList()
       void fetchRooms()

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -131,7 +131,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
           const client = getSearchClient()
           if (client) {
             try {
-              const mamContext = await client.chat.fetchContextAround(
+              const mamContext = await client.messages.fetchContextAround(
                 previewResult.conversationId,
                 targetDate.toISOString(),
                 CONTEXT_BATCH_SIZE
@@ -141,7 +141,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
               after = []
 
               // Trigger background catch-up to fill the gap (non-blocking)
-              void client.chat.catchUpTo(
+              void client.messages.catchUpTo(
                 previewResult.conversationId,
                 targetDate.toISOString(),
               )

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -330,7 +330,7 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
               onCatchUpAll={() => {
                 if (isCatchingUpRooms) return
                 setIsCatchingUpRooms(true)
-                void client.muc.resync().finally(() => setIsCatchingUpRooms(false))
+                void client.rooms.resync().finally(() => setIsCatchingUpRooms(false))
               }}
               isCatchingUp={isCatchingUpRooms}
               onMarkAllRead={markAllRoomsRead}

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
@@ -25,7 +25,7 @@ let mockStatus = 'online'
 // tests (which never reach a registered plugin); a stub for the import tests.
 let mockPlugin: Record<string, unknown> | null = null
 const mockClient = {
-  discovery: { checkPepSupport: mockCheckPepSupport },
+  server: { checkPepSupport: mockCheckPepSupport },
   e2ee: { getPlugin: (name: string) => (name === 'openpgp' ? mockPlugin : null) },
 }
 

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -220,7 +220,7 @@ export function EncryptionSettings() {
       return
     }
     let cancelled = false
-    client.discovery
+    client.server
       .checkPepSupport()
       .then((supported) => {
         if (!cancelled) setPepSupported(supported)

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -75,7 +75,7 @@ async function disableWebPush(client: any): Promise<void> {
 
     const notificationId = `${json.endpoint ?? subscription.endpoint}#${p256dh}#${auth}`
 
-    await client.webPush.disableSubscription(service.appId, 'webpush', notificationId)
+    await client.push.disableSubscription(service.appId, 'webpush', notificationId)
     connectionStore.getState().setWebPushEnabled(false)
   } catch (err) {
     console.error('[WebPush] Disable failed:', err)
@@ -92,7 +92,7 @@ async function enableWebPush(client: any): Promise<void> {
     // Trigger service discovery — the useWebPush hook will auto-register
     // once services become available and enabled is true
     try {
-      await client.webPush.queryServices()
+      await client.push.queryServices()
     } catch (err) {
       console.error('[WebPush] Re-enable: service discovery failed:', err)
     }

--- a/apps/fluux/src/demo/demoLoadOlder.ts
+++ b/apps/fluux/src/demo/demoLoadOlder.ts
@@ -3,7 +3,7 @@
  *
  * The real client answers `fetchOlderHistory` by querying MAM and prepending the result
  * via `roomStore.mergeRoomMAMMessages` / `chatStore.mergeMAMMessages` ('backward'). The
- * demo has no server, so we patch `client.chat.queryRoomMAM` (rooms) and `client.chat.queryMAM`
+ * demo has no server, so we patch `client.messages.queryRoomMAM` (rooms) and `client.messages.queryMAM`
  * (1:1) to synthesize a batch of OLDER messages on demand and feed them through the exact
  * same store path. This makes scroll-up actually prepend in demo mode — needed to exercise
  * the prepend-anchor scroll restore (and verify it on a real engine).
@@ -69,7 +69,7 @@ function buildOlderChatBatch(conversationId: string, oldest: Message, startIdx: 
 }
 
 type MAMable = {
-  chat: {
+  messages: {
     queryRoomMAM: (opts: { roomJid: string; before?: string }) => Promise<unknown>
     queryMAM: (opts: { with: string; before?: string }) => Promise<unknown>
   }
@@ -81,7 +81,7 @@ export function installDemoLoadOlder(client: MAMable): void {
   const roomGenerated = new Map<string, number>()
   const chatGenerated = new Map<string, number>()
 
-  client.chat.queryRoomMAM = async ({ roomJid }) => {
+  client.messages.queryRoomMAM = async ({ roomJid }) => {
     const rs = roomStore.getState()
     if (!roomJid.startsWith('stress-')) {
       rs.mergeRoomMAMMessages(roomJid, [], { count: 0 }, true, 'backward')
@@ -102,7 +102,7 @@ export function installDemoLoadOlder(client: MAMable): void {
     return { messages: batch, complete }
   }
 
-  client.chat.queryMAM = async ({ with: jid }) => {
+  client.messages.queryMAM = async ({ with: jid }) => {
     const cs = chatStore.getState()
     if (!jid.startsWith('stress-')) {
       cs.mergeMAMMessages(jid, [], { count: 0 }, true, 'backward')

--- a/apps/fluux/src/hooks/useFileUpload.test.ts
+++ b/apps/fluux/src/hooks/useFileUpload.test.ts
@@ -9,7 +9,7 @@ let mockHttpUploadService: { jid: string; maxFileSize?: number } | null = null
 vi.mock('@fluux/sdk', () => ({
   useXMPP: () => ({
     client: {
-      discovery: {
+      server: {
         requestUploadSlot: mockRequestUploadSlot,
       },
     },

--- a/apps/fluux/src/hooks/useFileUpload.ts
+++ b/apps/fluux/src/hooks/useFileUpload.ts
@@ -123,7 +123,7 @@ export function useFileUpload() {
   // context value) so it doesn't churn the `uploadFile` callback below.
   const requestUploadSlot = useCallback(
     (filename: string, size: number, contentType: string) => {
-      return client.discovery.requestUploadSlot(filename, size, contentType)
+      return client.server.requestUploadSlot(filename, size, contentType)
     },
     [client],
   )

--- a/apps/fluux/src/hooks/useLinkPreview.ts
+++ b/apps/fluux/src/hooks/useLinkPreview.ts
@@ -63,7 +63,7 @@ export function useLinkPreview() {
       }
 
       // Send the fastening with link preview
-      await client.chat.sendLinkPreview(to, messageId, preview)
+      await client.messages.sendLinkPreview(to, messageId, preview)
 
       setState({ isFetching: false, error: null })
     } catch (err) {

--- a/apps/fluux/src/hooks/useWebPush.ts
+++ b/apps/fluux/src/hooks/useWebPush.ts
@@ -72,7 +72,7 @@ async function registerPush(
     }
 
     console.log('[WebPush] Registering with XMPP server, endpoint:', endpoint)
-    await client.webPush.registerSubscription(endpoint, p256dh, auth, service.appId)
+    await client.push.registerSubscription(endpoint, p256dh, auth, service.appId)
     console.log('[WebPush] Registration complete!')
   } catch (err) {
     console.error('[WebPush] Registration failed:', err)

--- a/apps/fluux/src/utils/mcpTools.test.ts
+++ b/apps/fluux/src/utils/mcpTools.test.ts
@@ -216,7 +216,7 @@ describe('mcpTools', () => {
     it('forwards a known chat conversation to the SDK, which decides the wire type', async () => {
       chatStore.setState({ conversations: new Map([['alice@example.com', { id: 'alice@example.com' } as Conversation]]) })
       const sendMessage = vi.fn().mockResolvedValue('msg-123')
-      const client = { chat: { sendMessage } } as unknown as XMPPClient
+      const client = { messages: { sendMessage } } as unknown as XMPPClient
 
       const result = await sendMessageTool(client, 'alice@example.com', 'hi')
 
@@ -229,7 +229,7 @@ describe('mcpTools', () => {
         rooms: new Map([['room@conference.example.com', { jid: 'room@conference.example.com', joined: true } as Room]]),
       })
       const sendMessage = vi.fn().mockResolvedValue('msg-456')
-      const client = { chat: { sendMessage } } as unknown as XMPPClient
+      const client = { messages: { sendMessage } } as unknown as XMPPClient
 
       await sendMessageTool(client, 'room@conference.example.com', 'hi room')
 
@@ -241,14 +241,14 @@ describe('mcpTools', () => {
         rooms: new Map([['room@conference.example.com', { jid: 'room@conference.example.com', joined: false } as Room]]),
       })
       const sendMessage = vi.fn()
-      const client = { chat: { sendMessage } } as unknown as XMPPClient
+      const client = { messages: { sendMessage } } as unknown as XMPPClient
 
       await expect(sendMessageTool(client, 'room@conference.example.com', 'hi')).rejects.toThrow('Not joined to room')
       expect(sendMessage).not.toHaveBeenCalled()
     })
 
     it('rejects an unknown conversationId', async () => {
-      const client = { chat: { sendMessage: vi.fn() } } as unknown as XMPPClient
+      const client = { messages: { sendMessage: vi.fn() } } as unknown as XMPPClient
       await expect(sendMessageTool(client, 'ghost@example.com', 'hi')).rejects.toThrow('Unknown conversationId')
     })
 
@@ -256,7 +256,7 @@ describe('mcpTools', () => {
       vi.useFakeTimers()
       chatStore.setState({ conversations: new Map([['alice@example.com', { id: 'alice@example.com' } as Conversation]]) })
       const sendMessage = vi.fn().mockResolvedValue('msg-id')
-      const client = { chat: { sendMessage } } as unknown as XMPPClient
+      const client = { messages: { sendMessage } } as unknown as XMPPClient
 
       for (let i = 0; i < 10; i++) {
         await sendMessageTool(client, 'alice@example.com', `msg ${i}`)

--- a/apps/fluux/src/utils/mcpTools.ts
+++ b/apps/fluux/src/utils/mcpTools.ts
@@ -151,6 +151,6 @@ export async function sendMessageTool(
   if (room && !room.joined) {
     throw new Error(`Not joined to room: ${conversationId}`)
   }
-  const messageId = await client.chat.sendMessage(conversationId, body)
+  const messageId = await client.messages.sendMessage(conversationId, body)
   return { messageId }
 }

--- a/packages/fluux-sdk/examples/assistant.ts
+++ b/packages/fluux-sdk/examples/assistant.ts
@@ -46,22 +46,22 @@ async function answer(question: string): Promise<string> {
  */
 async function respond(client: XMPPClient, question: Question): Promise<void> {
   // Tell the asker it landed, before anything slow starts.
-  await client.chat.sendReaction(question.to, question.messageId, ['👀'])
-  await client.chat.sendChatState(question.to, 'composing')
+  await client.messages.sendReaction(question.to, question.messageId, ['👀'])
+  await client.messages.sendChatState(question.to, 'composing')
 
-  const placeholderId = await client.chat.sendMessage(question.to, 'Working on it…', {
+  const placeholderId = await client.messages.sendMessage(question.to, 'Working on it…', {
     replyTo: { id: question.messageId },
   })
 
   try {
     const text = await answer(question.text)
-    await client.chat.sendCorrection(question.to, placeholderId, text)
+    await client.messages.sendCorrection(question.to, placeholderId, text)
   } catch (error) {
     // The placeholder is already on everyone's screen, so a failure has to
     // replace it. Leaving it saying "Working on it…" forever is worse than
     // saying the work failed.
     const reason = error instanceof Error ? error.message : String(error)
-    await client.chat.sendCorrection(question.to, placeholderId, `Sorry, that failed: ${reason}`)
+    await client.messages.sendCorrection(question.to, placeholderId, `Sorry, that failed: ${reason}`)
   }
 }
 
@@ -125,7 +125,7 @@ async function main(): Promise<void> {
   console.log(`Connected as ${config.jid}`)
 
   if (room) {
-    await client.muc.joinRoom(room, nickname)
+    await client.rooms.joinRoom(room, nickname)
     console.log(`Joined ${room} as ${nickname}; mention me to ask something.`)
   }
 

--- a/packages/fluux-sdk/examples/notifier.ts
+++ b/packages/fluux-sdk/examples/notifier.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   const client = new XMPPClient()
 
   await client.connect(config)
-  await client.chat.sendMessage(recipient, body)
+  await client.messages.sendMessage(recipient, body)
 
   // Disconnect rather than exiting: it closes the stream cleanly, so the server
   // does not have to time the session out and the message is acknowledged

--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -86,6 +86,22 @@ describe('public API surface', () => {
     }
   })
 
+  it('names its modules after the domain, not after the XEPs they implement', () => {
+    // The classes stay MUC, Discovery, Roster: they implement those XEPs and
+    // say so. What a consumer types is the domain word.
+    const client = new XMPPClient()
+    try {
+      for (const name of ['muc', 'roster', 'discovery', 'webPush']) {
+        expect(name in client).toBe(false)
+      }
+      for (const name of ['rooms', 'contacts', 'server', 'push', 'messages']) {
+        expect(typeof (client as unknown as Record<string, unknown>)[name]).toBe('object')
+      }
+    } finally {
+      client.destroy()
+    }
+  })
+
   it('does not hand the stanza builder back through a hook', () => {
     // A named export is not the only door: `useXMPP` used to return `xml`,
     // which would have made every assertion above true and meaningless. The

--- a/packages/fluux-sdk/src/bindings/storeBindings.integration.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.integration.test.ts
@@ -215,19 +215,19 @@ describe('SDK Event Bindings Integration', () => {
   describe('Verify emitSDK is properly bound in modules', () => {
     it('should have emitSDK available on roster module deps', () => {
       // Verify the module has emitSDK in its deps
-      const roster = xmppClient.roster as any
+      const roster = xmppClient.contacts as any
       expect(roster.deps.emitSDK).toBeDefined()
       expect(typeof roster.deps.emitSDK).toBe('function')
     })
 
     it('should have emitSDK available on muc module deps', () => {
-      const muc = xmppClient.muc as any
+      const muc = xmppClient.rooms as any
       expect(muc.deps.emitSDK).toBeDefined()
       expect(typeof muc.deps.emitSDK).toBe('function')
     })
 
     it('should have emitSDK available on chat module deps', () => {
-      const chat = xmppClient.chat as any
+      const chat = xmppClient.messages as any
       expect(chat.deps.emitSDK).toBeDefined()
       expect(typeof chat.deps.emitSDK).toBe('function')
     })
@@ -236,7 +236,7 @@ describe('SDK Event Bindings Integration', () => {
   describe('Full flow: module emits → binding receives → store updates', () => {
     it('should update roster store when roster module emitSDK is called directly', () => {
       // Simulate what a module would do
-      const roster = xmppClient.roster as any
+      const roster = xmppClient.contacts as any
       const contacts = [{ jid: 'test@example.com', name: 'Test' }]
 
       // Call emitSDK like the module would
@@ -247,7 +247,7 @@ describe('SDK Event Bindings Integration', () => {
     })
 
     it('should update room store when muc module emitSDK is called directly', () => {
-      const muc = xmppClient.muc as any
+      const muc = xmppClient.rooms as any
       const room = { jid: 'room@conference.example.com', name: 'Test Room' }
 
       muc.deps.emitSDK('room:added', { room })
@@ -287,7 +287,7 @@ describe('SDK Event Bindings Integration', () => {
       ]
 
       // Use the module's deps.emitSDK like a real module would
-      const roster = xmppClient.roster as any
+      const roster = xmppClient.contacts as any
       roster.deps.emitSDK('roster:loaded', { contacts })
 
       // Verify the binding caught the event and called the store
@@ -312,7 +312,7 @@ describe('SDK Event Bindings Integration', () => {
         typingUsers: new Set(),
       }
 
-      const muc = xmppClient.muc as any
+      const muc = xmppClient.rooms as any
       muc.deps.emitSDK('room:added', { room })
 
       expect(mockStores.room.addRoom).toHaveBeenCalledTimes(1)

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -87,12 +87,12 @@ describe('XMPPClient', () => {
 
       // Modules should be available immediately
       expect(client.connection).toBeDefined()
-      expect(client.chat).toBeDefined()
-      expect(client.roster).toBeDefined()
-      expect(client.muc).toBeDefined()
+      expect(client.messages).toBeDefined()
+      expect(client.contacts).toBeDefined()
+      expect(client.rooms).toBeDefined()
       expect(client.admin).toBeDefined()
       expect(client.profile).toBeDefined()
-      expect(client.discovery).toBeDefined()
+      expect(client.server).toBeDefined()
       expect(client.internal.mam).toBeDefined()
       expect(client.blocking).toBeDefined()
     })
@@ -102,9 +102,9 @@ describe('XMPPClient', () => {
       const client = new XMPPClient()
 
       // Should have all the necessary methods
-      expect(typeof client.chat.sendMessage).toBe('function')
-      expect(typeof client.muc.joinRoom).toBe('function')
-      expect(typeof client.roster.addContact).toBe('function')
+      expect(typeof client.messages.sendMessage).toBe('function')
+      expect(typeof client.rooms.joinRoom).toBe('function')
+      expect(typeof client.contacts.addContact).toBe('function')
     })
 
     it('installs the crypto.randomUUID polyfill in the constructor (legacy webviews)', () => {
@@ -134,7 +134,7 @@ describe('XMPPClient', () => {
 
       // Modules should still work
       expect(client.connection).toBeDefined()
-      expect(client.chat).toBeDefined()
+      expect(client.messages).toBeDefined()
     })
 
     it('should create presenceActor automatically', () => {
@@ -260,7 +260,7 @@ describe('XMPPClient', () => {
       })
 
       // Emit via the chat module (which has access to emitSDK)
-      const chat = client.chat as any
+      const chat = client.messages as any
       chat.deps.emitSDK('chat:message', {
         message: {
           id: 'test',
@@ -370,30 +370,30 @@ describe('XMPPClient', () => {
   describe('namespace modules', () => {
     it('should expose all namespace modules after bindStores', () => {
       expect(xmppClient.connection).toBeDefined()
-      expect(xmppClient.chat).toBeDefined()
-      expect(xmppClient.roster).toBeDefined()
-      expect(xmppClient.muc).toBeDefined()
+      expect(xmppClient.messages).toBeDefined()
+      expect(xmppClient.contacts).toBeDefined()
+      expect(xmppClient.rooms).toBeDefined()
       expect(xmppClient.admin).toBeDefined()
       expect(xmppClient.profile).toBeDefined()
-      expect(xmppClient.discovery).toBeDefined()
+      expect(xmppClient.server).toBeDefined()
     })
 
     it('should have expected methods on chat module', () => {
-      expect(typeof xmppClient.chat.sendMessage).toBe('function')
-      expect(typeof xmppClient.chat.sendChatState).toBe('function')
-      expect(typeof xmppClient.chat.sendReaction).toBe('function')
+      expect(typeof xmppClient.messages.sendMessage).toBe('function')
+      expect(typeof xmppClient.messages.sendChatState).toBe('function')
+      expect(typeof xmppClient.messages.sendReaction).toBe('function')
     })
 
     it('should have expected methods on roster module', () => {
-      expect(typeof xmppClient.roster.addContact).toBe('function')
-      expect(typeof xmppClient.roster.removeContact).toBe('function')
-      expect(typeof xmppClient.roster.setPresence).toBe('function')
+      expect(typeof xmppClient.contacts.addContact).toBe('function')
+      expect(typeof xmppClient.contacts.removeContact).toBe('function')
+      expect(typeof xmppClient.contacts.setPresence).toBe('function')
     })
 
     it('should have expected methods on muc module', () => {
-      expect(typeof xmppClient.muc.joinRoom).toBe('function')
-      expect(typeof xmppClient.muc.leaveRoom).toBe('function')
-      expect(typeof xmppClient.muc.setBookmark).toBe('function')
+      expect(typeof xmppClient.rooms.joinRoom).toBe('function')
+      expect(typeof xmppClient.rooms.leaveRoom).toBe('function')
+      expect(typeof xmppClient.rooms.setBookmark).toBe('function')
     })
   })
 
@@ -840,8 +840,8 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const joinRoomSpy = vi.spyOn(newXmppClient.muc, 'joinRoom').mockResolvedValue()
-      const fetchBookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks')
+      const joinRoomSpy = vi.spyOn(newXmppClient.rooms, 'joinRoom').mockResolvedValue()
+      const fetchBookmarksSpy = vi.spyOn(newXmppClient.rooms, 'fetchBookmarks')
         .mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const connectPromise = newXmppClient.connect({
@@ -880,7 +880,7 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      const bookmarksSpy = vi.spyOn(newXmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const connectPromise = newXmppClient.connect({
         jid: 'user@example.com',
@@ -916,7 +916,7 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      const bookmarksSpy = vi.spyOn(newXmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Simulate a reconnect with short disconnect: set the disconnectedAtTimestamp
       // on the connection module, then connect triggers handleConnectionSuccess
@@ -997,7 +997,7 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      const bookmarksSpy = vi.spyOn(newXmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Simulate a reconnect with long disconnect (5 minutes ago)
       ;(newXmppClient.connection as any).disconnectedAtTimestamp = Date.now() - 300_000
@@ -1035,7 +1035,7 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      vi.spyOn(newXmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
       const refreshAvatarsSpy = vi.spyOn(newXmppClient.profile, 'refreshAllAvatarBlobUrls').mockResolvedValue()
 
       // Short disconnect (30s): WebKit keeps the blob URLs alive, so refreshing
@@ -1070,7 +1070,7 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      vi.spyOn(newXmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
       const refreshAvatarsSpy = vi.spyOn(newXmppClient.profile, 'refreshAllAvatarBlobUrls').mockResolvedValue()
 
       // Long disconnect (5 min) covers the OS sleep-wake case where WebKit may
@@ -1114,8 +1114,8 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const joinRoomSpy = vi.spyOn(newXmppClient.muc, 'joinRoom').mockResolvedValue()
-      vi.spyOn(newXmppClient.muc, 'fetchBookmarks')
+      const joinRoomSpy = vi.spyOn(newXmppClient.rooms, 'joinRoom').mockResolvedValue()
+      vi.spyOn(newXmppClient.rooms, 'fetchBookmarks')
         .mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const connectPromise = newXmppClient.connect({
@@ -1262,7 +1262,7 @@ describe('XMPPClient', () => {
       )
 
       // Try to send a message - should trigger dead socket handling
-      await expect(xmppClient.chat.sendMessage('alice@example.com', 'test')).rejects.toThrow()
+      await expect(xmppClient.messages.sendMessage('alice@example.com', 'test')).rejects.toThrow()
 
       // Should have logged dead connection and scheduled reconnect
       expect(mockStores.console.addEvent).toHaveBeenCalledWith(
@@ -1296,7 +1296,7 @@ describe('XMPPClient', () => {
       )
 
       try {
-        await xmppClient.chat.sendMessage('alice@example.com', 'test')
+        await xmppClient.messages.sendMessage('alice@example.com', 'test')
       } catch {
         // Expected to throw
       }
@@ -2026,12 +2026,12 @@ describe('XMPPClient', () => {
       // Set up a JID so discovery has a domain to query
       ;(xmppClient as any).currentJid = 'user@example.com'
 
-      const discoverSpy = vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
-      const fetchServerInfoSpy = vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
+      const discoverSpy = vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
+      const fetchServerInfoSpy = vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
       const fetchProfileSpy = vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
 
       // Make fetchRoster throw (simulating slow server + IQ timeout)
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockRejectedValue(new Error('IQ timeout'))
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockRejectedValue(new Error('IQ timeout'))
 
       // Call runFreshSessionSetup directly (private method)
       try {
@@ -2049,13 +2049,13 @@ describe('XMPPClient', () => {
     it('should call discoverHttpUploadService even when fetchBookmarks throws', async () => {
       ;(xmppClient as any).currentJid = 'user@example.com'
 
-      const discoverSpy = vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      const discoverSpy = vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
 
       // Let fetchRoster succeed but fetchBookmarks fail
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockRejectedValue(new Error('IQ timeout'))
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockRejectedValue(new Error('IQ timeout'))
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
 
       try {
@@ -2079,13 +2079,13 @@ describe('XMPPClient', () => {
       const markAllSpy = stores.room.markAllRoomsNotJoined as ReturnType<typeof vi.fn>
       markAllSpy.mockClear()
 
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
-      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
       // Bookmarks fails — simulates the socket dying mid-setup
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockRejectedValue(new Error('IQ timeout'))
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockRejectedValue(new Error('IQ timeout'))
 
       try {
         await (xmppClient as any).sessionLifecycle.runFreshSessionSetup(
@@ -2112,12 +2112,12 @@ describe('XMPPClient', () => {
       const markAllSpy = stores.room.markAllRoomsNotJoined as ReturnType<typeof vi.fn>
       markAllSpy.mockClear()
 
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
-      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
@@ -2137,14 +2137,14 @@ describe('XMPPClient', () => {
       const markAllSpy = stores.room.markAllRoomsNotJoined as ReturnType<typeof vi.fn>
       markAllSpy.mockClear()
 
-      const rejoinSpy = vi.spyOn(xmppClient.muc, 'rejoinActiveRooms').mockResolvedValue()
+      const rejoinSpy = vi.spyOn(xmppClient.rooms, 'rejoinActiveRooms').mockResolvedValue()
 
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
-      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
@@ -2168,20 +2168,20 @@ describe('XMPPClient', () => {
 
       const callOrder: string[] = []
 
-      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockImplementation(async () => {
+      vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockImplementation(async () => {
         callOrder.push('discoverHttpUploadService')
       })
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockImplementation(async () => {
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockImplementation(async () => {
         callOrder.push('fetchServerInfo')
       })
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockImplementation(async () => {
         callOrder.push('fetchOwnProfile')
       })
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockImplementation(async () => {
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockImplementation(async () => {
         callOrder.push('fetchRoster')
       })
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Mock conversation sync
       const convSync = (xmppClient as any).internal.conversationSync
@@ -2205,22 +2205,22 @@ describe('XMPPClient', () => {
     function setupAutojoinFreshSession() {
       ;(xmppClient as any).currentJid = 'user@example.com'
       ;(xmppClient as any).sessionLifecycle.sessionGeneration = 1
-      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
-      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.server, 'discoverHttpUploadService').mockResolvedValue()
       vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
-      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({
+      vi.spyOn(xmppClient.contacts, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.contacts, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.rooms, 'fetchBookmarks').mockResolvedValue({
         roomsToAutojoin: [{ jid: 'public@conf.example.com', nick: 'me' }],
         allRoomJids: ['public@conf.example.com'],
       })
       const convSync = (xmppClient as any).internal.conversationSync
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
-      vi.spyOn(xmppClient.muc, 'queryRoomFeatures').mockResolvedValue({
+      vi.spyOn(xmppClient.rooms, 'queryRoomFeatures').mockResolvedValue({
         supportsMAM: false, supportsReactions: true, supportsHats: false,
         isNonAnonymous: true, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Public',
       })
-      return vi.spyOn(xmppClient.muc, 'joinRoom').mockResolvedValue()
+      return vi.spyOn(xmppClient.rooms, 'joinRoom').mockResolvedValue()
     }
 
     it('does not autojoin a non-anonymous public bookmark that is not acknowledged', async () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -153,7 +153,7 @@ export interface InternalModules {
  *   }
  *
  *   const sendMessage = () => {
- *     client.chat.sendMessage('friend@example.com', 'Hello!')
+ *     client.messages.sendMessage('friend@example.com', 'Hello!')
  *   }
  *
  *   if (status !== 'online') return <button onClick={handleConnect}>Connect</button>
@@ -167,16 +167,16 @@ export interface InternalModules {
  *
  * // Chat operations. A room is addressed the same way: `chat` reads the room
  * // store to decide whether it is talking to a room or to a person.
- * client.chat.sendMessage('bob@example.com', 'Hello!')
- * client.chat.sendReaction('bob@example.com', 'msg-1', ['\u{1F44D}'])
+ * client.messages.sendMessage('bob@example.com', 'Hello!')
+ * client.messages.sendReaction('bob@example.com', 'msg-1', ['\u{1F44D}'])
  *
  * // MUC (Multi-User Chat) operations
- * client.muc.joinRoom('room@conference.example.com', 'alice')
- * client.chat.sendMessage('room@conference.example.com', 'Hello room!')
+ * client.rooms.joinRoom('room@conference.example.com', 'alice')
+ * client.messages.sendMessage('room@conference.example.com', 'Hello room!')
  *
  * // Roster operations
- * client.roster.addContact('bob@example.com', 'Bob')
- * client.roster.removeContact('bob@example.com')
+ * client.contacts.addContact('bob@example.com', 'Bob')
+ * client.contacts.removeContact('bob@example.com')
  *
  * // Profile operations
  * client.profile.publishOwnAvatar(imageData, 'image/png', 64, 64)
@@ -187,7 +187,7 @@ export interface InternalModules {
  * client.admin.executeAdminCommand('http://jabber.org/protocol/admin#add-user')
  *
  * // Service discovery
- * client.discovery.fetchServerInfo()
+ * client.server.fetchServerInfo()
  * ```
  *
  * @category Core
@@ -219,7 +219,7 @@ export class XMPPClient {
    * Chat module for 1:1 messaging.
    * Handles messages, reactions, chat states, corrections, and MAM queries.
    */
-  public chat!: Chat
+  public messages!: Chat
 
   /**
    * End-to-end encryption plugin host. `null` before the first successful
@@ -239,13 +239,13 @@ export class XMPPClient {
    * Roster management module.
    * Handles contact list, presence, and subscription management.
    */
-  public roster!: Roster
+  public contacts!: Roster
 
   /**
    * Multi-User Chat (MUC) module.
    * Handles room operations, bookmarks, and group messaging.
    */
-  public muc!: MUC
+  public rooms!: MUC
 
   /**
    * Server administration module (XEP-0133).
@@ -263,7 +263,7 @@ export class XMPPClient {
    * Service discovery module (XEP-0030).
    * Handles server feature discovery and HTTP upload service discovery.
    */
-  public discovery!: Discovery
+  public server!: Discovery
 
   /**
    * PubSub module (XEP-0060).
@@ -313,7 +313,7 @@ export class XMPPClient {
    * Web Push module (p1:push).
    * Handles VAPID-based push notification registration with ejabberd Business Edition.
    */
-  public webPush!: WebPush
+  public push!: WebPush
 
 
 
@@ -683,18 +683,18 @@ export class XMPPClient {
     this.connectionActor = this.connection.getConnectionActor()
     this.pubsub = new PubSub(moduleDeps)
     const mam = new MAM(moduleDeps)
-    this.chat = new Chat(moduleDeps, mam)
-    this.poll = new Poll(moduleDeps, this.chat)
-    this.roster = new Roster(moduleDeps)
-    this.muc = new MUC(moduleDeps, mam)
+    this.messages = new Chat(moduleDeps, mam)
+    this.poll = new Poll(moduleDeps, this.messages)
+    this.contacts = new Roster(moduleDeps)
+    this.rooms = new MUC(moduleDeps, mam)
     this.admin = new Admin(moduleDeps)
     this.profile = new Profile(moduleDeps)
-    this.discovery = new Discovery(moduleDeps)
+    this.server = new Discovery(moduleDeps)
     this.blocking = new Blocking(moduleDeps)
     this.ignore = new Ignore(moduleDeps)
     const conversationSync = new ConversationSync(moduleDeps)
     const mds = new Mds(moduleDeps)
-    this.webPush = new WebPush(moduleDeps)
+    this.push = new WebPush(moduleDeps)
     const entityTime = new EntityTime(moduleDeps)
     const lastActivity = new LastActivity(moduleDeps)
     this.internal = { mam, mds, conversationSync, entityTime, lastActivity }
@@ -703,12 +703,12 @@ export class XMPPClient {
     // churny bits (stores, JID, transport) are read through getters so a
     // re-init or reconnect always sees the live value.
     this.sessionLifecycle = new SessionLifecycleEngine({
-      discovery: this.discovery,
+      discovery: this.server,
       admin: this.admin,
-      roster: this.roster,
-      muc: this.muc,
+      roster: this.contacts,
+      muc: this.rooms,
       profile: this.profile,
-      webPush: this.webPush,
+      webPush: this.push,
       conversationSync: this.internal.conversationSync,
       getStores: () => this.stores,
       getCurrentJid: () => this.currentJid,
@@ -747,7 +747,7 @@ export class XMPPClient {
       // not from the position of a module in this list. See core/stanzaRouting.
       routeStanza(
         stanza,
-        [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster],
+        [this.pubsub, this.blocking, this.poll, this.messages, this.rooms, this.contacts],
         [this.internal.lastActivity],
       )
     })
@@ -928,7 +928,7 @@ export class XMPPClient {
    * client.subscribe('chat:message', ({ message }) => {
    *   console.log(`${message.from}: ${message.body}`)
    *   if (message.body?.includes('hello')) {
-   *     client.chat.sendMessage(message.from, 'Hello!')
+   *     client.messages.sendMessage(message.from, 'Hello!')
    *   }
    * })
    * ```
@@ -1288,7 +1288,7 @@ export class XMPPClient {
     this.stateSnapshot = undefined
 
     // Clean up MUC pending joins to prevent orphaned timeouts
-    this.muc?.cleanup()
+    this.rooms?.cleanup()
   }
 
   /**
@@ -1455,8 +1455,8 @@ export class XMPPClient {
       const showValue = currentShow || 'online'
       const statusValue = currentStatus ?? undefined
       Promise.all([
-        this.roster.setPresence(showValue, statusValue),
-        this.muc.sendPresenceToRooms(showValue, statusValue),
+        this.contacts.setPresence(showValue, statusValue),
+        this.rooms.sendPresenceToRooms(showValue, statusValue),
       ])
         .then(() => {
           // Reset error count on success
@@ -1794,7 +1794,7 @@ export class XMPPClient {
         await this.sendStanza(dataToElement(data))
       },
       queryDisco: async (jid) => {
-        return this.discovery.queryInfo(jid)
+        return this.server.queryInfo(jid)
       },
       publishPEP: async (node, item, options) => {
         await this.pubsub.publish(node, item, options)

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -1274,7 +1274,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().setActiveRoom(null)
       resolveBlockingCatchUp()
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
       expect(foregroundCatchUpCount).toBe(1)
 
@@ -1348,7 +1348,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().setActiveRoom(null)
       resolveBlockingCatchUp()
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
       expect(
         vi.mocked(mockClient.internal.mam.catchUpRoomHistory).mock.calls
@@ -1405,7 +1405,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
 
       roomStore.getState().setActiveRoom(null)
@@ -1466,7 +1466,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
 
       rejectForegroundCatchUp(new Error('Not connected during foreground query'))
@@ -1534,7 +1534,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       })
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
 
       rejectForegroundCatchUp(new Error('Not connected during foreground query'))
@@ -1939,12 +1939,12 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       // Wait for room catch-up to complete and member discovery to start
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalledTimes(1)
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalledTimes(1)
       })
 
       // Should query Room 1 but NOT quickchat Room 2
-      expect(mockClient.muc.queryRoomMembers).toHaveBeenCalledWith('room1@conference.example.com')
-      expect(mockClient.muc.queryRoomMembers).not.toHaveBeenCalledWith('room2@conference.example.com')
+      expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalledWith('room1@conference.example.com')
+      expect(mockClient.rooms.queryRoomMembers).not.toHaveBeenCalledWith('room2@conference.example.com')
     })
 
     it('should not crash if member discovery fails', async () => {
@@ -1961,7 +1961,7 @@ describe('setupBackgroundSyncSideEffects', () => {
         typingUsers: new Set(),
       })
 
-      ;(mockClient.muc.queryRoomMembers as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'))
+      ;(mockClient.rooms.queryRoomMembers as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'))
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -1978,7 +1978,7 @@ describe('setupBackgroundSyncSideEffects', () => {
 
       // Should not throw — error is silently caught
       await vi.waitFor(() => {
-        expect(mockClient.muc.queryRoomMembers).toHaveBeenCalled()
+        expect(mockClient.rooms.queryRoomMembers).toHaveBeenCalled()
       })
     })
   })

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -502,7 +502,7 @@ export function setupBackgroundSyncSideEffects(
                 logInfo('Background sync: aborting member discovery — disconnected')
                 break
               }
-              await client.muc.queryRoomMembers(room.jid)
+              await client.rooms.queryRoomMembers(room.jid)
             }
           }
         } catch {
@@ -533,7 +533,7 @@ export function setupBackgroundSyncSideEffects(
     logInfo('Background sync: fresh session — checking MAM support')
 
     // Discover MAM fulltext search capability (non-blocking, doesn't affect sync)
-    void client.discovery.discoverMAMSearchCapability()
+    void client.server.discoverMAMSearchCapability()
 
     // Warm the E2EE plugin cache for all known conversations. Independent of
     // MAM — these are PEP queries that don't require server-side MAM support.

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -150,7 +150,7 @@ describe('XMPPClient MAM', () => {
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
       // Execute query
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify IQ was sent with correct structure
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(1)
@@ -272,7 +272,7 @@ describe('XMPPClient MAM', () => {
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
       // Execute query
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify messages were collected
       expect(result.messages.length).toBe(2)
@@ -346,7 +346,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(1)
       expect(result.messages[0].body).toBe('Multi-archive entry')
@@ -365,7 +365,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify loading state was set
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-loading', { conversationId: 'alice@example.com', isLoading: true })
@@ -393,7 +393,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify chat:mam-messages was emitted with direction='backward' (no start filter)
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
@@ -411,7 +411,7 @@ describe('XMPPClient MAM', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request = vi.fn().mockRejectedValue(new Error('Network error'))
 
-      await expect(xmppClient.chat.queryMAM({ with: 'alice@example.com' })).rejects.toThrow('Network error')
+      await expect(xmppClient.messages.queryMAM({ with: 'alice@example.com' })).rejects.toThrow('Network error')
 
       // Verify error state was set
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-error', { conversationId: 'alice@example.com', error: 'Network error' })
@@ -431,7 +431,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.complete).toBe(false)
     })
@@ -493,7 +493,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(1)
       expect(result.messages[0].replyTo).toEqual({
@@ -565,7 +565,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(1)
       expect(result.messages[0].attachment).toBeDefined()
@@ -636,7 +636,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should still parse the message even without body text
       expect(result.messages.length).toBe(1)
@@ -745,7 +745,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should have only 1 message (fastening is applied, not a separate message)
       expect(result.messages.length).toBe(1)
@@ -773,7 +773,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify RSM element was included
       expect(capturedIq).toBeDefined()
@@ -809,7 +809,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com', max: 25 })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com', max: 25 })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -837,7 +837,7 @@ describe('XMPPClient MAM', () => {
       })
 
       // Pass a specific stanza-id to get messages before that ID
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: 'stanza-id-12345' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: 'stanza-id-12345' })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -866,7 +866,7 @@ describe('XMPPClient MAM', () => {
       })
 
       // Default before='' should create empty <before/> for latest messages
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -973,7 +973,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(callCount).toBe(2)
       const secondQueryEl = capturedIqs[1].children?.find((c: any) => c.name === 'query')
@@ -1042,7 +1042,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Message without body should be skipped
       expect(result.messages.length).toBe(0)
@@ -1136,7 +1136,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message, not the retraction stanza
       expect(result.messages.length).toBe(1)
@@ -1234,7 +1234,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message
       expect(result.messages.length).toBe(1)
@@ -1331,7 +1331,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message, not the correction stanza
       expect(result.messages.length).toBe(1)
@@ -1437,7 +1437,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message
       expect(result.messages.length).toBe(1)
@@ -1534,7 +1534,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message
       expect(result.messages.length).toBe(1)
@@ -1631,7 +1631,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message (malicious correction discarded)
       expect(result.messages.length).toBe(1)
@@ -1734,7 +1734,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message, not the reaction stanza
       expect(result.messages.length).toBe(1)
@@ -1838,7 +1838,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message
       expect(result.messages.length).toBe(1)
@@ -1975,7 +1975,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Should only have the original message
       expect(result.messages.length).toBe(1)
@@ -2114,7 +2114,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(1)
 
@@ -2246,7 +2246,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(1)
 
@@ -2320,7 +2320,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // No displayable messages in this batch
       expect(result.messages.length).toBe(0)
@@ -2400,7 +2400,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(0)
 
@@ -2490,7 +2490,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // The unresolved correction should include originalBody from the cached message
       const updateEvents = emitSDKSpy.mock.calls.filter(
@@ -2567,7 +2567,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result.messages.length).toBe(0)
 
@@ -2612,7 +2612,7 @@ describe('XMPPClient MAM', () => {
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
       // Query with start filter (forward direction, like fetching missed messages)
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com', start: '2026-01-21T19:00:00Z' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com', start: '2026-01-21T19:00:00Z' })
 
       // Direction should be 'forward' for queries with start filter
       // The store will set isCaughtUpToLive=true but NOT isHistoryComplete
@@ -2650,7 +2650,7 @@ describe('XMPPClient MAM', () => {
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
       // Query WITHOUT start filter (backward direction)
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: '' })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: '' })
 
       // Direction should be 'backward' for queries without start filter
       // The store will set isHistoryComplete=true
@@ -2683,7 +2683,7 @@ describe('XMPPClient MAM', () => {
       })
 
       // No `start` filter — only an `after` cursor, seeded from the MDS stanza-id.
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', after: 'mds-stanza-id', maxAutoPages: 5 })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', after: 'mds-stanza-id', maxAutoPages: 5 })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -2725,7 +2725,7 @@ describe('XMPPClient MAM', () => {
         return latestResponse
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', after: 'purged-stanza-id', maxAutoPages: 5 })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', after: 'purged-stanza-id', maxAutoPages: 5 })
 
       // Degraded successfully instead of throwing.
       expect(result.complete).toBe(true)
@@ -2758,7 +2758,7 @@ describe('XMPPClient MAM', () => {
         return latestResponse
       })
 
-      await xmppClient.chat.queryMAM({ with: 'alice@example.com', after: 'purged-stanza-id', maxAutoPages: 5 })
+      await xmppClient.messages.queryMAM({ with: 'alice@example.com', after: 'purged-stanza-id', maxAutoPages: 5 })
 
       // Without this, the persisted gap keeps the purged startId: every
       // session re-degrades and "Load missing messages" can never heal.
@@ -2776,7 +2776,7 @@ describe('XMPPClient MAM', () => {
       // page of an `after`-anchored query only.
       mockXmppClientInstance.iqCaller.request = vi.fn().mockRejectedValue({ condition: 'item-not-found' })
 
-      await expect(xmppClient.chat.queryMAM({ with: 'alice@example.com', before: 'stale-cursor' })).rejects.toBeTruthy()
+      await expect(xmppClient.messages.queryMAM({ with: 'alice@example.com', before: 'stale-cursor' })).rejects.toBeTruthy()
     })
 
     it('signal-only walk jumps to the persisted coverage floor once a page contains its topId (Codex r3 #4)', async () => {
@@ -2872,7 +2872,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: '' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: '' })
 
       // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's rsm.first:
       // everything between topId and bottomId is already proven signal-only.
@@ -2944,7 +2944,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: '' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: '' })
 
       expect(callCount).toBe(5) // MAM_BACKWARD_SIGNAL_RETRY_PAGES
       expect(result.messages).toHaveLength(0)
@@ -3062,7 +3062,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: '' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: '' })
 
       // Walk recovered: purge emitted, pre-jump cursor used, message found.
       expect(callCount).toBe(3)
@@ -3095,7 +3095,7 @@ describe('XMPPClient MAM', () => {
         return latestResponse
       })
 
-      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com', before: 'purged-id' })
+      const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: 'purged-id' })
 
       // Degraded to a plain fetch-latest instead of throwing.
       expect(callCount).toBe(2)
@@ -3148,7 +3148,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      await xmppClient.chat.queryRoomMAM({ roomJid })
+      await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify IQ was sent TO the room JID
       expect(capturedIq).toBeDefined()
@@ -3186,7 +3186,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      await xmppClient.chat.queryRoomMAM({ roomJid })
+      await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify query has FORM_TYPE but NO 'with' filter
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
@@ -3298,7 +3298,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid })
 
       expect(result.messages.length).toBe(2)
 
@@ -3338,7 +3338,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
-      await xmppClient.chat.queryRoomMAM({ roomJid })
+      await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify loading state was set and cleared
       expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-loading', { roomJid, isLoading: true })
@@ -3380,7 +3380,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
-      await xmppClient.chat.queryRoomMAM({ roomJid })
+      await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify room:mam-messages was emitted with direction='backward' (no start filter)
       expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
@@ -3413,7 +3413,7 @@ describe('XMPPClient MAM', () => {
 
       mockXmppClientInstance.iqCaller.request = vi.fn().mockRejectedValue(new Error('Room MAM not supported'))
 
-      await expect(xmppClient.chat.queryRoomMAM({ roomJid })).rejects.toThrow('Room MAM not supported')
+      await expect(xmppClient.messages.queryRoomMAM({ roomJid })).rejects.toThrow('Room MAM not supported')
 
       // Verify error state was set
       expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-error', { roomJid, error: 'Room MAM not supported' })
@@ -3451,7 +3451,7 @@ describe('XMPPClient MAM', () => {
         return mamResponse
       })
 
-      await xmppClient.chat.queryRoomMAM({ roomJid, before: 'stanza-id-12345' })
+      await xmppClient.messages.queryRoomMAM({ roomJid, before: 'stanza-id-12345' })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -3501,7 +3501,7 @@ describe('XMPPClient MAM', () => {
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
       // Query with start filter (forward direction)
-      await xmppClient.chat.queryRoomMAM({ roomJid, start: '2026-01-21T19:00:00Z' })
+      await xmppClient.messages.queryRoomMAM({ roomJid, start: '2026-01-21T19:00:00Z' })
 
       // Direction should be 'forward' for queries with start filter
       // The store will set isCaughtUpToLive=true but NOT isHistoryComplete
@@ -3554,7 +3554,7 @@ describe('XMPPClient MAM', () => {
       mockXmppClientInstance.iqCaller.request = vi.fn().mockResolvedValue(mamResponse)
 
       // Query with before filter (backward direction, for scroll-up loading)
-      await xmppClient.chat.queryRoomMAM({ roomJid, before: 'some-stanza-id' })
+      await xmppClient.messages.queryRoomMAM({ roomJid, before: 'some-stanza-id' })
 
       // Direction should be 'backward' for queries with before filter
       // The store will set isHistoryComplete=true
@@ -3596,7 +3596,7 @@ describe('XMPPClient MAM', () => {
       })
 
       // No `start` filter — only an `after` cursor, seeded from the MDS stanza-id.
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid, after: 'mds-stanza-id' })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid, after: 'mds-stanza-id' })
 
       const queryEl = capturedIq.children?.find((c: any) => c.name === 'query')
       const setEl = queryEl?.children?.find((c: any) => c.name === 'set')
@@ -3717,7 +3717,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Two IQs; the second advances the backward cursor to page 1's oldest.
       expect(callCount).toBe(2)
@@ -3847,7 +3847,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's rsm.first.
       expect(callCount).toBe(2)
@@ -3931,7 +3931,7 @@ describe('XMPPClient MAM', () => {
         ])
       })
 
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Same retry cap as the 1:1 backward path.
       expect(callCount).toBe(5)
@@ -3973,7 +3973,7 @@ describe('XMPPClient MAM', () => {
         return latestResponse
       })
 
-      const result = await xmppClient.chat.queryRoomMAM({ roomJid, after: 'purged-stanza-id' })
+      const result = await xmppClient.messages.queryRoomMAM({ roomJid, after: 'purged-stanza-id' })
 
       expect(result.complete).toBe(true)
       expect(callCount).toBe(2)
@@ -4017,7 +4017,7 @@ describe('XMPPClient MAM', () => {
         return latestResponse
       })
 
-      await xmppClient.chat.queryRoomMAM({ roomJid, after: 'purged-stanza-id' })
+      await xmppClient.messages.queryRoomMAM({ roomJid, after: 'purged-stanza-id' })
 
       expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-anchor-purged', {
         roomJid,
@@ -4098,8 +4098,8 @@ describe('XMPPClient MAM', () => {
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
       // Query MAM twice — same message should get the same stable ID
-      const result1 = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
-      const result2 = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+      const result1 = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
+      const result2 = await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       expect(result1.messages.length).toBe(1)
       expect(result2.messages.length).toBe(1)
@@ -4185,7 +4185,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'bob@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'bob@example.com' })
 
       expect(result.messages.length).toBe(1)
       // stanzaId should fall back to the MAM archive result id
@@ -4250,7 +4250,7 @@ describe('XMPPClient MAM', () => {
 
       vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
 
-      const result = await xmppClient.chat.queryMAM({ with: 'carol@example.com' })
+      const result = await xmppClient.messages.queryMAM({ with: 'carol@example.com' })
 
       expect(result.messages.length).toBe(1)
       // stanza-id from the message element should take priority over archive id

--- a/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
@@ -143,14 +143,14 @@ describe('XMPPClient Quick Chat', () => {
 
   describe('createQuickChat', () => {
     it('should create a quick chat room with generated JID', async () => {
-      const roomJid = await xmppClient.muc.createQuickChat('testuser')
+      const roomJid = await xmppClient.rooms.createQuickChat('testuser')
 
       // Room JID should follow pattern: quickchat-user-adj-noun-suffix@conference.example.com
       expect(roomJid).toMatch(/^quickchat-user-\w+-\w+-\w+@conference\.example\.com$/)
     })
 
     it('should add room to store with isQuickChat flag', async () => {
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       // Verify room:added was emitted with isQuickChat: true
       expect(emitSDKSpy).toHaveBeenCalledWith('room:added', {
@@ -162,7 +162,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should use topic as room name when provided', async () => {
-      await xmppClient.muc.createQuickChat('testuser', 'deploy issue')
+      await xmppClient.rooms.createQuickChat('testuser', 'deploy issue')
 
       // Should configure the room with the topic as name via iqCaller.request
       const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
@@ -181,7 +181,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should use creator name in room name when no topic provided', async () => {
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       // Should configure with "{creator} - {date}" name via iqCaller.request
       // Since getOwnNickname returns null, it falls back to JID local part "user"
@@ -201,7 +201,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should send presence to join the room', async () => {
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       // Should send presence to join room
       const sendCalls = mockXmppClientInstance.send.mock.calls
@@ -215,7 +215,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should configure room as non-persistent', async () => {
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       // Should send MUC#owner configuration with persistentroom = 0 via iqCaller.request
       const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
@@ -236,7 +236,7 @@ describe('XMPPClient Quick Chat', () => {
       // Disconnect the client
       await xmppClient.disconnect()
 
-      await expect(xmppClient.muc.createQuickChat('testuser')).rejects.toThrow()
+      await expect(xmppClient.rooms.createQuickChat('testuser')).rejects.toThrow()
     })
 
     it('should throw if MUC service not found', async () => {
@@ -256,12 +256,12 @@ describe('XMPPClient Quick Chat', () => {
         throw new Error('Not mocked')
       })
 
-      await expect(xmppClient.muc.createQuickChat('testuser')).rejects.toThrow('MUC service not available')
+      await expect(xmppClient.rooms.createQuickChat('testuser')).rejects.toThrow('MUC service not available')
     })
 
     it('should send invitations to specified contacts after room creation', async () => {
       const invitees = ['alice@example.com', 'bob@example.com']
-      await xmppClient.muc.createQuickChat('testuser', 'team sync', invitees)
+      await xmppClient.rooms.createQuickChat('testuser', 'team sync', invitees)
 
       // Find invitation messages in send calls
       const sendCalls = mockXmppClientInstance.send.mock.calls
@@ -290,7 +290,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should include reason in invitation when topic is provided', async () => {
-      await xmppClient.muc.createQuickChat('testuser', 'deploy issue', ['alice@example.com'])
+      await xmppClient.rooms.createQuickChat('testuser', 'deploy issue', ['alice@example.com'])
 
       const sendCalls = mockXmppClientInstance.send.mock.calls
       const invitationMessage = sendCalls.find((call: any[]) => {
@@ -312,7 +312,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should not send invitations when invitees array is empty', async () => {
-      await xmppClient.muc.createQuickChat('testuser', 'topic', [])
+      await xmppClient.rooms.createQuickChat('testuser', 'topic', [])
 
       const sendCalls = mockXmppClientInstance.send.mock.calls
       const invitationMessages = sendCalls.filter((call: any[]) => {
@@ -353,7 +353,7 @@ describe('XMPPClient Quick Chat', () => {
         return originalMock!(iq)
       })
 
-      await xmppClient.muc.createQuickChat('testuser', undefined, ['alice@example.com', 'bob@example.com'])
+      await xmppClient.rooms.createQuickChat('testuser', undefined, ['alice@example.com', 'bob@example.com'])
 
       // Find the room configuration IQ
       const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
@@ -415,7 +415,7 @@ describe('XMPPClient Quick Chat', () => {
         return originalMock!(iq)
       })
 
-      await xmppClient.muc.createQuickChat('testuser', undefined, ['alice@example.com', 'bob@example.com'])
+      await xmppClient.rooms.createQuickChat('testuser', undefined, ['alice@example.com', 'bob@example.com'])
 
       // Find the room configuration IQ
       const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
@@ -438,7 +438,7 @@ describe('XMPPClient Quick Chat', () => {
       // Mock getOwnNickname to return the creator's XEP-0172 nickname
       mockStores.connection.getOwnNickname = vi.fn().mockReturnValue('John Doe')
 
-      await xmppClient.muc.createQuickChat('testuser', undefined, ['alice@example.com'])
+      await xmppClient.rooms.createQuickChat('testuser', undefined, ['alice@example.com'])
 
       // Find the room configuration IQ
       const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
@@ -506,7 +506,7 @@ describe('XMPPClient Quick Chat', () => {
     it('sets the Prosody allow-member-invites field when the server advertises it', async () => {
       installConfigForm(['{http://prosody.im/protocol/muc}roomconfig_allowmemberinvites'])
 
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       const configCall = getConfigSubmit()
       expect(configCall).toBeDefined()
@@ -522,7 +522,7 @@ describe('XMPPClient Quick Chat', () => {
       // matching is by local name, so it should still be found and submitted verbatim.
       installConfigForm(['{urn:example:muc}roomconfig_allowmemberinvites'])
 
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       const configCall = getConfigSubmit()
       expect(configCall).toBeDefined()
@@ -533,7 +533,7 @@ describe('XMPPClient Quick Chat', () => {
     it('sets the ejabberd allowinvites field when the server advertises it', async () => {
       installConfigForm(['muc#roomconfig_allowinvites'])
 
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       const configCall = getConfigSubmit()
       expect(configCall).toBeDefined()
@@ -545,7 +545,7 @@ describe('XMPPClient Quick Chat', () => {
       // Prosody-style form without any allow-invites field at all.
       installConfigForm(['muc#roomconfig_persistentroom', 'muc#roomconfig_publicroom'])
 
-      await xmppClient.muc.createQuickChat('testuser')
+      await xmppClient.rooms.createQuickChat('testuser')
 
       const configCall = getConfigSubmit()
       // Config must still be submitted (otherwise the room stays locked)...
@@ -565,7 +565,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should send invitation stanza with correct structure', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -587,7 +587,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should include reason element when provided', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', 'Please join our discussion')
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', 'Please join our discussion')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const xElement = sentStanza.children.find((c: any) =>
@@ -600,7 +600,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should not include reason element when not provided', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const xElement = sentStanza.children.find((c: any) =>
@@ -616,12 +616,12 @@ describe('XMPPClient Quick Chat', () => {
       await xmppClient.disconnect()
 
       await expect(
-        xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
+        xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
       ).rejects.toThrow('Not connected')
     })
 
     it('should include quickchat element inside invite when isQuickChat is true', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', undefined, true)
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', undefined, true)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -635,7 +635,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should not include quickchat element when isQuickChat is false', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', undefined, false)
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com', undefined, false)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -649,7 +649,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should not include quickchat element when isQuickChat is not provided', async () => {
-      await xmppClient.muc.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
+      await xmppClient.rooms.sendMediatedInvitation('room@conference.example.com', 'alice@example.com')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -671,7 +671,7 @@ describe('XMPPClient Quick Chat', () => {
 
     it('should send invitations to all specified JIDs', async () => {
       const invitees = ['alice@example.com', 'bob@example.com', 'charlie@example.com']
-      await xmppClient.muc.sendMediatedInvitations('room@conference.example.com', invitees)
+      await xmppClient.rooms.sendMediatedInvitations('room@conference.example.com', invitees)
 
       // Should have sent 3 messages
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(3)
@@ -691,7 +691,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should include reason in all invitations when provided', async () => {
-      await xmppClient.muc.sendMediatedInvitations(
+      await xmppClient.rooms.sendMediatedInvitations(
         'room@conference.example.com',
         ['alice@example.com', 'bob@example.com'],
         'Join our meeting'
@@ -709,7 +709,7 @@ describe('XMPPClient Quick Chat', () => {
     })
 
     it('should include quickchat element in all invitations when isQuickChat is true', async () => {
-      await xmppClient.muc.sendMediatedInvitations(
+      await xmppClient.rooms.sendMediatedInvitations(
         'room@conference.example.com',
         ['alice@example.com', 'bob@example.com'],
         undefined,

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -639,7 +639,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('offline@example.com', 'composing')
+      await xmppClient.messages.sendChatState('offline@example.com', 'composing')
 
       // Should NOT have sent any stanza
       expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
@@ -656,7 +656,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('online@example.com', 'composing')
+      await xmppClient.messages.sendChatState('online@example.com', 'composing')
 
       // Should have sent the chat state
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -673,7 +673,7 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('away@example.com', 'composing')
+      await xmppClient.messages.sendChatState('away@example.com', 'composing')
 
       // Should have sent the chat state (away users can still receive)
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -683,7 +683,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // For groupchat, we don't check individual presence
-      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing')
+      await xmppClient.messages.sendChatState('room@conference.example.com', 'composing')
 
       // Should have sent the chat state
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -699,8 +699,8 @@ describe('XMPPClient Message', () => {
         subscription: 'both',
       })
 
-      await xmppClient.chat.sendChatState('online@example.com', 'composing')
-      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing')
+      await xmppClient.messages.sendChatState('online@example.com', 'composing')
+      await xmppClient.messages.sendChatState('room@conference.example.com', 'composing')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
       for (const [sentStanza] of mockXmppClientInstance.send.mock.calls) {
@@ -972,7 +972,7 @@ describe('XMPPClient Message', () => {
     it('should emit a reply fallback end counted in code points', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendMessage('alice@example.com', 'Thanks!', { replyTo: { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } } })
+      await xmppClient.messages.sendMessage('alice@example.com', 'Thanks!', { replyTo: { id: 'orig-1', to: 'alice@example.com', fallback: { author: 'alice', body: QUOTED } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find((c: any) => c.name === 'fallback')
@@ -989,7 +989,7 @@ describe('XMPPClient Message', () => {
       const body = '😀 hey @bob'
       const begin = body.indexOf('@bob')
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', body, { references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
+      await xmppClient.messages.sendMessage('room@conference.example.com', body, { references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
@@ -1006,7 +1006,7 @@ describe('XMPPClient Message', () => {
       const typed = 'yes @bob'
       const begin = typed.indexOf('@bob')
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', typed, { replyTo: { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } }, references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
+      await xmppClient.messages.sendMessage('room@conference.example.com', typed, { replyTo: { id: 'orig-2', to: 'room@conference.example.com/Emma', fallback: { author: 'Emma', body: QUOTED } }, references: [{ begin, end: begin + '@bob'.length, type: 'mention', uri: 'xmpp:room@conference.example.com/bob' }] })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const refEl = sentStanza.children.find((c: any) => c.name === 'reference')
@@ -1533,7 +1533,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍', '❤️'])
+      await xmppClient.messages.sendReaction('alice@example.com', 'msg-123', ['👍', '❤️'])
 
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
 
@@ -1568,7 +1568,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // getMessage returns undefined (default mock behavior)
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'])
+      await xmppClient.messages.sendReaction('alice@example.com', 'msg-123', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -1597,7 +1597,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', [])
+      await xmppClient.messages.sendReaction('alice@example.com', 'msg-123', [])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1611,7 +1611,7 @@ describe('XMPPClient Message', () => {
     it('should update local store after sending reaction', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'msg-123', ['👍'])
+      await xmppClient.messages.sendReaction('alice@example.com', 'msg-123', ['👍'])
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:reactions', {
         isLive: true,
@@ -1626,7 +1626,7 @@ describe('XMPPClient Message', () => {
       await connectClient()
 
       // Send with full JID - should be stripped to bare JID
-      await xmppClient.chat.sendReaction('alice@example.com/mobile', 'msg-123', ['👍'])
+      await xmppClient.messages.sendReaction('alice@example.com/mobile', 'msg-123', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sentStanza.attrs.to).toBe('alice@example.com')
@@ -1644,7 +1644,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
+      await xmppClient.messages.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1663,7 +1663,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
+      await xmppClient.messages.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1676,7 +1676,7 @@ describe('XMPPClient Message', () => {
       mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: 'room@conference.example.com', nickname: 'me' })
       // getMessage returns undefined (default mock behavior)
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'unknown-msg-id', ['👍'])
+      await xmppClient.messages.sendReaction('room@conference.example.com', 'unknown-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1695,7 +1695,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['🎉'])
+      await xmppClient.messages.sendReaction('room@conference.example.com', 'client-msg-id', ['🎉'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -1727,7 +1727,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice', fallback: { author: 'alice', body: 'Original message' } } })
+      await xmppClient.messages.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice', fallback: { author: 'alice', body: 'Original message' } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1746,7 +1746,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice' } })
+      await xmppClient.messages.sendMessage('room@conference.example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'room@conference.example.com/alice' } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1768,7 +1768,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: false,
       })
 
-      await xmppClient.chat.sendMessage('alice@example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'alice@example.com' } })
+      await xmppClient.messages.sendMessage('alice@example.com', 'My reply', { replyTo: { id: 'client-msg-id', to: 'alice@example.com' } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1794,7 +1794,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: false,
       })
 
-      await xmppClient.chat.sendMessage('bob@example.com', 'Nice!', { replyTo: { id: 'a1b2c3d4-uuid-style-id', to: 'bob@example.com', fallback: { author: 'bob', body: 'Check this out' } } })
+      await xmppClient.messages.sendMessage('bob@example.com', 'Nice!', { replyTo: { id: 'a1b2c3d4-uuid-style-id', to: 'bob@example.com', fallback: { author: 'bob', body: 'Check this out' } } })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
@@ -1816,7 +1816,7 @@ describe('XMPPClient Message', () => {
         from: 'alice@example.com',
       })
 
-      await xmppClient.chat.sendReaction('alice@example.com', 'client-msg-id', ['👍'])
+      await xmppClient.messages.sendReaction('alice@example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1836,7 +1836,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/alice',
       })
 
-      await xmppClient.chat.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
+      await xmppClient.messages.sendReaction('room@conference.example.com', 'client-msg-id', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
@@ -1858,7 +1858,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
+      await xmppClient.messages.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1882,7 +1882,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
+      await xmppClient.messages.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1907,7 +1907,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
+      await xmppClient.messages.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1931,7 +1931,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
+      await xmppClient.messages.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1951,7 +1951,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -1976,7 +1976,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2000,7 +2000,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2022,7 +2022,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2051,7 +2051,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', attachment.url, { attachment: attachment })
 
       // Body should be empty because the URL is fallback text for OOB
       // (our client understands OOB, so we strip the fallback)
@@ -2083,7 +2083,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('alice@example.com', userText, { attachment: attachment })
+      await xmppClient.messages.sendMessage('alice@example.com', userText, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2115,7 +2115,7 @@ describe('XMPPClient Message', () => {
     it('should not include fallback when no attachment', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendMessage('alice@example.com', 'Hello, world!')
+      await xmppClient.messages.sendMessage('alice@example.com', 'Hello, world!')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const fallbackEl = sentStanza.children.find(
@@ -2135,7 +2135,7 @@ describe('XMPPClient Message', () => {
       it('sends groupchat to a JID the room store knows', async () => {
         await connectClient()
 
-        await xmppClient.chat.sendMessage('room@conference.example.com', 'hello room')
+        await xmppClient.messages.sendMessage('room@conference.example.com', 'hello room')
 
         expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('groupchat')
       })
@@ -2143,7 +2143,7 @@ describe('XMPPClient Message', () => {
       it('sends chat to any other JID', async () => {
         await connectClient()
 
-        await xmppClient.chat.sendMessage('alice@example.com', 'hello alice')
+        await xmppClient.messages.sendMessage('alice@example.com', 'hello alice')
 
         expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('chat')
       })
@@ -2151,7 +2151,7 @@ describe('XMPPClient Message', () => {
       it('resolves from the bare JID, so a full occupant JID still reads as its room', async () => {
         await connectClient()
 
-        await xmppClient.chat.sendReaction('room@conference.example.com/bob', 'msg-1', ['\u{1F44D}'])
+        await xmppClient.messages.sendReaction('room@conference.example.com/bob', 'msg-1', ['\u{1F44D}'])
 
         expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('groupchat')
       })
@@ -2159,7 +2159,7 @@ describe('XMPPClient Message', () => {
       it('treats a room it has not joined as a person, which is what the server would enforce', async () => {
         await connectClient()
 
-        await xmppClient.chat.sendMessage('other@conference.example.com', 'hello')
+        await xmppClient.messages.sendMessage('other@conference.example.com', 'hello')
 
         expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.type).toBe('chat')
       })
@@ -2175,7 +2175,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', attachment.url, { attachment: attachment })
+      await xmppClient.messages.sendMessage('room@conference.example.com', attachment.url, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -2204,7 +2204,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendMessage('room@conference.example.com', userText, { attachment: attachment })
+      await xmppClient.messages.sendMessage('room@conference.example.com', userText, { attachment: attachment })
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2227,7 +2227,7 @@ describe('XMPPClient Message', () => {
   describe('sendCorrection (XEP-0308)', () => {
     it('should throw error if not connected', async () => {
       await expect(
-        xmppClient.chat.sendCorrection('contact@example.com', 'msg-123', 'Fixed message')
+        xmppClient.messages.sendCorrection('contact@example.com', 'msg-123', 'Fixed message')
       ).rejects.toThrow('Not connected')
     })
 
@@ -2242,7 +2242,7 @@ describe('XMPPClient Message', () => {
         from: 'me@example.com',
       })
 
-      await xmppClient.chat.sendCorrection('contact@example.com/resource', 'original-msg-123', 'Fixed message')
+      await xmppClient.messages.sendCorrection('contact@example.com/resource', 'original-msg-123', 'Fixed message')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2288,7 +2288,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated caption', attachment)
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', 'Updated caption', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2320,7 +2320,7 @@ describe('XMPPClient Message', () => {
         },
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2348,7 +2348,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', '', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobFallbackEl = sentStanza.children.find(
@@ -2370,7 +2370,7 @@ describe('XMPPClient Message', () => {
       })
 
       // No attachment passed = attachment removed
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Message without attachment')
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', 'Message without attachment')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const oobEl = sentStanza.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'jabber:x:oob')
@@ -2402,7 +2402,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', userText, attachment)
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', userText, attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
@@ -2449,7 +2449,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Updated', attachment)
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', 'Updated', attachment)
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2473,7 +2473,7 @@ describe('XMPPClient Message', () => {
         attachment: { url: 'https://upload.example.com/old.jpg' },
       })
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Now just text')
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', 'Now just text')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2504,7 +2504,7 @@ describe('XMPPClient Message', () => {
         mediaType: 'image/jpeg',
       }
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'original-msg-123', 'Fixed', attachment)
+      await xmppClient.messages.sendCorrection('room@conference.example.com', 'original-msg-123', 'Fixed', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
@@ -2538,7 +2538,7 @@ describe('XMPPClient Message', () => {
         from: 'room@conference.example.com/me',
       })
 
-      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Fixed')
+      await xmppClient.messages.sendCorrection('room@conference.example.com', 'client-msg-id', 'Fixed')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -2771,14 +2771,14 @@ describe('XMPPClient Message', () => {
   describe('sendRetraction (XEP-0424)', () => {
     it('should throw error if not connected', async () => {
       await expect(
-        xmppClient.chat.sendRetraction('contact@example.com', 'msg-123')
+        xmppClient.messages.sendRetraction('contact@example.com', 'msg-123')
       ).rejects.toThrow('Not connected')
     })
 
     it('should send retraction stanza with correct structure for chat', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendRetraction('contact@example.com/resource', 'original-msg-123')
+      await xmppClient.messages.sendRetraction('contact@example.com/resource', 'original-msg-123')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2811,7 +2811,7 @@ describe('XMPPClient Message', () => {
     it('should send retraction stanza with full JID for groupchat', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-msg-456')
+      await xmppClient.messages.sendRetraction('room@conference.example.com', 'original-msg-456')
 
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
@@ -2842,7 +2842,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'original-msg-123')
+      await xmppClient.messages.sendRetraction('contact@example.com', 'original-msg-123')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
@@ -2869,7 +2869,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'original-room-msg-456')
+      await xmppClient.messages.sendRetraction('room@conference.example.com', 'original-room-msg-456')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', {
         roomJid: 'room@conference.example.com',
@@ -2887,7 +2887,7 @@ describe('XMPPClient Message', () => {
       // Mock that the message doesn't exist
       vi.mocked(mockStores.chat.getMessage).mockReturnValue(undefined)
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'non-existent-msg')
+      await xmppClient.messages.sendRetraction('contact@example.com', 'non-existent-msg')
 
       // Should still send the stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -2901,7 +2901,7 @@ describe('XMPPClient Message', () => {
       // Mock that the message doesn't exist
       vi.mocked(mockStores.room.getMessage).mockReturnValue(undefined)
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'non-existent-msg')
+      await xmppClient.messages.sendRetraction('room@conference.example.com', 'non-existent-msg')
 
       // Should still send the stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -2912,7 +2912,7 @@ describe('XMPPClient Message', () => {
     it('should default to chat type when type not specified', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'msg-123')
+      await xmppClient.messages.sendRetraction('contact@example.com', 'msg-123')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sentStanza.attrs.type).toBe('chat')
@@ -2933,7 +2933,7 @@ describe('XMPPClient Message', () => {
         isOutgoing: true,
       })
 
-      await xmppClient.chat.sendRetraction('room@conference.example.com', 'client-msg-id')
+      await xmppClient.messages.sendRetraction('room@conference.example.com', 'client-msg-id')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const retractEl = sentStanza.children.find(
@@ -3256,7 +3256,7 @@ describe('XMPPClient Message', () => {
     it('should include origin-id element in outgoing sendMessage stanza', async () => {
       await connectClient()
 
-      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello')
+      const msgId = await xmppClient.messages.sendMessage('alice@example.com', 'Hello')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3270,7 +3270,7 @@ describe('XMPPClient Message', () => {
     it('should set originId on local message object for outgoing sendMessage', async () => {
       await connectClient()
 
-      const msgId = await xmppClient.chat.sendMessage('alice@example.com', 'Hello')
+      const msgId = await xmppClient.messages.sendMessage('alice@example.com', 'Hello')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
         message: expect.objectContaining({
@@ -3285,7 +3285,7 @@ describe('XMPPClient Message', () => {
     it('should include origin-id element in outgoing resendMessage stanza', async () => {
       await connectClient()
 
-      await xmppClient.chat.resendMessage('contact@example.com', 'Hello again', 'original-msg-id')
+      await xmppClient.messages.resendMessage('contact@example.com', 'Hello again', 'original-msg-id')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3299,7 +3299,7 @@ describe('XMPPClient Message', () => {
     it('should include origin-id element in outgoing reaction stanza', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendReaction('contact@example.com', 'msg-123', ['👍'])
+      await xmppClient.messages.sendReaction('contact@example.com', 'msg-123', ['👍'])
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3318,7 +3318,7 @@ describe('XMPPClient Message', () => {
         body: 'Original text',
       })
 
-      await xmppClient.chat.sendCorrection('contact@example.com', 'original-msg-123', 'Fixed text')
+      await xmppClient.messages.sendCorrection('contact@example.com', 'original-msg-123', 'Fixed text')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3337,7 +3337,7 @@ describe('XMPPClient Message', () => {
         body: 'To be retracted',
       })
 
-      await xmppClient.chat.sendRetraction('contact@example.com', 'original-msg-123')
+      await xmppClient.messages.sendRetraction('contact@example.com', 'original-msg-123')
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const originIdEl = sentStanza.children.find(
@@ -3423,7 +3423,7 @@ describe('XMPPClient Message', () => {
     it('should send stanza with same message ID and not emit chat:message event', async () => {
       await connectClient()
 
-      await xmppClient.chat.resendMessage('contact@example.com', 'Hello again', 'original-msg-id')
+      await xmppClient.messages.resendMessage('contact@example.com', 'Hello again', 'original-msg-id')
 
       // Verify the stanza was sent with the same ID
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -3446,7 +3446,7 @@ describe('XMPPClient Message', () => {
         mimeType: 'application/pdf',
       }
 
-      await xmppClient.chat.resendMessage('contact@example.com', 'Check this', 'msg-with-file', attachment)
+      await xmppClient.messages.resendMessage('contact@example.com', 'Check this', 'msg-with-file', attachment)
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sentStanza.attrs.id).toBe('msg-with-file')
@@ -4268,7 +4268,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
 
     // Should not throw — opportunistic + unverified = silent plaintext fallback.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 
@@ -4277,7 +4277,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = makeE2EEManager({ isVerified: true }) as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow(E2EEEncryptionRequiredError)
   })
 
@@ -4286,7 +4286,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = makeE2EEManager({ policy: 'strict', isVerified: false }) as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow(E2EEEncryptionRequiredError)
   })
 
@@ -4297,7 +4297,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     // A selected plugin failing to encrypt must never fall back to plaintext;
     // the original plugin error propagates so the UI can surface it.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow('plugin boom')
   })
 
@@ -4308,7 +4308,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     // Core downgrade-protection fix: even opportunistic + unverified must NOT
     // silently send plaintext when a selected plugin fails to encrypt.
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).rejects.toThrow('plugin boom')
   })
 
@@ -4321,7 +4321,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = mgr as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 
@@ -4333,7 +4333,7 @@ describe('XMPPClient Message — E2EE downgrade protection', () => {
     xmppClient.e2ee = mgr as any
 
     await expect(
-      xmppClient.chat.sendMessage('bob@example.com', 'hello'),
+      xmppClient.messages.sendMessage('bob@example.com', 'hello'),
     ).resolves.not.toThrow()
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -78,21 +78,21 @@ import type { StanzaClaim } from '../stanzaRouting'
  * chat states (typing indicators), and Message Archive Management (MAM).
  *
  * @remarks
- * This module is accessed via `client.chat` on the XMPPClient instance.
+ * This module is accessed via `client.messages` on the XMPPClient instance.
  * Most methods support both 1:1 chat and groupchat (MUC) message types.
  *
  * @example Sending a message
  * ```typescript
  * // Send a 1:1 message
- * await client.chat.sendMessage('user@example.com', 'Hello!')
+ * await client.messages.sendMessage('user@example.com', 'Hello!')
  *
  * // Send a group chat message
- * await client.chat.sendMessage('room@conference.example.com', 'Hello room!')
+ * await client.messages.sendMessage('room@conference.example.com', 'Hello room!')
  * ```
  *
  * @example Sending a reply
  * ```typescript
- * await client.chat.sendMessage('user@example.com', 'I agree!', {
+ * await client.messages.sendMessage('user@example.com', 'I agree!', {
  *   replyTo: {
  *     id: 'original-message-id',
  *     to: 'user@example.com',
@@ -104,30 +104,30 @@ import type { StanzaClaim } from '../stanzaRouting'
  * @example Typing indicators
  * ```typescript
  * // User is typing
- * await client.chat.sendChatState('user@example.com', 'composing')
+ * await client.messages.sendChatState('user@example.com', 'composing')
  *
  * // User stopped typing
- * await client.chat.sendChatState('user@example.com', 'paused')
+ * await client.messages.sendChatState('user@example.com', 'paused')
  * ```
  *
  * @example Reactions (XEP-0444)
  * ```typescript
- * await client.chat.sendReaction('user@example.com', 'message-id', ['👍', '❤️'])
+ * await client.messages.sendReaction('user@example.com', 'message-id', ['👍', '❤️'])
  * ```
  *
  * @example Message correction (XEP-0308)
  * ```typescript
- * await client.chat.sendCorrection('user@example.com', 'original-id', 'Fixed typo')
+ * await client.messages.sendCorrection('user@example.com', 'original-id', 'Fixed typo')
  * ```
  *
  * @example Message retraction (XEP-0424)
  * ```typescript
- * await client.chat.sendRetraction('user@example.com', 'message-id')
+ * await client.messages.sendRetraction('user@example.com', 'message-id')
  * ```
  *
  * @example Fetching message history (XEP-0313 MAM)
  * ```typescript
- * const result = await client.chat.queryMAM({
+ * const result = await client.messages.queryMAM({
  *   with: 'user@example.com',
  *   max: 50
  * })
@@ -792,12 +792,12 @@ export class Chat extends BaseModule {
    *
    * @example Simple message
    * ```typescript
-   * const msgId = await client.chat.sendMessage('user@example.com', 'Hello!')
+   * const msgId = await client.messages.sendMessage('user@example.com', 'Hello!')
    * ```
    *
    * @example Message with attachment
    * ```typescript
-   * const msgId = await client.chat.sendMessage('user@example.com', 'Check this out', {
+   * const msgId = await client.messages.sendMessage('user@example.com', 'Check this out', {
    *   attachment: {
    *     url: 'https://example.com/file.pdf',
    *     name: 'document.pdf',
@@ -1144,13 +1144,13 @@ export class Chat extends BaseModule {
    * @example
    * ```typescript
    * // User started typing
-   * await client.chat.sendChatState('user@example.com', 'composing')
+   * await client.messages.sendChatState('user@example.com', 'composing')
    *
    * // User paused typing
-   * await client.chat.sendChatState('user@example.com', 'paused')
+   * await client.messages.sendChatState('user@example.com', 'paused')
    *
    * // User is active in the conversation
-   * await client.chat.sendChatState('user@example.com', 'active')
+   * await client.messages.sendChatState('user@example.com', 'active')
    * ```
    *
    * @remarks
@@ -1205,13 +1205,13 @@ export class Chat extends BaseModule {
    * @example
    * ```typescript
    * // Add reactions to a message
-   * await client.chat.sendReaction('user@example.com', 'msg-123', ['👍', '❤️'])
+   * await client.messages.sendReaction('user@example.com', 'msg-123', ['👍', '❤️'])
    *
    * // Remove all your reactions from a message
-   * await client.chat.sendReaction('user@example.com', 'msg-123', [])
+   * await client.messages.sendReaction('user@example.com', 'msg-123', [])
    *
    * // React in a MUC room
-   * await client.chat.sendReaction('room@conference.example.com', 'msg-456', ['🎉'])
+   * await client.messages.sendReaction('room@conference.example.com', 'msg-456', ['🎉'])
    * ```
    */
   async sendReaction(to: string, messageId: string, emojis: string[]): Promise<void> {
@@ -1303,10 +1303,10 @@ export class Chat extends BaseModule {
    * @example
    * ```typescript
    * // Correct a typo in a message
-   * await client.chat.sendCorrection('user@example.com', 'msg-123', 'Fixed the typo')
+   * await client.messages.sendCorrection('user@example.com', 'msg-123', 'Fixed the typo')
    *
    * // Correct a message in a MUC room
-   * await client.chat.sendCorrection('room@conference.example.com', 'msg-456', 'Updated content')
+   * await client.messages.sendCorrection('room@conference.example.com', 'msg-456', 'Updated content')
    * ```
    *
    * @remarks
@@ -1444,10 +1444,10 @@ export class Chat extends BaseModule {
    * @example
    * ```typescript
    * // Retract a message
-   * await client.chat.sendRetraction('user@example.com', 'msg-123')
+   * await client.messages.sendRetraction('user@example.com', 'msg-123')
    *
    * // Retract a message in a MUC room
-   * await client.chat.sendRetraction('room@conference.example.com', 'msg-456')
+   * await client.messages.sendRetraction('room@conference.example.com', 'msg-456')
    * ```
    *
    * @remarks
@@ -1528,10 +1528,10 @@ export class Chat extends BaseModule {
    * @example
    * ```typescript
    * // Send confetti animation
-   * await client.chat.sendEasterEgg('user@example.com', 'confetti')
+   * await client.messages.sendEasterEgg('user@example.com', 'confetti')
    *
    * // Send fireworks in a room
-   * await client.chat.sendEasterEgg('room@conference.example.com', 'fireworks')
+   * await client.messages.sendEasterEgg('room@conference.example.com', 'fireworks')
    * ```
    *
    * @remarks
@@ -1586,7 +1586,7 @@ export class Chat extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.chat.sendLinkPreview('user@example.com', 'msg-123', {
+   * await client.messages.sendLinkPreview('user@example.com', 'msg-123', {
    *   url: 'https://example.com/article',
    *   title: 'Article Title',
    *   description: 'A brief description of the article',
@@ -1661,7 +1661,7 @@ export class Chat extends BaseModule {
    *
    * @example Fetch recent messages
    * ```typescript
-   * const result = await client.chat.queryMAM({
+   * const result = await client.messages.queryMAM({
    *   with: 'user@example.com',
    *   max: 50
    * })
@@ -1671,11 +1671,11 @@ export class Chat extends BaseModule {
    * @example Load older messages (pagination)
    * ```typescript
    * // Initial load
-   * const initial = await client.chat.queryMAM({ with: 'user@example.com' })
+   * const initial = await client.messages.queryMAM({ with: 'user@example.com' })
    *
    * // Load more (older messages)
    * if (!initial.complete && initial.rsm?.first) {
-   *   const older = await client.chat.queryMAM({
+   *   const older = await client.messages.queryMAM({
    *     with: 'user@example.com',
    *     before: initial.rsm.first
    *   })
@@ -1705,7 +1705,7 @@ export class Chat extends BaseModule {
    *
    * @example Fetch recent room messages
    * ```typescript
-   * const result = await client.chat.queryRoomMAM({
+   * const result = await client.messages.queryRoomMAM({
    *   roomJid: 'room@conference.example.com',
    *   max: 50
    * })
@@ -1826,7 +1826,7 @@ export class Chat extends BaseModule {
    * ```typescript
    * declare const at: string
    *
-   * const { messages } = await client.chat.fetchContextAround('room@conference.example.com', at, 50)
+   * const { messages } = await client.messages.fetchContextAround('room@conference.example.com', at, 50)
    * ```
    */
   async fetchContextAround(

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -66,7 +66,7 @@ describe('MUC Whispers', () => {
       const room = createMockRoom('room@conference.example.com', { joined: true, nickname: 'me' })
       vi.mocked(mockStores.room.getRoom).mockReturnValue(room)
 
-      const id = await xmppClient.chat.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
+      const id = await xmppClient.messages.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
 
       expect(typeof id).toBe('string')
       expect(id.length).toBeGreaterThan(0)
@@ -102,7 +102,7 @@ describe('MUC Whispers', () => {
       })
       vi.mocked(mockStores.room.getRoom).mockReturnValue(room)
 
-      await xmppClient.chat.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
+      await xmppClient.messages.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('room:whisper', expect.objectContaining({
         roomJid: 'room@conference.example.com',
@@ -289,7 +289,7 @@ describe('MUC Whispers', () => {
       // Pass the message-id (w-msg-1) to the operation; assert that the protocol
       // reference is the origin-id (w-1). If the code used message-id, this would
       // be 'w-msg-1' and the test would fail — proving origin-id is used.
-      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed secret')
+      await xmppClient.messages.sendCorrection(ROOM, 'w-msg-1', 'fixed secret')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -310,7 +310,7 @@ describe('MUC Whispers', () => {
         nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'm-1', 'hi fixed')
+      await xmppClient.messages.sendCorrection(ROOM, 'm-1', 'hi fixed')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)
@@ -324,7 +324,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       await expect(
-        xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'x'),
+        xmppClient.messages.sendCorrection(ROOM, 'w-msg-1', 'x'),
       ).rejects.toThrow(WhisperCounterpartGoneError)
       expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
     })
@@ -336,7 +336,7 @@ describe('MUC Whispers', () => {
       ])))
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed')
+      await xmppClient.messages.sendCorrection(ROOM, 'w-msg-1', 'fixed')
 
       expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
     })
@@ -347,7 +347,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
-      await xmppClient.chat.sendReaction(ROOM, 'w-msg-1', ['👍'])
+      await xmppClient.messages.sendReaction(ROOM, 'w-msg-1', ['👍'])
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -367,7 +367,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
-      await xmppClient.chat.sendRetraction(ROOM, 'w-msg-1')
+      await xmppClient.messages.sendRetraction(ROOM, 'w-msg-1')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -388,7 +388,7 @@ describe('MUC Whispers', () => {
         from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendReaction(ROOM, 'm-1', ['👍'])
+      await xmppClient.messages.sendReaction(ROOM, 'm-1', ['👍'])
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)
@@ -406,7 +406,7 @@ describe('MUC Whispers', () => {
         from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
       } as any)
 
-      await xmppClient.chat.sendRetraction(ROOM, 'm-1')
+      await xmppClient.messages.sendRetraction(ROOM, 'm-1')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(ROOM)
@@ -418,7 +418,7 @@ describe('MUC Whispers', () => {
     it('sendWhisperChatState sends a private chat-state to room/nick (muc#user, no-store)', async () => {
       await connectClient()
 
-      await xmppClient.chat.sendWhisperChatState(ROOM, 'bob', 'composing')
+      await xmppClient.messages.sendWhisperChatState(ROOM, 'bob', 'composing')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)

--- a/packages/fluux-sdk/src/core/modules/Discovery.httpupload.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.httpupload.test.ts
@@ -560,7 +560,7 @@ describe('XMPPClient HTTP Upload', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(slotResponse)
 
-      const slot = await xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+      const slot = await xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
 
       expect(slot).toEqual({
         putUrl: 'https://upload.example.com/put/abc123',
@@ -590,7 +590,7 @@ describe('XMPPClient HTTP Upload', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(slotResponse)
 
-      const slot = await xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+      const slot = await xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
 
       expect(slot.headers).toEqual({
         'Authorization': 'Bearer token123',
@@ -612,7 +612,7 @@ describe('XMPPClient HTTP Upload', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(slotResponse)
 
-      await xmppClient.discovery.requestUploadSlot('document.pdf', 5242880, 'application/pdf')
+      await xmppClient.server.requestUploadSlot('document.pdf', 5242880, 'application/pdf')
 
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -638,7 +638,7 @@ describe('XMPPClient HTTP Upload', () => {
 
     it('should throw error when file exceeds max size', async () => {
       await expect(
-        xmppClient.discovery.requestUploadSlot('huge.zip', 100000000, 'application/zip') // 100MB
+        xmppClient.server.requestUploadSlot('huge.zip', 100000000, 'application/zip') // 100MB
       ).rejects.toThrow('File too large')
     })
 
@@ -646,7 +646,7 @@ describe('XMPPClient HTTP Upload', () => {
       mockStores.connection.getHttpUploadService = vi.fn().mockReturnValue(null)
 
       await expect(
-        xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+        xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
       ).rejects.toThrow('HTTP Upload service not available')
     })
 
@@ -654,7 +654,7 @@ describe('XMPPClient HTTP Upload', () => {
       await xmppClient.disconnect()
 
       await expect(
-        xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+        xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
       ).rejects.toThrow('Not connected')
     })
 
@@ -673,7 +673,7 @@ describe('XMPPClient HTTP Upload', () => {
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(invalidSlotResponse)
 
       await expect(
-        xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+        xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
       ).rejects.toThrow('Invalid upload slot response')
     })
 
@@ -682,7 +682,7 @@ describe('XMPPClient HTTP Upload', () => {
 
       // Error instances are re-thrown directly
       await expect(
-        xmppClient.discovery.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
+        xmppClient.server.requestUploadSlot('test.jpg', 1024, 'image/jpeg')
       ).rejects.toThrow('quota-exceeded')
     })
 
@@ -706,7 +706,7 @@ describe('XMPPClient HTTP Upload', () => {
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(slotResponse)
 
       // Should not throw even for large files when no limit is set
-      const slot = await xmppClient.discovery.requestUploadSlot('huge.zip', 500000000, 'application/zip')
+      const slot = await xmppClient.server.requestUploadSlot('huge.zip', 500000000, 'application/zip')
       expect(slot.putUrl).toBeDefined()
     })
   })

--- a/packages/fluux-sdk/src/core/modules/Discovery.mamsearch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.mamsearch.test.ts
@@ -101,7 +101,7 @@ describe('Discovery MAM Search Capability', () => {
     mockXmppClientInstance._emit('online')
     await connectPromise
 
-    await xmppClient.discovery.discoverMAMSearchCapability()
+    await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
     expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: true })
@@ -144,7 +144,7 @@ describe('Discovery MAM Search Capability', () => {
     mockXmppClientInstance._emit('online')
     await connectPromise
 
-    await xmppClient.discovery.discoverMAMSearchCapability()
+    await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
     expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
@@ -173,7 +173,7 @@ describe('Discovery MAM Search Capability', () => {
     mockXmppClientInstance._emit('online')
     await connectPromise
 
-    await xmppClient.discovery.discoverMAMSearchCapability()
+    await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
     expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
@@ -191,7 +191,7 @@ describe('Discovery MAM Search Capability', () => {
     mockXmppClientInstance._emit('online')
     await connectPromise
 
-    await xmppClient.discovery.discoverMAMSearchCapability()
+    await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
     expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
@@ -231,7 +231,7 @@ describe('Discovery MAM Search Capability', () => {
     mockXmppClientInstance._emit('online')
     await connectPromise
 
-    await xmppClient.discovery.discoverMAMSearchCapability()
+    await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
     // Should not be fooled by fulltext in a non-MAM form

--- a/packages/fluux-sdk/src/core/modules/Discovery.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.ts
@@ -47,11 +47,11 @@ export function discoSupportsPep(disco: {
  * @example
  * ```typescript
  * // Access via XMPPClient
- * client.discovery.fetchServerInfo()
- * client.discovery.discoverHttpUploadService()
+ * client.server.fetchServerInfo()
+ * client.server.discoverHttpUploadService()
  *
  * // Request upload slot for file sharing
- * const slot = await client.discovery.requestUploadSlot('photo.jpg', 1024000, 'image/jpeg')
+ * const slot = await client.server.requestUploadSlot('photo.jpg', 1024000, 'image/jpeg')
  * // PUT file to slot.putUrl, then share slot.getUrl in message
  * ```
  *

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -141,7 +141,7 @@ interface UnresolvedModifications {
  *
  * @remarks
  * This module is accessed via `client.mam` on the XMPPClient instance.
- * For convenience, `queryMAM` and `queryRoomMAM` are also available via `client.chat`.
+ * For convenience, `queryMAM` and `queryRoomMAM` are also available via `client.messages`.
  *
  * @example Fetch recent 1:1 messages
  * ```typescript

--- a/packages/fluux-sdk/src/core/modules/MUC.hats.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.hats.test.ts
@@ -147,7 +147,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(hatListResponse([]))
 
-      await xmppClient.muc.listHats('room@conference.example.com')
+      await xmppClient.rooms.listHats('room@conference.example.com')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       expect(sentIq.attrs.to).toBe('room@conference.example.com')
@@ -176,7 +176,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       ])
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const hats = await xmppClient.muc.listHats('room@conference.example.com')
+      const hats = await xmppClient.rooms.listHats('room@conference.example.com')
 
       expect(hats).toHaveLength(2)
       expect(hats[0]).toEqual({ uri: 'http://example.com/hats#moderator', title: 'Moderator', hue: 210 })
@@ -187,7 +187,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(hatListResponse([]))
 
-      const hats = await xmppClient.muc.listHats('room@conference.example.com')
+      const hats = await xmppClient.rooms.listHats('room@conference.example.com')
       expect(hats).toEqual([])
     })
 
@@ -201,7 +201,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       ])
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const hats = await xmppClient.muc.listHats('room@conference.example.com')
+      const hats = await xmppClient.rooms.listHats('room@conference.example.com')
       expect(hats).toHaveLength(1)
       expect(hats[0].title).toBe('Valid')
     })
@@ -214,7 +214,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResultResponse())
 
-      await xmppClient.muc.createHat('room@conference.example.com', 'Speaker', 'http://example.com/hats#speaker', 120)
+      await xmppClient.rooms.createHat('room@conference.example.com', 'Speaker', 'http://example.com/hats#speaker', 120)
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       const command = sentIq.children[0]
@@ -238,7 +238,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResultResponse())
 
-      await xmppClient.muc.createHat('room@conference.example.com', 'Guest', 'http://example.com/hats#guest')
+      await xmppClient.rooms.createHat('room@conference.example.com', 'Guest', 'http://example.com/hats#guest')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       const command = sentIq.children[0]
@@ -253,7 +253,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('forbidden'))
 
       await expect(
-        xmppClient.muc.createHat('room@conference.example.com', 'X', 'urn:x')
+        xmppClient.rooms.createHat('room@conference.example.com', 'X', 'urn:x')
       ).rejects.toThrow('forbidden')
     })
   })
@@ -265,7 +265,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResultResponse())
 
-      await xmppClient.muc.destroyHat('room@conference.example.com', 'http://example.com/hats#old')
+      await xmppClient.rooms.destroyHat('room@conference.example.com', 'http://example.com/hats#old')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       const command = sentIq.children[0]
@@ -285,7 +285,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(hatListResponse([]))
 
-      await xmppClient.muc.listHatAssignments('room@conference.example.com')
+      await xmppClient.rooms.listHatAssignments('room@conference.example.com')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       const command = sentIq.children[0]
@@ -310,7 +310,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       ])
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const assignments = await xmppClient.muc.listHatAssignments('room@conference.example.com')
+      const assignments = await xmppClient.rooms.listHatAssignments('room@conference.example.com')
 
       expect(assignments).toHaveLength(2)
       expect(assignments[0]).toEqual({
@@ -344,7 +344,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       ])
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(response)
 
-      const assignments = await xmppClient.muc.listHatAssignments('room@conference.example.com')
+      const assignments = await xmppClient.rooms.listHatAssignments('room@conference.example.com')
       expect(assignments).toHaveLength(1)
       expect(assignments[0].jid).toBe('alice@example.com')
     })
@@ -357,7 +357,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResultResponse())
 
-      await xmppClient.muc.assignHat('room@conference.example.com', 'alice@example.com', 'urn:hat:mod')
+      await xmppClient.rooms.assignHat('room@conference.example.com', 'alice@example.com', 'urn:hat:mod')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       expect(sentIq.attrs.to).toBe('room@conference.example.com')
@@ -461,7 +461,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
         .mockResolvedValueOnce(serverForm)
         .mockResolvedValueOnce(completedResponse)
 
-      await xmppClient.muc.assignHat(
+      await xmppClient.rooms.assignHat(
         'room@conference.example.com',
         'user@example.com',
         'xmpp:process-one:devteam',
@@ -514,7 +514,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
         .mockResolvedValueOnce(serverForm)
         .mockResolvedValueOnce(emptyResultResponse())
 
-      await xmppClient.muc.destroyHat('room@conference.example.com', 'urn:hat:mod')
+      await xmppClient.rooms.destroyHat('room@conference.example.com', 'urn:hat:mod')
 
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(2)
 
@@ -545,7 +545,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
         .mockResolvedValueOnce(serverForm)
         .mockResolvedValueOnce(emptyResultResponse())
 
-      await xmppClient.muc.createHat('room@conference.example.com', 'Moderator', 'urn:hat:mod', 210)
+      await xmppClient.rooms.createHat('room@conference.example.com', 'Moderator', 'urn:hat:mod', 210)
 
       const fieldMap = submittedFields(1)
       expect(fieldMap).not.toBeNull()
@@ -569,7 +569,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
         .mockResolvedValueOnce(serverForm)
         .mockResolvedValueOnce(emptyResultResponse())
 
-      await xmppClient.muc.assignHat(
+      await xmppClient.rooms.assignHat(
         'room@conference.example.com',
         'user@example.com',
         'urn:hat:mod',
@@ -589,7 +589,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResultResponse())
 
-      await xmppClient.muc.unassignHat('room@conference.example.com', 'bob@example.com', 'urn:hat:mod')
+      await xmppClient.rooms.unassignHat('room@conference.example.com', 'bob@example.com', 'urn:hat:mod')
 
       const sentIq = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
       const command = sentIq.children[0]
@@ -607,7 +607,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('not-allowed'))
 
       await expect(
-        xmppClient.muc.unassignHat('room@conference.example.com', 'bob@example.com', 'urn:hat:mod')
+        xmppClient.rooms.unassignHat('room@conference.example.com', 'bob@example.com', 'urn:hat:mod')
       ).rejects.toThrow('not-allowed')
     })
   })
@@ -620,7 +620,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       // A server that accepts the IQ and simply never answers.
       mockXmppClientInstance.iqCaller.request.mockReturnValue(new Promise(() => {}))
 
-      const pending = xmppClient.muc.destroyHat('room@conference.example.com', 'urn:hat:mod')
+      const pending = xmppClient.rooms.destroyHat('room@conference.example.com', 'urn:hat:mod')
       const outcome = pending.then(() => 'resolved', (err: unknown) => err)
 
       // Still pending just before the budget elapses...
@@ -656,7 +656,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
         })
         .mockReturnValueOnce(new Promise(() => {}))
 
-      const outcome = xmppClient.muc
+      const outcome = xmppClient.rooms
         .destroyHat('room@conference.example.com', 'urn:hat:mod')
         .then(() => 'resolved', (err: unknown) => err)
 
@@ -678,7 +678,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       })
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(stanzaError)
 
-      const err = await xmppClient.muc
+      const err = await xmppClient.rooms
         .destroyHat('room@conference.example.com', 'urn:hat:mod')
         .catch((e: unknown) => e)
 
@@ -692,7 +692,7 @@ describe('MUC Hat Management (XEP-0317)', () => {
       await connectClient()
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('Not connected'))
 
-      const err = await xmppClient.muc
+      const err = await xmppClient.rooms
         .createHat('room@conference.example.com', 'Mod', 'urn:hat:mod')
         .catch((e: unknown) => e)
 

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -57,16 +57,16 @@ import type { StanzaClaim } from '../stanzaRouting'
  * persistent room bookmarks.
  *
  * @remarks
- * This module is accessed via `client.muc` on the XMPPClient instance.
+ * This module is accessed via `client.rooms` on the XMPPClient instance.
  *
  * @example Joining a room
  * ```typescript
- * await client.muc.joinRoom('room@conference.example.com', 'MyNickname')
+ * await client.rooms.joinRoom('room@conference.example.com', 'MyNickname')
  * ```
  *
  * @example Creating a quick chat (temporary room)
  * ```typescript
- * const roomJid = await client.muc.createQuickChat('MyNick', 'Discussion topic', [
+ * const roomJid = await client.rooms.createQuickChat('MyNick', 'Discussion topic', [
  *   'alice@example.com',
  *   'bob@example.com'
  * ])
@@ -75,22 +75,22 @@ import type { StanzaClaim } from '../stanzaRouting'
  * @example Managing bookmarks
  * ```typescript
  * // Fetch all bookmarks
- * const { roomsToAutojoin } = await client.muc.fetchBookmarks()
+ * const { roomsToAutojoin } = await client.rooms.fetchBookmarks()
  *
  * // Add a bookmark with autojoin
- * await client.muc.setBookmark('room@conference.example.com', {
+ * await client.rooms.setBookmark('room@conference.example.com', {
  *   name: 'Team Chat',
  *   nick: 'Me',
  *   autojoin: true
  * })
  *
  * // Remove a bookmark
- * await client.muc.removeBookmark('room@conference.example.com')
+ * await client.rooms.removeBookmark('room@conference.example.com')
  * ```
  *
  * @example Inviting users
  * ```typescript
- * await client.muc.inviteToRoom('room@conference.example.com', 'user@example.com', 'Join us!')
+ * await client.rooms.inviteToRoom('room@conference.example.com', 'user@example.com', 'Join us!')
  * ```
  *
  * @category Core
@@ -718,10 +718,10 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Basic join
-   * await client.muc.joinRoom('room@conference.example.com', 'MyNick')
+   * await client.rooms.joinRoom('room@conference.example.com', 'MyNick')
    *
    * // Join with password and limited history
-   * await client.muc.joinRoom('private@conference.example.com', 'MyNick', {
+   * await client.rooms.joinRoom('private@conference.example.com', 'MyNick', {
    *   password: 'secret',
    *   maxHistory: 10
    * })
@@ -889,7 +889,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.leaveRoom('room@conference.example.com')
+   * await client.rooms.leaveRoom('room@conference.example.com')
    * ```
    *
    * @remarks
@@ -1069,10 +1069,10 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Simple invitation
-   * await client.muc.inviteToRoom('room@conference.example.com', 'user@example.com')
+   * await client.rooms.inviteToRoom('room@conference.example.com', 'user@example.com')
    *
    * // Invitation with reason and password
-   * await client.muc.inviteToRoom('private@conference.example.com', 'user@example.com',
+   * await client.rooms.inviteToRoom('private@conference.example.com', 'user@example.com',
    *   'Join our meeting!', 'room-password')
    * ```
    */
@@ -1102,7 +1102,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.sendMediatedInvitation(
+   * await client.rooms.sendMediatedInvitation(
    *   'quickchat-xyz@conference.example.com',
    *   'user@example.com',
    *   'Quick discussion',
@@ -1145,7 +1145,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.sendMediatedInvitations(
+   * await client.rooms.sendMediatedInvitations(
    *   'room@conference.example.com',
    *   ['alice@example.com', 'bob@example.com', 'carol@example.com'],
    *   'Team meeting'
@@ -1168,7 +1168,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * const mucService = await client.muc.discoverMucService()
+   * const mucService = await client.rooms.discoverMucService()
    * if (mucService) {
    *   console.log(`MUC service available at: ${mucService}`)
    * }
@@ -1234,7 +1234,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * const features = await client.muc.queryRoomFeatures('room@conference.example.com')
+   * const features = await client.rooms.queryRoomFeatures('room@conference.example.com')
    * if (features?.supportsMAM) {
    *   console.log('Room archives messages via MAM')
    * }
@@ -1366,13 +1366,13 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Create a quick chat with some contacts
-   * const roomJid = await client.muc.createQuickChat('Me', 'Project discussion', [
+   * const roomJid = await client.rooms.createQuickChat('Me', 'Project discussion', [
    *   'alice@example.com',
    *   'bob@example.com'
    * ])
    *
    * // Create a solo quick chat (invite others later)
-   * const soloRoomJid = await client.muc.createQuickChat('Me', 'Notes')
+   * const soloRoomJid = await client.rooms.createQuickChat('Me', 'Notes')
    * ```
    *
    * @remarks
@@ -1505,7 +1505,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.submitRoomConfig('room@conference.example.com', {
+   * await client.rooms.submitRoomConfig('room@conference.example.com', {
    *   'muc#roomconfig_roomname': 'New Room Name',
    *   'muc#roomconfig_persistentroom': '1',
    *   'muc#roomconfig_publicroom': '0',
@@ -1557,7 +1557,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.setSubject('room@conference.example.com', 'New topic for discussion')
+   * await client.rooms.setSubject('room@conference.example.com', 'New topic for discussion')
    * ```
    */
   /**
@@ -1571,7 +1571,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.resync()
+   * await client.rooms.resync()
    * ```
    */
   async resync(options: { days?: number; concurrency?: number } = {}): Promise<void> {
@@ -1607,7 +1607,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.createRoom(
+   * await client.rooms.createRoom(
    *   'team@conference.example.com',
    *   'MyNick',
    *   { name: 'Team Chat', description: 'Our team room', membersOnly: true },
@@ -1681,7 +1681,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.destroyRoom('old-room@conference.example.com', 'Moving to new room')
+   * await client.rooms.destroyRoom('old-room@conference.example.com', 'Moving to new room')
    * ```
    */
   async destroyRoom(roomJid: string, reason?: string, alternateRoomJid?: string): Promise<void> {
@@ -1782,10 +1782,10 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Enable notifications for all messages (session only)
-   * await client.muc.setRoomNotifyAll('room@conference.example.com', true)
+   * await client.rooms.setRoomNotifyAll('room@conference.example.com', true)
    *
    * // Enable and save to bookmark
-   * await client.muc.setRoomNotifyAll('room@conference.example.com', true, true)
+   * await client.rooms.setRoomNotifyAll('room@conference.example.com', true, true)
    * ```
    */
   async setRoomNotifyAll(roomJid: string, notifyAll: boolean, persistent: boolean = false): Promise<void> {
@@ -1820,11 +1820,11 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * const { roomsToAutojoin, allRoomJids } = await client.muc.fetchBookmarks()
+   * const { roomsToAutojoin, allRoomJids } = await client.rooms.fetchBookmarks()
    *
    * // Auto-join bookmarked rooms
    * for (const room of roomsToAutojoin) {
-   *   await client.muc.joinRoom(room.jid, room.nick, { password: room.password })
+   *   await client.rooms.joinRoom(room.jid, room.nick, { password: room.password })
    * }
    *
    * console.log(`Loaded ${allRoomJids.length} bookmarked rooms`)
@@ -1930,14 +1930,14 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Bookmark with autojoin
-   * await client.muc.setBookmark('team@conference.example.com', {
+   * await client.rooms.setBookmark('team@conference.example.com', {
    *   name: 'Team Chat',
    *   nick: 'Me',
    *   autojoin: true
    * })
    *
    * // Bookmark a private room
-   * await client.muc.setBookmark('private@conference.example.com', {
+   * await client.rooms.setBookmark('private@conference.example.com', {
    *   name: 'Private Room',
    *   nick: 'Me',
    *   password: 'secret',
@@ -2011,7 +2011,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * await client.muc.removeBookmark('room@conference.example.com')
+   * await client.rooms.removeBookmark('room@conference.example.com')
    * ```
    *
    * @remarks
@@ -2046,7 +2046,7 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Typically called during reconnection
-   * await client.muc.rejoinActiveRooms([
+   * await client.rooms.rejoinActiveRooms([
    *   { jid: 'room1@conference.example.com', nickname: 'Me' },
    *   { jid: 'room2@conference.example.com', nickname: 'Me', password: 'pass' }
    * ])
@@ -2082,11 +2082,11 @@ export class MUC extends BaseModule {
    * @example
    * ```typescript
    * // Fetch first page of rooms
-   * const { rooms, pagination } = await client.muc.fetchRoomList('conference.example.com', { max: 20 })
+   * const { rooms, pagination } = await client.rooms.fetchRoomList('conference.example.com', { max: 20 })
    *
    * // Fetch next page
    * if (pagination?.last) {
-   *   const nextPage = await client.muc.fetchRoomList('conference.example.com', {
+   *   const nextPage = await client.rooms.fetchRoomList('conference.example.com', {
    *     max: 20,
    *     after: pagination.last
    *   })
@@ -2138,7 +2138,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * const options = await client.muc.fetchRoomOptions('room@conference.example.com')
+   * const options = await client.rooms.fetchRoomOptions('room@conference.example.com')
    * if (options) {
    *   console.log('Room name:', options['muc#roomconfig_roomname'])
    *   console.log('Persistent:', options['muc#roomconfig_persistentroom'])
@@ -2188,7 +2188,7 @@ export class MUC extends BaseModule {
    *
    * @example
    * ```typescript
-   * const members = await client.muc.queryRoomMembers('room@conference.example.com')
+   * const members = await client.rooms.queryRoomMembers('room@conference.example.com')
    * for (const member of members) {
    *   console.log(`${member.nick || member.jid}: ${member.affiliation}`)
    * }

--- a/packages/fluux-sdk/src/core/modules/Poll.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Poll.test.ts
@@ -223,7 +223,7 @@ describe('Poll module', () => {
   describe('vote', () => {
     it('should delegate to chat.sendReaction in single-vote mode', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -243,7 +243,7 @@ describe('Poll module', () => {
 
     it('should enforce single-vote: remove previous poll vote', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -263,7 +263,7 @@ describe('Poll module', () => {
 
     it('should preserve non-poll reactions in single-vote mode', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -283,7 +283,7 @@ describe('Poll module', () => {
 
     it('should toggle off vote in single-vote mode', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -303,7 +303,7 @@ describe('Poll module', () => {
 
     it('should toggle vote in multi-vote mode', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -324,7 +324,7 @@ describe('Poll module', () => {
 
     it('should toggle off in multi-vote mode', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -560,7 +560,7 @@ describe('Poll module', () => {
 
     it('should allow vote on poll with future deadline', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -579,7 +579,7 @@ describe('Poll module', () => {
 
     it('should allow vote on poll without deadline', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -675,7 +675,7 @@ describe('Poll module', () => {
   describe('vote edge cases', () => {
     it('should reject vote with emoji not in poll options', async () => {
       await connectClient()
-      vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -694,7 +694,7 @@ describe('Poll module', () => {
 
     it('should handle voting on closed poll (already closed by closePoll)', async () => {
       await connectClient()
-      vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       // closePoll marks the poll as closed in localPolls, but vote() receives
       // PollData directly — it doesn't check localPolls. This test documents
@@ -710,12 +710,12 @@ describe('Poll module', () => {
 
       // Vote should succeed — poll module only checks deadline, not closed state
       await xmppClient.poll.vote('room@conf.example.com', 'msg-1', '1️⃣', [], poll)
-      expect(xmppClient.chat.sendReaction).toHaveBeenCalled()
+      expect(xmppClient.messages.sendReaction).toHaveBeenCalled()
     })
 
     it('should reject vote when isClosed=true is passed', async () => {
       await connectClient()
-      vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',
@@ -733,7 +733,7 @@ describe('Poll module', () => {
 
     it('should allow vote when isClosed is undefined', async () => {
       await connectClient()
-      const sendReactionSpy = vi.spyOn(xmppClient.chat, 'sendReaction').mockResolvedValue()
+      const sendReactionSpy = vi.spyOn(xmppClient.messages, 'sendReaction').mockResolvedValue()
 
       const poll = {
         title: 'Q?',

--- a/packages/fluux-sdk/src/core/modules/Presence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Presence.test.ts
@@ -456,8 +456,8 @@ describe('XMPPClient Presence', () => {
 
     it('fails the join on a 401 instead of leaving it pending', async () => {
       await connectClient()
-      await xmppClient.muc.joinRoom('secret@conference.example.com', 'mynick')
-      const result = xmppClient.muc.joinResult('secret@conference.example.com')
+      await xmppClient.rooms.joinRoom('secret@conference.example.com', 'mynick')
+      const result = xmppClient.rooms.joinResult('secret@conference.example.com')
 
       mockXmppClientInstance._emit(
         'stanza',
@@ -471,8 +471,8 @@ describe('XMPPClient Presence', () => {
 
     it('fails the join on a nickname conflict', async () => {
       await connectClient()
-      await xmppClient.muc.joinRoom('room@conference.example.com', 'taken')
-      const result = xmppClient.muc.joinResult('room@conference.example.com')
+      await xmppClient.rooms.joinRoom('room@conference.example.com', 'taken')
+      const result = xmppClient.rooms.joinResult('room@conference.example.com')
 
       mockXmppClientInstance._emit(
         'stanza',
@@ -1705,7 +1705,7 @@ describe('XMPPClient Presence', () => {
       mockPresence.getStatusMessage.mockReturnValue('Busy')
 
       // Join a room
-      await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')
+      await xmppClient.rooms.joinRoom('room@conference.example.com', 'testnick')
 
       // Find the join presence stanza
       const sendCalls = mockXmppClientInstance.send.mock.calls
@@ -1737,7 +1737,7 @@ describe('XMPPClient Presence', () => {
       mockPresence.getStatusMessage.mockReturnValue(null)
 
       // Join a room
-      await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')
+      await xmppClient.rooms.joinRoom('room@conference.example.com', 'testnick')
 
       // Find the join presence stanza
       const sendCalls = mockXmppClientInstance.send.mock.calls
@@ -1764,7 +1764,7 @@ describe('XMPPClient Presence', () => {
       mockPresence.getStatusMessage.mockReturnValue(null)
 
       // Join a room
-      await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')
+      await xmppClient.rooms.joinRoom('room@conference.example.com', 'testnick')
 
       // Find the join presence stanza
       const sendCalls = mockXmppClientInstance.send.mock.calls
@@ -1796,7 +1796,7 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance.send.mockClear()
 
       // Send presence update to rooms
-      await xmppClient.muc.sendPresenceToRooms('dnd', 'In a meeting')
+      await xmppClient.rooms.sendPresenceToRooms('dnd', 'In a meeting')
 
       const sendCalls = mockXmppClientInstance.send.mock.calls
 
@@ -1833,7 +1833,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance.send.mockClear()
 
-      await xmppClient.muc.sendPresenceToRooms('online')
+      await xmppClient.rooms.sendPresenceToRooms('online')
 
       const sendCalls = mockXmppClientInstance.send.mock.calls
       expect(sendCalls).toHaveLength(1)
@@ -1855,7 +1855,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance.send.mockClear()
 
-      await xmppClient.muc.sendPresenceToRooms('away')
+      await xmppClient.rooms.sendPresenceToRooms('away')
 
       const sendCalls = mockXmppClientInstance.send.mock.calls
       // Should only send to room1 (room2 is still joining)
@@ -1926,7 +1926,7 @@ describe('XMPPClient Presence', () => {
       mockStores.connection.getStatus.mockReturnValue('online')
 
       // Spy on the roster.setPresence method
-      const setPresenceSpy = vi.spyOn(xmppClient.roster, 'setPresence').mockResolvedValue()
+      const setPresenceSpy = vi.spyOn(xmppClient.contacts, 'setPresence').mockResolvedValue()
 
       ;(xmppClient as any).setupPresenceSync(mockActor as any)
 
@@ -1945,7 +1945,7 @@ describe('XMPPClient Presence', () => {
       mockStores.connection.getStatus.mockReturnValue('online')
 
       // Spy on the roster.setPresence method
-      const setPresenceSpy = vi.spyOn(xmppClient.roster, 'setPresence').mockResolvedValue()
+      const setPresenceSpy = vi.spyOn(xmppClient.contacts, 'setPresence').mockResolvedValue()
 
       ;(xmppClient as any).setupPresenceSync(mockActor as any)
 
@@ -1967,7 +1967,7 @@ describe('XMPPClient Presence', () => {
       mockStores.connection.getStatus.mockReturnValue('disconnected')
 
       // Spy on the roster.setPresence method
-      const setPresenceSpy = vi.spyOn(xmppClient.roster, 'setPresence').mockResolvedValue()
+      const setPresenceSpy = vi.spyOn(xmppClient.contacts, 'setPresence').mockResolvedValue()
 
       ;(xmppClient as any).setupPresenceSync(mockActor as any)
 
@@ -1988,7 +1988,7 @@ describe('XMPPClient Presence', () => {
       mockStores.connection.getStatus.mockReturnValue('online')
 
       // Spy on the roster.setPresence method
-      const setPresenceSpy = vi.spyOn(xmppClient.roster, 'setPresence').mockResolvedValue()
+      const setPresenceSpy = vi.spyOn(xmppClient.contacts, 'setPresence').mockResolvedValue()
 
       ;(xmppClient as any).setupPresenceSync(mockActor as any)
 
@@ -2011,7 +2011,7 @@ describe('XMPPClient Presence', () => {
       mockStores.connection.getStatus.mockReturnValue('online')
 
       // Spy on the roster.setPresence method
-      const setPresenceSpy = vi.spyOn(xmppClient.roster, 'setPresence').mockResolvedValue()
+      const setPresenceSpy = vi.spyOn(xmppClient.contacts, 'setPresence').mockResolvedValue()
 
       ;(xmppClient as any).setupPresenceSync(mockActor as any)
 

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -77,14 +77,14 @@ describe('XMPPClient Roster', () => {
 
   describe('addContact', () => {
     it('should throw error when not connected', async () => {
-      await expect(xmppClient.roster.addContact('contact@example.com')).rejects.toThrow('Not connected')
+      await expect(xmppClient.contacts.addContact('contact@example.com')).rejects.toThrow('Not connected')
     })
 
     it('should send subscribe presence without nickname', async () => {
       await connectClient()
 
       // Add contact without nickname
-      await xmppClient.roster.addContact('contact@example.com')
+      await xmppClient.contacts.addContact('contact@example.com')
 
       // Should have sent exactly one stanza (subscribe presence)
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -99,7 +99,7 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Add contact with nickname
-      await xmppClient.roster.addContact('contact@example.com', 'My Friend')
+      await xmppClient.contacts.addContact('contact@example.com', 'My Friend')
 
       // Should have sent two stanzas
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
@@ -125,7 +125,7 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Add contact with empty nickname
-      await xmppClient.roster.addContact('contact@example.com', '')
+      await xmppClient.contacts.addContact('contact@example.com', '')
 
       // Should have sent only one stanza (subscribe presence)
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -138,14 +138,14 @@ describe('XMPPClient Roster', () => {
 
   describe('acceptSubscription', () => {
     it('should throw error when not connected', async () => {
-      await expect(xmppClient.roster.acceptSubscription('contact@example.com')).rejects.toThrow('Not connected')
+      await expect(xmppClient.contacts.acceptSubscription('contact@example.com')).rejects.toThrow('Not connected')
     })
 
     it('should send subscribed and subscribe presence', async () => {
       await connectClient()
 
       // Accept subscription
-      await xmppClient.roster.acceptSubscription('contact@example.com')
+      await xmppClient.contacts.acceptSubscription('contact@example.com')
 
       // Should have sent two stanzas
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
@@ -167,7 +167,7 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Accept subscription
-      await xmppClient.roster.acceptSubscription('contact@example.com')
+      await xmppClient.contacts.acceptSubscription('contact@example.com')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('events:subscription-request-removed', { from: 'contact@example.com' })
     })
@@ -175,14 +175,14 @@ describe('XMPPClient Roster', () => {
 
   describe('rejectSubscription', () => {
     it('should throw error when not connected', async () => {
-      await expect(xmppClient.roster.rejectSubscription('contact@example.com')).rejects.toThrow('Not connected')
+      await expect(xmppClient.contacts.rejectSubscription('contact@example.com')).rejects.toThrow('Not connected')
     })
 
     it('should send unsubscribed presence', async () => {
       await connectClient()
 
       // Reject subscription
-      await xmppClient.roster.rejectSubscription('contact@example.com')
+      await xmppClient.contacts.rejectSubscription('contact@example.com')
 
       // Should have sent one stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -197,7 +197,7 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Reject subscription
-      await xmppClient.roster.rejectSubscription('contact@example.com')
+      await xmppClient.contacts.rejectSubscription('contact@example.com')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('events:subscription-request-removed', { from: 'contact@example.com' })
     })
@@ -205,14 +205,14 @@ describe('XMPPClient Roster', () => {
 
   describe('renameContact', () => {
     it('should throw error when not connected', async () => {
-      await expect(xmppClient.roster.renameContact('contact@example.com', 'New Name')).rejects.toThrow('Not connected')
+      await expect(xmppClient.contacts.renameContact('contact@example.com', 'New Name')).rejects.toThrow('Not connected')
     })
 
     it('should send roster set IQ with new name', async () => {
       await connectClient()
 
       // Rename contact
-      await xmppClient.roster.renameContact('contact@example.com', 'New Display Name')
+      await xmppClient.contacts.renameContact('contact@example.com', 'New Display Name')
 
       // Should have sent one stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -230,14 +230,14 @@ describe('XMPPClient Roster', () => {
 
   describe('removeContact', () => {
     it('should throw error when not connected', async () => {
-      await expect(xmppClient.roster.removeContact('contact@example.com')).rejects.toThrow('Not connected')
+      await expect(xmppClient.contacts.removeContact('contact@example.com')).rejects.toThrow('Not connected')
     })
 
     it('should send roster remove IQ', async () => {
       await connectClient()
 
       // Remove contact
-      await xmppClient.roster.removeContact('contact@example.com')
+      await xmppClient.contacts.removeContact('contact@example.com')
 
       // Should have sent one stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -425,7 +425,7 @@ describe('XMPPClient Roster', () => {
       await connectPromise
       vi.clearAllMocks()
 
-      await xmppClient.roster.setPresence('away', 'Be right back')
+      await xmppClient.contacts.setPresence('away', 'Be right back')
 
       // Find the presence stanza
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -466,7 +466,7 @@ describe('XMPPClient Roster', () => {
       const machineSend = vi.spyOn(xmppClient.presenceActor, 'send')
 
       // Call setPresence (as setupPresenceSync does when machine state changes)
-      await xmppClient.roster.setPresence('away', 'Auto away')
+      await xmppClient.contacts.setPresence('away', 'Auto away')
 
       // Verify presence was sent
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -489,7 +489,7 @@ describe('XMPPClient Roster', () => {
         machineSend.mockClear()
         vi.mocked(mockXmppClientInstance.send).mockClear()
 
-        await xmppClient.roster.setPresence(show, 'Status message')
+        await xmppClient.contacts.setPresence(show, 'Status message')
 
         // Verify presence was sent
         expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -514,7 +514,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue('online')
       mockPresence.getPreAutoAwayStatusMessage.mockReturnValue(null)
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should send presence WITHOUT <show> element (which means 'online')
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -543,7 +543,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue('online')
       mockPresence.getPreAutoAwayStatusMessage.mockReturnValue(null)
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should restore to online (not preserve 'away')
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -567,7 +567,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue(null)
       mockPresence.getStatusMessage.mockReturnValue('Out for lunch')
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should default to 'online' (no show element in XMPP)
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -585,7 +585,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue('online')
       mockPresence.getStatusMessage.mockReturnValue('In a meeting')
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should preserve 'dnd' status
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -605,7 +605,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue('away')
       mockPresence.getPreAutoAwayStatusMessage.mockReturnValue('Be right back')
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should restore to 'away' (the saved status)
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -629,7 +629,7 @@ describe('XMPPClient Roster', () => {
       mockPresence.getPreAutoAwayState.mockReturnValue(null)
       mockPresence.getStatusMessage.mockReturnValue(null)
 
-      await xmppClient.roster.sendInitialPresence()
+      await xmppClient.contacts.sendInitialPresence()
 
       // Should send presence WITHOUT <show> element
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
@@ -992,7 +992,7 @@ describe('XMPPClient Roster', () => {
           presence: 'offline',
         })
 
-        await xmppClient.roster.rejectSubscription('requester@example.com')
+        await xmppClient.contacts.rejectSubscription('requester@example.com')
 
         // Should have sent 2 stanzas: unsubscribed + roster remove
         expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
@@ -1017,7 +1017,7 @@ describe('XMPPClient Roster', () => {
           presence: 'offline',
         })
 
-        await xmppClient.roster.rejectSubscription('requester@example.com')
+        await xmppClient.contacts.rejectSubscription('requester@example.com')
 
         // Should only send unsubscribed, not roster remove
         expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -35,10 +35,10 @@ import type { StanzaClaim } from '../stanzaRouting'
  * @example
  * ```typescript
  * // Access via XMPPClient
- * client.roster.addContact('user@example.com', 'Display Name')
- * client.roster.removeContact('user@example.com')
- * client.roster.setPresence('away', 'Be right back')
- * client.roster.acceptSubscription('user@example.com')
+ * client.contacts.addContact('user@example.com', 'Display Name')
+ * client.contacts.removeContact('user@example.com')
+ * client.contacts.setPresence('away', 'Be right back')
+ * client.contacts.acceptSubscription('user@example.com')
  * ```
  *
  * @category Modules

--- a/packages/fluux-sdk/src/core/modules/WebPush.test.ts
+++ b/packages/fluux-sdk/src/core/modules/WebPush.test.ts
@@ -96,7 +96,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(servicesResponse)
 
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
 
       // IQ must not include a 'to' attribute — server handles it itself
       const sentIQ = mockXmppClientInstance.iqCaller.request.mock.calls[0][0]
@@ -125,7 +125,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(servicesResponse)
 
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
 
       expect(services).toHaveLength(2)
       expect(services[0].appId).toBe('app1')
@@ -147,7 +147,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(servicesResponse)
 
-      await xmppClient.webPush.queryServices()
+      await xmppClient.push.queryServices()
 
       expect(emitSDKSpy).toHaveBeenCalledWith('connection:webpush-services', {
         services: [{ vapidKey: 'VAPID_KEY', appId: 'test' }],
@@ -160,7 +160,7 @@ describe('WebPush Module', () => {
       const emptyResponse = createMockElement('iq', { type: 'result' })
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(emptyResponse)
 
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
 
       expect(services).toEqual([])
     })
@@ -182,7 +182,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(servicesResponse)
 
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
 
       expect(services).toHaveLength(1)
       expect(services[0].appId).toBe('valid')
@@ -193,7 +193,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('Service unavailable'))
 
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
 
       expect(services).toEqual([])
       expect(emitSDKSpy).toHaveBeenCalledWith('connection:webpush-services', { services: [] })
@@ -201,7 +201,7 @@ describe('WebPush Module', () => {
 
     it('should return empty array when not connected', async () => {
       // Don't connect - JID is null
-      const services = await xmppClient.webPush.queryServices()
+      const services = await xmppClient.push.queryServices()
       expect(services).toEqual([])
     })
 
@@ -220,7 +220,7 @@ describe('WebPush Module', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(servicesResponse)
 
-      await xmppClient.webPush.queryServices()
+      await xmppClient.push.queryServices()
 
       expect(emitSDKSpy).toHaveBeenCalledWith('console:event', {
         message: expect.stringContaining('1 VAPID service(s) available'),
@@ -237,7 +237,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.registerSubscription(
+      await xmppClient.push.registerSubscription(
         'https://fcm.googleapis.com/fcm/send/abc123',
         'p256dh_key_value',
         'auth_secret_value',
@@ -288,7 +288,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.registerSubscription(
+      await xmppClient.push.registerSubscription(
         'https://fcm.googleapis.com/fcm/send/abc123',
         'p256dh_key',
         'auth_key',
@@ -307,7 +307,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.registerSubscription(
+      await xmppClient.push.registerSubscription(
         'https://fcm.googleapis.com/fcm/send/abc123',
         'p256dh_key',
         'auth_key',
@@ -326,7 +326,7 @@ describe('WebPush Module', () => {
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('Forbidden'))
 
       await expect(
-        xmppClient.webPush.registerSubscription(
+        xmppClient.push.registerSubscription(
           'https://fcm.googleapis.com/fcm/send/abc123',
           'p256dh_key',
           'auth_key',
@@ -338,7 +338,7 @@ describe('WebPush Module', () => {
     it('should throw when not connected', async () => {
       // Don't connect
       await expect(
-        xmppClient.webPush.registerSubscription(
+        xmppClient.push.registerSubscription(
           'https://fcm.googleapis.com/fcm/send/abc123',
           'p256dh_key',
           'auth_key',
@@ -356,7 +356,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.disableSubscription(
+      await xmppClient.push.disableSubscription(
         'fluux.io',
         'webpush',
         'https://fcm.googleapis.com/fcm/send/abc123#p256dh_key#auth_key'
@@ -395,7 +395,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.disableSubscription(
+      await xmppClient.push.disableSubscription(
         'fluux.io',
         'webpush',
         'endpoint#p256dh#auth'
@@ -413,7 +413,7 @@ describe('WebPush Module', () => {
         createMockElement('iq', { type: 'result' })
       )
 
-      await xmppClient.webPush.disableSubscription(
+      await xmppClient.push.disableSubscription(
         'fluux.io',
         'webpush',
         'endpoint#p256dh#auth'
@@ -431,13 +431,13 @@ describe('WebPush Module', () => {
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('Forbidden'))
 
       await expect(
-        xmppClient.webPush.disableSubscription('fluux.io', 'webpush', 'endpoint#key#auth')
+        xmppClient.push.disableSubscription('fluux.io', 'webpush', 'endpoint#key#auth')
       ).rejects.toThrow('Forbidden')
     })
 
     it('should throw when not connected', async () => {
       await expect(
-        xmppClient.webPush.disableSubscription('fluux.io', 'webpush', 'endpoint#key#auth')
+        xmppClient.push.disableSubscription('fluux.io', 'webpush', 'endpoint#key#auth')
       ).rejects.toThrow('Not connected')
     })
   })

--- a/packages/fluux-sdk/src/core/modules/WebPush.ts
+++ b/packages/fluux-sdk/src/core/modules/WebPush.ts
@@ -28,10 +28,10 @@ import type { WebPushService } from '../types'
  * declare const appId: string
  *
  * // Query available push services
- * const services = await client.webPush.queryServices()
+ * const services = await client.push.queryServices()
  *
  * // Register a push subscription (after PushManager.subscribe())
- * await client.webPush.registerSubscription(endpoint, p256dh, auth, appId)
+ * await client.push.registerSubscription(endpoint, p256dh, auth, appId)
  * ```
  *
  * @category Modules

--- a/packages/fluux-sdk/src/core/networkScenario.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/networkScenario.testHelpers.ts
@@ -86,8 +86,8 @@ export function simulateDisconnect(
 ): void {
   connectionStore.getState().setStatus('reconnecting')
   if (options?.clearMocks) {
-    vi.mocked(client.chat.queryMAM).mockClear()
-    vi.mocked(client.chat.queryRoomMAM).mockClear()
+    vi.mocked(client.messages.queryMAM).mockClear()
+    vi.mocked(client.messages.queryRoomMAM).mockClear()
   }
 }
 

--- a/packages/fluux-sdk/src/core/sideEffectHost.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHost.ts
@@ -108,8 +108,8 @@ export interface SideEffectHost extends SDKEventSource, ClientEventSource {
   retryPendingDecrypts(): Promise<number>
   /** Null until an identity is logged in — every caller must handle that. */
   readonly e2ee: E2EEWarmupHost | null
-  readonly muc: MucSideEffectHost
-  readonly discovery: DiscoverySideEffectHost
+  readonly rooms: MucSideEffectHost
+  readonly server: DiscoverySideEffectHost
   /**
    * The modules the SDK drives rather than offers. Grouped so the client can
    * keep them off its public surface: a consumer has no reason to name MAM,

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -52,10 +52,10 @@ export function createMockClient() {
         discoverNewConversationsFromRoster: vi.fn().mockResolvedValue(undefined),
       },
     },
-    muc: {
+    rooms: {
       queryRoomMembers: vi.fn().mockResolvedValue([]),
     },
-    discovery: {
+    server: {
       discoverMAMSearchCapability: vi.fn().mockResolvedValue(undefined),
     },
     isConnected: vi.fn().mockReturnValue(true),

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -37,7 +37,7 @@ export function createMockClient() {
   const sdkHandlers = new Map<string, Set<(payload: unknown) => void>>()
 
   const client = {
-    chat: {
+    messages: {
       queryMAM: vi.fn().mockResolvedValue(undefined),
       queryRoomMAM: vi.fn().mockResolvedValue(undefined),
     },

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -734,7 +734,7 @@ export const createMockXMPPClientForHooks = () => ({
   sendRawXml: vi.fn(),
 
   // Namespace modules
-  roster: {
+  contacts: {
     addContact: vi.fn(),
     removeContact: vi.fn(),
     renameContact: vi.fn(),
@@ -763,7 +763,7 @@ export const createMockXMPPClientForHooks = () => ({
     clearRoomAvatar: vi.fn(),
     changePassword: vi.fn(),
   },
-  chat: {
+  messages: {
     sendMessage: vi.fn(),
     sendChatState: vi.fn(),
     sendReaction: vi.fn(),
@@ -780,7 +780,7 @@ export const createMockXMPPClientForHooks = () => ({
       catchUpRoomHistory: vi.fn(),
     },
   },
-  muc: {
+  rooms: {
     joinRoom: vi.fn(),
     // Resolves by default: callers that await the join outcome (acceptInvitation)
     // treat a rejection as "the server refused", so the neutral default is success.
@@ -802,7 +802,7 @@ export const createMockXMPPClientForHooks = () => ({
     fetchRoomList: vi.fn(),
     fetchRoomOptions: vi.fn(),
   },
-  discovery: {
+  server: {
     requestUploadSlot: vi.fn(),
   },
   poll: {

--- a/packages/fluux-sdk/src/demo/DemoClient.join.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.join.test.ts
@@ -22,11 +22,11 @@ describe('DemoClient MUC join', () => {
     const client = makeClient()
 
     const roomJid = 'demoroom@conference.fluux.chat'
-    await client.muc.joinRoom(roomJid, 'me')
+    await client.rooms.joinRoom(roomJid, 'me')
 
     // If the demo failed to settle the deferred, this await would never resolve
     // and the test would hit the vitest timeout (i.e. fail loudly).
-    await expect(client.muc.joinResult(roomJid)).resolves.toBeUndefined()
+    await expect(client.rooms.joinResult(roomJid)).resolves.toBeUndefined()
   })
 
   // Issue #1126: the demo simulates a password-protected room so the whole
@@ -42,8 +42,8 @@ describe('DemoClient MUC join', () => {
       const client = makeClient()
       seed(client)
 
-      await client.muc.joinRoom(ROOM, 'me')
-      const result = client.muc.joinResult(ROOM)
+      await client.rooms.joinRoom(ROOM, 'me')
+      const result = client.rooms.joinResult(ROOM)
 
       await expect(result).rejects.toMatchObject({ condition: 'not-authorized' })
       // Not left spinning: the row must become interactive again.
@@ -54,24 +54,24 @@ describe('DemoClient MUC join', () => {
       const client = makeClient()
       seed(client)
 
-      await client.muc.joinRoom(ROOM, 'me', { password: 'nope' })
+      await client.rooms.joinRoom(ROOM, 'me', { password: 'nope' })
 
-      await expect(client.muc.joinResult(ROOM)).rejects.toMatchObject({ condition: 'not-authorized' })
+      await expect(client.rooms.joinResult(ROOM)).rejects.toMatchObject({ condition: 'not-authorized' })
     })
 
     it('accepts the right password and remembers it for the next join', async () => {
       const client = makeClient()
       seed(client)
 
-      await client.muc.joinRoom(ROOM, 'me', { password: 'fluux' })
-      await expect(client.muc.joinResult(ROOM)).resolves.toBeUndefined()
+      await client.rooms.joinRoom(ROOM, 'me', { password: 'fluux' })
+      await expect(client.rooms.joinResult(ROOM)).resolves.toBeUndefined()
 
       // The password that worked is now on the room, so a rejoin needs no prompt.
       await vi.waitFor(() => expect(roomStore.getState().getRoom(ROOM)?.password).toBe('fluux'))
 
-      await client.muc.leaveRoom(ROOM)
-      await client.muc.joinRoom(ROOM, 'me')
-      await expect(client.muc.joinResult(ROOM)).resolves.toBeUndefined()
+      await client.rooms.leaveRoom(ROOM)
+      await client.rooms.joinRoom(ROOM, 'me')
+      await expect(client.rooms.joinResult(ROOM)).resolves.toBeUndefined()
     })
   })
 })

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -754,7 +754,7 @@ export class DemoClient extends XMPPClient {
       // self-presence through muc.handle(), so the success path that normally
       // settles it never runs. Without this, awaiting joinResult() (e.g. in
       // JoinRoomModal) would hang forever in demo mode.
-      this.muc.confirmSimulatedJoin(roomJid)
+      this.rooms.confirmSimulatedJoin(roomJid)
 
       // For a password-protected room, also run the REAL post-join bookkeeping by
       // routing a status-110 self-presence: that is what records the password
@@ -764,7 +764,7 @@ export class DemoClient extends XMPPClient {
       // refuseJoin is: the pending join only exists once joinRoom() resumes.
       if (this.roomPasswords.has(roomJid)) {
         setTimeout(() => {
-          this.muc.handle(this.selfPresence(roomJid, selfOccupant) as unknown as Parameters<typeof this.muc.handle>[0])
+          this.rooms.handle(this.selfPresence(roomJid, selfOccupant) as unknown as Parameters<typeof this.rooms.handle>[0])
         }, 0)
       }
 
@@ -815,7 +815,7 @@ export class DemoClient extends XMPPClient {
       { from: `${roomJid}/${nick}`, to: this.selfJid, type: 'error' },
       [this.mockElement('x', { xmlns: NS_MUC }), error]
     )
-    this.muc.handle(presence as unknown as Parameters<typeof this.muc.handle>[0])
+    this.rooms.handle(presence as unknown as Parameters<typeof this.rooms.handle>[0])
   }
 
   // -------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/hooks/continueCatchUp.cursor.test.tsx
+++ b/packages/fluux-sdk/src/hooks/continueCatchUp.cursor.test.tsx
@@ -61,8 +61,8 @@ const seedRoomMessages = (messages: Array<{ timestamp?: Date; stanzaId?: string 
 }
 
 beforeEach(() => {
-  vi.mocked(mockClient.chat.queryMAM).mockReset().mockResolvedValue(undefined)
-  vi.mocked(mockClient.chat.queryRoomMAM).mockReset().mockResolvedValue(undefined)
+  vi.mocked(mockClient.messages.queryMAM).mockReset().mockResolvedValue(undefined)
+  vi.mocked(mockClient.messages.queryRoomMAM).mockReset().mockResolvedValue(undefined)
   chatStore.setState({
     conversations: new Map(),
     conversationEntities: new Map(),
@@ -110,7 +110,7 @@ describe('continueChatCatchUp cursor selection', () => {
       await result.current.continueChatCatchUp()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({
       with: CONV,
       after: 'gap-id-1',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -130,7 +130,7 @@ describe('continueChatCatchUp cursor selection', () => {
       await result.current.continueChatCatchUp()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({
       with: CONV,
       start: '2026-05-14T09:00:00.000Z',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -149,7 +149,7 @@ describe('continueChatCatchUp cursor selection', () => {
       await result.current.continueChatCatchUp()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({
       with: CONV,
       after: 'newest-id',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -161,14 +161,14 @@ describe('continueChatCatchUp cursor selection', () => {
     chatStore.setState({
       conversationGaps: new Map([[CONV, { start: Date.now(), startId: 'gap-id-1' } as never]]),
     })
-    vi.mocked(mockClient.chat.queryMAM).mockRejectedValue(new Error('boom'))
+    vi.mocked(mockClient.messages.queryMAM).mockRejectedValue(new Error('boom'))
     const { result } = renderHook(() => useChatActive(), { wrapper })
 
     await act(async () => {
       await result.current.continueChatCatchUp()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalled()
+    expect(mockClient.messages.queryMAM).toHaveBeenCalled()
     expect(chatStore.getState().getMAMQueryState(CONV).isLoading).toBe(false)
   })
 })
@@ -184,7 +184,7 @@ describe('continueRoomCatchUp cursor selection', () => {
       await result.current.continueRoomCatchUp()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledWith({
       roomJid: ROOM,
       after: 'gap-id-1',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -203,7 +203,7 @@ describe('continueRoomCatchUp cursor selection', () => {
       await result.current.continueRoomCatchUp()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledWith({
       roomJid: ROOM,
       start: '2026-05-14T09:00:00.000Z',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -222,7 +222,7 @@ describe('continueRoomCatchUp cursor selection', () => {
       await result.current.continueRoomCatchUp()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledWith({
       roomJid: ROOM,
       after: 'newest-id',
       max: MAM_CATCHUP_FORWARD_MAX,
@@ -234,14 +234,14 @@ describe('continueRoomCatchUp cursor selection', () => {
     roomStore.setState({
       roomGaps: new Map([[ROOM, { start: Date.now(), startId: 'gap-id-1' } as never]]),
     })
-    vi.mocked(mockClient.chat.queryRoomMAM).mockRejectedValue(new Error('boom'))
+    vi.mocked(mockClient.messages.queryRoomMAM).mockRejectedValue(new Error('boom'))
     const { result } = renderHook(() => useRoomActive(), { wrapper })
 
     await act(async () => {
       await result.current.continueRoomCatchUp()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalled()
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalled()
     expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/hooks/continueCatchUp.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/continueCatchUp.regression.test.tsx
@@ -44,8 +44,8 @@ describe('continueCatchUp always clears the MAM loading flag', () => {
   const ROOM = 'room@conference.example.com'
 
   beforeEach(() => {
-    vi.mocked(mockClient.chat.queryMAM).mockReset().mockResolvedValue(undefined)
-    vi.mocked(mockClient.chat.queryRoomMAM).mockReset().mockResolvedValue(undefined)
+    vi.mocked(mockClient.messages.queryMAM).mockReset().mockResolvedValue(undefined)
+    vi.mocked(mockClient.messages.queryRoomMAM).mockReset().mockResolvedValue(undefined)
     chatStore.setState({
       conversations: new Map(),
       conversationEntities: new Map(),
@@ -78,7 +78,7 @@ describe('continueCatchUp always clears the MAM loading flag', () => {
       await result.current.continueChatCatchUp()
     })
 
-    expect(mockClient.chat.queryMAM).not.toHaveBeenCalled()
+    expect(mockClient.messages.queryMAM).not.toHaveBeenCalled()
     expect(chatStore.getState().getMAMQueryState(CONV).isLoading).toBe(false)
   })
 
@@ -102,7 +102,7 @@ describe('continueCatchUp always clears the MAM loading flag', () => {
       await result.current.continueRoomCatchUp()
     })
 
-    expect(mockClient.chat.queryRoomMAM).not.toHaveBeenCalled()
+    expect(mockClient.messages.queryRoomMAM).not.toHaveBeenCalled()
     expect(roomStore.getState().getRoomMAMQueryState(ROOM).isLoading).toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
@@ -6,7 +6,7 @@
  * `fetchOlderHistory` must NEVER send a client-generated message id as the RSM
  * `<before>` cursor — the server rejects it with item-not-found and dead-ends
  * "load older history". These tests exercise the real hook wiring
- * (useChat → createFetchOlderHistory → client.chat.queryMAM) to prove the
+ * (useChat → createFetchOlderHistory → client.messages.queryMAM) to prove the
  * cursor is always a server stanzaId, or the id-independent timestamp recovery,
  * but never a client UUID. They fail against the original
  * `messages[0].stanzaId || messages[0].id` cursor.
@@ -69,7 +69,7 @@ const incoming = (id: string, ts: string, stanzaId: string): Message => ({
 
 describe('useChat fetchOlderHistory — MAM cursor regression', () => {
   beforeEach(() => {
-    vi.mocked(mockClient.chat.queryMAM).mockReset().mockResolvedValue(undefined)
+    vi.mocked(mockClient.messages.queryMAM).mockReset().mockResolvedValue(undefined)
   })
 
   it('uses the oldest server stanzaId as the cursor — never the client id — when the oldest message is outgoing', async () => {
@@ -84,10 +84,10 @@ describe('useChat fetchOlderHistory — MAM cursor regression', () => {
       await result.current.fetchOlderHistory()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
     // The client UUID must never be used as a cursor.
-    const before = vi.mocked(mockClient.chat.queryMAM).mock.calls[0][0].before
+    const before = vi.mocked(mockClient.messages.queryMAM).mock.calls[0][0].before
     expect(before).not.toBe('uuid-sent')
   })
 
@@ -104,9 +104,9 @@ describe('useChat fetchOlderHistory — MAM cursor regression', () => {
       await result.current.fetchOlderHistory()
     })
 
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
-    const before = vi.mocked(mockClient.chat.queryMAM).mock.calls[0][0].before
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
+    const before = vi.mocked(mockClient.messages.queryMAM).mock.calls[0][0].before
     expect(before).not.toBe('uuid-sent')
   })
 
@@ -122,14 +122,14 @@ describe('useChat fetchOlderHistory — MAM cursor regression', () => {
     })
 
     // Recovery: query by the `end` timestamp of the oldest message, empty before.
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
-    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.messages.queryMAM).toHaveBeenCalledWith({
       with: CONV,
       end: new Date('2026-06-01T10:00:00Z').toISOString(),
       before: '',
     })
     // No call ever uses a client UUID as `before`.
-    for (const [opts] of vi.mocked(mockClient.chat.queryMAM).mock.calls) {
+    for (const [opts] of vi.mocked(mockClient.messages.queryMAM).mock.calls) {
       expect(['uuid-1', 'uuid-2']).not.toContain(opts.before)
     }
   })

--- a/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
@@ -29,8 +29,8 @@ function wrapper({ children }: { children: ReactNode }) {
  */
 describe('useChatActions.sendMessage (options object)', () => {
   beforeEach(() => {
-    mockClient.chat.sendMessage.mockClear()
-    mockClient.chat.sendMessage.mockResolvedValue('msg-id-1')
+    mockClient.messages.sendMessage.mockClear()
+    mockClient.messages.sendMessage.mockResolvedValue('msg-id-1')
   })
 
   it('sends a plain message with no options at all', async () => {
@@ -40,7 +40,7 @@ describe('useChatActions.sendMessage (options object)', () => {
       await result.current.sendMessage('bob@example.com', 'hi')
     })
 
-    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith('bob@example.com', 'hi', undefined)
+    expect(mockClient.messages.sendMessage).toHaveBeenCalledWith('bob@example.com', 'hi', undefined)
   })
 
   it('passes the options object straight through to the SDK', async () => {
@@ -52,7 +52,7 @@ describe('useChatActions.sendMessage (options object)', () => {
       await result.current.sendMessage('bob@example.com', 'see this', { replyTo, attachment })
     })
 
-    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith('bob@example.com', 'see this', {
+    expect(mockClient.messages.sendMessage).toHaveBeenCalledWith('bob@example.com', 'see this', {
       replyTo,
       attachment,
     })

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -31,7 +31,7 @@ export function useChatActions() {
       // A 1:1 message carries no mentions: those address room occupants.
       options?: Omit<SendMessageOptions, 'references'>
     ): Promise<string> => {
-      return await client.chat.sendMessage(to, body, options)
+      return await client.messages.sendMessage(to, body, options)
     },
     [client]
   )
@@ -71,35 +71,35 @@ export function useChatActions() {
 
   const sendChatState = useCallback(
     async (to: string, state: ChatStateNotification) => {
-      await client.chat.sendChatState(to, state)
+      await client.messages.sendChatState(to, state)
     },
     [client]
   )
 
   const sendReaction = useCallback(
     async (to: string, messageId: string, emojis: string[]) => {
-      await client.chat.sendReaction(to, messageId, emojis)
+      await client.messages.sendReaction(to, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (conversationId: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(conversationId, messageId, newBody, attachment)
+      await client.messages.sendCorrection(conversationId, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (conversationId: string, messageId: string) => {
-      await client.chat.sendRetraction(conversationId, messageId)
+      await client.messages.sendRetraction(conversationId, messageId)
     },
     [client]
   )
 
   const sendEasterEgg = useCallback(
     async (to: string, animation: string) => {
-      await client.chat.sendEasterEgg(to, animation)
+      await client.messages.sendEasterEgg(to, animation)
     },
     [client]
   )
@@ -191,13 +191,13 @@ export function useChatActions() {
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)
           if (conversation) {
-            await client.chat.queryMAM({ with: conversation.id, before: beforeId })
+            await client.messages.queryMAM({ with: conversation.id, before: beforeId })
           }
         },
         queryMAMByEndTime: async (id, endIso) => {
           const conversation = chatStore.getState().conversations.get(id)
           if (conversation) {
-            await client.chat.queryMAM({ with: conversation.id, end: endIso, before: '' })
+            await client.messages.queryMAM({ with: conversation.id, end: endIso, before: '' })
           }
         },
         errorLogPrefix: 'Failed to fetch older chat history',

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -205,7 +205,7 @@ export function useChatActive() {
       // Clear the error before resending
       chatStore.getState().updateMessage(conversationId, messageId, { deliveryError: undefined })
 
-      await client.chat.resendMessage(conversationId, message.body, messageId, message.attachment)
+      await client.messages.resendMessage(conversationId, message.body, messageId, message.attachment)
     },
     [client]
   )
@@ -227,7 +227,7 @@ export function useChatActive() {
         getMessages: (id) => chatStore.getState().messages.get(id) || [],
         getGap: (id) => chatStore.getState().conversationGaps.get(id),
         queryMAM: async (id, options) => {
-          await client.chat.queryMAM({ with: id, ...options })
+          await client.messages.queryMAM({ with: id, ...options })
         },
       }),
     [client]

--- a/packages/fluux-sdk/src/hooks/useConnection.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useConnection.test.tsx
@@ -426,7 +426,7 @@ describe('useConnection hook', () => {
         put: { url: 'https://upload.example.com/put/abc', headers: {} },
         get: 'https://upload.example.com/get/abc',
       }
-      mockClient.discovery.requestUploadSlot.mockResolvedValue(slot)
+      mockClient.server.requestUploadSlot.mockResolvedValue(slot)
 
       await act(async () => {
         const uploadSlot = await result.current.requestUploadSlot(
@@ -437,7 +437,7 @@ describe('useConnection hook', () => {
         expect(uploadSlot).toEqual(slot)
       })
 
-      expect(mockClient.discovery.requestUploadSlot).toHaveBeenCalledWith('photo.jpg', 1024, 'image/jpeg')
+      expect(mockClient.server.requestUploadSlot).toHaveBeenCalledWith('photo.jpg', 1024, 'image/jpeg')
     })
   })
 
@@ -445,7 +445,7 @@ describe('useConnection hook', () => {
     it('should call client.sendLinkPreview for chat', async () => {
       const { result } = renderHook(() => useConnection(), { wrapper })
 
-      mockClient.chat.sendLinkPreview.mockResolvedValue(undefined)
+      mockClient.messages.sendLinkPreview.mockResolvedValue(undefined)
 
       const preview = {
         url: 'https://example.com/article',
@@ -461,7 +461,7 @@ describe('useConnection hook', () => {
         )
       })
 
-      expect(mockClient.chat.sendLinkPreview).toHaveBeenCalledWith(
+      expect(mockClient.messages.sendLinkPreview).toHaveBeenCalledWith(
         'alice@example.com',
         'msg-123',
         preview,
@@ -471,7 +471,7 @@ describe('useConnection hook', () => {
     it('should call client.sendLinkPreview for groupchat', async () => {
       const { result } = renderHook(() => useConnection(), { wrapper })
 
-      mockClient.chat.sendLinkPreview.mockResolvedValue(undefined)
+      mockClient.messages.sendLinkPreview.mockResolvedValue(undefined)
 
       const preview = {
         url: 'https://example.com/article',
@@ -486,7 +486,7 @@ describe('useConnection hook', () => {
         )
       })
 
-      expect(mockClient.chat.sendLinkPreview).toHaveBeenCalledWith(
+      expect(mockClient.messages.sendLinkPreview).toHaveBeenCalledWith(
         'room@conference.example.com',
         'msg-456',
         preview,

--- a/packages/fluux-sdk/src/hooks/useConnectionActions.ts
+++ b/packages/fluux-sdk/src/hooks/useConnectionActions.ts
@@ -113,7 +113,7 @@ export function useConnectionActions() {
 
   const requestUploadSlot = useCallback(
     async (filename: string, size: number, contentType: string) => {
-      return client.discovery.requestUploadSlot(filename, size, contentType)
+      return client.server.requestUploadSlot(filename, size, contentType)
     },
     [client]
   )
@@ -124,7 +124,7 @@ export function useConnectionActions() {
       originalMessageId: string,
       preview: LinkPreview
     ) => {
-      await client.chat.sendLinkPreview(to, originalMessageId, preview)
+      await client.messages.sendLinkPreview(to, originalMessageId, preview)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useEvents.test.tsx
@@ -61,25 +61,25 @@ describe('useEvents hook', () => {
     it('should call client.acceptSubscription when acceptSubscription is called', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.roster.acceptSubscription.mockResolvedValue(undefined)
+      mockClient.contacts.acceptSubscription.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.acceptSubscription('alice@example.com')
       })
 
-      expect(mockClient.roster.acceptSubscription).toHaveBeenCalledWith('alice@example.com')
+      expect(mockClient.contacts.acceptSubscription).toHaveBeenCalledWith('alice@example.com')
     })
 
     it('should call client.rejectSubscription when rejectSubscription is called', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.roster.rejectSubscription.mockResolvedValue(undefined)
+      mockClient.contacts.rejectSubscription.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.rejectSubscription('alice@example.com')
       })
 
-      expect(mockClient.roster.rejectSubscription).toHaveBeenCalledWith('alice@example.com')
+      expect(mockClient.contacts.rejectSubscription).toHaveBeenCalledWith('alice@example.com')
     })
   })
 
@@ -114,7 +114,7 @@ describe('useEvents hook', () => {
     it('should add contact and create conversation when acceptStranger is called', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.roster.addContact.mockResolvedValue(undefined)
+      mockClient.contacts.addContact.mockResolvedValue(undefined)
 
       act(() => {
         eventsStore.getState().addStrangerMessage('stranger@example.com', 'Hello!')
@@ -126,7 +126,7 @@ describe('useEvents hook', () => {
       })
 
       // Should add contact with local part as nickname
-      expect(mockClient.roster.addContact).toHaveBeenCalledWith('stranger@example.com', 'stranger')
+      expect(mockClient.contacts.addContact).toHaveBeenCalledWith('stranger@example.com', 'stranger')
 
       // Should create conversation
       const conversations = Array.from(chatStore.getState().conversations.values())
@@ -183,7 +183,7 @@ describe('useEvents hook', () => {
     it('should join room when acceptInvitation is called', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       // Set up current JID for default nickname
       act(() => {
@@ -198,7 +198,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('room@conference.example.com')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'room@conference.example.com',
         'myuser',  // local part of JID
         { password: undefined, isQuickChat: false }
@@ -211,7 +211,7 @@ describe('useEvents hook', () => {
     it('should prefer the profile username (XEP-0172 nick) over the JID local part', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       act(() => {
         connectionStore.getState().setJid('myuser@example.com/resource')
@@ -226,7 +226,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('room@conference.example.com')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'room@conference.example.com',
         'Alice',  // profile username, not the JID local part
         { password: undefined, isQuickChat: false }
@@ -236,7 +236,7 @@ describe('useEvents hook', () => {
     it('should join room with password from invitation', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       act(() => {
         connectionStore.getState().setJid('myuser@example.com/resource')
@@ -252,7 +252,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('room@conference.example.com')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'room@conference.example.com',
         'myuser',
         { password: 'secret123', isQuickChat: false }
@@ -266,10 +266,10 @@ describe('useEvents hook', () => {
     it('keeps the invitation and rethrows when the server refuses the join', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
       // ...Once: the mock client is shared across tests and vi.clearAllMocks()
       // keeps implementations, so a persistent rejection would leak into them.
-      mockClient.muc.joinResult.mockRejectedValueOnce(
+      mockClient.rooms.joinResult.mockRejectedValueOnce(
         new RoomJoinError('room@conference.example.com', 'not-authorized')
       )
 
@@ -290,7 +290,7 @@ describe('useEvents hook', () => {
     it('retries with a password supplied by the caller, overriding the invitation one', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       act(() => {
         connectionStore.getState().setJid('myuser@example.com/resource')
@@ -306,7 +306,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('room@conference.example.com', 'typed-by-user')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'room@conference.example.com',
         'myuser',
         { password: 'typed-by-user', isQuickChat: false }
@@ -317,7 +317,7 @@ describe('useEvents hook', () => {
     it('should join room with isQuickChat flag from invitation', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       act(() => {
         connectionStore.getState().setJid('myuser@example.com/resource')
@@ -335,7 +335,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('quickchat-user-happy-fox@conference.example.com')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'quickchat-user-happy-fox@conference.example.com',
         'myuser',
         { password: undefined, isQuickChat: true }
@@ -438,7 +438,7 @@ describe('useEvents hook', () => {
     it('should update when events are handled', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.roster.acceptSubscription.mockResolvedValue(undefined)
+      mockClient.contacts.acceptSubscription.mockResolvedValue(undefined)
 
       act(() => {
         eventsStore.getState().addSubscriptionRequest('alice@example.com')
@@ -460,7 +460,7 @@ describe('useEvents hook', () => {
     it('should handle empty JID gracefully in acceptStranger', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.roster.addContact.mockResolvedValue(undefined)
+      mockClient.contacts.addContact.mockResolvedValue(undefined)
 
       act(() => {
         eventsStore.getState().addStrangerMessage('stranger@example.com', 'Hello')
@@ -471,13 +471,13 @@ describe('useEvents hook', () => {
         await result.current.acceptStranger('stranger@example.com')
       })
 
-      expect(mockClient.roster.addContact).toHaveBeenCalledWith('stranger@example.com', 'stranger')
+      expect(mockClient.contacts.addContact).toHaveBeenCalledWith('stranger@example.com', 'stranger')
     })
 
     it('should use "user" as default nickname when JID is null in acceptInvitation', async () => {
       const { result } = renderHook(() => useEvents(), { wrapper })
 
-      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      mockClient.rooms.joinRoom.mockResolvedValue(undefined)
 
       act(() => {
         // Don't set JID
@@ -491,7 +491,7 @@ describe('useEvents hook', () => {
         await result.current.acceptInvitation('room@conference.example.com')
       })
 
-      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+      expect(mockClient.rooms.joinRoom).toHaveBeenCalledWith(
         'room@conference.example.com',
         'user',  // default when JID is null
         { password: undefined, isQuickChat: false }

--- a/packages/fluux-sdk/src/hooks/useEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useEvents.ts
@@ -102,14 +102,14 @@ export function useEvents() {
 
   const acceptSubscription = useCallback(
     async (jid: string) => {
-      await client.roster.acceptSubscription(jid)
+      await client.contacts.acceptSubscription(jid)
     },
     [client]
   )
 
   const rejectSubscription = useCallback(
     async (jid: string) => {
-      await client.roster.rejectSubscription(jid)
+      await client.contacts.rejectSubscription(jid)
     },
     [client]
   )
@@ -118,7 +118,7 @@ export function useEvents() {
   const acceptStranger = useCallback(
     async (jid: string) => {
       // Add to roster (sends subscription request)
-      await client.roster.addContact(jid, getLocalPart(jid))
+      await client.contacts.addContact(jid, getLocalPart(jid))
 
       // Create conversation
       const conversation: Conversation = {
@@ -189,7 +189,7 @@ export function useEvents() {
       const roomPassword = password || invitation?.password
 
       // Join the room with isQuickChat flag from invitation
-      await client.muc.joinRoom(roomJid, defaultNick, {
+      await client.rooms.joinRoom(roomJid, defaultNick, {
         password: roomPassword,
         isQuickChat: invitation?.isQuickChat,
       })
@@ -198,7 +198,7 @@ export function useEvents() {
       // refuse it (password required, members-only, nickname taken). Wait for the
       // outcome so the failure reaches the caller and the invitation survives —
       // dropping it on a refusal would strand the user with no way to retry.
-      await client.muc.joinResult(roomJid)
+      await client.rooms.joinResult(roomJid)
 
       // Remove from invitations
       removeMucInvitation(roomJid)

--- a/packages/fluux-sdk/src/hooks/useRoom.fetchOlderHistory.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoom.fetchOlderHistory.regression.test.tsx
@@ -5,7 +5,7 @@
  *
  * Room `fetchOlderHistory` must NEVER send a client-generated message id as the
  * RSM `<before>` cursor. This exercises the real hook wiring
- * (useRoom → createFetchOlderHistory → client.chat.queryRoomMAM) to prove the
+ * (useRoom → createFetchOlderHistory → client.messages.queryRoomMAM) to prove the
  * cursor is a server stanzaId, or the empty-string "get latest" sentinel, but
  * never a client UUID. Fails against the original
  * `messages[0].stanzaId || messages[0].id` cursor.
@@ -71,7 +71,7 @@ const other = (id: string, ts: string, stanzaId: string): RoomMessage => ({
 
 describe('useRoom fetchOlderHistory — MUC MAM cursor regression', () => {
   beforeEach(() => {
-    vi.mocked(mockClient.chat.queryRoomMAM).mockReset().mockResolvedValue(undefined)
+    vi.mocked(mockClient.messages.queryRoomMAM).mockReset().mockResolvedValue(undefined)
   })
 
   it('uses the oldest server stanzaId as the cursor — never the client id — when the oldest message is our own', async () => {
@@ -85,9 +85,9 @@ describe('useRoom fetchOlderHistory — MUC MAM cursor regression', () => {
       await result.current.fetchOlderHistory()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledTimes(1)
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: 'archive-1' })
-    const before = vi.mocked(mockClient.chat.queryRoomMAM).mock.calls[0][0].before
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: 'archive-1' })
+    const before = vi.mocked(mockClient.messages.queryRoomMAM).mock.calls[0][0].before
     expect(before).not.toBe('uuid-own')
   })
 
@@ -102,9 +102,9 @@ describe('useRoom fetchOlderHistory — MUC MAM cursor regression', () => {
       await result.current.fetchOlderHistory()
     })
 
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledTimes(1)
-    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: '' })
-    const before = vi.mocked(mockClient.chat.queryRoomMAM).mock.calls[0][0].before
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.messages.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: '' })
+    const before = vi.mocked(mockClient.messages.queryRoomMAM).mock.calls[0][0].before
     expect(['uuid-1', 'uuid-2']).not.toContain(before)
   })
 })

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -57,21 +57,21 @@ export function useRoomActions() {
 
   const joinRoom = useCallback(
     async (roomJid: string, nickname: string, options?: { maxHistory?: number; password?: string; knownFeatures?: RoomFeatures | null }) => {
-      await client.muc.joinRoom(roomJid, nickname, options)
+      await client.rooms.joinRoom(roomJid, nickname, options)
     },
     [client]
   )
 
   const joinResult = useCallback(
     async (roomJid: string): Promise<void> => {
-      await client.muc.joinResult(roomJid)
+      await client.rooms.joinResult(roomJid)
     },
     [client]
   )
 
   const changeNick = useCallback(
     async (roomJid: string, newNick: string): Promise<void> => {
-      await client.muc.changeNick(roomJid, newNick)
+      await client.rooms.changeNick(roomJid, newNick)
     },
     [client]
   )
@@ -84,7 +84,7 @@ export function useRoomActions() {
    */
   const getRoomInfo = useCallback(
     async (roomJid: string): Promise<RoomFeatures | null> => {
-      return await client.muc.queryRoomFeatures(roomJid)
+      return await client.rooms.queryRoomFeatures(roomJid)
     },
     [client]
   )
@@ -101,14 +101,14 @@ export function useRoomActions() {
 
   const createQuickChat = useCallback(
     async (nickname: string, topic?: string, invitees?: string[]): Promise<string> => {
-      return await client.muc.createQuickChat(nickname, topic, invitees)
+      return await client.rooms.createQuickChat(nickname, topic, invitees)
     },
     [client]
   )
 
   const leaveRoom = useCallback(
     async (roomJid: string) => {
-      await client.muc.leaveRoom(roomJid)
+      await client.rooms.leaveRoom(roomJid)
     },
     [client]
   )
@@ -143,49 +143,49 @@ export function useRoomActions() {
       // is required here even though the protocol leaves it optional.
       options?: RoomSendMessageOptions
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, options)
+      return await client.messages.sendMessage(roomJid, body, options)
     },
     [client]
   )
 
   const sendReaction = useCallback(
     async (roomJid: string, messageId: string, emojis: string[]) => {
-      await client.chat.sendReaction(roomJid, messageId, emojis)
+      await client.messages.sendReaction(roomJid, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(roomJid, messageId, newBody, attachment)
+      await client.messages.sendCorrection(roomJid, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (roomJid: string, messageId: string) => {
-      await client.chat.sendRetraction(roomJid, messageId)
+      await client.messages.sendRetraction(roomJid, messageId)
     },
     [client]
   )
 
   const sendChatState = useCallback(
     async (roomJid: string, state: ChatStateNotification) => {
-      await client.chat.sendChatState(roomJid, state)
+      await client.messages.sendChatState(roomJid, state)
     },
     [client]
   )
 
   const sendWhisperChatState = useCallback(
     async (roomJid: string, nick: string, state: ChatStateNotification) => {
-      await client.chat.sendWhisperChatState(roomJid, nick, state)
+      await client.messages.sendWhisperChatState(roomJid, nick, state)
     },
     [client]
   )
 
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
-      await client.chat.sendEasterEgg(roomJid, animation)
+      await client.messages.sendEasterEgg(roomJid, animation)
     },
     [client]
   )
@@ -232,7 +232,7 @@ export function useRoomActions() {
         getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
         clearInvalidArchiveCursor: (id, cursor) => roomStore.getState().clearMessageStanzaId(id, cursor),
         queryMAM: async (id, beforeId) => {
-          await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
+          await client.messages.queryRoomMAM({ roomJid: id, before: beforeId })
         },
         errorLogPrefix: 'Failed to fetch older room history',
       }),

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -188,28 +188,28 @@ export function useRoomActive() {
 
   const joinRoom = useCallback(
     async (roomJid: string, nickname: string, options?: { maxHistory?: number; password?: string; knownFeatures?: RoomFeatures | null }) => {
-      await client.muc.joinRoom(roomJid, nickname, options)
+      await client.rooms.joinRoom(roomJid, nickname, options)
     },
     [client]
   )
 
   const joinResult = useCallback(
     async (roomJid: string): Promise<void> => {
-      await client.muc.joinResult(roomJid)
+      await client.rooms.joinResult(roomJid)
     },
     [client],
   )
 
   const changeNick = useCallback(
     async (roomJid: string, newNick: string): Promise<void> => {
-      await client.muc.changeNick(roomJid, newNick)
+      await client.rooms.changeNick(roomJid, newNick)
     },
     [client],
   )
 
   // Pre-join room inspection + real-JID-exposure acknowledgement (issue #37)
   const getRoomInfo = useCallback(
-    async (roomJid: string): Promise<RoomFeatures | null> => client.muc.queryRoomFeatures(roomJid),
+    async (roomJid: string): Promise<RoomFeatures | null> => client.rooms.queryRoomFeatures(roomJid),
     [client]
   )
   const acknowledgeNonAnonymousRoom = useCallback((roomJid: string) => {
@@ -228,56 +228,56 @@ export function useRoomActive() {
       // is required here even though the protocol leaves it optional.
       options?: RoomSendMessageOptions
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, options)
+      return await client.messages.sendMessage(roomJid, body, options)
     },
     [client]
   )
 
   const sendWhisper = useCallback(
     async (roomJid: string, nick: string, body: string): Promise<string> => {
-      return await client.chat.sendWhisper(roomJid, nick, body)
+      return await client.messages.sendWhisper(roomJid, nick, body)
     },
     [client]
   )
 
   const sendReaction = useCallback(
     async (roomJid: string, messageId: string, emojis: string[]) => {
-      await client.chat.sendReaction(roomJid, messageId, emojis)
+      await client.messages.sendReaction(roomJid, messageId, emojis)
     },
     [client]
   )
 
   const sendCorrection = useCallback(
     async (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => {
-      await client.chat.sendCorrection(roomJid, messageId, newBody, attachment)
+      await client.messages.sendCorrection(roomJid, messageId, newBody, attachment)
     },
     [client]
   )
 
   const retractMessage = useCallback(
     async (roomJid: string, messageId: string) => {
-      await client.chat.sendRetraction(roomJid, messageId)
+      await client.messages.sendRetraction(roomJid, messageId)
     },
     [client]
   )
 
   const sendChatState = useCallback(
     async (roomJid: string, state: ChatStateNotification) => {
-      await client.chat.sendChatState(roomJid, state)
+      await client.messages.sendChatState(roomJid, state)
     },
     [client]
   )
 
   const sendWhisperChatState = useCallback(
     async (roomJid: string, nick: string, state: ChatStateNotification) => {
-      await client.chat.sendWhisperChatState(roomJid, nick, state)
+      await client.messages.sendWhisperChatState(roomJid, nick, state)
     },
     [client]
   )
 
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
-      await client.chat.sendEasterEgg(roomJid, animation)
+      await client.messages.sendEasterEgg(roomJid, animation)
     },
     [client]
   )
@@ -319,7 +319,7 @@ export function useRoomActive() {
         getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
         clearInvalidArchiveCursor: (id, cursor) => roomStore.getState().clearMessageStanzaId(id, cursor),
         queryMAM: async (id, beforeId) => {
-          await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
+          await client.messages.queryRoomMAM({ roomJid: id, before: beforeId })
         },
         errorLogPrefix: 'Failed to fetch older room history',
       }),
@@ -341,7 +341,7 @@ export function useRoomActive() {
         getMessages: (id) => roomStore.getState().rooms.get(id)?.messages || [],
         getGap: (id) => roomStore.getState().roomGaps.get(id),
         queryMAM: async (id, options) => {
-          await client.chat.queryRoomMAM({ roomJid: id, ...options })
+          await client.messages.queryRoomMAM({ roomJid: id, ...options })
         },
       }),
     [client]

--- a/packages/fluux-sdk/src/hooks/useRoomManagement.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomManagement.ts
@@ -29,35 +29,35 @@ export function useRoomManagement() {
       },
       options?: { invitees?: string[] }
     ) => {
-      await client.muc.createRoom(roomJid, nickname, config, options)
+      await client.rooms.createRoom(roomJid, nickname, config, options)
     },
     [client]
   )
 
   const destroyRoom = useCallback(
     async (roomJid: string, reason?: string, alternateRoomJid?: string) => {
-      await client.muc.destroyRoom(roomJid, reason, alternateRoomJid)
+      await client.rooms.destroyRoom(roomJid, reason, alternateRoomJid)
     },
     [client]
   )
 
   const roomExists = useCallback(
     async (roomJid: string): Promise<boolean> => {
-      return client.muc.roomExists(roomJid)
+      return client.rooms.roomExists(roomJid)
     },
     [client]
   )
 
   const submitRoomConfig = useCallback(
     async (roomJid: string, values: Record<string, string | string[]>) => {
-      await client.muc.submitRoomConfig(roomJid, values)
+      await client.rooms.submitRoomConfig(roomJid, values)
     },
     [client]
   )
 
   const setSubject = useCallback(
     async (roomJid: string, subject: string) => {
-      await client.muc.setSubject(roomJid, subject)
+      await client.rooms.setSubject(roomJid, subject)
     },
     [client]
   )
@@ -67,35 +67,35 @@ export function useRoomManagement() {
       roomJid: string,
       options: { name: string; nick: string; autojoin?: boolean; password?: string }
     ) => {
-      await client.muc.setBookmark(roomJid, options)
+      await client.rooms.setBookmark(roomJid, options)
     },
     [client]
   )
 
   const removeBookmark = useCallback(
     async (roomJid: string) => {
-      await client.muc.removeBookmark(roomJid)
+      await client.rooms.removeBookmark(roomJid)
     },
     [client]
   )
 
   const setRoomNotifyAll = useCallback(
     async (roomJid: string, notifyAll: boolean, persistent: boolean = false) => {
-      await client.muc.setRoomNotifyAll(roomJid, notifyAll, persistent)
+      await client.rooms.setRoomNotifyAll(roomJid, notifyAll, persistent)
     },
     [client]
   )
 
   const inviteToRoom = useCallback(
     async (roomJid: string, inviteeJid: string, reason?: string) => {
-      await client.muc.sendMediatedInvitation(roomJid, inviteeJid, reason)
+      await client.rooms.sendMediatedInvitation(roomJid, inviteeJid, reason)
     },
     [client]
   )
 
   const inviteMultipleToRoom = useCallback(
     async (roomJid: string, inviteeJids: string[], reason?: string) => {
-      await client.muc.sendMediatedInvitations(roomJid, inviteeJids, reason)
+      await client.rooms.sendMediatedInvitations(roomJid, inviteeJids, reason)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomModeration.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomModeration.ts
@@ -18,28 +18,28 @@ export function useRoomModeration() {
 
   const moderateMessage = useCallback(
     async (roomJid: string, stanzaId: string, reason?: string) => {
-      await client.muc.moderateMessage(roomJid, stanzaId, reason)
+      await client.rooms.moderateMessage(roomJid, stanzaId, reason)
     },
     [client]
   )
 
   const setAffiliation = useCallback(
     async (roomJid: string, userJid: string, affiliation: RoomAffiliation, reason?: string) => {
-      await client.muc.setAffiliation(roomJid, userJid, affiliation, reason)
+      await client.rooms.setAffiliation(roomJid, userJid, affiliation, reason)
     },
     [client]
   )
 
   const setRole = useCallback(
     async (roomJid: string, nick: string, role: RoomRole, reason?: string) => {
-      await client.muc.setRole(roomJid, nick, role, reason)
+      await client.rooms.setRole(roomJid, nick, role, reason)
     },
     [client]
   )
 
   const queryAffiliationList = useCallback(
     async (roomJid: string, affiliation: RoomAffiliation) => {
-      return client.muc.queryAffiliationList(roomJid, affiliation)
+      return client.rooms.queryAffiliationList(roomJid, affiliation)
     },
     [client]
   )
@@ -47,42 +47,42 @@ export function useRoomModeration() {
   // XEP-0317: Hat management
   const listHats = useCallback(
     async (roomJid: string) => {
-      return client.muc.listHats(roomJid)
+      return client.rooms.listHats(roomJid)
     },
     [client]
   )
 
   const createHat = useCallback(
     async (roomJid: string, title: string, uri: string, hue?: number) => {
-      await client.muc.createHat(roomJid, title, uri, hue)
+      await client.rooms.createHat(roomJid, title, uri, hue)
     },
     [client]
   )
 
   const destroyHat = useCallback(
     async (roomJid: string, uri: string) => {
-      await client.muc.destroyHat(roomJid, uri)
+      await client.rooms.destroyHat(roomJid, uri)
     },
     [client]
   )
 
   const listHatAssignments = useCallback(
     async (roomJid: string) => {
-      return client.muc.listHatAssignments(roomJid)
+      return client.rooms.listHatAssignments(roomJid)
     },
     [client]
   )
 
   const assignHat = useCallback(
     async (roomJid: string, userJid: string, hatUri: string) => {
-      await client.muc.assignHat(roomJid, userJid, hatUri)
+      await client.rooms.assignHat(roomJid, userJid, hatUri)
     },
     [client]
   )
 
   const unassignHat = useCallback(
     async (roomJid: string, userJid: string, hatUri: string) => {
-      await client.muc.unassignHat(roomJid, userJid, hatUri)
+      await client.rooms.unassignHat(roomJid, userJid, hatUri)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoster.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoster.test.tsx
@@ -177,49 +177,49 @@ describe('useRoster hook', () => {
     it('should call client.addContact when addContact is called', async () => {
       const { result } = renderHook(() => useRoster(), { wrapper })
 
-      mockClient.roster.addContact.mockResolvedValue(undefined)
+      mockClient.contacts.addContact.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.addContact('newuser@example.com', 'New User')
       })
 
-      expect(mockClient.roster.addContact).toHaveBeenCalledWith('newuser@example.com', 'New User')
+      expect(mockClient.contacts.addContact).toHaveBeenCalledWith('newuser@example.com', 'New User')
     })
 
     it('should call client.addContact without nickname if not provided', async () => {
       const { result } = renderHook(() => useRoster(), { wrapper })
 
-      mockClient.roster.addContact.mockResolvedValue(undefined)
+      mockClient.contacts.addContact.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.addContact('newuser@example.com')
       })
 
-      expect(mockClient.roster.addContact).toHaveBeenCalledWith('newuser@example.com', undefined)
+      expect(mockClient.contacts.addContact).toHaveBeenCalledWith('newuser@example.com', undefined)
     })
 
     it('should call client.removeContact when removeContact is called', async () => {
       const { result } = renderHook(() => useRoster(), { wrapper })
 
-      mockClient.roster.removeContact.mockResolvedValue(undefined)
+      mockClient.contacts.removeContact.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.removeContact('alice@example.com')
       })
 
-      expect(mockClient.roster.removeContact).toHaveBeenCalledWith('alice@example.com')
+      expect(mockClient.contacts.removeContact).toHaveBeenCalledWith('alice@example.com')
     })
 
     it('should call client.renameContact when renameContact is called', async () => {
       const { result } = renderHook(() => useRoster(), { wrapper })
 
-      mockClient.roster.renameContact.mockResolvedValue(undefined)
+      mockClient.contacts.renameContact.mockResolvedValue(undefined)
 
       await act(async () => {
         await result.current.renameContact('alice@example.com', 'Alice Smith')
       })
 
-      expect(mockClient.roster.renameContact).toHaveBeenCalledWith('alice@example.com', 'Alice Smith')
+      expect(mockClient.contacts.renameContact).toHaveBeenCalledWith('alice@example.com', 'Alice Smith')
     })
 
     // Removed: Avatar caching was deprecated and removed from SDK

--- a/packages/fluux-sdk/src/hooks/useRoster.ts
+++ b/packages/fluux-sdk/src/hooks/useRoster.ts
@@ -82,21 +82,21 @@ export function useRoster() {
 
   const removeContact = useCallback(
     async (jid: string) => {
-      await client.roster.removeContact(jid)
+      await client.contacts.removeContact(jid)
     },
     [client]
   )
 
   const addContact = useCallback(
     async (jid: string, nick?: string) => {
-      await client.roster.addContact(jid, nick)
+      await client.contacts.addContact(jid, nick)
     },
     [client]
   )
 
   const renameContact = useCallback(
     async (jid: string, name: string) => {
-      await client.roster.renameContact(jid, name)
+      await client.contacts.renameContact(jid, name)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRosterActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRosterActions.ts
@@ -54,21 +54,21 @@ export function useRosterActions() {
 
   const removeContact = useCallback(
     async (jid: string) => {
-      await client.roster.removeContact(jid)
+      await client.contacts.removeContact(jid)
     },
     [client]
   )
 
   const addContact = useCallback(
     async (jid: string, nick?: string) => {
-      await client.roster.addContact(jid, nick)
+      await client.contacts.addContact(jid, nick)
     },
     [client]
   )
 
   const renameContact = useCallback(
     async (jid: string, name: string) => {
-      await client.roster.renameContact(jid, name)
+      await client.contacts.renameContact(jid, name)
     },
     [client]
   )
@@ -120,7 +120,7 @@ export function useRosterActions() {
    */
   const acceptSubscription = useCallback(
     async (jid: string) => {
-      await client.roster.acceptSubscription(jid)
+      await client.contacts.acceptSubscription(jid)
     },
     [client]
   )
@@ -130,7 +130,7 @@ export function useRosterActions() {
    */
   const rejectSubscription = useCallback(
     async (jid: string) => {
-      await client.roster.rejectSubscription(jid)
+      await client.contacts.rejectSubscription(jid)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useXMPP.ts
+++ b/packages/fluux-sdk/src/hooks/useXMPP.ts
@@ -106,7 +106,7 @@ export function useXMPP() {
 
   const setPresence = useCallback(
     async (show?: 'away' | 'dnd' | 'xa', status?: string) => {
-      await client.roster.setPresence(show || 'online', status)
+      await client.contacts.setPresence(show || 'online', status)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -601,7 +601,7 @@ export type { XMPPStanzaError, XMPPErrorType } from './utils/xmppError'
 export { classifyConnectionError, extractTransportErrorClass, humanizeTransportError } from './core/modules/transportErrors'
 export type { ConnectionErrorKind } from './core/modules/transportErrors'
 
-// MUC join failure error (rejected by client.muc.joinResult)
+// MUC join failure error (rejected by client.rooms.joinResult)
 export { RoomJoinError, WhisperCounterpartGoneError, HatCommandError, IQTimeoutError } from './core/errors'
 
 // XEP-0045: MUC Permission Utilities

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -55,7 +55,7 @@
  * // no React and no extra setup needed.
  * const client = new XMPPClient()
  * await client.connect({ jid: 'bot@example.com', password: 'secret', server: 'example.com' })
- * client.chat.sendMessage('user@example.com', 'Hello!')
+ * client.messages.sendMessage('user@example.com', 'Hello!')
  * ```
  *
  * @packageDocumentation

--- a/packages/fluux-sdk/src/utils/debugUtils.ts
+++ b/packages/fluux-sdk/src/utils/debugUtils.ts
@@ -88,7 +88,7 @@ function createDebugUtils(client: XMPPClient): FluuxDebugUtils {
 
         console.log(`[FLUUX_DEBUG] Catching up ${roomJid} from ${startISO}...`)
         try {
-          await client.chat.queryRoomMAM({
+          await client.messages.queryRoomMAM({
             roomJid,
             start: startISO,
             max: 500, // Reasonable limit per room

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -3360,7 +3360,10 @@ test.describe('Insertion drift while scrolled up', () => {
       store.setState({ loadOlderMessagesFromCache: async () => 0 })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const demo = (window as any).__demoClient
-      if (demo?.chat) demo.chat.queryRoomMAM = async () => {}
+      // Returning false rather than skipping: a silently un-stubbed loader
+      // fails much later, as an assertion about rows that looks unrelated.
+      if (!demo?.messages) return false
+      demo.messages.queryRoomMAM = async () => {}
       return true
     })
     expect(stubbed, 'the older-history loaders must be stubbable for this scenario').toBe(true)
@@ -3493,15 +3496,15 @@ test.describe('Insertion drift while scrolled up', () => {
     const gated = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const demo = (window as any).__demoClient
-      if (!demo?.chat) return false
-      const original = demo.chat.queryRoomMAM.bind(demo.chat)
+      if (!demo?.messages) return false
+      const original = demo.messages.queryRoomMAM.bind(demo.messages)
       let open: () => void = () => {}
       const gate = new Promise<void>((resolve) => {
         open = resolve
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(window as any).__releaseOlderLoad = open
-      demo.chat.queryRoomMAM = async (options: unknown) => {
+      demo.messages.queryRoomMAM = async (options: unknown) => {
         await gate
         return original(options)
       }


### PR DESCRIPTION
Second of the three steps: renames, now that the internal modules are out of the way (#1270).

`client.muc` names a XEP; a user joins a room. Same for `roster`, which is the protocol's word for a contact list, and `discovery`, which is how you ask a server what it can do.

| Before | After |
|---|---|
| `client.muc` | `client.rooms` |
| `client.roster` | `client.contacts` |
| `client.discovery` | `client.server` |
| `client.webPush` | `client.push` |
| `client.chat` | `client.messages` |

`chat` moves too because it was the name that had started lying: since #1259 that module addresses rooms as readily as people, so `messages` is what it actually is. A room is still joined through `rooms` and written to through `messages`, which is the order XEP-0045 §7.4 requires anyway.

Internals keep the protocol's vocabulary, as agreed: the classes are still `MUC`, `Roster`, `Discovery`, the files keep their names, and `SessionLifecycleDeps` still asks for `muc` and `discovery` — the client maps to them at the boundary. `SideEffectHost` follows the accessor, because it reads those modules off the client and two names for one object would be worse than one.

`barrelSurface.test.ts` asserts both halves: the XEP names are gone from the client, and the domain names are there.

## Not in this PR

Moving `sendWhisper` and `sendWhisperChatState` onto `rooms`. They belong there — a whisper only exists in a room — but that moves protocol behaviour rather than a name, and my first attempt at automating the extraction cut far more than intended. It deserves its own diff.

## Note

The doc examples were the loudest consequence: 51 of them taught the old names. The checker added in #1267 listed every one, which is the first time it has paid for itself on a change of this shape.