### PR TITLE
refactor(scroll): give the seven executors one ownership guard

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -287,6 +287,14 @@ export interface ResidentTopExecutor {
   ) => void
 }
 
+/**
+ * The part of an execution its ownership guard reads. Every executor's state satisfies it, which is
+ * what lets {@link PositioningController.isExecutionCurrent} be written once instead of seven times.
+ */
+interface TrackedExecution {
+  request: { conversationId: string; generation: number }
+}
+
 interface SavedPositionExecutionState {
   request: SavedPositionRequest
   executor: SavedPositionExecutor
@@ -1726,17 +1734,27 @@ export class PositioningController {
     }
   }
 
-  private isLiveEdgeExecutionCurrent(
-    execution: LiveEdgeExecutionState,
+  /**
+   * Whether an execution still owns the position: it is the one its slot holds, and the model still
+   * points at its request. The seven executors each wrap this under their own name; the wrappers are
+   * what the call sites read, and this is the single definition they agree on.
+   */
+  private isExecutionCurrent<T extends TrackedExecution>(
+    slot: T | null,
+    execution: T,
   ): boolean {
     return (
-      this.liveEdgeExecution === execution &&
+      slot === execution &&
       isCurrentGeneration(
         this.model,
         execution.request.conversationId,
         execution.request.generation,
       )
     )
+  }
+
+  private isLiveEdgeExecutionCurrent(execution: LiveEdgeExecutionState): boolean {
+    return this.isExecutionCurrent(this.liveEdgeExecution, execution)
   }
 
   private driveAnchorPreservation(
@@ -1971,17 +1989,8 @@ export class PositioningController {
     }
   }
 
-  private isAnchorPreservationExecutionCurrent(
-    execution: AnchorPreservationExecutionState,
-  ): boolean {
-    return (
-      this.anchorPreservationExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isAnchorPreservationExecutionCurrent(execution: AnchorPreservationExecutionState): boolean {
+    return this.isExecutionCurrent(this.anchorPreservationExecution, execution)
   }
 
   private startDirectionalHistoryLoop(
@@ -2182,17 +2191,8 @@ export class PositioningController {
     }
   }
 
-  private isDirectionalHistoryExecutionCurrent(
-    execution: DirectionalHistoryExecutionState,
-  ): boolean {
-    return (
-      this.directionalHistoryExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isDirectionalHistoryExecutionCurrent(execution: DirectionalHistoryExecutionState): boolean {
+    return this.isExecutionCurrent(this.directionalHistoryExecution, execution)
   }
 
   private startResidentTopLoop(
@@ -2383,17 +2383,8 @@ export class PositioningController {
     }
   }
 
-  private isResidentTopExecutionCurrent(
-    execution: ResidentTopExecutionState,
-  ): boolean {
-    return (
-      this.residentTopExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isResidentTopExecutionCurrent(execution: ResidentTopExecutionState): boolean {
+    return this.isExecutionCurrent(this.residentTopExecution, execution)
   }
 
   private driveExplicitTarget(
@@ -2714,17 +2705,8 @@ export class PositioningController {
     }
   }
 
-  private isExplicitTargetExecutionCurrent(
-    execution: ExplicitTargetExecutionState,
-  ): boolean {
-    return (
-      this.explicitTargetExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isExplicitTargetExecutionCurrent(execution: ExplicitTargetExecutionState): boolean {
+    return this.isExecutionCurrent(this.explicitTargetExecution, execution)
   }
 
   private finishExplicitTargetExecution(
@@ -3038,17 +3020,8 @@ export class PositioningController {
     }
   }
 
-  private isUnreadExecutionCurrent(
-    execution: UnreadMarkerExecutionState,
-  ): boolean {
-    return (
-      this.unreadExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isUnreadExecutionCurrent(execution: UnreadMarkerExecutionState): boolean {
+    return this.isExecutionCurrent(this.unreadExecution, execution)
   }
 
   private finishUnreadExecution(
@@ -3535,17 +3508,8 @@ export class PositioningController {
     }
   }
 
-  private isSavedExecutionCurrent(
-    execution: SavedPositionExecutionState,
-  ): boolean {
-    return (
-      this.savedExecution === execution &&
-      isCurrentGeneration(
-        this.model,
-        execution.request.conversationId,
-        execution.request.generation,
-      )
-    )
+  private isSavedExecutionCurrent(execution: SavedPositionExecutionState): boolean {
+    return this.isExecutionCurrent(this.savedExecution, execution)
   }
 
   private cancelExecutionsIfSuperseded(): void {


### PR DESCRIPTION
The seven executor state machines each carried their own `isXExecutionCurrent`, byte-identical to the other six modulo the slot field and the state type. They now delegate to a single `isExecutionCurrent(slot, execution)`, with a `TrackedExecution` interface naming the only thing the guard reads: the request an execution serves.

−36 lines net; calls to `isCurrentGeneration` drop from 15 to 8.

The seven named wrappers stay. They are what the ~30 call sites read, and renaming them would turn a behaviour-preserving change into a noisy diff.

## What actually covers this

Not the lease conformance suite from #1269. That guards the lease built in `begin*Operation`, which inlines its own conditions and never calls this one — a different guard from the one unified here, a distinction I had wrong until the mutation showed it. Neutralising the shared guard fails seven tests, all in `positioningController.test.ts`, and none in the conformance suite.

So the net for this slice is the controller ownership tests, and they do the job.

## Why this slice first

Of the differences across the seven, the guards were the only ones already proven identical — #1269 established by mutation that their conditions are mutually redundant under every publicly reachable scenario, so unifying them cannot change reachable behaviour. The `cancel`/`finish` shapes and the frame loop are the remaining slices, in that order; the frame loop is the one that touches genuinely distinct behaviour, and anchor preservation should get controller-level ownership coverage before it is attempted.
