### PR TITLE
refactor(sdk): move the whisper SDK verbs onto rooms

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -991,60 +991,6 @@ export class Chat extends BaseModule {
     return id
   }
 
-  /**
-   * XEP-0045 §7.5: send a private message ("whisper") to a single room
-   * occupant. Unlike {@link sendMessage}, this preserves the `/nick`
-   * resource (sendMessage strips it for type='chat') and emits `room:whisper`
-   * instead of `chat:message` so the message is tracked as a private room
-   * message rather than a 1:1 conversation. The XEP-0334 `<no-store>` hint
-   * keeps it off the server archive; it is still persisted locally.
-   *
-   * @param roomJid bare room JID, e.g. 'room@conference.example.com'
-   * @param nick    target occupant's nickname
-   * @param body    message text
-   * @returns the generated message id
-   */
-  async sendWhisper(roomJid: string, nick: string, body: string): Promise<string> {
-    const id = generateUUID()
-    const to = `${roomJid}/${nick}`
-
-    const message = xml('message', { to, type: 'chat', id },
-      xml('body', {}, body),
-      xml('active', { xmlns: NS_CHATSTATES }),
-      xml('x', { xmlns: NS_MUC_USER }),
-      createOriginIdElement(id),
-      xml('no-store', { xmlns: NS_HINTS }),
-    )
-    await this.deps.sendStanza(message)
-
-    const room = this.deps.stores?.room.getRoom(roomJid)
-    if (!room) logWarn(`sendWhisper: room ${roomJid} not found in store — sender nick will be empty`)
-    const ourNick = room?.nickname || ''
-    // Counterpart's stable occupant-id (XEP-0421), resolved from the live occupant
-    // list, so a persisted thread can be re-bound to the same person later.
-    const targetOccupantId = room?.occupants.get(nick)?.occupantId
-    const whisper: RoomMessage = {
-      type: 'groupchat',
-      id,
-      originId: id,
-      roomJid,
-      from: `${roomJid}/${ourNick}`,
-      nick: ourNick,
-      body,
-      timestamp: new Date(),
-      isOutgoing: true,
-      isPrivate: true,
-      whisperWith: nick,
-      ...(targetOccupantId && { whisperWithOccupantId: targetOccupantId }),
-    }
-    this.deps.emitSDK('room:whisper', {
-      roomJid,
-      message: whisper,
-      incrementUnread: false,
-      incrementMentions: false,
-    })
-    return id
-  }
 
   /**
    * Resend a previously failed message.
@@ -1176,20 +1122,6 @@ export class Chat extends BaseModule {
     await this.deps.sendStanza(message)
   }
 
-  /**
-   * Send a chat state (XEP-0085) privately to a single room occupant — the typing
-   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState on the room,
-   * which broadcasts to the room, this addresses room/nick with the muc#user marker
-   * and a no-store hint, so the room never sees that you are whispering.
-   */
-  async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void> {
-    const message = xml('message', { to: `${roomJid}/${nick}`, type: 'chat' },
-      xml(state, { xmlns: NS_CHATSTATES }),
-      xml('x', { xmlns: NS_MUC_USER }),
-      xml('no-store', { xmlns: NS_HINTS }),
-    )
-    await this.deps.sendStanza(message)
-  }
 
   /**
    * Send or update reactions on a message (XEP-0444).

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -7,6 +7,7 @@ import { generateUUID } from '../../utils/uuid'
 import { generateQuickChatSlug } from '../wordlist'
 import { hasStableOccupantIdentity, isNonAnonymousRoom, isPrivateRoom } from '../roomCapabilities'
 import { parseBookmarkItem } from '../bookmarkItem'
+import { createOriginIdElement } from './messagingUtils'
 import { PRESENCE_PRIORITY } from '../config'
 import {
   NS_MUC,
@@ -28,6 +29,8 @@ import {
   NS_COMMANDS,
   NS_RETRACT,
   NS_MESSAGE_MODERATE,
+  NS_CHATSTATES,
+  NS_HINTS,
 } from '../namespaces'
 import type {
   Room,
@@ -40,6 +43,8 @@ import type {
   RSMResponse,
   AdminRoom,
   RoomFeatures,
+  RoomMessage,
+  ChatStateNotification,
 } from '../types'
 import type { StoredRoomMessage } from '../types/message-internal'
 import { parseXMPPError, formatXMPPError, hasErrorCondition } from '../../utils/xmppError'
@@ -1547,19 +1552,75 @@ export class MUC extends BaseModule {
   }
 
   /**
-   * Set the room subject/topic (XEP-0045).
+   * XEP-0045 §7.5: send a private message ("whisper") to a single room
+   * occupant. Unlike `messages.sendMessage`, this preserves the `/nick`
+   * resource (sending to a person strips it) and emits `room:whisper`
+   * instead of `chat:message` so the message is tracked as a private room
+   * message rather than a 1:1 conversation. The XEP-0334 `<no-store>` hint
+   * keeps it off the server archive; it is still persisted locally.
    *
-   * Sends a groupchat message with a `<subject>` element.
-   * The server will echo this back as a room subject change.
-   *
-   * @param roomJid - The room JID
-   * @param subject - The new subject text
-   *
-   * @example
-   * ```typescript
-   * await client.rooms.setSubject('room@conference.example.com', 'New topic for discussion')
-   * ```
+   * @param roomJid bare room JID, e.g. 'room@conference.example.com'
+   * @param nick    target occupant's nickname
+   * @param body    message text
+   * @returns the generated message id
    */
+  async sendWhisper(roomJid: string, nick: string, body: string): Promise<string> {
+    const id = generateUUID()
+    const to = `${roomJid}/${nick}`
+
+    const message = xml('message', { to, type: 'chat', id },
+      xml('body', {}, body),
+      xml('active', { xmlns: NS_CHATSTATES }),
+      xml('x', { xmlns: NS_MUC_USER }),
+      createOriginIdElement(id),
+      xml('no-store', { xmlns: NS_HINTS }),
+    )
+    await this.deps.sendStanza(message)
+
+    const room = this.deps.stores?.room.getRoom(roomJid)
+    if (!room) logWarn(`sendWhisper: room ${roomJid} not found in store — sender nick will be empty`)
+    const ourNick = room?.nickname || ''
+    // Counterpart's stable occupant-id (XEP-0421), resolved from the live occupant
+    // list, so a persisted thread can be re-bound to the same person later.
+    const targetOccupantId = room?.occupants.get(nick)?.occupantId
+    const whisper: RoomMessage = {
+      type: 'groupchat',
+      id,
+      originId: id,
+      roomJid,
+      from: `${roomJid}/${ourNick}`,
+      nick: ourNick,
+      body,
+      timestamp: new Date(),
+      isOutgoing: true,
+      isPrivate: true,
+      whisperWith: nick,
+      ...(targetOccupantId && { whisperWithOccupantId: targetOccupantId }),
+    }
+    this.deps.emitSDK('room:whisper', {
+      roomJid,
+      message: whisper,
+      incrementUnread: false,
+      incrementMentions: false,
+    })
+    return id
+  }
+
+  /**
+   * Send a chat state (XEP-0085) privately to a single room occupant — the typing
+   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState on the room,
+   * which broadcasts to the room, this addresses room/nick with the muc#user marker
+   * and a no-store hint, so the room never sees that you are whispering.
+   */
+  async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void> {
+    const message = xml('message', { to: `${roomJid}/${nick}`, type: 'chat' },
+      xml(state, { xmlns: NS_CHATSTATES }),
+      xml('x', { xmlns: NS_MUC_USER }),
+      xml('no-store', { xmlns: NS_HINTS }),
+    )
+    await this.deps.sendStanza(message)
+  }
+
   /**
    * Re-fetch recent history for every joined room that supports archiving.
    *
@@ -1578,6 +1639,20 @@ export class MUC extends BaseModule {
     await this.mam.forceCatchUpAllRooms(options)
   }
 
+  /**
+   * Set the room subject/topic (XEP-0045).
+   *
+   * Sends a groupchat message with a `<subject>` element.
+   * The server will echo this back as a room subject change.
+   *
+   * @param roomJid - The room JID
+   * @param subject - The new subject text
+   *
+   * @example
+   * ```typescript
+   * await client.rooms.setSubject('room@conference.example.com', 'New topic for discussion')
+   * ```
+   */
   async setSubject(roomJid: string, subject: string): Promise<void> {
     const msg = xml(
       'message',

--- a/packages/fluux-sdk/src/core/modules/MUC.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.whisper.test.ts
@@ -66,7 +66,7 @@ describe('MUC Whispers', () => {
       const room = createMockRoom('room@conference.example.com', { joined: true, nickname: 'me' })
       vi.mocked(mockStores.room.getRoom).mockReturnValue(room)
 
-      const id = await xmppClient.messages.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
+      const id = await xmppClient.rooms.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
 
       expect(typeof id).toBe('string')
       expect(id.length).toBeGreaterThan(0)
@@ -102,7 +102,7 @@ describe('MUC Whispers', () => {
       })
       vi.mocked(mockStores.room.getRoom).mockReturnValue(room)
 
-      await xmppClient.messages.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
+      await xmppClient.rooms.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
 
       expect(emitSDKSpy).toHaveBeenCalledWith('room:whisper', expect.objectContaining({
         roomJid: 'room@conference.example.com',
@@ -418,7 +418,7 @@ describe('MUC Whispers', () => {
     it('sendWhisperChatState sends a private chat-state to room/nick (muc#user, no-store)', async () => {
       await connectClient()
 
-      await xmppClient.messages.sendWhisperChatState(ROOM, 'bob', 'composing')
+      await xmppClient.rooms.sendWhisperChatState(ROOM, 'bob', 'composing')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -178,7 +178,7 @@ export function useRoomActions() {
 
   const sendWhisperChatState = useCallback(
     async (roomJid: string, nick: string, state: ChatStateNotification) => {
-      await client.messages.sendWhisperChatState(roomJid, nick, state)
+      await client.rooms.sendWhisperChatState(roomJid, nick, state)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -235,7 +235,7 @@ export function useRoomActive() {
 
   const sendWhisper = useCallback(
     async (roomJid: string, nick: string, body: string): Promise<string> => {
-      return await client.messages.sendWhisper(roomJid, nick, body)
+      return await client.rooms.sendWhisper(roomJid, nick, body)
     },
     [client]
   )
@@ -270,7 +270,7 @@ export function useRoomActive() {
 
   const sendWhisperChatState = useCallback(
     async (roomJid: string, nick: string, state: ChatStateNotification) => {
-      await client.messages.sendWhisperChatState(roomJid, nick, state)
+      await client.rooms.sendWhisperChatState(roomJid, nick, state)
     },
     [client]
   )


### PR DESCRIPTION
The last piece deferred from #1271.

A whisper is a room concept — XEP-0045 §7.5, a private message to one occupant, addressed `room/nick` with the `muc#user` marker and a `<no-store>` hint so the room never sees it. It lived on the messaging module only because that is where message sending happened to be written.

`sendWhisper` and `sendWhisperChatState` move to `rooms`, unchanged. They never used the messaging module's internals: both build a stanza from `deps.sendStanza`, `deps.stores` and `deps.emitSDK`, which every module has. 68 lines out, 75 in — the extra seven are imports.

## Receiving stays where it is

One stanza router claims `<message>`, and an incoming whisper travels the same decrypt, fastening, correction and retraction path as any other room message. Splitting that would mean duplicating it, or extracting it into a third collaborator, to buy nothing. `Chat.whisper.test.ts` is renamed to `MUC.whisper.test.ts` because its send half moved and its subject was already `MUC Whispers`; it still covers both directions.

## Verification

`build:sdk`, `typecheck` 0 errors, `check:examples` 184 compiled, `lint` 0 errors, `npm test` green (SDK 240 files / 6058 tests, app 455 / 6047), and `npm run test:scroll` 98/98 — run this time, since the e2e harness is an API consumer like any other.