### PR TITLE
build: fail when a doc comment loses its declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       # Before `npm ci`, because it needs no dependencies and fails in under a
       # second: a comment regression should not wait on an install and a build.
       # The gate validates itself before it gates anything, as the classifier does.
-      - name: Comments describe the code, not the development history
+      - name: Comments describe the code they are attached to
         run: npm run check:comments
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:sdk": "npm run build -w @fluux/sdk",
     "prebuild:app": "npm run guard:sdk-link",
     "build:app": "npm run build -w @xmpp/fluux",
-    "check:comments": "node --test scripts/check-comment-provenance.test.mjs && node scripts/check-comment-provenance.mjs",
+    "check:comments": "node --test scripts/check-comment-provenance.test.mjs scripts/check-orphaned-jsdoc.test.mjs && node scripts/check-comment-provenance.mjs && node scripts/check-orphaned-jsdoc.mjs",
     "check:examples": "node --test scripts/check-jsdoc-examples.test.mjs && node scripts/check-jsdoc-examples.mjs",
     "check:anomaly:prod": "npm run build:app && node scripts/check-anomaly-elimination.mjs",
     "check:anomaly:dev": "FLUUX_ANOMALY=1 npm run build:app && FLUUX_ANOMALY=1 node scripts/check-anomaly-elimination.mjs",

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -283,13 +283,6 @@ export class Profile extends BaseModule {
   }
 
   /**
-   * Fetch a room's avatar from its vCard (XEP-0054).
-   * MUC rooms don't support PEP, so avatars are always via vCard-temp.
-   *
-   * @param roomJid - The room's bare JID
-   * @param knownHash - Optional hash from XEP-0153 presence (used for cache key)
-   */
-  /**
    * Fetch an occupant's avatar from their vCard (XEP-0398).
    *
    * XEP-0398 defines how MUC occupant avatars work:
@@ -457,6 +450,13 @@ export class Profile extends BaseModule {
     }
   }
 
+  /**
+   * Fetch a room's avatar from its vCard (XEP-0054).
+   * MUC rooms don't support PEP, so avatars are always via vCard-temp.
+   *
+   * @param roomJid - The room's bare JID
+   * @param knownHash - Optional hash from XEP-0153 presence (used for cache key)
+   */
   async fetchRoomAvatar(roomJid: string, knownHash?: string): Promise<void> {
     const bareJid = getBareJid(roomJid)
 

--- a/packages/fluux-sdk/src/core/modules/WebPush.ts
+++ b/packages/fluux-sdk/src/core/modules/WebPush.ts
@@ -88,18 +88,6 @@ export class WebPush extends BaseModule {
   }
 
   /**
-   * Register a web push subscription with the server.
-   *
-   * Sends a `<push xmlns='p1:push'>` IQ with the browser push subscription
-   * details (endpoint, p256dh key, auth secret) to register for push
-   * notifications.
-   *
-   * @param endpoint - Push service endpoint URL from PushSubscription
-   * @param p256dh - Client public key (base64 encoded) from PushSubscription.getKey('p256dh')
-   * @param auth - Authentication secret (base64 encoded) from PushSubscription.getKey('auth')
-   * @param appId - Application identifier from the VAPID service
-   */
-  /**
    * Disable push notifications on the server for a specific device.
    *
    * Sends a `<disable xmlns='p1:push'>` IQ with the app ID and device token
@@ -143,6 +131,18 @@ export class WebPush extends BaseModule {
     }
   }
 
+  /**
+   * Register a web push subscription with the server.
+   *
+   * Sends a `<push xmlns='p1:push'>` IQ with the browser push subscription
+   * details (endpoint, p256dh key, auth secret) to register for push
+   * notifications.
+   *
+   * @param endpoint - Push service endpoint URL from PushSubscription
+   * @param p256dh - Client public key (base64 encoded) from PushSubscription.getKey('p256dh')
+   * @param auth - Authentication secret (base64 encoded) from PushSubscription.getKey('auth')
+   * @param appId - Application identifier from the VAPID service
+   */
   async registerSubscription(
     endpoint: string,
     p256dh: string,

--- a/scripts/check-orphaned-jsdoc.mjs
+++ b/scripts/check-orphaned-jsdoc.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+//
+// Fail when a doc comment loses the declaration it documents.
+//
+// Inserting a method or a type between a doc comment and what it described
+// leaves the comment attached to the next thing instead. The code compiles,
+// the tests pass, and the generated documentation is confidently wrong: the
+// parameters listed belong to another function. Nothing else in the toolchain
+// looks at this — `tsc` skips comments, and the example checker compiles the
+// fenced code inside them, not what they are attached to.
+//
+// The signal is narrow on purpose. A comment carrying `@param` or `@returns`
+// documents something callable, so it must be followed by a declaration. If
+// the next thing is another doc comment, the first one has been stranded.
+//
+// Two properties this file must keep:
+//
+//   1. No false positives. A guard that cries wolf gets an exemption list, and
+//      an exemption list is how a guard stops guarding. Adjacent doc comments
+//      are common and legitimate — a module description followed by a
+//      constant's, for instance — which is why the rule asks for `@param` or
+//      `@returns` rather than flagging adjacency alone.
+//
+//   2. No git, no network. A pure filesystem scan, identical locally and in
+//      CI. The detector is a pure string -> findings function, exercised by
+//      the sibling test.
+//
+// What it does NOT catch: a stranded comment with no `@param` or `@returns`,
+// which reads as ordinary prose and cannot be told apart from a section
+// heading. Widening it means guessing, so it stays narrow.
+//
+// Usage:
+//   node scripts/check-orphaned-jsdoc.mjs
+//
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+
+/** Roots to scan, relative to the repository root. */
+const SCAN_ROOTS = ['packages', 'apps/fluux/src']
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx']
+const SKIP_DIRECTORIES = new Set(['node_modules', 'dist', 'build', 'coverage', 'gen', 'src-tauri'])
+
+/** Tags that only make sense on something callable. */
+const CALLABLE_TAGS = /^\s*\*\s*@(param|returns?)\b/m
+
+/**
+ * Find doc comments that document a callable but are followed by another doc
+ * comment rather than by a declaration.
+ *
+ * @param source - File contents.
+ * @returns One finding per stranded comment, with its 1-based opening line.
+ */
+export function findOrphanedDocComments(source) {
+  const lines = source.split('\n')
+  const findings = []
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (lines[i].trim() !== '*/') continue
+    if (!lines[i + 1].trim().startsWith('/**')) continue
+
+    // Walk back to the opening of the block that just closed.
+    let start = i
+    while (start > 0 && !lines[start].trim().startsWith('/**')) start--
+    if (!lines[start].trim().startsWith('/**')) continue
+
+    const block = lines.slice(start, i + 1).join('\n')
+    if (!CALLABLE_TAGS.test(block)) continue
+
+    const subject = lines
+      .slice(start + 1, i)
+      .map((line) => line.replace(/^\s*\*\s?/, '').trim())
+      .find((line) => line.length > 0)
+
+    findings.push({ line: start + 1, summary: subject ?? '' })
+  }
+
+  return findings
+}
+
+function sourceFiles(root) {
+  const found = []
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry)
+    if (statSync(full).isDirectory()) {
+      if (!SKIP_DIRECTORIES.has(entry)) found.push(...sourceFiles(full))
+      continue
+    }
+    if (SOURCE_EXTENSIONS.some((ext) => entry.endsWith(ext))) found.push(full)
+  }
+  return found
+}
+
+function main() {
+  const violations = []
+  for (const root of SCAN_ROOTS) {
+    for (const file of sourceFiles(join(REPO_ROOT, root))) {
+      for (const finding of findOrphanedDocComments(readFileSync(file, 'utf8'))) {
+        violations.push({ file: relative(REPO_ROOT, file), ...finding })
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log('OK: every @param/@returns comment still has its declaration.')
+    return 0
+  }
+
+  console.error(`\n${violations.length} doc comment(s) lost the declaration they document.\n`)
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}`)
+    if (v.summary) console.error(`      ${v.summary}`)
+  }
+  console.error(
+    '\nSomething was inserted between the comment and what it described, so it\n' +
+      'now documents the next declaration. Move the comment back down to it.\n',
+  )
+  return 1
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main())
+}

--- a/scripts/check-orphaned-jsdoc.test.mjs
+++ b/scripts/check-orphaned-jsdoc.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { findOrphanedDocComments } from './check-orphaned-jsdoc.mjs'
+
+test('flags a @param comment followed by another doc comment', () => {
+  const source = [
+    '  /**',
+    '   * Set the subject.',
+    '   * @param roomJid - The room',
+    '   */',
+    '  /**',
+    '   * Something else entirely.',
+    '   */',
+    '  async somethingElse() {}',
+  ].join('\n')
+
+  const found = findOrphanedDocComments(source)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].line, 1)
+  assert.equal(found[0].summary, 'Set the subject.')
+})
+
+test('flags @returns as well, since it also documents a callable', () => {
+  const source = ['/**', ' * Reads a thing.', ' * @returns the thing', ' */', '/** Next. */', 'const x = 1'].join('\n')
+  assert.equal(findOrphanedDocComments(source).length, 1)
+})
+
+test('leaves a @param comment alone when a declaration follows it', () => {
+  const source = ['  /**', '   * Set the subject.', '   * @param roomJid - The room', '   */', '  async setSubject() {}'].join('\n')
+  assert.deepEqual(findOrphanedDocComments(source), [])
+})
+
+test('leaves adjacent comments alone when the first documents no callable', () => {
+  // A module description followed by a constant's: the common legitimate shape.
+  const source = [
+    '/**',
+    ' * Multi-User Chat module.',
+    ' * @category Core',
+    ' */',
+    '/** Default timeout. */',
+    'const JOIN_TIMEOUT_MS = 30000',
+  ].join('\n')
+  assert.deepEqual(findOrphanedDocComments(source), [])
+})
+
+test('leaves a blank line between comments alone', () => {
+  // Separated blocks read as two independent comments, not a stranding.
+  const source = ['/**', ' * Does a thing.', ' * @param a - first', ' */', '', '/** Next. */', 'const x = 1'].join('\n')
+  assert.deepEqual(findOrphanedDocComments(source), [])
+})
+
+test('reports every stranded comment in a file', () => {
+  const one = ['/**', ' * A.', ' * @param a - x', ' */', '/** B. */', 'const b = 1'].join('\n')
+  const two = ['/**', ' * C.', ' * @param c - x', ' */', '/** D. */', 'const d = 1'].join('\n')
+  assert.equal(findOrphanedDocComments(`${one}\n${two}`).length, 2)
+})
+
+test('ignores line comments that merely mention @param', () => {
+  const source = ['// @param is not a doc tag here', 'const x = 1'].join('\n')
+  assert.deepEqual(findOrphanedDocComments(source), [])
+})


### PR DESCRIPTION
Inserting a method between a doc comment and what it described leaves the comment on the next declaration. The code compiles, the tests pass, and the generated documentation is confidently wrong: the parameters listed belong to another function.

Nothing in the toolchain looks at this. `tsc` skips comments, and the example checker from #1267 compiles the fenced code *inside* them rather than what they are attached to. I made this mistake twice in a row while moving code around (#1270 and #1273), and caught it both times only by re-reading the diff.

## The rule

A comment carrying `@param` or `@returns` documents something callable, so it must be followed by a declaration and not by another doc comment.

It is narrow on purpose, so it never needs an exemption list — and an exemption list is how a guard stops guarding. Adjacent doc comments are common and legitimate (a module description above a constant's), which is why adjacency alone is not the signal: that shape appears 23 times in the tree, the `@param` shape three times, and all three were real.

What it does not catch: a stranded comment with no `@param` or `@returns`, which reads as ordinary prose and cannot be told apart from a section heading. Widening it means guessing.

It runs beside the provenance check, before `npm ci`, and validates its own detector first.

## What turning it on found

Two comments already stranded, both predating this work:

- `WebPush.registerSubscription` — its comment had been documenting `disableSubscription`
- `Profile.fetchRoomAvatar` — its comment had been documenting `fetchOccupantAvatar`

Both are moved back to the method they describe.