### PR TITLE
refactor(sdk): give the raw PEP read a home on the escape hatch

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -5,7 +5,7 @@ import { useConnectionStatus, useXMPPContext, hasFastToken, getBareJid, getDomai
 import { registerE2EEPlugins } from './e2ee/registerPlugins'
 import { isKeyLocked } from './e2ee/webPassphraseStore'
 import { attemptCachedUnlockOrPrompt } from '@/e2ee/silentRestore'
-import { probeRemoteIdentityState, identityChoiceFromProbe } from './e2ee/secretKeyProbe'
+import { probeRemoteIdentityState, identityChoiceFromProbe, pepReaderFor } from './e2ee/secretKeyProbe'
 import type { BackupProbeResult } from './e2ee/OpenPGPPluginBase'
 import { isOpenpgpEnabled } from './stores/encryptionSettingsStore'
 import { useToastStore } from './stores/toastStore'
@@ -268,7 +268,7 @@ function App() {
             // missing local key only needs one when the server holds an
             // identity to reconcile against.
             if (recoveryNeeded || hasNoLocal) {
-              const state = await probeRemoteIdentityState(client, accountJid)
+              const state = await probeRemoteIdentityState(pepReaderFor(client), accountJid)
               if (recoveryNeeded || state.hasServerIdentity) {
                 setPendingIdentityChoice({
                   accountJid,

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -20,6 +20,7 @@ import { KeyPickerDialog } from '@/components/KeyPickerDialog'
 import type { KeyBundle, BackupProbeResult } from '@/e2ee/OpenPGPPluginBase'
 import {
   probeRemoteIdentityState,
+  pepReaderFor,
   identityChoiceFromProbe,
   SecretKeyBackupProbeError,
 } from '@/e2ee/secretKeyProbe'
@@ -317,7 +318,7 @@ export function EncryptionSettings() {
         reason: 'local-key-unrecoverable'
       }
       try {
-        const state = await probeRemoteIdentityState(client, bareJid)
+        const state = await probeRemoteIdentityState(pepReaderFor(client), bareJid)
         next = {
           accountJid: bareJid,
           ...identityChoiceFromProbe(state),
@@ -409,7 +410,7 @@ export function EncryptionSettings() {
           ? await plugin.hasNoLocalKey()
           : false
         if (hasNoLocal) {
-          const state = await probeRemoteIdentityState(client, bareJid)
+          const state = await probeRemoteIdentityState(pepReaderFor(client), bareJid)
           if (state.hasServerIdentity) {
             setPendingIdentityChoice({
               accountJid: bareJid,
@@ -469,7 +470,7 @@ export function EncryptionSettings() {
           ? await plugin.hasNoLocalKey()
           : false
       if (!recoveryNeeded && !hasNoLocal) return
-      const state = await probeRemoteIdentityState(client, bareJid)
+      const state = await probeRemoteIdentityState(pepReaderFor(client), bareJid)
       // For a missing key we only prompt when the server has an identity to
       // reconcile against; an unrecoverable local key always needs a decision
       // (import/replace remain available even with no server backup).

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -65,7 +65,6 @@ import {
   type E2EEErrorKind,
 } from '@fluux/sdk'
 import { discoSupportsPep, getBareJid } from '@fluux/sdk'
-import type { XMPPClient } from '@fluux/sdk/core'
 import {
   clearBackedUpFingerprint,
   readBackedUpFingerprint,
@@ -907,7 +906,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     let publishedFingerprints: string[] = []
     try {
       publishedFingerprints = await probeRemotePublishedFingerprints(
-        this.makePepProbeAdapter(),
+        this.requireCtx().xmpp.queryPEP,
         ctx.account.jid,
       )
     } catch (err) {
@@ -988,7 +987,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     let identityState
     try {
       identityState = await probeRemoteIdentityState(
-        this.makePepProbeAdapter(),
+        this.requireCtx().xmpp.queryPEP,
         accountJid,
       )
     } catch (err) {
@@ -1015,21 +1014,6 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
           `(from the server backup or a file) or explicitly retire the published identity.`,
       )
     }
-  }
-
-  /**
-   * Adapter that lets the standalone PEP probe helpers (which take an
-   * XMPPClient) run against this plugin's `ctx.xmpp.queryPEP`. The
-   * shape match is exact for the one call site they touch (`pubsub.query`).
-   */
-  protected makePepProbeAdapter(): XMPPClient {
-    const ctx = this.requireCtx()
-    return {
-      pubsub: {
-        query: (jid: string, node: string, max?: number) =>
-          ctx.xmpp.queryPEP(jid, node, max),
-      },
-    } as unknown as XMPPClient
   }
 
   async retractPublicKeys(): Promise<void> {

--- a/apps/fluux/src/e2ee/secretKeyProbe.test.ts
+++ b/apps/fluux/src/e2ee/secretKeyProbe.test.ts
@@ -14,9 +14,8 @@ import {
   probeRemoteIdentityState,
   SecretKeyBackupProbeError,
   identityChoiceFromProbe,
+  type PepReader,
 } from './secretKeyProbe'
-import type { XMPPClient } from '@fluux/sdk/core'
-import type { PEPItem } from '@fluux/sdk'
 
 const ALICE = 'alice@example.com'
 const SECRET_KEY_NODE = 'urn:xmpp:openpgp:0:secret-key'
@@ -28,14 +27,6 @@ const OX_NS = 'urn:xmpp:openpgp:0'
  * the probe touches. The mock is typed via `unknown` cast — building a
  * full XMPPClient stub is overkill for testing one function.
  */
-function makeClient(
-  query: (jid: string, node: string, maxItems?: number) => Promise<PEPItem[]>,
-): XMPPClient {
-  return {
-    pubsub: { query },
-  } as unknown as XMPPClient
-}
-
 function bytesToBinaryString(bytes: Uint8Array): string {
   const chunks: string[] = []
   const chunkSize = 0x8000
@@ -103,7 +94,7 @@ function encodeOpenPgpArmorForXep0373(armored: string): string {
 describe('probeRemoteSecretKeyBackup', () => {
   it('returns the decoded armored backup when one is published', async () => {
     const armored = makeOpenPgpArmor('PGP MESSAGE', 'fake-backup')
-    const client = makeClient(async (jid, node, maxItems) => {
+    const readPep: PepReader = async (jid, node, maxItems) => {
       expect(jid).toBe(ALICE)
       expect(node).toBe(SECRET_KEY_NODE)
       expect(maxItems).toBe(1)
@@ -117,9 +108,9 @@ describe('probeRemoteSecretKeyBackup', () => {
           },
         },
       ]
-    })
+    }
 
-    const recovered = await probeRemoteSecretKeyBackup(client, ALICE)
+    const recovered = await probeRemoteSecretKeyBackup(readPep, ALICE)
     expect(recovered).toContain('BEGIN PGP MESSAGE')
     expect(readOpenPgpArmorPayloadForTest(recovered!)).toBe('fake-backup')
   })
@@ -127,18 +118,18 @@ describe('probeRemoteSecretKeyBackup', () => {
   it('returns null when the server reports item-not-found', async () => {
     // The canonical "this user has never published a backup" outcome.
     // The flow's auto-fresh-generate branch is the correct response here.
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('item-not-found')
-    })
+    }
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).resolves.toBeNull()
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).resolves.toBeNull()
   })
 
   it('returns null when the node exists but has no parseable items', async () => {
     // A node with stray items (or items in an unknown shape) is also a
     // "no usable backup" answer — we got a successful response from the
     // server, just nothing actionable in it.
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'something-else',
         payload: {
@@ -147,40 +138,40 @@ describe('probeRemoteSecretKeyBackup', () => {
           children: [],
         },
       },
-    ])
+    ]
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).resolves.toBeNull()
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).resolves.toBeNull()
   })
 
   it('throws SecretKeyBackupProbeError on a transient transport failure', async () => {
     // This is THE security-relevant case. A network blip used to be
     // swallowed and treated as "no backup" — letting the settings flow
     // overwrite the existing server backup with a fresh identity.
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('Not connected')
-    })
+    }
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).rejects.toBeInstanceOf(
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })
 
   it('throws on a permission error from the server', async () => {
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('forbidden')
-    })
+    }
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).rejects.toBeInstanceOf(
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })
 
   it('throws on an IQ timeout', async () => {
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('IQ timeout after 30000ms')
-    })
+    }
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).rejects.toBeInstanceOf(
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })
@@ -190,7 +181,7 @@ describe('probeRemoteSecretKeyBackup', () => {
     // — there's *something* there, we just can't read it. Auto-generating
     // a fresh key would still clobber the existing backup, so refuse to
     // silently treat as null.
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -199,9 +190,9 @@ describe('probeRemoteSecretKeyBackup', () => {
           children: ['!!not-valid-base64!!'],
         },
       },
-    ])
+    ]
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).rejects.toBeInstanceOf(
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })
@@ -210,12 +201,12 @@ describe('probeRemoteSecretKeyBackup', () => {
     // The caller may want to log the underlying error or surface its
     // message. The wrapper captures it via the `cause` field.
     const original = new Error('Socket not available')
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw original
-    })
+    }
 
     try {
-      await probeRemoteSecretKeyBackup(client, ALICE)
+      await probeRemoteSecretKeyBackup(readPep, ALICE)
       expect.fail('expected SecretKeyBackupProbeError to be thrown')
     } catch (err) {
       expect(err).toBeInstanceOf(SecretKeyBackupProbeError)
@@ -231,14 +222,14 @@ describe('probeRemoteSecretKeyBackup', () => {
     const query = vi.fn(async () => {
       throw new Error('item-not-found')
     })
-    const client = makeClient(query)
-    await probeRemoteSecretKeyBackup(client, ALICE)
+    const readPep: PepReader = query
+    await probeRemoteSecretKeyBackup(readPep, ALICE)
     expect(query).toHaveBeenCalledTimes(1)
   })
 
   it('ignores the legacy Fluux <data/> backup shape', async () => {
     const armored = makeOpenPgpArmor('PGP MESSAGE', 'legacy-backup')
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -253,15 +244,15 @@ describe('probeRemoteSecretKeyBackup', () => {
           ],
         },
       },
-    ])
+    ]
 
-    await expect(probeRemoteSecretKeyBackup(client, ALICE)).resolves.toBeNull()
+    await expect(probeRemoteSecretKeyBackup(readPep, ALICE)).resolves.toBeNull()
   })
 })
 
 describe('probeRemotePublishedFingerprints', () => {
   it('returns the fingerprints listed in the metadata node', async () => {
-    const client = makeClient(async (jid, node, maxItems) => {
+    const readPep: PepReader = async (jid, node, maxItems) => {
       expect(jid).toBe(ALICE)
       expect(node).toBe(PUBLIC_KEYS_METADATA_NODE)
       expect(maxItems).toBe(1)
@@ -285,8 +276,8 @@ describe('probeRemotePublishedFingerprints', () => {
           },
         },
       ]
-    })
-    const fps = await probeRemotePublishedFingerprints(client, ALICE)
+    }
+    const fps = await probeRemotePublishedFingerprints(readPep, ALICE)
     expect(fps).toEqual([
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
@@ -297,7 +288,7 @@ describe('probeRemotePublishedFingerprints', () => {
     // Multi-device or rotation history: the metadata can list more than
     // one published key. The probe surfaces them all so callers can detect
     // a non-empty server-side identity regardless of count.
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -317,8 +308,8 @@ describe('probeRemotePublishedFingerprints', () => {
           ],
         },
       },
-    ])
-    const fps = await probeRemotePublishedFingerprints(client, ALICE)
+    ]
+    const fps = await probeRemotePublishedFingerprints(readPep, ALICE)
     expect(fps).toEqual(['11'.repeat(20), '22'.repeat(20)])
   })
 
@@ -326,7 +317,7 @@ describe('probeRemotePublishedFingerprints', () => {
     // openpgp.js currently advertises both attrs with the same value when
     // generating v4 keys (RFC 9580 v6 should differ — that's a separate
     // bug). The probe normalizes so callers don't double-count.
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -344,22 +335,22 @@ describe('probeRemotePublishedFingerprints', () => {
           ],
         },
       },
-    ])
-    const fps = await probeRemotePublishedFingerprints(client, ALICE)
+    ]
+    const fps = await probeRemotePublishedFingerprints(readPep, ALICE)
     expect(fps).toEqual(['cc'.repeat(20)])
   })
 
   it('returns empty array when the server reports item-not-found', async () => {
     // The canonical "no public key has ever been published" outcome. Safe
     // to proceed to fresh-key generation in this case.
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('item-not-found')
-    })
-    await expect(probeRemotePublishedFingerprints(client, ALICE)).resolves.toEqual([])
+    }
+    await expect(probeRemotePublishedFingerprints(readPep, ALICE)).resolves.toEqual([])
   })
 
   it('returns empty array when the node exists but has no public-keys-list item', async () => {
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -368,12 +359,12 @@ describe('probeRemotePublishedFingerprints', () => {
           children: [],
         },
       },
-    ])
-    await expect(probeRemotePublishedFingerprints(client, ALICE)).resolves.toEqual([])
+    ]
+    await expect(probeRemotePublishedFingerprints(readPep, ALICE)).resolves.toEqual([])
   })
 
   it('returns empty array when the list is empty', async () => {
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -382,8 +373,8 @@ describe('probeRemotePublishedFingerprints', () => {
           children: [],
         },
       },
-    ])
-    await expect(probeRemotePublishedFingerprints(client, ALICE)).resolves.toEqual([])
+    ]
+    await expect(probeRemotePublishedFingerprints(readPep, ALICE)).resolves.toEqual([])
   })
 
   it('throws SecretKeyBackupProbeError on transport failure', async () => {
@@ -391,24 +382,24 @@ describe('probeRemotePublishedFingerprints', () => {
     // collapse to "no published key", because the silent-fork bug downstream
     // is exactly the same — generating a fresh key would publish a fingerprint
     // that competes with whatever is actually on the server.
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('Not connected')
-    })
-    await expect(probeRemotePublishedFingerprints(client, ALICE)).rejects.toBeInstanceOf(
+    }
+    await expect(probeRemotePublishedFingerprints(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })
 
   it('throws on permission errors and timeouts', async () => {
-    const forbiddenClient = makeClient(async () => {
+    const forbiddenClient = async () => {
       throw new Error('forbidden')
-    })
+    }
     await expect(probeRemotePublishedFingerprints(forbiddenClient, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
-    const timeoutClient = makeClient(async () => {
+    const timeoutClient = async () => {
       throw new Error('IQ timeout after 30000ms')
-    })
+    }
     await expect(probeRemotePublishedFingerprints(timeoutClient, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
@@ -418,8 +409,8 @@ describe('probeRemotePublishedFingerprints', () => {
     const query = vi.fn(async () => {
       throw new Error('item-not-found')
     })
-    const client = makeClient(query)
-    await probeRemotePublishedFingerprints(client, ALICE)
+    const readPep: PepReader = query
+    await probeRemotePublishedFingerprints(readPep, ALICE)
     expect(query).toHaveBeenCalledTimes(1)
   })
 
@@ -427,7 +418,7 @@ describe('probeRemotePublishedFingerprints', () => {
     // Malformed entry — no v4 or v6 attribute. Skip silently rather than
     // throw: the user clearly has nothing to lose if we treat this entry as
     // absent. The OTHER entries (if any) are still surfaced.
-    const client = makeClient(async () => [
+    const readPep: PepReader = async () => [
       {
         id: 'current',
         payload: {
@@ -439,8 +430,8 @@ describe('probeRemotePublishedFingerprints', () => {
           ],
         },
       },
-    ])
-    const fps = await probeRemotePublishedFingerprints(client, ALICE)
+    ]
+    const fps = await probeRemotePublishedFingerprints(readPep, ALICE)
     expect(fps).toEqual(['dd'.repeat(20)])
   })
 })
@@ -451,7 +442,7 @@ describe('probeRemoteIdentityState', () => {
     // need the unified state to decide whether silent generation is safe.
     const armored = makeOpenPgpArmor('PGP MESSAGE', 'fake-backup')
     const calls: string[] = []
-    const client = makeClient(async (_jid, node) => {
+    const readPep: PepReader = async (_jid, node) => {
       calls.push(node)
       if (node === SECRET_KEY_NODE) {
         return [
@@ -484,9 +475,9 @@ describe('probeRemoteIdentityState', () => {
         ]
       }
       throw new Error(`unexpected node: ${node}`)
-    })
+    }
 
-    const state = await probeRemoteIdentityState(client, ALICE)
+    const state = await probeRemoteIdentityState(readPep, ALICE)
     expect(state.backupMessage).toContain('BEGIN PGP MESSAGE')
     expect(state.publishedFingerprints).toEqual(['ee'.repeat(20)])
     expect(state.hasServerIdentity).toBe(true)
@@ -496,10 +487,10 @@ describe('probeRemoteIdentityState', () => {
   })
 
   it('reports no server-side identity when both nodes are absent', async () => {
-    const client = makeClient(async () => {
+    const readPep: PepReader = async () => {
       throw new Error('item-not-found')
-    })
-    const state = await probeRemoteIdentityState(client, ALICE)
+    }
+    const state = await probeRemoteIdentityState(readPep, ALICE)
     expect(state.backupMessage).toBeNull()
     expect(state.publishedFingerprints).toEqual([])
     expect(state.hasServerIdentity).toBe(false)
@@ -511,7 +502,7 @@ describe('probeRemoteIdentityState', () => {
     // metadata and leave the existing private-key holder (another device)
     // unable to receive messages. hasServerIdentity must be true so the
     // guard upstream refuses to generate.
-    const client = makeClient(async (_jid, node) => {
+    const readPep: PepReader = async (_jid, node) => {
       if (node === SECRET_KEY_NODE) throw new Error('item-not-found')
       if (node === PUBLIC_KEYS_METADATA_NODE) {
         return [
@@ -532,9 +523,9 @@ describe('probeRemoteIdentityState', () => {
         ]
       }
       throw new Error(`unexpected node: ${node}`)
-    })
+    }
 
-    const state = await probeRemoteIdentityState(client, ALICE)
+    const state = await probeRemoteIdentityState(readPep, ALICE)
     expect(state.backupMessage).toBeNull()
     expect(state.publishedFingerprints).toEqual(['ff'.repeat(20)])
     expect(state.hasServerIdentity).toBe(true)
@@ -545,7 +536,7 @@ describe('probeRemoteIdentityState', () => {
     // secret-key backup persists. Still NOT safe to silent-generate, because
     // restoring the backup is a legitimate recovery path.
     const armored = makeOpenPgpArmor('PGP MESSAGE', 'orphan-backup')
-    const client = makeClient(async (_jid, node) => {
+    const readPep: PepReader = async (_jid, node) => {
       if (node === SECRET_KEY_NODE) {
         return [
           {
@@ -560,9 +551,9 @@ describe('probeRemoteIdentityState', () => {
       }
       if (node === PUBLIC_KEYS_METADATA_NODE) throw new Error('item-not-found')
       throw new Error(`unexpected node: ${node}`)
-    })
+    }
 
-    const state = await probeRemoteIdentityState(client, ALICE)
+    const state = await probeRemoteIdentityState(readPep, ALICE)
     expect(state.backupMessage).toContain('BEGIN PGP MESSAGE')
     expect(state.publishedFingerprints).toEqual([])
     expect(state.hasServerIdentity).toBe(true)
@@ -571,11 +562,11 @@ describe('probeRemoteIdentityState', () => {
   it('propagates SecretKeyBackupProbeError if either sub-probe throws', async () => {
     // Don't silently degrade: a transient failure on either node means we
     // can't make a safe decision, so the upstream MUST surface a retry.
-    const client = makeClient(async (_jid, node) => {
+    const readPep: PepReader = async (_jid, node) => {
       if (node === SECRET_KEY_NODE) throw new Error('item-not-found')
       throw new Error('Not connected')
-    })
-    await expect(probeRemoteIdentityState(client, ALICE)).rejects.toBeInstanceOf(
+    }
+    await expect(probeRemoteIdentityState(readPep, ALICE)).rejects.toBeInstanceOf(
       SecretKeyBackupProbeError,
     )
   })

--- a/apps/fluux/src/e2ee/secretKeyProbe.ts
+++ b/apps/fluux/src/e2ee/secretKeyProbe.ts
@@ -24,6 +24,24 @@
  */
 
 import type { XMPPClient } from '@fluux/sdk/core'
+// Raw PEP: XEP-0373's nodes are not modelled by the SDK. This is the only
+// place in the app that reaches for the escape hatch, and `pepReaderFor` is
+// what keeps it to one line.
+import { queryPepNode, type PEPItem } from '@fluux/sdk/xmpp'
+
+/**
+ * Reads items from a PEP node.
+ *
+ * The probes take one of these rather than a client, because they run from two
+ * places that have different things in hand: the settings flow has a client
+ * and no plugin yet, and the plugin has `ctx.xmpp.queryPEP` and no client.
+ */
+export type PepReader = (jid: string, node: string, maxItems?: number) => Promise<PEPItem[]>
+
+/** The reader a caller holding a connected client should pass. */
+export function pepReaderFor(client: XMPPClient): PepReader {
+  return (jid, node, maxItems) => queryPepNode(client, jid, node, maxItems)
+}
 import type { BackupProbeResult } from './OpenPGPPluginBase'
 
 const OX_NAMESPACE = 'urn:xmpp:openpgp:0'
@@ -57,12 +75,12 @@ export class SecretKeyBackupProbeError extends Error {
  * module docstring for why we refuse to swallow those.
  */
 export async function probeRemoteSecretKeyBackup(
-  client: XMPPClient,
+  readPep: PepReader,
   bareJid: string,
 ): Promise<string | null> {
-  let items: Awaited<ReturnType<XMPPClient['pubsub']['query']>>
+  let items: PEPItem[]
   try {
-    items = await client.pubsub.query(bareJid, SECRET_KEY_NODE, 1)
+    items = await readPep(bareJid, SECRET_KEY_NODE, 1)
   } catch (err) {
     // `item-not-found` is the only error condition that means "the
     // user has never published a backup" — every server we care about
@@ -129,12 +147,12 @@ export interface RemoteIdentityState {
  * let the caller silent-generate over an existing identity.
  */
 export async function probeRemotePublishedFingerprints(
-  client: XMPPClient,
+  readPep: PepReader,
   bareJid: string,
 ): Promise<string[]> {
-  let items: Awaited<ReturnType<XMPPClient['pubsub']['query']>>
+  let items: PEPItem[]
   try {
-    items = await client.pubsub.query(bareJid, PUBLIC_KEYS_METADATA_NODE, 1)
+    items = await readPep(bareJid, PUBLIC_KEYS_METADATA_NODE, 1)
   } catch (err) {
     if (isItemNotFoundError(err)) return []
     throw new SecretKeyBackupProbeError(err)
@@ -177,12 +195,12 @@ export async function probeRemotePublishedFingerprints(
  * silent-fork decision.
  */
 export async function probeRemoteIdentityState(
-  client: XMPPClient,
+  readPep: PepReader,
   bareJid: string,
 ): Promise<RemoteIdentityState> {
   const [backupMessage, publishedFingerprints] = await Promise.all([
-    probeRemoteSecretKeyBackup(client, bareJid),
-    probeRemotePublishedFingerprints(client, bareJid),
+    probeRemoteSecretKeyBackup(readPep, bareJid),
+    probeRemotePublishedFingerprints(readPep, bareJid),
   ])
   return {
     backupMessage,

--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -77,13 +77,19 @@ describe('public API surface', () => {
     // belongs — inside — while the client reads as domain API.
     const client = new XMPPClient()
     try {
-      for (const name of ['mam', 'mds', 'conversationSync', 'entityTime', 'lastActivity']) {
+      for (const name of ['mam', 'mds', 'conversationSync', 'entityTime', 'lastActivity', 'pubsub']) {
         expect(name in client).toBe(false)
       }
       expect(typeof client.internal.mam).toBe('object')
     } finally {
       client.destroy()
     }
+  })
+
+  it('offers the raw PEP read on the escape hatch, not on the client', () => {
+    // Reading a node the SDK does not model means naming the node and walking
+    // its payload: protocol work, and `@fluux/sdk/xmpp` is where that lives.
+    expect(Object.keys(xmpp)).toContain('queryPepNode')
   })
 
   it('names its modules after the domain, not after the XEPs they implement', () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -120,6 +120,7 @@ export interface InternalModules {
   conversationSync: ConversationSync
   entityTime: EntityTime
   lastActivity: LastActivity
+  pubsub: PubSub
 }
 
 /**
@@ -264,12 +265,6 @@ export class XMPPClient {
    * Handles server feature discovery and HTTP upload service discovery.
    */
   public server!: Discovery
-
-  /**
-   * PubSub module (XEP-0060).
-   * Handles incoming PubSub events for avatars, nicknames, and other PEP data.
-   */
-  public pubsub!: PubSub
 
   /**
    * Blocking module (XEP-0191).
@@ -681,7 +676,7 @@ export class XMPPClient {
 
     this.connection = new Connection(moduleDeps)
     this.connectionActor = this.connection.getConnectionActor()
-    this.pubsub = new PubSub(moduleDeps)
+    const pubsub = new PubSub(moduleDeps)
     const mam = new MAM(moduleDeps)
     this.messages = new Chat(moduleDeps, mam)
     this.poll = new Poll(moduleDeps, this.messages)
@@ -697,7 +692,7 @@ export class XMPPClient {
     this.push = new WebPush(moduleDeps)
     const entityTime = new EntityTime(moduleDeps)
     const lastActivity = new LastActivity(moduleDeps)
-    this.internal = { mam, mds, conversationSync, entityTime, lastActivity }
+    this.internal = { mam, mds, conversationSync, entityTime, lastActivity, pubsub }
 
     // Post-connection orchestration. Drives the domain modules just built; the
     // churny bits (stores, JID, transport) are read through getters so a
@@ -747,7 +742,7 @@ export class XMPPClient {
       // not from the position of a module in this list. See core/stanzaRouting.
       routeStanza(
         stanza,
-        [this.pubsub, this.blocking, this.poll, this.messages, this.rooms, this.contacts],
+        [this.internal.pubsub, this.blocking, this.poll, this.messages, this.rooms, this.contacts],
         [this.internal.lastActivity],
       )
     })
@@ -1797,19 +1792,19 @@ export class XMPPClient {
         return this.server.queryInfo(jid)
       },
       publishPEP: async (node, item, options) => {
-        await this.pubsub.publish(node, item, options)
+        await this.internal.pubsub.publish(node, item, options)
       },
       retractPEP: async (node, itemId) => {
-        await this.pubsub.retract(node, itemId)
+        await this.internal.pubsub.retract(node, itemId)
       },
       deletePEP: async (node) => {
-        await this.pubsub.deleteNode(node)
+        await this.internal.pubsub.deleteNode(node)
       },
       queryPEP: async (jid, node, maxItems) => {
-        return this.pubsub.query(jid, node, maxItems)
+        return this.internal.pubsub.query(jid, node, maxItems)
       },
       subscribePEP: (jid, node, cb) => {
-        return this.pubsub.subscribe(jid, node, cb)
+        return this.internal.pubsub.subscribe(jid, node, cb)
       },
     }
   }

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -344,7 +344,7 @@ describe('PubSub Module', () => {
     it('returns true (handled) for MDS PubSub event messages', async () => {
       await connectClient()
 
-      const result = xmppClient.pubsub.handle(mdsEvent('user@example.com', [
+      const result = xmppClient.internal.pubsub.handle(mdsEvent('user@example.com', [
         {
           name: 'item',
           attrs: { id: 'juliet@capulet.example' },
@@ -418,7 +418,7 @@ describe('PubSub Module', () => {
     it('returns true (handled) for conversations PubSub event messages', async () => {
       await connectClient()
 
-      const result = xmppClient.pubsub.handle(convEvent('user@example.com', [
+      const result = xmppClient.internal.pubsub.handle(convEvent('user@example.com', [
         { name: 'conversation', attrs: { jid: 'alice@example.com' } },
       ]))
 
@@ -460,7 +460,7 @@ describe('PubSub Module', () => {
         },
       ])
 
-      const result = xmppClient.pubsub.handle(pubsubMessage)
+      const result = xmppClient.internal.pubsub.handle(pubsubMessage)
       expect(result).toBe(true)
     })
 
@@ -473,7 +473,7 @@ describe('PubSub Module', () => {
         { name: 'body', text: 'Hello' },
       ])
 
-      const result = xmppClient.pubsub.handle(regularMessage)
+      const result = xmppClient.internal.pubsub.handle(regularMessage)
       expect(result).toBe(false)
     })
 
@@ -484,7 +484,7 @@ describe('PubSub Module', () => {
         from: 'contact@example.com',
       }, [])
 
-      const result = xmppClient.pubsub.handle(presenceStanza)
+      const result = xmppClient.internal.pubsub.handle(presenceStanza)
       expect(result).toBe(false)
     })
   })

--- a/packages/fluux-sdk/src/xmpp/index.ts
+++ b/packages/fluux-sdk/src/xmpp/index.ts
@@ -29,6 +29,12 @@ export type { Element } from '@xmpp/client'
 // Fluux-specific nodes (NS_CONVERSATIONS, NS_FLUUX_VERIFICATIONS).
 export * from '../core/namespaces'
 
+// XEP-0060/XEP-0163: read a PEP node the SDK does not model. The nodes it does
+// model — avatars, nicknames, bookmarks, read markers — reach you as domain
+// state instead.
+export { queryPepNode } from './pep'
+export type { PEPItem } from '../core/e2ee'
+
 // XEP-0004: Data Forms — read and submit a form carried in a stanza.
 // The `DataForm` shapes themselves stay on the main entry: an app renders
 // admin forms without ever touching the wire.

--- a/packages/fluux-sdk/src/xmpp/pep.ts
+++ b/packages/fluux-sdk/src/xmpp/pep.ts
@@ -1,0 +1,50 @@
+/**
+ * Raw PEP reads, for nodes the SDK does not model.
+ *
+ * @module XMPP/PEP
+ */
+
+import type { XMPPClient } from '../core/XMPPClient'
+import type { PEPItem } from '../core/e2ee'
+
+/**
+ * Read items from a PEP node by name (XEP-0060, XEP-0163).
+ *
+ * The SDK models the PEP nodes it understands — avatars, nicknames, bookmarks,
+ * read markers — and exposes them as domain state. This is for the ones it does
+ * not: you name the node, and you get its items with their payloads as
+ * {@link XMLElementData}, element names and namespaces included. Interpreting
+ * that is the caller's job.
+ *
+ * The E2EE plugin surface offers the same read through `PluginContext.xmpp`,
+ * which is where a plugin should get it. This exists for the case a plugin
+ * cannot cover: code that must query a node *before* any plugin is registered.
+ *
+ * @param client - A connected client.
+ * @param jid - Bare JID whose node to read; the account's own JID for a
+ *   personal node.
+ * @param node - The node's name, e.g. `urn:xmpp:openpgp:0:public-keys`.
+ * @param maxItems - Cap on returned items, mapped to PubSub's `max_items`.
+ *   Omit for the server's default.
+ * @returns The node's items, oldest-first as the server returned them. An
+ *   absent node raises the server's `item-not-found`, which callers usually
+ *   want to tell apart from an empty node.
+ *
+ * @example
+ * ```typescript
+ * import { queryPepNode } from '@fluux/sdk/xmpp'
+ *
+ * const items = await queryPepNode(client, 'bob@example.com', 'urn:xmpp:openpgp:0:public-keys', 1)
+ * for (const item of items) {
+ *   if (item.payload.name === 'public-keys-list') console.log(item.id)
+ * }
+ * ```
+ */
+export async function queryPepNode(
+  client: XMPPClient,
+  jid: string,
+  node: string,
+  maxItems?: number,
+): Promise<PEPItem[]> {
+  return client.internal.pubsub.query(jid, node, maxItems)
+}


### PR DESCRIPTION
The last XEP name on the client, and the piece deferred from #1270.

`client.pubsub`'s only consumer outside the SDK is the app's OpenPGP probe, which names two XEP-0373 node URNs and walks their payloads by element name and namespace. That is protocol work, and `@fluux/sdk/xmpp` is where protocol work lives. So the module joins `client.internal`, and the escape hatch gains `queryPepNode(client, jid, node, maxItems?)`.

Of the two options considered, exposing the plugin primitives on the client was ruled out by the probe itself: it is a *plugin-less* probe by design, run from the settings toggle **before** any plugin is registered, because the restore-first flow has to know whether a backup exists before it offers to generate a key.

## What the change surfaced

The probe took an `XMPPClient` for a reason that turned out to be backwards. It runs from two places holding different things: the settings flow has a client and no plugin, the plugin has `ctx.xmpp.queryPEP` and no client. So `OpenPGPPluginBase` had been fabricating a fake client shaped `{ pubsub: { query } }` purely to satisfy the parameter — and the probe's own test did the same.

The probes now take the read itself (`PepReader`). Both shims are gone, the plugin passes its primitive directly, and the escape hatch is imported at exactly one line in the app, inside `pepReaderFor`.

## Verification

`build:sdk`, `typecheck` 0 errors, `check:examples` 185 compiled, `check:comments` clean, `lint` 0 errors, `npm test` green (SDK 240 files / 6059 tests, app 455 / 6047), including the 28 probe tests that cover the item-not-found versus operational-failure distinction the flow depends on.

`barrelSurface.test.ts` now asserts `pubsub` is off the client and `queryPepNode` is on the escape hatch.