### PR TITLE
refactor(sdk): leave one event bus on the client

### DIFF
--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -86,6 +86,22 @@ describe('public API surface', () => {
     }
   })
 
+  it('offers one event bus to a consumer, not two', () => {
+    // `subscribe` carries the state the stores are built from. The client's own
+    // signal bus is what the SDK's side effects listen to, and it moved to the
+    // internal surface so nobody has to guess which of the two to reach for.
+    // `onStanza` stays: it is the named door to the raw feed.
+    const client = new XMPPClient()
+    try {
+      expect('on' in client).toBe(false)
+      expect(typeof client.subscribe).toBe('function')
+      expect(typeof client.onStanza).toBe('function')
+      expect(typeof client.internal.on).toBe('function')
+    } finally {
+      client.destroy()
+    }
+  })
+
   it('offers the raw PEP read on the escape hatch, not on the client', () => {
     // Reading a node the SDK does not model means naming the node and walking
     // its payload: protocol work, and `@fluux/sdk/xmpp` is where that lives.

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -400,7 +400,7 @@ describe('XMPPClient', () => {
   describe('event emitter', () => {
     it('should emit online event on connection', async () => {
       const onlineHandler = vi.fn()
-      xmppClient.on('online', onlineHandler)
+      xmppClient.internal.on('online', onlineHandler)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -417,7 +417,7 @@ describe('XMPPClient', () => {
 
     it('should allow unsubscribing from events', async () => {
       const onlineHandler = vi.fn()
-      const unsubscribe = xmppClient.on('online', onlineHandler)
+      const unsubscribe = xmppClient.internal.on('online', onlineHandler)
 
       unsubscribe()
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -114,7 +114,14 @@ import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, d
  *
  * @internal
  */
-export interface InternalModules {
+export interface InternalSurface {
+  /**
+   * The client's own signal bus: connection lifecycle and raw stanzas, which
+   * the SDK's side effects listen to. A consumer uses `subscribe` instead —
+   * that bus carries the state the stores are built from — or `onStanza` for
+   * the raw feed.
+   */
+  on<K extends keyof XMPPClientEvents>(event: K, handler: XMPPClientEvents[K]): () => void
   mam: MAM
   mds: Mds
   conversationSync: ConversationSync
@@ -302,7 +309,7 @@ export class XMPPClient {
    *
    * @internal
    */
-  public internal!: InternalModules
+  public internal!: InternalSurface
 
   /**
    * Web Push module (p1:push).
@@ -692,7 +699,10 @@ export class XMPPClient {
     this.push = new WebPush(moduleDeps)
     const entityTime = new EntityTime(moduleDeps)
     const lastActivity = new LastActivity(moduleDeps)
-    this.internal = { mam, mds, conversationSync, entityTime, lastActivity, pubsub }
+    this.internal = {
+      on: (event, handler) => this.subscribeToBus(event, handler as ClientEvents[typeof event]),
+      mam, mds, conversationSync, entityTime, lastActivity, pubsub,
+    }
 
     // Post-connection orchestration. Drives the domain modules just built; the
     // churny bits (stores, JID, transport) are read through getters so a
@@ -843,32 +853,6 @@ export class XMPPClient {
   // Event Handling
   // ============================================================================
 
-  /**
-   * Subscribe to client events.
-   *
-   * @param event - The event name to subscribe to
-   * @param handler - The callback function to invoke when the event fires
-   * @returns A function to unsubscribe from the event
-   *
-   * @example
-   * ```typescript
-   * // Subscribe to message events
-   * const unsubscribe = client.on('message', (message) => {
-   *   console.log('Received:', message.body)
-   * })
-   *
-   * // Later, unsubscribe
-   * unsubscribe()
-   * ```
-   */
-  on<K extends keyof XMPPClientEvents>(
-    event: K,
-    handler: XMPPClientEvents[K]
-  ): () => void {
-    // `ClientEvents` is the intersection, so for a public K the two handler
-    // types are the same; TypeScript cannot see that through the generic.
-    return this.subscribeToBus(event, handler as ClientEvents[K])
-  }
 
   /**
    * Subscribe to a signal the client raises for itself. Separate from {@link on}
@@ -973,7 +957,7 @@ export class XMPPClient {
    * ```
    */
   onStanza(handler: (stanza: Element) => void): () => void {
-    return this.on('stanza', handler)
+    return this.subscribeToBus('stanza', handler)
   }
 
   // ============================================================================

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -515,7 +515,7 @@ export function setupBackgroundSyncSideEffects(
   // A transport 'online' starts fresh-session sync. An uninterrupted resume can
   // also be followed by a synthetic 'online' when cache integrity forces full
   // setup; preserve the resume boundary and confirmed joins on that upgrade.
-  const unsubscribeOnline = client.on('online', () => {
+  const unsubscribeOnline = client.internal.on('online', () => {
     const followsUninterruptedResume = uninterruptedResumeMayEmitSyntheticOnline
     uninterruptedResumeMayEmitSyntheticOnline = false
     sessionGeneration += 1
@@ -557,7 +557,7 @@ export function setupBackgroundSyncSideEffects(
   // is a `{ before: '' }` fetch-latest that populates the archive and sets the
   // preview; a gap-open room forward-fills from its recorded gap). Caught-up rooms
   // are skipped, so this stays out of SM's "server replays, no MAM" path.
-  const unsubscribeResumed = client.on('resumed', () => {
+  const unsubscribeResumed = client.internal.on('resumed', () => {
     sessionGeneration += 1
     uninterruptedResumeMayEmitSyntheticOnline = true
     isFreshSession = false

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -166,7 +166,7 @@ export function setupChatSideEffects(
 
   // Fresh session: catch up MAM for the active conversation.
   // 'online' fires only on fresh sessions (not SM resumption).
-  const unsubscribeOnline = client.on('online', () => {
+  const unsubscribeOnline = client.internal.on('online', () => {
     isFreshSession = true
     sessionStartTime = Date.now()
 
@@ -183,7 +183,7 @@ export function setupChatSideEffects(
   })
 
   // SM resumption: no MAM catchup needed — server replays undelivered stanzas
-  const unsubscribeResumed = client.on('resumed', () => {
+  const unsubscribeResumed = client.internal.on('resumed', () => {
     isFreshSession = false
     if (debug) console.log('[SideEffects] Chat: SM resumption — skipping MAM catchup')
 

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.ts
@@ -114,7 +114,7 @@ export function setupConversationSyncSideEffects(
   // handleFreshSession's merge complete. The 'online' event fires
   // at the end of handleFreshSession, and background sync starts
   // creating conversations after that.
-  const unsubscribeOnline = client.on('online', () => {
+  const unsubscribeOnline = client.internal.on('online', () => {
     syncEnabled = false
     lastPublishedSnapshot = undefined
 
@@ -126,7 +126,7 @@ export function setupConversationSyncSideEffects(
   })
 
   // SM resumption: no sync needed
-  const unsubscribeResumed = client.on('resumed', () => {
+  const unsubscribeResumed = client.internal.on('resumed', () => {
     syncEnabled = false
   })
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -80,12 +80,11 @@ function makeClient() {
     retractDisplayed: vi.fn().mockResolvedValue(undefined),
   }
   return {
-    on: register,
     subscribe: register,
     _emit: (event: string, payload?: unknown) => {
       for (const handler of handlers[event] ?? []) handler(payload)
     },
-    internal: { mds },
+    internal: { on: register, mds },
   }
 }
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -234,10 +234,9 @@ function makeClient() {
     retractDisplayed: vi.fn().mockResolvedValue(undefined),
   }
   return {
-    on: register,
     subscribe: register,
     _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
-    internal: { mds },
+    internal: { on: register, mds },
   }
 }
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -208,11 +208,10 @@ function makeClient() {
 
   return {
     // Connection lifecycle events ('online'/'resumed') use client.on(...).
-    on: register,
     // SDK events ('read:displayed-synced') use client.subscribe(...).
     subscribe: register,
     _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
-    internal: { mds },
+    internal: { on: register, mds },
   }
 }
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -821,7 +821,7 @@ export function setupMdsSideEffects(
 
   // Fresh session: seed from the node, then enable publishing. Publishing stays
   // disabled for the whole async seed so the seeded positions aren't republished.
-  const unsubscribeOnline = client.on('online', () => {
+  const unsubscribeOnline = client.internal.on('online', () => {
     syncEnabled = false
     sessionEpoch++
     nodeSnapshotAuthoritative = false
@@ -931,7 +931,7 @@ export function setupMdsSideEffects(
   )
 
   // SM resumption: server replays notifications; keep publishing enabled, no reseed.
-  const unsubscribeResumed = client.on('resumed', () => {
+  const unsubscribeResumed = client.internal.on('resumed', () => {
     dirty.open()
     lastConsideredPointerIdentity.clear()
     syncEnabled = true

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -145,7 +145,7 @@ describe('XMPPClient Message', () => {
     it('should emit message event for incoming messages', async () => {
       await connectClient()
       const messageHandler = vi.fn()
-      xmppClient.on('message', messageHandler)
+      xmppClient.internal.on('message', messageHandler)
 
       const messageStanza = createMockElement('message', {
         from: 'contact@example.com',
@@ -389,7 +389,7 @@ describe('XMPPClient Message', () => {
     it('should NOT emit message event for sent carbons', async () => {
       await connectClient()
       const messageHandler = vi.fn()
-      xmppClient.on('message', messageHandler)
+      xmppClient.internal.on('message', messageHandler)
 
       const carbonStanza = createMockElement('message', {
         from: 'user@example.com',

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -2222,7 +2222,7 @@ describe('XMPPClient Connection', () => {
   describe('event emitter', () => {
     it('should emit online event on connection', async () => {
       const onlineHandler = vi.fn()
-      xmppClient.on('online', onlineHandler)
+      xmppClient.internal.on('online', onlineHandler)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -2239,7 +2239,7 @@ describe('XMPPClient Connection', () => {
 
     it('should allow unsubscribing from events', async () => {
       const handler = vi.fn()
-      const unsubscribe = xmppClient.on('online', handler)
+      const unsubscribe = xmppClient.internal.on('online', handler)
 
       // Unsubscribe before connecting
       unsubscribe()

--- a/packages/fluux-sdk/src/core/modules/Presence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Presence.test.ts
@@ -223,7 +223,7 @@ describe('XMPPClient Presence', () => {
     it('should emit presence event with aggregated presence', async () => {
       await connectClient()
       const presenceHandler = vi.fn()
-      xmppClient.on('presence', presenceHandler)
+      xmppClient.internal.on('presence', presenceHandler)
 
       const presenceStanza = createMockElement('presence', {
         from: 'contact@example.com/resource',

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -681,10 +681,10 @@ describe('XMPPClient Own Avatar', () => {
       // `avatarMetadataUpdate` is an internal signal, deliberately absent from
       // the public `on` surface. Reaching the bus directly is the point here:
       // this asserts what the module emits, not what a consumer can subscribe to.
-      const onInternal = xmppClient as unknown as {
+      const bus = xmppClient.internal as unknown as {
         on: (event: 'avatarMetadataUpdate', handler: (jid: string, hash: string | null) => void) => () => void
       }
-      onInternal.on('avatarMetadataUpdate', (jid, hash) => {
+      bus.on('avatarMetadataUpdate', (jid, hash) => {
         emittedEvents.push({ jid, hash })
       })
 

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -320,7 +320,7 @@ export function setupRoomSideEffects(
   // Fresh sessions require a self-presence confirmation before room MAM starts.
   // A missing-marker upgrade can also emit a synthetic 'online' after 'resumed';
   // that uninterrupted path must retain resume-seeded fetch tracking.
-  const unsubscribeOnline = client.on('online', () => {
+  const unsubscribeOnline = client.internal.on('online', () => {
     const followsUninterruptedResume = uninterruptedResumeMayEmitSyntheticOnline
     freshSessionRequiresJoinConfirmation = true
     if (!followsUninterruptedResume) {
@@ -358,7 +358,7 @@ export function setupRoomSideEffects(
   // after a reconnect" bug). hasQueried (set on any completed MAM query, even an
   // empty result) is the durable signal; it's separate from "has resident
   // messages" so a room caught up via live delivery is still covered.
-  const unsubscribeResumed = client.on('resumed', () => {
+  const unsubscribeResumed = client.internal.on('resumed', () => {
     // A missing cache marker upgrades this same transport session to full fresh
     // setup, which emits a synthetic online only after room rejoins can finish.
     // Keep that next online distinguishable from a later fresh transport session.

--- a/packages/fluux-sdk/src/core/sideEffectHost.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHost.ts
@@ -102,7 +102,7 @@ export interface E2EEWarmupHost {
  *
  * @category Internal
  */
-export interface SideEffectHost extends SDKEventSource, ClientEventSource {
+export interface SideEffectHost extends SDKEventSource {
   isConnected(): boolean
   /** Re-runs decryption for payloads stashed while the key was unavailable. */
   retryPendingDecrypts(): Promise<number>
@@ -117,6 +117,8 @@ export interface SideEffectHost extends SDKEventSource, ClientEventSource {
    * exposed elsewhere.
    */
   readonly internal: {
+    /** The client's own signal bus (see `ClientEventSource`). */
+    readonly on: ClientEventSource['on']
     readonly mam: MamSideEffectHost
     readonly mds: MdsSideEffectHost
     readonly conversationSync: ConversationSyncSideEffectHost

--- a/packages/fluux-sdk/src/core/sideEffectHostConformance.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHostConformance.ts
@@ -31,4 +31,9 @@ type Provides<Contract> = XMPPClient extends Contract ? true : false
 // against the interface named in the alias to find the member that drifted.
 export type ClientProvidesSideEffectHost = Assert<Provides<SideEffectHost>>
 export type ClientProvidesSDKEventSource = Assert<Provides<SDKEventSource>>
-export type ClientProvidesClientEventSource = Assert<Provides<ClientEventSource>>
+// The signal bus is deliberately NOT on the client's public surface: a
+// consumer subscribes to SDK events, or reads raw stanzas through `onStanza`.
+// It is reachable on the internal surface, and that is what must keep holding.
+export type ClientInternalProvidesClientEventSource = Assert<
+  XMPPClient['internal'] extends ClientEventSource ? true : false
+>

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -42,6 +42,11 @@ export function createMockClient() {
       queryRoomMAM: vi.fn().mockResolvedValue(undefined),
     },
     internal: {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (!handlers.has(event)) handlers.set(event, new Set())
+        handlers.get(event)!.add(handler)
+        return () => handlers.get(event)?.delete(handler)
+      }),
       mam: {
         refreshConversationPreviews: vi.fn().mockResolvedValue(undefined),
         refreshArchivedConversationPreviews: vi.fn().mockResolvedValue(undefined),
@@ -61,11 +66,6 @@ export function createMockClient() {
     isConnected: vi.fn().mockReturnValue(true),
     retryPendingDecrypts: vi.fn().mockResolvedValue(0),
     e2ee: null as any,
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      if (!handlers.has(event)) handlers.set(event, new Set())
-      handlers.get(event)!.add(handler)
-      return () => handlers.get(event)?.delete(handler)
-    }),
     subscribe: vi.fn((event: string, handler: (payload: unknown) => void) => {
       if (!sdkHandlers.has(event)) sdkHandlers.set(event, new Set())
       sdkHandlers.get(event)!.add(handler)

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -33,18 +33,22 @@ export type {
 // ============================================================================
 
 /**
- * The client's public event surface, and a compatibility contract.
+ * The shape of the client's own signal bus.
  *
- * `@fluux/sdk/core` is consumed directly by bots and CLIs, for which these
- * events are the API: removing or changing one breaks them. Anything the SDK
- * emits purely to talk to itself belongs in {@link InternalClientEvents}
- * instead, so the two are not mistaken for each other.
+ * Connection lifecycle and raw stanzas, which the SDK's side effects listen
+ * to. It is reached on `client.internal`, not on the client: a consumer
+ * observes through `client.subscribe`, which carries the state the stores are
+ * built from, or through `client.onStanza` for the raw feed. Two buses on the
+ * public surface meant guessing which one to reach for, and the SDK's own
+ * documentation guessed wrong.
+ *
+ * Anything the SDK emits purely to talk to itself belongs in
+ * {@link InternalClientEvents} instead, so the two are not mistaken for each
+ * other.
  *
  * @example
  * ```typescript
- * client.on('message', (msg) => console.log('New message:', msg.body))
- * client.on('online', () => console.log('Connected!'))
- * client.on('error', (err) => console.error('Error:', err))
+ * client.internal.on('online', () => console.log('Connected!'))
  * ```
  *
  * @category Core

--- a/packages/fluux-sdk/src/hooks/useXMPP.ts
+++ b/packages/fluux-sdk/src/hooks/useXMPP.ts
@@ -50,22 +50,6 @@ import type { Element } from '@xmpp/client'
  * }
  * ```
  *
- * @example Subscribing to client events
- * ```tsx
- * function ConnectionMonitor() {
- *   const { on } = useXMPP()
- *
- *   useEffect(() => {
- *     const unsubscribe = on('online', () => {
- *       console.log('Connected')
- *     })
- *     return unsubscribe
- *   }, [on])
- *
- *   return null
- * }
- * ```
- *
  * @example Building stanzas with the xml helper
  * ```tsx
  * // The builder is protocol vocabulary, so it comes from the escape hatch
@@ -111,16 +95,6 @@ export function useXMPP() {
     [client]
   )
 
-  const on = useCallback(
-    <K extends keyof import('../core/types').XMPPClientEvents>(
-      event: K,
-      handler: import('../core/types').XMPPClientEvents[K]
-    ) => {
-      return client.on(event, handler)
-    },
-    [client]
-  )
-
   return {
     /**
      * The underlying XMPPClient instance.
@@ -137,11 +111,6 @@ export function useXMPP() {
      * Subscribe to raw stanza events
      */
     onStanza,
-
-    /**
-     * Subscribe to any client event
-     */
-    on,
 
     /**
      * Set presence status

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -18,6 +18,10 @@
  * - **`@fluux/sdk/core`** - Core-only: XMPPClient, types (for bots/CLI/other frameworks)
  * - **`@fluux/sdk/stores`** - Direct Zustand store access
  *
+ * Everything the SDK observes reaches you through one bus: `client.subscribe`,
+ * or the hooks built on it. Raw stanzas have their own named door,
+ * `client.onStanza`.
+ *
  * None of those describes XMPP on the wire: conversations, rooms, contacts and
  * presence are the vocabulary, and no XEP has to be read to use them. Raw
  * namespaces, the stanza builder and the wire parsers are the escape hatch on


### PR DESCRIPTION
Based on #1275, so the diff shows only this change — it will retarget to `main` when that merges.

A consumer had two doors and no way to tell which was theirs: `subscribe` for the events the stores are built from, `on` for the client's own signals. The SDK's own documentation guessed wrong about it, which is how the example checker found it in #1267.

## Why removing it costs nothing

Nothing outside the SDK used `on`. Its nine events are consumed 37 times, every one of them inside the SDK's side effects; the app observes state through the stores, and nothing destructured `on` from `useXMPP()`. Two of the nine, `roster` and `reconnecting`, had no subscriber at all.

So the bus joins the internal surface as `client.internal.on`, beside the modules it serves, and `SideEffectHost` names it there too since that is where it reads it from.

`subscribe` is now the one bus a consumer sees, and `onStanza` stays as the named door to the raw feed. Those are the two things a bot actually reaches for, and the main entry now says so.

## A promise this removes

`XMPPClientEvents` documented itself as "the client's public event surface, and a compatibility contract… `@fluux/sdk/core` is consumed directly by bots and CLIs, for which these events are the API." That is the promise this change withdraws, so the doc now describes what it is: the shape of an internal signal bus. `InternalClientEvents`, separated in #1252, is unaffected.

`sideEffectHostConformance.ts` keeps asserting the client provides the bus — now against `XMPPClient['internal']`, so a drift still fails to compile.

## Verification

`build:sdk`, `typecheck` 0 errors, `check:examples` 183 compiled, `check:comments` clean, `lint` 0 errors, `npm test` green (SDK 240 files / 6060 tests, app 455 / 6047). `barrelSurface.test.ts` asserts `on` is off the client while `subscribe`, `onStanza` and `internal.on` are all present.