### PR TITLE
refactor(sdk): name the events after the domain too

### DIFF
--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -186,7 +186,7 @@ const RECOUNT_DEFERRAL_REASONS = [
   'pointerless-defer',
   'pending-remote-displayed',
   'no-floor',
-  'mam-not-caught-up',
+  'history-not-caught-up',
   'context-changed',
   'coverage-missing',
   'coverage-unresolvable',

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -81,7 +81,7 @@ vi.mock('@fluux/sdk', () => ({
     clearAnimation: mockClearAnimation,
     clearFirstNewMessageId: mockClearFirstNewMessageId,
     supportsMAM: mockSupportsMAM,
-    activeMAMState: mockActiveMAMState,
+    activeHistoryState: mockActiveMAMState,
     fetchHistory: mockFetchHistory,
     fetchOlderHistory: vi.fn(),
     // Draft management
@@ -112,7 +112,7 @@ vi.mock('@fluux/sdk', () => ({
     firstNewMessageId: undefined,
     readPointerId: undefined,
     supportsMAM: mockSupportsMAM,
-    activeMAMState: mockActiveMAMState,
+    activeHistoryState: mockActiveMAMState,
     fetchHistory: mockFetchHistory,
     fetchOlderHistory: vi.fn(),
     getDraft: vi.fn(() => ''),

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -57,7 +57,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, readPointerId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, activeMAMState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, readPointerId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, activeHistoryState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   const interiorPlacementVersion = useChatStore((state) => {
     const id = state.activeConversationId
     return id ? state.interiorPlacementVersions.get(id) ?? 0 : 0
@@ -214,8 +214,8 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     handleMouseLeave,
   } = useMessageSelection(activeMessages, scrollRef, isAtBottomRef, {
     onReachedFirstMessage: fetchOlderHistory,
-    isLoadingOlder: activeMAMState?.isLoading,
-    isHistoryComplete: activeMAMState?.isHistoryComplete,
+    isLoadingOlder: activeHistoryState?.isLoading,
+    isHistoryComplete: activeHistoryState?.isHistoryComplete,
     onEnterPressed: (id: string) => useExpandedMessagesStore.getState().toggle(id),
     onKeyboardNavigate: () => { isAtBottomRef.current = false },
   })
@@ -582,14 +582,14 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             isDarkMode={resolvedMode === 'dark'}
           onScrollToTop={fetchOlderHistory}
           onLoadAround={loadMessagesAround}
-          isLoadingOlder={activeMAMState?.isLoading ?? false}
+          isLoadingOlder={activeHistoryState?.isLoading ?? false}
           onLoadNewer={loadNewer}
           windowAtLiveEdge={windowAtLiveEdge}
           onJumpToLatest={recenterToLatest}
-          isHistoryComplete={activeMAMState?.isHistoryComplete ?? false}
-          forwardGapTimestamp={activeMAMState?.forwardGapTimestamp}
+          isHistoryComplete={activeHistoryState?.isHistoryComplete ?? false}
+          forwardGapTimestamp={activeHistoryState?.forwardGapTimestamp}
           onCatchUpHistory={continueChatCatchUp}
-          isCatchingUp={activeMAMState?.isLoading ?? false}
+          isCatchingUp={activeHistoryState?.isLoading ?? false}
           // SDK auto-fetches cache + MAM in background, no blocking spinner needed
           isInitialLoading={false}
           highlightTerms={find.highlightTerms}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -99,7 +99,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Active-room state + messaging/scroll actions. Poll / moderation /
   // management actions come from the focused hooks below (they subscribe to no
   // store, so they add no re-render triggers).
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeHistoryState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
   const interiorPlacementVersion = useRoomStore((state) => {
     const jid = state.activeRoomJid
     return jid ? state.interiorPlacementVersions.get(jid) ?? 0 : 0
@@ -297,8 +297,8 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     handleMouseLeave,
   } = useMessageSelection(activeMessages, scrollRef, isAtBottomRef, {
     onReachedFirstMessage: fetchOlderHistory,
-    isLoadingOlder: activeMAMState?.isLoading,
-    isHistoryComplete: activeRoom?.supportsMAM === false || activeMAMState?.isHistoryComplete,
+    isLoadingOlder: activeHistoryState?.isLoading,
+    isHistoryComplete: activeRoom?.supportsMAM === false || activeHistoryState?.isHistoryComplete,
     onEnterPressed: (id: string) => useExpandedMessagesStore.getState().toggle(id),
     onKeyboardNavigate: () => { isAtBottomRef.current = false },
   })
@@ -632,11 +632,11 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             isDarkMode={resolvedMode === 'dark'}
             onScrollToTop={fetchOlderHistory}
             onLoadAround={loadMessagesAround}
-            isLoadingOlder={activeMAMState?.isLoading}
+            isLoadingOlder={activeHistoryState?.isLoading}
             onLoadNewer={loadNewer}
             windowAtLiveEdge={windowAtLiveEdge}
             onJumpToLatest={recenterToLatest}
-            isHistoryComplete={activeRoom.supportsMAM === false || activeMAMState?.isHistoryComplete}
+            isHistoryComplete={activeRoom.supportsMAM === false || activeHistoryState?.isHistoryComplete}
             onNickContextMenu={handleNickContextMenu}
             onNickTouchStart={handleNickTouchStart}
             onNickTouchEnd={handleNickTouchEnd}
@@ -644,9 +644,9 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             highlightTerms={find.highlightTerms}
             currentMatchId={find.currentMatchId}
             lastSentMessageId={lastSentMessageId}
-            forwardGapTimestamp={activeMAMState?.forwardGapTimestamp}
+            forwardGapTimestamp={activeHistoryState?.forwardGapTimestamp}
             onCatchUpHistory={continueRoomCatchUp}
-            isCatchingUp={activeMAMState?.isLoading}
+            isCatchingUp={activeHistoryState?.isLoading}
             />
           </MediaAutoloadProvider>
         </div>

--- a/apps/fluux/src/components/sidebar-components/MucInvitationItem.tsx
+++ b/apps/fluux/src/components/sidebar-components/MucInvitationItem.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from 'react-i18next'
-import { getLocalPart, type MucInvitation } from '@fluux/sdk'
+import { getLocalPart, type RoomInvitation } from '@fluux/sdk'
 import { Check, X, DoorOpen } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 
 interface MucInvitationItemProps {
-  invitation: MucInvitation
+  invitation: RoomInvitation
   onAccept: () => void
   onDecline: () => void
 }

--- a/apps/fluux/src/demo/perfHarness.ts
+++ b/apps/fluux/src/demo/perfHarness.ts
@@ -124,9 +124,9 @@ export async function installPerfHarness(opts: { scan?: boolean } = {}): Promise
       jid: `perf${i}@fluux.chat`, name: `Perf User ${i}`, presence: 'offline', subscription: 'both',
     }))
     return measureScenario(`rosterStorm:${count}`, async () => {
-      c.emitSDK('roster:loaded', { contacts: [...existing, ...synth] })
+      c.emitSDK('contacts:loaded', { contacts: [...existing, ...synth] })
       for (let i = 0; i < count; i++) {
-        c.emitSDK('roster:presence', { fullJid: `perf${i}@fluux.chat/web`, show: shows[i % shows.length], priority: 1 })
+        c.emitSDK('contacts:presence', { fullJid: `perf${i}@fluux.chat/web`, show: shows[i % shows.length], priority: 1 })
         await step(stepMs)
       }
     })
@@ -141,7 +141,7 @@ export async function installPerfHarness(opts: { scan?: boolean } = {}): Promise
     const shows: Array<string | null> = [null, 'away']
     return measureScenario(`presenceFlap:${target}`, async () => {
       for (let i = 0; i < times; i++) {
-        c.emitSDK('roster:presence', { fullJid: `${target}/web`, show: shows[i % 2], priority: 1 })
+        c.emitSDK('contacts:presence', { fullJid: `${target}/web`, show: shows[i % 2], priority: 1 })
         await step(stepMs)
       }
     })

--- a/packages/fluux-sdk/src/bindings/storeBindings.integration.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.integration.test.ts
@@ -165,7 +165,7 @@ describe('SDK Event Bindings Integration', () => {
       const contacts = [{ jid: 'alice@example.com', name: 'Alice', presence: 'online' }]
 
       // Act - directly call emitSDK to verify the binding works
-      xmppClient['emitSDK']('roster:loaded', { contacts } as any)
+      xmppClient['emitSDK']('contacts:loaded', { contacts } as any)
 
       // Assert
       expect(mockStores.roster.setContacts).toHaveBeenCalledWith(contacts)
@@ -240,7 +240,7 @@ describe('SDK Event Bindings Integration', () => {
       const contacts = [{ jid: 'test@example.com', name: 'Test' }]
 
       // Call emitSDK like the module would
-      roster.deps.emitSDK('roster:loaded', { contacts })
+      roster.deps.emitSDK('contacts:loaded', { contacts })
 
       // Verify the store method was called via the binding
       expect(mockStores.roster.setContacts).toHaveBeenCalledWith(contacts)
@@ -265,7 +265,7 @@ describe('SDK Event Bindings Integration', () => {
       vi.clearAllMocks()
 
       // Try to emit an event
-      xmppClient['emitSDK']('roster:loaded', { contacts: [] })
+      xmppClient['emitSDK']('contacts:loaded', { contacts: [] })
 
       // Should not have been called
       expect(mockStores.roster.setContacts).not.toHaveBeenCalled()
@@ -288,7 +288,7 @@ describe('SDK Event Bindings Integration', () => {
 
       // Use the module's deps.emitSDK like a real module would
       const roster = xmppClient.contacts as any
-      roster.deps.emitSDK('roster:loaded', { contacts })
+      roster.deps.emitSDK('contacts:loaded', { contacts })
 
       // Verify the binding caught the event and called the store
       expect(mockStores.roster.setContacts).toHaveBeenCalledTimes(1)
@@ -325,14 +325,14 @@ describe('SDK Event Bindings Integration', () => {
 
       // Check that we have handlers registered for key events
       // Note: connection:status is NOT handled by storeBindings (handled directly by Connection.ts)
-      expect(client.sdkEventHandlers.has('roster:loaded')).toBe(true)
+      expect(client.sdkEventHandlers.has('contacts:loaded')).toBe(true)
       expect(client.sdkEventHandlers.has('room:added')).toBe(true)
       expect(client.sdkEventHandlers.has('chat:message')).toBe(true)
 
       // Check handler counts - we have 2 handlers per event:
       // 1. Auto-bindings created in XMPPClient constructor (to global Zustand stores)
       // 2. Test bindings created in beforeEach (to mock stores)
-      expect(client.sdkEventHandlers.get('roster:loaded')?.size).toBe(2)
+      expect(client.sdkEventHandlers.get('contacts:loaded')?.size).toBe(2)
       expect(client.sdkEventHandlers.get('room:added')?.size).toBe(2)
     })
   })

--- a/packages/fluux-sdk/src/bindings/storeBindings.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.test.ts
@@ -63,7 +63,7 @@ describe('createStoreBindings', () => {
 
     it('should handle connection:own-vcard', () => {
       const vcard = { fullName: 'Alice Smith', org: 'Acme Corp', email: 'alice@acme.com', country: 'France' }
-      mockClient.emit('connection:own-vcard', { vcard })
+      mockClient.emit('connection:own-profile', { vcard })
       expect(mockStores.connection.setOwnVCard).toHaveBeenCalledWith(vcard)
     })
 
@@ -207,12 +207,12 @@ describe('createStoreBindings', () => {
 
   describe('MAM anchor-purged events (purged id-exact catch-up cursor)', () => {
     it('chat:mam-anchor-purged strips the matching gap anchor via clearConversationGapAnchor', () => {
-      mockClient.emit('chat:mam-anchor-purged', { conversationId: 'alice@example.com', after: 'purged-id' })
+      mockClient.emit('chat:history-anchor-purged', { conversationId: 'alice@example.com', after: 'purged-id' })
       expect(mockStores.chat.clearConversationGapAnchor).toHaveBeenCalledWith('alice@example.com', 'purged-id')
     })
 
     it('room:mam-anchor-purged strips the matching gap anchor via clearRoomGapAnchor', () => {
-      mockClient.emit('room:mam-anchor-purged', { roomJid: 'room@conference.example.com', after: 'purged-id' })
+      mockClient.emit('room:history-anchor-purged', { roomJid: 'room@conference.example.com', after: 'purged-id' })
       expect(mockStores.room.clearRoomGapAnchor).toHaveBeenCalledWith('room@conference.example.com', 'purged-id')
     })
   })
@@ -533,24 +533,24 @@ describe('createStoreBindings', () => {
   describe('roster events', () => {
     it('should handle roster:loaded', () => {
       const contacts: Contact[] = [{ jid: 'alice@example.com', name: 'Alice', presence: 'offline', subscription: 'both' }]
-      mockClient.emit('roster:loaded', { contacts })
+      mockClient.emit('contacts:loaded', { contacts })
       expect(mockStores.roster.setContacts).toHaveBeenCalledWith(contacts)
     })
 
     it('should handle roster:contact', () => {
       const contact: Contact = { jid: 'bob@example.com', name: 'Bob', presence: 'offline', subscription: 'both' }
-      mockClient.emit('roster:contact', { contact })
+      mockClient.emit('contacts:contact', { contact })
       expect(mockStores.roster.addOrUpdateContact).toHaveBeenCalledWith(contact)
     })
 
     it('should handle roster:contact-removed', () => {
-      mockClient.emit('roster:contact-removed', { jid: 'bob@example.com' })
+      mockClient.emit('contacts:contact-removed', { jid: 'bob@example.com' })
       expect(mockStores.roster.removeContact).toHaveBeenCalledWith('bob@example.com')
     })
 
     it('should handle roster:presence', () => {
       const lastInteraction = new Date(1234567890)
-      mockClient.emit('roster:presence', {
+      mockClient.emit('contacts:presence', {
         fullJid: 'alice@example.com/phone',
         show: 'away',
         priority: 0,
@@ -564,17 +564,17 @@ describe('createStoreBindings', () => {
     })
 
     it('should handle roster:presence-offline', () => {
-      mockClient.emit('roster:presence-offline', { fullJid: 'alice@example.com/phone' })
+      mockClient.emit('contacts:presence-offline', { fullJid: 'alice@example.com/phone' })
       expect(mockStores.roster.removePresence).toHaveBeenCalledWith('alice@example.com/phone')
     })
 
     it('should handle roster:presence-error', () => {
-      mockClient.emit('roster:presence-error', { jid: 'alice@example.com', error: 'Remote server not found' })
+      mockClient.emit('contacts:presence-error', { jid: 'alice@example.com', error: 'Remote server not found' })
       expect(mockStores.roster.setPresenceError).toHaveBeenCalledWith('alice@example.com', 'Remote server not found')
     })
 
     it('should handle roster:avatar', () => {
-      mockClient.emit('roster:avatar', {
+      mockClient.emit('contacts:avatar', {
         jid: 'alice@example.com',
         avatar: 'data:image/png...',
         avatarHash: 'hash123',
@@ -605,7 +605,7 @@ describe('createStoreBindings', () => {
     })
 
     it('should handle events:muc-invitation', () => {
-      mockClient.emit('events:muc-invitation', {
+      mockClient.emit('events:room-invitation', {
         roomJid: 'room@conference.example.com',
         from: 'alice@example.com',
         reason: 'Join us!',
@@ -624,7 +624,7 @@ describe('createStoreBindings', () => {
     })
 
     it('should handle events:muc-invitation-removed', () => {
-      mockClient.emit('events:muc-invitation-removed', { roomJid: 'room@conference.example.com' })
+      mockClient.emit('events:room-invitation-removed', { roomJid: 'room@conference.example.com' })
       expect(mockStores.events.removeMucInvitation).toHaveBeenCalledWith('room@conference.example.com')
     })
 
@@ -806,7 +806,7 @@ describe('createStoreBindings', () => {
     it('should unsubscribe all handlers when called', () => {
       // Emit an event before unsubscribe
       const contacts = [{ jid: 'alice@example.com', name: 'Alice', presence: 'online' as const, subscription: 'both' as const }]
-      mockClient.emit('roster:loaded', { contacts })
+      mockClient.emit('contacts:loaded', { contacts })
       expect(mockStores.roster.setContacts).toHaveBeenCalledTimes(1)
 
       // Call unsubscribe
@@ -816,7 +816,7 @@ describe('createStoreBindings', () => {
       vi.mocked(mockStores.roster.setContacts).mockClear()
 
       // Emit the event again - should not be handled
-      mockClient.emit('roster:loaded', { contacts })
+      mockClient.emit('contacts:loaded', { contacts })
       expect(mockStores.roster.setContacts).not.toHaveBeenCalled()
     })
   })

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -115,7 +115,7 @@ export function createStoreBindings(
     stores.connection.setHttpUploadService(service)
   })
 
-  on('connection:mam-fulltext-search', ({ supported }) => {
+  on('connection:history-search', ({ supported }) => {
     const stores = getStores()
     stores.connection.setMAMFulltextSearch(supported)
   })
@@ -130,7 +130,7 @@ export function createStoreBindings(
     stores.connection.setOwnNickname(nickname)
   })
 
-  on('connection:own-vcard', ({ vcard }) => {
+  on('connection:own-profile', ({ vcard }) => {
     const stores = getStores()
     stores.connection.setOwnVCard(vcard)
   })
@@ -276,24 +276,24 @@ export function createStoreBindings(
     }
   })
 
-  on('chat:mam-loading', ({ conversationId, isLoading }) => {
+  on('chat:history-loading', ({ conversationId, isLoading }) => {
     const stores = getStores()
     stores.chat.setMAMLoading(conversationId, isLoading)
   })
 
-  on('chat:mam-error', ({ conversationId, error }) => {
+  on('chat:history-error', ({ conversationId, error }) => {
     const stores = getStores()
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('chat:history-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
     stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // A purged id-exact anchor (item-not-found degrade): strip the matching
   // startId from the persisted gap so the timestamp fallback can progress.
-  on('chat:mam-anchor-purged', ({ conversationId, after }) => {
+  on('chat:history-anchor-purged', ({ conversationId, after }) => {
     const stores = getStores()
     stores.chat.clearConversationGapAnchor(conversationId, after)
   })
@@ -301,7 +301,7 @@ export function createStoreBindings(
   // A purged coverage-record anchor (item-not-found degrade): drop the record
   // so later resumes don't re-anchor on the dead id forever. Guarded on the
   // exact bottomId — a record that already advanced is left untouched.
-  on('chat:mam-coverage-purged', ({ conversationId, before }) => {
+  on('chat:history-coverage-purged', ({ conversationId, before }) => {
     const stores = getStores()
     stores.chat.clearConversationCoverage(conversationId, before)
   })
@@ -467,29 +467,29 @@ export function createStoreBindings(
     }
   })
 
-  on('room:mam-loading', ({ roomJid, isLoading }) => {
+  on('room:history-loading', ({ roomJid, isLoading }) => {
     const stores = getStores()
     stores.room.setRoomMAMLoading(roomJid, isLoading)
   })
 
-  on('room:mam-error', ({ roomJid, error }) => {
+  on('room:history-error', ({ roomJid, error }) => {
     const stores = getStores()
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('room:history-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
     stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // Room twin of chat:mam-anchor-purged (see above).
-  on('room:mam-anchor-purged', ({ roomJid, after }) => {
+  on('room:history-anchor-purged', ({ roomJid, after }) => {
     const stores = getStores()
     stores.room.clearRoomGapAnchor(roomJid, after)
   })
 
   // Room twin of chat:mam-coverage-purged (see above).
-  on('room:mam-coverage-purged', ({ roomJid, before }) => {
+  on('room:history-coverage-purged', ({ roomJid, before }) => {
     const stores = getStores()
     stores.room.clearRoomCoverage(roomJid, before)
   })
@@ -510,27 +510,27 @@ export function createStoreBindings(
   // Roster Events
   // ============================================================================
 
-  on('roster:loaded', ({ contacts }) => {
+  on('contacts:loaded', ({ contacts }) => {
     const stores = getStores()
     stores.roster.setContacts(contacts)
   })
 
-  on('roster:contact', ({ contact }) => {
+  on('contacts:contact', ({ contact }) => {
     const stores = getStores()
     stores.roster.addOrUpdateContact(contact)
   })
 
-  on('roster:contact-updated', ({ jid, updates }) => {
+  on('contacts:contact-updated', ({ jid, updates }) => {
     const stores = getStores()
     stores.roster.updateContact(jid, updates)
   })
 
-  on('roster:contact-removed', ({ jid }) => {
+  on('contacts:contact-removed', ({ jid }) => {
     const stores = getStores()
     stores.roster.removeContact(jid)
   })
 
-  on('roster:presence', (payload) => {
+  on('contacts:presence', (payload) => {
     const stores = getStores()
     stores.roster.updatePresence(
       payload.fullJid,
@@ -542,17 +542,17 @@ export function createStoreBindings(
     )
   })
 
-  on('roster:presence-offline', ({ fullJid }) => {
+  on('contacts:presence-offline', ({ fullJid }) => {
     const stores = getStores()
     stores.roster.removePresence(fullJid)
   })
 
-  on('roster:presence-error', ({ jid, error }) => {
+  on('contacts:presence-error', ({ jid, error }) => {
     const stores = getStores()
     stores.roster.setPresenceError(jid, error)
   })
 
-  on('roster:avatar', ({ jid, avatar, avatarHash }) => {
+  on('contacts:avatar', ({ jid, avatar, avatarHash }) => {
     const stores = getStores()
     stores.roster.updateAvatar(jid, avatar, avatarHash)
   })
@@ -581,7 +581,7 @@ export function createStoreBindings(
     stores.events.removeStrangerMessages(from)
   })
 
-  on('events:muc-invitation', (payload) => {
+  on('events:room-invitation', (payload) => {
     const stores = getStores()
     stores.events.addMucInvitation(
       payload.roomJid,
@@ -593,7 +593,7 @@ export function createStoreBindings(
     )
   })
 
-  on('events:muc-invitation-removed', ({ roomJid }) => {
+  on('events:room-invitation-removed', ({ roomJid }) => {
     const stores = getStores()
     stores.events.removeMucInvitation(roomJid)
   })
@@ -666,7 +666,7 @@ export function createStoreBindings(
     stores.admin.setSelectedVhost(vhost)
   })
 
-  on('admin:muc-service', ({ mucServiceJid }) => {
+  on('admin:room-service', ({ mucServiceJid }) => {
     const stores = getStores()
     stores.admin.setMucServiceJid(mucServiceJid)
   })

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -244,7 +244,7 @@ describe('XMPPClient', () => {
 
       // Key SDK events should have handlers registered from auto-bindings
       // Note: connection:status is handled directly by Connection.ts (not via storeBindings)
-      expect(handlers.has('roster:loaded')).toBe(true)
+      expect(handlers.has('contacts:loaded')).toBe(true)
       expect(handlers.has('chat:message')).toBe(true)
       expect(handlers.has('room:added')).toBe(true)
     })
@@ -566,7 +566,7 @@ describe('XMPPClient', () => {
 
     it('should handle roster events', () => {
       const handler = vi.fn()
-      xmppClient.subscribe('roster:contact', handler)
+      xmppClient.subscribe('contacts:contact', handler)
 
       const mockContact = {
         jid: 'alice@example.com',
@@ -575,7 +575,7 @@ describe('XMPPClient', () => {
         status: 'online' as const,
       }
 
-      ;(xmppClient as any).emitSDK('roster:contact', { contact: mockContact })
+      ;(xmppClient as any).emitSDK('contacts:contact', { contact: mockContact })
 
       expect(handler).toHaveBeenCalledWith({ contact: mockContact })
     })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -916,7 +916,7 @@ export class XMPPClient {
    * ```typescript
    * declare const myStore: { setContacts(contacts: Contact[]): void }
    *
-   * client.subscribe('roster:loaded', ({ contacts }) => {
+   * client.subscribe('contacts:loaded', ({ contacts }) => {
    *   myStore.setContacts(contacts)
    * })
    * ```

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -37,7 +37,7 @@ export type {
   FileAttachment,
   FileEncryption,
   ThumbnailInfo,
-  MAMQueryState,
+  HistoryQueryState,
   RSMResponse,
   // Room types (separated for fine-grained subscriptions)
   Room,

--- a/packages/fluux-sdk/src/core/modules/Admin.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.ts
@@ -935,7 +935,7 @@ export class Admin extends BaseModule {
           // Look for MUC identity (category="conference")
           for (const identity of identities) {
             if (identity.attrs.category === 'conference') {
-              this.deps.emitSDK('admin:muc-service', { mucServiceJid: jid })
+              this.deps.emitSDK('admin:room-service', { mucServiceJid: jid })
               return jid
             }
           }

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -368,9 +368,9 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify loading state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-loading', { conversationId: 'alice@example.com', isLoading: true })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: true })
       // Verify loading state was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-loading', { conversationId: 'alice@example.com', isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false })
     })
 
     it('should merge messages into store on success', async () => {
@@ -396,7 +396,7 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify chat:mam-messages was emitted with direction='backward' (no start filter)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
         rsm: expect.any(Object),
@@ -414,9 +414,9 @@ describe('XMPPClient MAM', () => {
       await expect(xmppClient.messages.queryMAM({ with: 'alice@example.com' })).rejects.toThrow('Network error')
 
       // Verify error state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-error', { conversationId: 'alice@example.com', error: 'Network error' })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-error', { conversationId: 'alice@example.com', error: 'Network error' })
       // Verify loading was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-loading', { conversationId: 'alice@example.com', isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false })
     })
 
     it('should parse complete=false correctly', async () => {
@@ -2616,7 +2616,7 @@ describe('XMPPClient MAM', () => {
 
       // Direction should be 'forward' for queries with start filter
       // The store will set isCaughtUpToLive=true but NOT isHistoryComplete
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', {
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
         rsm: expect.any(Object),
@@ -2654,7 +2654,7 @@ describe('XMPPClient MAM', () => {
 
       // Direction should be 'backward' for queries without start filter
       // The store will set isHistoryComplete=true
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
         rsm: expect.any(Object),
@@ -2696,7 +2696,7 @@ describe('XMPPClient MAM', () => {
 
       expect(result.complete).toBe(true)
       // Forward direction (parity with `start`-anchored catch-up).
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         direction: 'forward',
       }))
     })
@@ -2762,7 +2762,7 @@ describe('XMPPClient MAM', () => {
 
       // Without this, the persisted gap keeps the purged startId: every
       // session re-degrades and "Load missing messages" can never heal.
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-anchor-purged', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-anchor-purged', {
         conversationId: 'alice@example.com',
         after: 'purged-stanza-id',
       })
@@ -2952,7 +2952,7 @@ describe('XMPPClient MAM', () => {
 
       // The single empty emit carries the walk extent: the store records
       // coverage {bottomId: p5-first, topId: p1-last} — the durable resume.
-      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'chat:mam-messages')
+      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'chat:history-messages')
       expect(mamEmits).toHaveLength(1)
       expect(mamEmits[0][1]).toMatchObject({
         conversationId: 'alice@example.com',
@@ -3066,7 +3066,7 @@ describe('XMPPClient MAM', () => {
 
       // Walk recovered: purge emitted, pre-jump cursor used, message found.
       expect(callCount).toBe(3)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-coverage-purged', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-coverage-purged', {
         conversationId: 'alice@example.com',
         before: 'purged-floor',
       })
@@ -3107,7 +3107,7 @@ describe('XMPPClient MAM', () => {
       expect(retryBeforeEl?.children?.[0]).toBeUndefined() // before:'' — empty element
 
       // The stale record is dropped so later resumes don't re-anchor on it.
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-coverage-purged', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-coverage-purged', {
         conversationId: 'alice@example.com',
         before: 'purged-id',
       })
@@ -3341,8 +3341,8 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify loading state was set and cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-loading', { roomJid, isLoading: true })
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-loading', { roomJid, isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: true })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false })
     })
 
     it('should merge room messages into store on success', async () => {
@@ -3383,7 +3383,7 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify room:mam-messages was emitted with direction='backward' (no start filter)
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid,
         messages: expect.any(Array),
         rsm: expect.objectContaining({ first: 'first-id', last: 'last-id' }),
@@ -3416,9 +3416,9 @@ describe('XMPPClient MAM', () => {
       await expect(xmppClient.messages.queryRoomMAM({ roomJid })).rejects.toThrow('Room MAM not supported')
 
       // Verify error state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-error', { roomJid, error: 'Room MAM not supported' })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-error', { roomJid, error: 'Room MAM not supported' })
       // Verify loading was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-loading', { roomJid, isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false })
     })
 
     it('should use RSM before parameter for pagination', async () => {
@@ -3505,7 +3505,7 @@ describe('XMPPClient MAM', () => {
 
       // Direction should be 'forward' for queries with start filter
       // The store will set isCaughtUpToLive=true but NOT isHistoryComplete
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', {
         roomJid,
         messages: expect.any(Array),
         rsm: expect.any(Object),
@@ -3558,7 +3558,7 @@ describe('XMPPClient MAM', () => {
 
       // Direction should be 'backward' for queries with before filter
       // The store will set isHistoryComplete=true
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid,
         messages: expect.any(Array),
         rsm: expect.any(Object),
@@ -3606,7 +3606,7 @@ describe('XMPPClient MAM', () => {
       expect(afterEl?.children?.[0]).toBe('mds-stanza-id')
 
       expect(result.complete).toBe(true)
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         direction: 'forward',
       }))
     })
@@ -3729,7 +3729,7 @@ describe('XMPPClient MAM', () => {
       // ONE room:mam-messages emit carrying the accumulated set, still flagged
       // with the ORIGINAL fetch-latest so the page that finally carries
       // messages is seam-checked as part of the fetch-latest.
-      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:mam-messages')
+      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:history-messages')
       expect(mamEmits).toHaveLength(1)
       expect(mamEmits[0][1]).toMatchObject({
         roomJid,
@@ -3935,7 +3935,7 @@ describe('XMPPClient MAM', () => {
 
       // Same retry cap as the 1:1 backward path.
       expect(callCount).toBe(5)
-      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:mam-messages')
+      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:history-messages')
       expect(mamEmits).toHaveLength(1)
       expect((mamEmits[0][1] as { messages: unknown[] }).messages).toHaveLength(0)
       expect(result.messages).toHaveLength(0)
@@ -4019,7 +4019,7 @@ describe('XMPPClient MAM', () => {
 
       await xmppClient.messages.queryRoomMAM({ roomJid, after: 'purged-stanza-id' })
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-anchor-purged', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-anchor-purged', {
         roomJid,
         after: 'purged-stanza-id',
       })

--- a/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
@@ -758,7 +758,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Verify SDK event was emitted with isQuickChat: true
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'room@conference.example.com',
         from: 'alice@example.com',
         reason: 'Join quick chat: deploy issue',
@@ -793,7 +793,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Verify SDK event was emitted with isQuickChat: false
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'room@conference.example.com',
         from: 'alice@example.com',
         reason: 'Join our room',
@@ -824,7 +824,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Verify SDK event was emitted with isQuickChat: true
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'room@conference.example.com',
         from: 'alice@example.com',
         reason: 'Quick discussion',
@@ -859,7 +859,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Should emit with room JID as fallback for 'from'
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'room@conference.example.com',
         from: 'room@conference.example.com', // Fallback to room JID
         reason: 'Join our room',
@@ -895,7 +895,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Should still detect as quickchat based on JID pattern
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'quickchat-user-happy-fox-a1b2@conference.example.com',
         from: 'alice@example.com',
         reason: 'Join quick chat: deploy issue',
@@ -925,7 +925,7 @@ describe('XMPPClient Quick Chat', () => {
       mockXmppClientInstance._emit('stanza', invitationStanza)
 
       // Should still detect as quickchat based on JID pattern
-      expect(emitSDKSpy).toHaveBeenCalledWith('events:muc-invitation', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('events:room-invitation', {
         roomJid: 'quickchat-user-happy-fox-a1b2@conference.example.com',
         from: 'alice@example.com',
         reason: 'Quick discussion',

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -54,12 +54,12 @@ import type {
   FileAttachment,
   SendMessageOptions,
   ChatStateNotification,
-  MAMQueryOptions,
-  MAMResult,
+  HistoryQueryOptions,
+  HistoryResult,
   MessageSecurityContext,
   RoomMessage,
-  RoomMAMQueryOptions,
-  RoomMAMResult,
+  RoomHistoryQueryOptions,
+  RoomHistoryResult,
   PollClosedData,
 } from '../types'
 import { getCorrectionStanzaIds } from '../types/message-internal'
@@ -1619,7 +1619,7 @@ export class Chat extends BaseModule {
    * - Handles corrections and retractions within the MAM results
    * - Sets loading state in the store during the query
    */
-  async queryMAM(options: MAMQueryOptions): Promise<MAMResult> {
+  async queryMAM(options: HistoryQueryOptions): Promise<HistoryResult> {
     return this.mamModule.queryArchive(options)
   }
 
@@ -1649,7 +1649,7 @@ export class Chat extends BaseModule {
    * - Messages are automatically merged into the room store
    * - The room must be joined to fetch its MAM archive
    */
-  async queryRoomMAM(options: RoomMAMQueryOptions): Promise<RoomMAMResult> {
+  async queryRoomMAM(options: RoomHistoryQueryOptions): Promise<RoomHistoryResult> {
     return this.mamModule.queryRoomArchive(options)
   }
 
@@ -2034,7 +2034,7 @@ export class Chat extends BaseModule {
         // when forwarding invitations.
         const isQuickChat = !!stanza.getChild('quickchat', NS_FLUUX) || isQuickChatJid(roomJid)
         // SDK event only - binding calls store.addMucInvitation
-        this.deps.emitSDK('events:muc-invitation', {
+        this.deps.emitSDK('events:room-invitation', {
           roomJid,
           from,
           reason: directInvite.attrs.reason,
@@ -2064,7 +2064,7 @@ export class Chat extends BaseModule {
       const isQuickChat = !!invite.getChild('quickchat', NS_FLUUX) || isQuickChatJid(roomJid)
       if (roomJid) {
         // SDK event only - binding calls store.addMucInvitation
-        this.deps.emitSDK('events:muc-invitation', {
+        this.deps.emitSDK('events:room-invitation', {
           roomJid,
           from: inviteFrom,
           reason,

--- a/packages/fluux-sdk/src/core/modules/Discovery.mamsearch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.mamsearch.test.ts
@@ -104,7 +104,7 @@ describe('Discovery MAM Search Capability', () => {
     await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: true })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:history-search', { supported: true })
   })
 
   it('should report no fulltext support when MAM form lacks fulltext field', async () => {
@@ -147,7 +147,7 @@ describe('Discovery MAM Search Capability', () => {
     await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:history-search', { supported: false })
   })
 
   it('should report no fulltext support when no MAM form is present', async () => {
@@ -176,7 +176,7 @@ describe('Discovery MAM Search Capability', () => {
     await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:history-search', { supported: false })
   })
 
   it('should handle disco#info failure gracefully', async () => {
@@ -194,7 +194,7 @@ describe('Discovery MAM Search Capability', () => {
     await xmppClient.server.discoverMAMSearchCapability()
     await waitForAsyncOps()
 
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:history-search', { supported: false })
   })
 
   it('should ignore non-MAM data forms', async () => {
@@ -235,6 +235,6 @@ describe('Discovery MAM Search Capability', () => {
     await waitForAsyncOps()
 
     // Should not be fooled by fulltext in a non-MAM form
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:mam-fulltext-search', { supported: false })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:history-search', { supported: false })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Discovery.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.ts
@@ -361,7 +361,7 @@ export class Discovery extends BaseModule {
       const result = await this.deps.sendIQ(iq)
       const query = result.getChild('query', NS_DISCO_INFO)
       if (!query) {
-        this.deps.emitSDK('connection:mam-fulltext-search', { supported: false })
+        this.deps.emitSDK('connection:history-search', { supported: false })
         return
       }
 
@@ -379,14 +379,14 @@ export class Discovery extends BaseModule {
         }
       }
 
-      this.deps.emitSDK('connection:mam-fulltext-search', { supported: supportsFulltext })
+      this.deps.emitSDK('connection:history-search', { supported: supportsFulltext })
       if (supportsFulltext) {
         logInfo('MAM fulltext search: supported')
       }
     } catch (err) {
       // Disco query failed — assume no fulltext support
       logWarn(`MAM search capability discovery failed: ${err instanceof Error ? err.message : String(err)}`)
-      this.deps.emitSDK('connection:mam-fulltext-search', { supported: false })
+      this.deps.emitSDK('connection:history-search', { supported: false })
     }
   }
 

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -148,7 +148,7 @@ describe('MAM Background Catch-Up', () => {
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalled()
 
       // The emitted mam-messages event should have direction='forward' (start filter used)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         direction: 'forward',
       }))
@@ -171,7 +171,7 @@ describe('MAM Background Catch-Up', () => {
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalled()
 
       // The emitted mam-messages event should have direction='backward' (no start filter = before="" query)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         direction: 'backward',
       }))
@@ -375,7 +375,7 @@ describe('MAM Background Catch-Up', () => {
       await catchUpPromise
 
       // Should emit forward query starting from the live message timestamp (08:00), not the delayed one (10:00)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         direction: 'forward',
       }))
@@ -419,7 +419,7 @@ describe('MAM Background Catch-Up', () => {
       // Should use forward query from the newest delayed message timestamp
       // (not fall back to backward query) so merge uses full sort and
       // correctly positions messages sent from other clients while offline
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         direction: 'forward',
       }))
@@ -1301,7 +1301,7 @@ describe('MAM Background Catch-Up', () => {
       expect(mockStores.room.loadMessagesFromCache).toHaveBeenCalledWith('room1@conference.example.com', { limit: 100, peek: true })
 
       // The emitted room:mam-messages event should have direction='forward' (start filter used)
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid: 'room1@conference.example.com',
         direction: 'forward',
       }))
@@ -1325,7 +1325,7 @@ describe('MAM Background Catch-Up', () => {
       expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalled()
 
       // The emitted room:mam-messages event should have direction='backward' (no start = before="" query)
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid: 'room1@conference.example.com',
         direction: 'backward',
       }))
@@ -1444,7 +1444,7 @@ describe('MAM Background Catch-Up', () => {
       expect(queriedRooms).toContain('room2@conference.example.com')
 
       // Should use forward direction (start filter = fixed date, not from cache)
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         direction: 'forward',
       }))
     })
@@ -1551,7 +1551,7 @@ describe('MAM Background Catch-Up', () => {
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         preserveGapMarker: true,
       }))
     })
@@ -1719,7 +1719,7 @@ describe('MAM Background Catch-Up', () => {
       await discoverPromise
 
       // The emitted event should have direction='backward' (before="" query)
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:mam-messages', expect.objectContaining({
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'bob@example.com',
         direction: 'backward',
       }))

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -1073,7 +1073,7 @@ describe('MAM forward catch-up — cross-page modification resolution (1:1)', ()
 
     await queryPromise
 
-    const mamEvent = h.emitted.find((e) => e.event === 'chat:mam-messages')
+    const mamEvent = h.emitted.find((e) => e.event === 'chat:history-messages')
     expect(mamEvent).toBeDefined()
     const messages = mamEvent!.payload.messages as Array<{
       id: string

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -74,14 +74,14 @@ import { isItemNotFoundError } from '../../hooks/shared/mamCursor'
 import type {
   Message,
   RoomMessage,
-  MAMQueryOptions,
-  MAMResult,
-  RoomMAMQueryOptions,
-  RoomMAMResult,
+  HistoryQueryOptions,
+  HistoryResult,
+  RoomHistoryQueryOptions,
+  RoomHistoryResult,
   RSMResponse,
-  MAMSearchOptions,
-  RoomMAMSearchOptions,
-  MAMPagingSearchOptions,
+  HistorySearchOptions,
+  RoomHistorySearchOptions,
+  HistoryPagingSearchOptions,
 } from '../types'
 import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, parseStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, isMessageSignal } from './messagingUtils'
 import { getDomain } from '../jid'
@@ -189,7 +189,7 @@ export class MAM extends BaseModule {
    * @param options.before - RSM cursor for pagination (empty string for latest, or message ID for older)
    * @returns Query result with messages, completion status, and pagination info
    */
-  async queryArchive(options: MAMQueryOptions): Promise<MAMResult> {
+  async queryArchive(options: HistoryQueryOptions): Promise<HistoryResult> {
     const { with: withJid, max = 50, before = '', start, end, after, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const conversationId = getBareJid(withJid)
     const mamStart = Date.now()
@@ -244,7 +244,7 @@ export class MAM extends BaseModule {
     let sawCoverageTop = false
     const maxAutoPages = isForwardPaginate ? maxAutoPagesOpt : MAM_BACKWARD_SIGNAL_RETRY_PAGES // cap to avoid infinite loops
 
-    this.deps.emitSDK('chat:mam-loading', { conversationId, isLoading: true })
+    this.deps.emitSDK('chat:history-loading', { conversationId, isLoading: true })
 
     try {
       for (let page = 0; page < maxAutoPages; page++) {
@@ -304,7 +304,7 @@ export class MAM extends BaseModule {
               // every session — and every "Load missing messages" click —
               // re-anchors on it and re-degrades forever. Keeping the gap's
               // start timestamp lets the next resume fall back to it and progress.
-              this.deps.emitSDK('chat:mam-anchor-purged', { conversationId, after })
+              this.deps.emitSDK('chat:history-anchor-purged', { conversationId, after })
               const degraded = await this.queryArchive({ with: withJid, max, before: '', preserveGapMarker })
               // Mark the result so callers (the catch-up orchestrator) can tell
               // this is ALREADY a fetch-latest page and skip issuing another one.
@@ -315,7 +315,7 @@ export class MAM extends BaseModule {
               // drop the stale record (this degrade site is the only place that
               // KNOWS the id is gone) and degrade to fetch-latest.
               logInfo(`MAM before-cursor purged for ...@${getDomain(conversationId) || '*'} — degrading to fetch-latest`)
-              this.deps.emitSDK('chat:mam-coverage-purged', { conversationId, before: currentBefore })
+              this.deps.emitSDK('chat:history-coverage-purged', { conversationId, before: currentBefore })
               const degraded = await this.queryArchive({ with: withJid, max, before: '', preserveGapMarker })
               return { ...degraded, degradedToFetchLatest: true }
             }
@@ -325,7 +325,7 @@ export class MAM extends BaseModule {
               // aborting the walk — otherwise the record survives and every
               // session re-jumps onto the dead id (Codex r4 #6).
               logInfo(`MAM coverage floor purged mid-walk for ...@${getDomain(conversationId) || '*'} — resuming from pre-jump cursor`)
-              this.deps.emitSDK('chat:mam-coverage-purged', { conversationId, before: coverageRecord.bottomId })
+              this.deps.emitSDK('chat:history-coverage-purged', { conversationId, before: coverageRecord.bottomId })
               currentBefore = preJumpCursor
               preJumpCursor = undefined // one recovery per walk
               continue
@@ -420,7 +420,7 @@ export class MAM extends BaseModule {
         modifications.retractions.length + modifications.corrections.length +
         modifications.fastenings.length + modifications.reactions.length > 0
 
-      this.deps.emitSDK('chat:mam-messages', {
+      this.deps.emitSDK('chat:history-messages', {
         conversationId,
         messages: allMessages,
         rsm: lastRsm,
@@ -462,10 +462,10 @@ export class MAM extends BaseModule {
       } else {
         logErr(`MAM error: ...@${getDomain(conversationId) || '*'} — ${msg}`)
       }
-      this.deps.emitSDK('chat:mam-error', { conversationId, error: msg })
+      this.deps.emitSDK('chat:history-error', { conversationId, error: msg })
       throw error
     } finally {
-      this.deps.emitSDK('chat:mam-loading', { conversationId, isLoading: false })
+      this.deps.emitSDK('chat:history-loading', { conversationId, isLoading: false })
     }
   }
 
@@ -478,7 +478,7 @@ export class MAM extends BaseModule {
    * @param options.before - RSM cursor for pagination (empty string for latest, or message ID for older)
    * @returns Query result with messages, completion status, and pagination info
    */
-  async queryRoomArchive(options: RoomMAMQueryOptions): Promise<RoomMAMResult> {
+  async queryRoomArchive(options: RoomHistoryQueryOptions): Promise<RoomHistoryResult> {
     const { roomJid, max = 50, before, after, start, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const roomMamStart = Date.now()
     // `after` alone (the XEP-0490 pointer-seed catch-up) selects forward mode
@@ -531,7 +531,7 @@ export class MAM extends BaseModule {
     const room = this.deps.stores?.room.getRoom(roomJid)
     const myNickname = room?.nickname || ''
 
-    this.deps.emitSDK('room:mam-loading', { roomJid, isLoading: true })
+    this.deps.emitSDK('room:history-loading', { roomJid, isLoading: true })
 
     try {
       for (let page = 0; page < maxAutoPages; page++) {
@@ -587,7 +587,7 @@ export class MAM extends BaseModule {
               logInfo(`Room MAM after-cursor purged for ${roomJid} — degrading to fetch-latest`)
               // Strip the purged id from the persisted gap anchor — see the
               // 1:1 twin in queryArchive for the full rationale.
-              this.deps.emitSDK('room:mam-anchor-purged', { roomJid, after })
+              this.deps.emitSDK('room:history-anchor-purged', { roomJid, after })
               const degraded = await this.queryRoomArchive({ roomJid, max, before: '', preserveGapMarker })
               // Mark the result so callers (the catch-up orchestrator) can tell
               // this is ALREADY a fetch-latest page and skip issuing another one.
@@ -598,7 +598,7 @@ export class MAM extends BaseModule {
               // drop the stale record and degrade to fetch-latest (see the 1:1
               // twin in queryArchive).
               logInfo(`Room MAM before-cursor purged for ${roomJid} — degrading to fetch-latest`)
-              this.deps.emitSDK('room:mam-coverage-purged', { roomJid, before: currentBefore })
+              this.deps.emitSDK('room:history-coverage-purged', { roomJid, before: currentBefore })
               const degraded = await this.queryRoomArchive({ roomJid, max, before: '', preserveGapMarker })
               return { ...degraded, degradedToFetchLatest: true }
             }
@@ -606,7 +606,7 @@ export class MAM extends BaseModule {
               // Jumped-to floor purged mid-walk — resume from the pre-jump
               // cursor (see the 1:1 twin in queryArchive; Codex r4 #6).
               logInfo(`Room MAM coverage floor purged mid-walk for ${roomJid} — resuming from pre-jump cursor`)
-              this.deps.emitSDK('room:mam-coverage-purged', { roomJid, before: coverageRecord.bottomId })
+              this.deps.emitSDK('room:history-coverage-purged', { roomJid, before: coverageRecord.bottomId })
               currentBefore = preJumpCursor
               preJumpCursor = undefined // one recovery per walk
               continue
@@ -643,7 +643,7 @@ export class MAM extends BaseModule {
             this.emitUnresolvedRoomModifications(roomJid, unresolved)
 
             // Emit each page's messages immediately so the store can update incrementally
-            this.deps.emitSDK('room:mam-messages', {
+            this.deps.emitSDK('room:history-messages', {
               roomJid,
               messages: collectedMessages,
               rsm,
@@ -724,7 +724,7 @@ export class MAM extends BaseModule {
           (msg, from) => msg.from === from,
           (from) => getResource(from) || from
         )
-        this.deps.emitSDK('room:mam-messages', {
+        this.deps.emitSDK('room:history-messages', {
           roomJid,
           messages: allMessages,
           rsm: lastRsm,
@@ -762,10 +762,10 @@ export class MAM extends BaseModule {
       } else {
         logErr(`Room MAM error: ${roomJid} — ${msg}`)
       }
-      this.deps.emitSDK('room:mam-error', { roomJid, error: msg })
+      this.deps.emitSDK('room:history-error', { roomJid, error: msg })
       throw error
     } finally {
-      this.deps.emitSDK('room:mam-loading', { roomJid, isLoading: false })
+      this.deps.emitSDK('room:history-loading', { roomJid, isLoading: false })
     }
   }
 
@@ -783,7 +783,7 @@ export class MAM extends BaseModule {
    * @param options - Search options
    * @returns Messages matching the query, with pagination info
    */
-  async searchArchive(options: MAMSearchOptions): Promise<MAMResult> {
+  async searchArchive(options: HistorySearchOptions): Promise<HistoryResult> {
     const { query, with: withJid, max = 20, before } = options
     const queryId = `mam_search_${generateUUID()}`
 
@@ -852,7 +852,7 @@ export class MAM extends BaseModule {
    * @param options - Search options
    * @returns Room messages matching the query, with pagination info
    */
-  async searchRoomArchive(options: RoomMAMSearchOptions): Promise<RoomMAMResult> {
+  async searchRoomArchive(options: RoomHistorySearchOptions): Promise<RoomHistoryResult> {
     const { query, roomJid, max = 20, before } = options
     const queryId = `mam_rsearch_${generateUUID()}`
 
@@ -919,9 +919,9 @@ export class MAM extends BaseModule {
    * @returns Matching messages
    */
   async searchConversationByPaging(
-    options: MAMPagingSearchOptions,
+    options: HistoryPagingSearchOptions,
     signal?: AbortSignal
-  ): Promise<MAMResult> {
+  ): Promise<HistoryResult> {
     const { query, with: withJid, end, maxPages = 20, maxResults = 50 } = options
     const parsed = parseSearchQuery(query)
     const phraseTokens = parsed.phrases.flatMap((p) => tokenize(p))
@@ -1060,7 +1060,7 @@ export class MAM extends BaseModule {
         : undefined
 
       if (isRoom) {
-        // RoomMAMQueryOptions has no `end` filter (unlike the 1:1 branch below) —
+        // RoomHistoryQueryOptions has no `end` filter (unlike the 1:1 branch below) —
         // rooms rely on RSM pagination + the oldestInPage/targetTime check below
         // to stop at the target instead. `endFilter` is intentionally unused here.
         const result = await this.queryRoomArchive({

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -1586,7 +1586,7 @@ describe('MUC Module', () => {
       const result = await muc.discoverMucService()
 
       expect(result).toBe('conference.example.com')
-      expect(mockEmitSDK).toHaveBeenCalledWith('admin:muc-service', { mucServiceJid: 'conference.example.com' })
+      expect(mockEmitSDK).toHaveBeenCalledWith('admin:room-service', { mucServiceJid: 'conference.example.com' })
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -1215,7 +1215,7 @@ export class MUC extends BaseModule {
           logInfo(`MUC service: ${jid}`)
 
           // Emit MUC service JID so the admin store can populate it
-          this.deps.emitSDK('admin:muc-service', { mucServiceJid: jid })
+          this.deps.emitSDK('admin:room-service', { mucServiceJid: jid })
 
           return jid
         }

--- a/packages/fluux-sdk/src/core/modules/Presence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Presence.test.ts
@@ -86,7 +86,7 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
       // SDK event: roster:presence with show=null (meaning online), priority defaults to 0
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/resource',
         show: null, // null = online
         priority: 0,
@@ -107,7 +107,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/mobile',
         show: 'away',
         priority: 0,
@@ -129,7 +129,7 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
       // xa is passed directly, store handles mapping to PresenceStatus
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/desktop',
         show: 'xa',
         priority: 0,
@@ -150,7 +150,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/work',
         show: 'dnd',
         priority: 0,
@@ -171,10 +171,10 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
       // Unavailable emits roster:presence-offline, not roster:presence
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-offline', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-offline', {
         fullJid: 'contact@example.com/resource'
       })
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
     })
 
     it('should include status message when present', async () => {
@@ -189,7 +189,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/phone',
         show: 'away',
         priority: 0,
@@ -210,7 +210,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/mobile',
         show: null,
         priority: 50,
@@ -251,7 +251,7 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
       // Full JID is passed in SDK event (store extracts bare JID internally)
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/very-long-resource-identifier',
         show: null,
         priority: 0,
@@ -268,8 +268,8 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence-offline', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence-offline', expect.anything())
     })
 
     it('should extract client name from caps element (XEP-0115)', async () => {
@@ -291,7 +291,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/mobile',
         show: null,
         priority: 0,
@@ -320,7 +320,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', presenceStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', {
         fullJid: 'contact@example.com/desktop',
         show: null,
         priority: 0,
@@ -354,7 +354,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', errorStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-error', {
         jid: 'contact@example.com',
         error: 'User not found'
       })
@@ -381,7 +381,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', errorStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-error', {
         jid: 'contact@example.com',
         error: 'Service unavailable'
       })
@@ -399,7 +399,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', errorStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-error', {
         jid: 'contact@example.com',
         error: 'Undefined condition'
       })
@@ -415,7 +415,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', errorStanza)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-error', {
         jid: 'contact@example.com',
         error: 'Unknown error'
       })
@@ -433,7 +433,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', errorStanza)
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
     })
   })
 
@@ -466,7 +466,7 @@ describe('XMPPClient Presence', () => {
 
       await expect(result).rejects.toMatchObject({ condition: 'not-authorized', errorType: 'auth' })
       // The room must not be filed as a contact presence error either.
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence-error', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence-error', expect.anything())
     })
 
     it('fails the join on a nickname conflict', async () => {
@@ -490,7 +490,7 @@ describe('XMPPClient Presence', () => {
         joinError('contact@example.com/phone', 'service-unavailable', 'cancel')
       )
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence-error', {
         jid: 'contact@example.com',
         error: expect.any(String),
       })
@@ -546,7 +546,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', subscribedStanza)
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
       expect(emitSDKSpy).not.toHaveBeenCalledWith('events:subscription-request', expect.anything())
     })
 
@@ -560,7 +560,7 @@ describe('XMPPClient Presence', () => {
 
       mockXmppClientInstance._emit('stanza', unsubscribeStanza)
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
     })
 
     it('should handle unsubscribed presence without emitting roster:presence', async () => {
@@ -574,7 +574,7 @@ describe('XMPPClient Presence', () => {
       mockXmppClientInstance._emit('stanza', unsubscribedStanza)
 
       // Should NOT emit roster:presence (unsubscribed is not a presence update)
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
       // Should emit system notification about the denial
       expect(emitSDKSpy).toHaveBeenCalledWith('events:system-notification', expect.objectContaining({
         type: 'subscription-denied',
@@ -1560,7 +1560,7 @@ describe('XMPPClient Presence', () => {
       })
 
       // Should NOT have emitted roster:presence event
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence', expect.anything())
     })
 
     it('should remove resource when receiving unavailable presence from own JID', async () => {
@@ -1580,7 +1580,7 @@ describe('XMPPClient Presence', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-resource-offline', { resource: 'mobile' })
 
       // Should NOT have emitted roster:presence-offline event
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence-offline', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:presence-offline', expect.anything())
     })
 
     it('should track online resource (no show element)', async () => {
@@ -1622,7 +1622,7 @@ describe('XMPPClient Presence', () => {
       // Should NOT track this as another resource (no connection:own-resource event)
       expect(emitSDKSpy).not.toHaveBeenCalledWith('connection:own-resource', expect.anything())
       // Should treat it as regular presence (roster:presence event emitted)
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence', expect.anything())
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:presence', expect.anything())
     })
 
     it('should parse XEP-0319 idle time for own resource', async () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -975,7 +975,7 @@ describe('XMPPClient Own Avatar', () => {
 
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:avatar', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:avatar', {
         jid: 'alice@example.com', avatar: 'blob:fresh-contact1', avatarHash: 'hash-c1',
       })
       expect(emitSDKSpy).toHaveBeenCalledWith('room:updated', {
@@ -996,7 +996,7 @@ describe('XMPPClient Own Avatar', () => {
 
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:avatar', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:avatar', expect.anything())
     })
 
     it('should be a no-op when no cached avatars exist', async () => {
@@ -1138,7 +1138,7 @@ describe('XMPPClient Own Avatar', () => {
 
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:avatar', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:avatar', {
         jid: 'seb@example.com', avatar: 'blob:fresh-seb', avatarHash: 'hash-seb',
       })
     })
@@ -1181,7 +1181,7 @@ describe('XMPPClient Own Avatar', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-avatar', {
         avatar: 'blob:fresh-self', hash: 'hash-self',
       })
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:avatar', expect.objectContaining({ jid: 'user@example.com' }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:avatar', expect.objectContaining({ jid: 'user@example.com' }))
     })
   })
 
@@ -1947,7 +1947,7 @@ describe('XMPPClient Own Avatar', () => {
       expect(mockXmppClientInstance.iqCaller.request).not.toHaveBeenCalled()
 
       // Should emit avatar update with cached URL
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:avatar', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:avatar', {
         jid: 'contact@example.com',
         avatar: 'blob:already-cached',
         avatarHash: 'cached-hash',

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -529,7 +529,7 @@ export class Profile extends BaseModule {
     if (bareJid === getBareJid(currentJid ?? '')) {
       this.deps.emitSDK('connection:own-avatar', { avatar, hash })
     } else {
-      this.deps.emitSDK('roster:avatar', { jid: bareJid, avatar, avatarHash: hash ?? undefined })
+      this.deps.emitSDK('contacts:avatar', { jid: bareJid, avatar, avatarHash: hash ?? undefined })
     }
   }
 
@@ -592,7 +592,7 @@ export class Profile extends BaseModule {
 
     const bareJid = getBareJid(currentJid)
     const vcard = await this.fetchVCard(bareJid)
-    this.deps.emitSDK('connection:own-vcard', { vcard })
+    this.deps.emitSDK('connection:own-profile', { vcard })
     return vcard
   }
 
@@ -649,7 +649,7 @@ export class Profile extends BaseModule {
       xml('vCard', { xmlns: NS_VCARD_TEMP }, ...children)
     )
     await this.deps.sendIQ(setIq)
-    this.deps.emitSDK('connection:own-vcard', { vcard: info })
+    this.deps.emitSDK('connection:own-profile', { vcard: info })
   }
 
   /**
@@ -902,7 +902,7 @@ export class Profile extends BaseModule {
     try {
       const cachedUrl = await getCachedAvatar(avatarHash)
       if (cachedUrl) {
-        this.deps.emitSDK('roster:avatar', { jid, avatar: cachedUrl, avatarHash })
+        this.deps.emitSDK('contacts:avatar', { jid, avatar: cachedUrl, avatarHash })
         return true
       }
     } catch (error) {
@@ -964,10 +964,10 @@ export class Profile extends BaseModule {
         if (contact && !contact.avatarHash) {
           const cachedUrl = await getCachedAvatar(mapping.hash)
           if (cachedUrl) {
-            this.deps.emitSDK('roster:avatar', { jid: mapping.jid, avatar: cachedUrl, avatarHash: mapping.hash })
+            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: cachedUrl, avatarHash: mapping.hash })
           } else {
             // At least set the hash so we can try fetching later
-            this.deps.emitSDK('roster:avatar', { jid: mapping.jid, avatar: null, avatarHash: mapping.hash })
+            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: null, avatarHash: mapping.hash })
           }
         }
       }
@@ -1043,7 +1043,7 @@ export class Profile extends BaseModule {
           }
           const contact = this.deps.stores?.roster.getContact(mapping.jid)
           if (contact) {
-            this.deps.emitSDK('roster:avatar', { jid: mapping.jid, avatar: url, avatarHash: mapping.hash })
+            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: url, avatarHash: mapping.hash })
           }
         } else if (mapping.type === 'room') {
           const room = this.deps.stores?.room.getRoom(mapping.jid)

--- a/packages/fluux-sdk/src/core/modules/Profile.vcard.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcard.test.ts
@@ -263,7 +263,7 @@ describe('XMPPClient fetchOwnVCard', () => {
       email: undefined,
       country: undefined,
     })
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-vcard', {
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-profile', {
       vcard: { fullName: 'My Name', org: 'My Company', email: undefined, country: undefined },
     })
   })
@@ -276,7 +276,7 @@ describe('XMPPClient fetchOwnVCard', () => {
     const result = await xmppClient.profile.fetchOwnVCard()
 
     expect(result).toBeNull()
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-vcard', { vcard: null })
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-profile', { vcard: null })
   })
 })
 
@@ -346,7 +346,7 @@ describe('XMPPClient publishOwnVCard', () => {
     expect(vcardCalls.length).toBeGreaterThan(0)
 
     // Verify event emitted with new data
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-vcard', {
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-profile', {
       vcard: { fullName: 'New Name', email: 'me@test.com' },
     })
   })
@@ -359,7 +359,7 @@ describe('XMPPClient publishOwnVCard', () => {
 
     await xmppClient.profile.publishOwnVCard({ org: 'Acme Corp', country: 'France' })
 
-    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-vcard', {
+    expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-profile', {
       vcard: { org: 'Acme Corp', country: 'France' },
     })
   })

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -194,7 +194,7 @@ describe('PubSub Module', () => {
 
       mockXmppClientInstance._emit('stanza', pubsubMessage)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact-updated', { jid: 'contact@example.com', updates: { name: 'New Nickname' } })
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact-updated', { jid: 'contact@example.com', updates: { name: 'New Nickname' } })
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/PubSub.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.ts
@@ -326,7 +326,7 @@ export class PubSub extends BaseModule {
 
     if (nick) {
       // SDK event only - binding calls store.updateContact
-      this.deps.emitSDK('roster:contact-updated', { jid: bareFrom, updates: { name: nick } })
+      this.deps.emitSDK('contacts:contact-updated', { jid: bareFrom, updates: { name: nick } })
     }
   }
 

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -308,7 +308,7 @@ describe('XMPPClient Roster', () => {
       // Handler should return truthy to indicate it handled the IQ
       expect(result).toBe(true)
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact', {
         contact: {
           jid: 'newcontact@example.com',
           name: 'New Contact',
@@ -349,7 +349,7 @@ describe('XMPPClient Roster', () => {
         'set'
       )
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact-removed', { jid: 'removed@example.com' })
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact-removed', { jid: 'removed@example.com' })
     })
 
     it('should use JID as name when name attribute is missing', async () => {
@@ -381,7 +381,7 @@ describe('XMPPClient Roster', () => {
         'set'
       )
 
-      expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact', {
+      expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact', {
         contact: {
           jid: 'noname@example.com',
           name: 'noname', // Falls back to local part of JID
@@ -1140,8 +1140,8 @@ describe('XMPPClient Roster', () => {
         mockXmppClientInstance._emit('stanza', rosterPush)
 
         // Should emit roster:contact-removed (not roster:contact)
-        expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact-removed', { jid: 'denied@example.com' })
-        expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:contact', expect.anything())
+        expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact-removed', { jid: 'denied@example.com' })
+        expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:contact', expect.anything())
 
         // Should also send roster remove IQ to server
         expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
@@ -1178,7 +1178,7 @@ describe('XMPPClient Roster', () => {
         mockXmppClientInstance._emit('stanza', rosterPush)
 
         // Should emit roster:contact normally (not removed)
-        expect(emitSDKSpy).toHaveBeenCalledWith('roster:contact', {
+        expect(emitSDKSpy).toHaveBeenCalledWith('contacts:contact', {
           contact: {
             jid: 'newcontact@example.com',
             name: 'New Contact',
@@ -1187,7 +1187,7 @@ describe('XMPPClient Roster', () => {
             groups: [],
           },
         })
-        expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:contact-removed', expect.anything())
+        expect(emitSDKSpy).not.toHaveBeenCalledWith('contacts:contact-removed', expect.anything())
       })
     })
   })

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -121,7 +121,7 @@ export class Roster extends BaseModule {
           presence: 'offline',
         }))
         // SDK event only - binding should call store.setContacts
-        this.deps.emitSDK('roster:loaded', { contacts })
+        this.deps.emitSDK('contacts:loaded', { contacts })
 
         // Log roster distribution
         const subs: Record<string, number> = {}
@@ -138,7 +138,7 @@ export class Roster extends BaseModule {
         items.forEach((item: Element) => {
           if (item.attrs.subscription === 'remove') {
             // SDK event only - binding calls store.removeContact
-            this.deps.emitSDK('roster:contact-removed', { jid: item.attrs.jid })
+            this.deps.emitSDK('contacts:contact-removed', { jid: item.attrs.jid })
           } else {
             const contact: Contact = {
               jid: item.attrs.jid,
@@ -152,13 +152,13 @@ export class Roster extends BaseModule {
             // and the contact now has subscription="none", remove the ghost entry.
             if (contact.subscription === 'none' && this._pendingSubscriptionDenials.has(contact.jid)) {
               this._pendingSubscriptionDenials.delete(contact.jid)
-              this.deps.emitSDK('roster:contact-removed', { jid: contact.jid })
+              this.deps.emitSDK('contacts:contact-removed', { jid: contact.jid })
               this.removeContact(contact.jid)
               return
             }
 
             // SDK events only - bindings call store methods
-            this.deps.emitSDK('roster:contact', { contact })
+            this.deps.emitSDK('contacts:contact', { contact })
             this.deps.emitSDK('chat:conversation-name', { conversationId: contact.jid, name: contact.name })
           }
         })
@@ -171,7 +171,7 @@ export class Roster extends BaseModule {
     const errorReason = error ? formatXMPPError(error) : 'Unknown error'
 
     // SDK event only - binding calls store.setPresenceError
-    this.deps.emitSDK('roster:presence-error', { jid: bareFrom, error: errorReason })
+    this.deps.emitSDK('contacts:presence-error', { jid: bareFrom, error: errorReason })
   }
 
   private handleSubscribe(bareFrom: string): void {
@@ -310,12 +310,12 @@ export class Roster extends BaseModule {
 
     if (type === 'unavailable') {
       // SDK event only - binding calls store.removePresence
-      this.deps.emitSDK('roster:presence-offline', { fullJid: from })
+      this.deps.emitSDK('contacts:presence-offline', { fullJid: from })
       const contact = this.deps.stores?.roster.getContact(bareFrom)
       this.deps.emit('presence', bareFrom, contact?.presence || 'offline', contact?.statusMessage)
     } else {
       // SDK event only - binding calls store.updatePresence
-      this.deps.emitSDK('roster:presence', {
+      this.deps.emitSDK('contacts:presence', {
         fullJid: from,
         show,
         priority,

--- a/packages/fluux-sdk/src/core/types/events.ts
+++ b/packages/fluux-sdk/src/core/types/events.ts
@@ -40,7 +40,7 @@ export interface StrangerMessage {
  *
  * @category Events
  */
-export interface MucInvitation {
+export interface RoomInvitation {
   /** Unique invitation ID */
   id: string
   /** Room JID to join */

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -59,7 +59,7 @@ export type {
 export type {
   SubscriptionRequest,
   StrangerMessage,
-  MucInvitation,
+  RoomInvitation,
   SystemNotificationType,
   SystemNotification,
 } from './events'
@@ -100,17 +100,17 @@ export type { LinkPreview } from './media'
 export type {
   RSMRequest,
   RSMResponse,
-  MAMQueryOptions,
-  MAMResult,
-  MAMQueryState,
-  MAMQueryDirection,
+  HistoryQueryOptions,
+  HistoryResult,
+  HistoryQueryState,
+  HistoryQueryDirection,
   CoverageRecord,
   MergeArchiveExtras,
-  RoomMAMQueryOptions,
-  RoomMAMResult,
-  MAMSearchOptions,
-  RoomMAMSearchOptions,
-  MAMPagingSearchOptions,
+  RoomHistoryQueryOptions,
+  RoomHistoryResult,
+  HistorySearchOptions,
+  RoomHistorySearchOptions,
+  HistoryPagingSearchOptions,
 } from './pagination'
 
 // Read-state types (cache order and read pointer)
@@ -193,7 +193,7 @@ export type {
   ConnectionEvents,
   ChatEvents,
   RoomEvents,
-  RosterEvents,
+  ContactsEvents,
   NotificationEvents,
   BlockingEvents,
   AdminEvents,

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -45,7 +45,7 @@ export interface RSMResponse {
  *
  * @category MAM
  */
-export interface MAMQueryOptions {
+export interface HistoryQueryOptions {
   /** Bare JID of conversation partner */
   with: string
   /** Maximum results to return (default 50) */
@@ -82,7 +82,7 @@ export interface MAMQueryOptions {
  *
  * @category MAM
  */
-export interface MAMResult {
+export interface HistoryResult {
   /** Retrieved messages */
   messages: Message[]
   /** True if no more messages before this batch */
@@ -102,7 +102,7 @@ export interface MAMResult {
  *
  * @category MAM
  */
-export interface RoomMAMQueryOptions {
+export interface RoomHistoryQueryOptions {
   /** Room JID to query archive for */
   roomJid: string
   /** Maximum results to return (default 50) */
@@ -132,7 +132,7 @@ export interface RoomMAMQueryOptions {
  *
  * @category MAM
  */
-export interface RoomMAMResult {
+export interface RoomHistoryResult {
   /** Retrieved room messages */
   messages: RoomMessage[]
   /** True if no more messages before this batch */
@@ -152,7 +152,7 @@ export interface RoomMAMResult {
  *
  * @category MAM
  */
-export interface MAMSearchOptions {
+export interface HistorySearchOptions {
   /** Fulltext search query */
   query: string
   /** Optional: scope to a specific conversation (bare JID) */
@@ -168,7 +168,7 @@ export interface MAMSearchOptions {
  *
  * @category MAM
  */
-export interface RoomMAMSearchOptions {
+export interface RoomHistorySearchOptions {
   /** Fulltext search query */
   query: string
   /** Room JID to search */
@@ -186,7 +186,7 @@ export interface RoomMAMSearchOptions {
  *
  * @category MAM
  */
-export interface MAMPagingSearchOptions {
+export interface HistoryPagingSearchOptions {
   /** Text query to match against message bodies */
   query: string
   /** Conversation partner bare JID */
@@ -212,7 +212,7 @@ export interface MAMPagingSearchOptions {
  *
  * @category MAM
  */
-export interface MAMQueryState {
+export interface HistoryQueryState {
   /** True while query is in progress */
   isLoading: boolean
   /** Error message if query failed */
@@ -259,7 +259,7 @@ export interface MAMQueryState {
  *
  * @category MAM
  */
-export type MAMQueryDirection = 'backward' | 'forward'
+export type HistoryQueryDirection = 'backward' | 'forward'
 
 /**
  * Persisted contiguous-with-live coverage.
@@ -267,7 +267,7 @@ export type MAMQueryDirection = 'backward' | 'forward'
  * A `CoverageRecord` is POSITIVE, DURABLE data: the archive id of the oldest
  * entry proven contiguous with the live edge for this device. Unlike a gap
  * interval (which describes a hole and vanishes when the hole closes) or
- * {@link MAMQueryState.coverageBottomUnproven} (session-scoped), the record
+ * {@link HistoryQueryState.coverageBottomUnproven} (session-scoped), the record
  * survives fresh sessions and gap closure, so:
  * - the read-pointer stitch seeds its backward walk from it and never from a
  *   disjoint cache island (e.g. a fetchContext window);

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -18,7 +18,7 @@ import type { HttpUploadService } from './upload'
 import type { WebPushService, WebPushStatus } from './webpush'
 import type { AdminCommand, AdminSession, ServerStats } from './admin'
 import type { RSMResponse } from './pagination'
-import type { MAMQueryDirection } from './pagination'
+import type { HistoryQueryDirection } from './pagination'
 import type { SystemNotificationType } from './events'
 import type { XMPPErrorType, XMPPStanzaError } from '../../utils/xmppError'
 
@@ -55,7 +55,7 @@ export interface ConnectionEvents {
   }
 
   /** MAM fulltext search capability discovered */
-  'connection:mam-fulltext-search': {
+  'connection:history-search': {
     supported: boolean
   }
 
@@ -71,7 +71,7 @@ export interface ConnectionEvents {
   }
 
   /** Own vCard changed */
-  'connection:own-vcard': {
+  'connection:own-profile': {
     vcard: VCardInfo | null
   }
 
@@ -207,24 +207,24 @@ export interface ChatEvents {
   }
 
   /** MAM loading state changed */
-  'chat:mam-loading': {
+  'chat:history-loading': {
     conversationId: string
     isLoading: boolean
   }
 
   /** MAM error occurred */
-  'chat:mam-error': {
+  'chat:history-error': {
     conversationId: string
     error: string | null
   }
 
   /** MAM messages loaded */
-  'chat:mam-messages': {
+  'chat:history-messages': {
     conversationId: string
     messages: Message[]
     rsm: RSMResponse
     complete: boolean
-    direction: MAMQueryDirection
+    direction: HistoryQueryDirection
     /** When true, leave the gap marker untouched (bounded windowed context queries). */
     preserveGapMarker?: boolean
     /** The query was a `before:''` fetch-latest (seam formation candidate). */
@@ -254,7 +254,7 @@ export interface ChatEvents {
    * the next resume — including "Load missing messages" — uses the timestamp
    * fallback and progresses, instead of re-degrading on the purged id forever.
    */
-  'chat:mam-anchor-purged': {
+  'chat:history-anchor-purged': {
     conversationId: string
     /** The purged archive id the query was anchored on. */
     after: string
@@ -266,7 +266,7 @@ export interface ChatEvents {
    * fetch-latest. Bindings drop the matching coverage record so later
    * resumes don't re-anchor on the dead id forever.
    */
-  'chat:mam-coverage-purged': {
+  'chat:history-coverage-purged': {
     conversationId: string
     /** The purged archive id the query was anchored on. */
     before: string
@@ -440,13 +440,13 @@ export interface RoomEvents {
   }
 
   /** Room MAM loading state */
-  'room:mam-loading': {
+  'room:history-loading': {
     roomJid: string
     isLoading: boolean
   }
 
   /** Room MAM error */
-  'room:mam-error': {
+  'room:history-error': {
     roomJid: string
     error: string | null
   }
@@ -463,12 +463,12 @@ export interface RoomEvents {
   }
 
   /** Room MAM messages loaded */
-  'room:mam-messages': {
+  'room:history-messages': {
     roomJid: string
     messages: RoomMessage[]
     rsm: RSMResponse
     complete: boolean
-    direction: MAMQueryDirection
+    direction: HistoryQueryDirection
     /** When true, leave the gap marker untouched (bounded force-repair queries). */
     preserveGapMarker?: boolean
     /** The query was a `before:''` fetch-latest (seam formation candidate). */
@@ -497,14 +497,14 @@ export interface RoomEvents {
    * a fetch-latest. Bindings strip the matching `startId` from the persisted
    * GapInterval so the timestamp fallback can progress.
    */
-  'room:mam-anchor-purged': {
+  'room:history-anchor-purged': {
     roomJid: string
     /** The purged archive id the query was anchored on. */
     after: string
   }
 
   /** Room twin of `chat:mam-coverage-purged`. */
-  'room:mam-coverage-purged': {
+  'room:history-coverage-purged': {
     roomJid: string
     /** The purged archive id the query was anchored on. */
     before: string
@@ -535,30 +535,30 @@ export interface RoomEvents {
 // Roster Events
 // ============================================================================
 
-export interface RosterEvents {
+export interface ContactsEvents {
   /** Full roster loaded */
-  'roster:loaded': {
+  'contacts:loaded': {
     contacts: Contact[]
   }
 
   /** Contact added or updated */
-  'roster:contact': {
+  'contacts:contact': {
     contact: Contact
   }
 
   /** Contact properties updated */
-  'roster:contact-updated': {
+  'contacts:contact-updated': {
     jid: string
     updates: Partial<Contact>
   }
 
   /** Contact removed */
-  'roster:contact-removed': {
+  'contacts:contact-removed': {
     jid: string
   }
 
   /** Contact presence updated */
-  'roster:presence': {
+  'contacts:presence': {
     fullJid: string
     show: PresenceShow | null
     priority: number
@@ -568,18 +568,18 @@ export interface RosterEvents {
   }
 
   /** Contact went offline */
-  'roster:presence-offline': {
+  'contacts:presence-offline': {
     fullJid: string
   }
 
   /** Presence error for contact */
-  'roster:presence-error': {
+  'contacts:presence-error': {
     jid: string
     error: string
   }
 
   /** Contact avatar updated */
-  'roster:avatar': {
+  'contacts:avatar': {
     jid: string
     avatar: string | null
     avatarHash?: string
@@ -613,7 +613,7 @@ export interface NotificationEvents {
   }
 
   /** MUC invitation received */
-  'events:muc-invitation': {
+  'events:room-invitation': {
     roomJid: string
     from: string
     reason?: string
@@ -623,7 +623,7 @@ export interface NotificationEvents {
   }
 
   /** MUC invitation handled */
-  'events:muc-invitation-removed': {
+  'events:room-invitation-removed': {
     roomJid: string
   }
 
@@ -705,7 +705,7 @@ export interface AdminEvents {
   }
 
   /** MUC service discovered */
-  'admin:muc-service': {
+  'admin:room-service': {
     mucServiceJid: string
   }
 }
@@ -776,7 +776,7 @@ export interface SDKEvents
   extends ConnectionEvents,
     ChatEvents,
     RoomEvents,
-    RosterEvents,
+    ContactsEvents,
     NotificationEvents,
     BlockingEvents,
     AdminEvents,

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -27,8 +27,8 @@ import type { Room, RoomMessage, RoomOccupant, RoomAffiliation } from './room'
 import type { SystemNotificationType } from './events'
 import type { AdminCommand, AdminSession, ServerStats } from './admin'
 import type {
-  MAMQueryState,
-  MAMQueryDirection,
+  HistoryQueryState,
+  HistoryQueryDirection,
   CoverageRecord,
   MergeArchiveExtras,
   RSMResponse,
@@ -157,8 +157,8 @@ export interface ChatBindings {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
-  getMAMQueryState: (conversationId: string) => MAMQueryState
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
+  getMAMQueryState: (conversationId: string) => HistoryQueryState
   resetMAMStates: () => void
 
   /** Persisted contiguous-with-live coverage record, if any. */
@@ -434,8 +434,8 @@ export interface RoomBindings {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
-  getRoomMAMQueryState: (roomJid: string) => MAMQueryState
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
+  getRoomMAMQueryState: (roomJid: string) => HistoryQueryState
   resetRoomMAMStates: () => void
 
   /** Persisted contiguous-with-live coverage record, if any. */

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -390,9 +390,9 @@ export class DemoClient extends XMPPClient {
     }
 
     // Roster: load contacts then set presence per-resource
-    this.emitSDK('roster:loaded', { contacts: data.contacts })
+    this.emitSDK('contacts:loaded', { contacts: data.contacts })
     for (const presence of data.presences) {
-      this.emitSDK('roster:presence', presence)
+      this.emitSDK('contacts:presence', presence)
     }
 
     // Conversations: create each, then add messages
@@ -436,7 +436,7 @@ export class DemoClient extends XMPPClient {
     }
 
     // Set MUC service JID so BrowseRoomsModal can discover it
-    this.emitSDK('admin:muc-service', { mucServiceJid: this.conferenceService })
+    this.emitSDK('admin:room-service', { mucServiceJid: this.conferenceService })
 
     // Mark all history as complete so the "load earlier messages" spinner
     // never appears — there is no MAM server to query in demo mode.
@@ -576,7 +576,7 @@ export class DemoClient extends XMPPClient {
         this.emitSDK('chat:reactions', step.data as Parameters<typeof this.emitSDK<'chat:reactions'>>[1])
         break
       case 'presence':
-        this.emitSDK('roster:presence', step.data as Parameters<typeof this.emitSDK<'roster:presence'>>[1])
+        this.emitSDK('contacts:presence', step.data as Parameters<typeof this.emitSDK<'contacts:presence'>>[1])
         break
       case 'room-typing':
         this.emitSDK('room:typing', step.data as Parameters<typeof this.emitSDK<'room:typing'>>[1])

--- a/packages/fluux-sdk/src/hooks/shared/createContinueCatchUp.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createContinueCatchUp.ts
@@ -24,7 +24,7 @@
  */
 
 import { connectionStore } from '../../stores/connectionStore'
-import type { MAMQueryState } from '../../core/types'
+import type { HistoryQueryState } from '../../core/types'
 import {
   selectCatchUpQuery,
   MAM_CACHE_LOAD_LIMIT,
@@ -44,7 +44,7 @@ export interface ContinueCatchUpDeps {
   /**
    * Get the MAM query state for the target.
    */
-  getMAMState: (id: string) => MAMQueryState
+  getMAMState: (id: string) => HistoryQueryState
 
   /**
    * Set the MAM loading state for the target.

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createFetchOlderHistory, type FetchOlderHistoryDeps } from './createFetchOlderHistory'
-import type { MAMQueryState } from '../../core/types'
+import type { HistoryQueryState } from '../../core/types'
 import { connectionStore } from '../../stores/connectionStore'
 
 // Mock the connection store to return 'online' status.
@@ -23,7 +23,7 @@ describe('createFetchOlderHistory', () => {
     deps = {
       getActiveId: vi.fn(() => 'conv-1'),
       isValidTarget: vi.fn(() => true),
-      getMAMState: vi.fn((): MAMQueryState => ({
+      getMAMState: vi.fn((): HistoryQueryState => ({
         isLoading: false,
         hasQueried: true,
         isHistoryComplete: false,

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
@@ -6,7 +6,7 @@
  * store-specific customization.
  */
 
-import type { MAMQueryState } from '../../core/types'
+import type { HistoryQueryState } from '../../core/types'
 import { connectionStore } from '../../stores/connectionStore'
 import { isItemNotFoundError } from './mamCursor'
 
@@ -28,7 +28,7 @@ export interface FetchOlderHistoryDeps {
   /**
    * Get the MAM query state for the target.
    */
-  getMAMState: (id: string) => MAMQueryState
+  getMAMState: (id: string) => HistoryQueryState
 
   /**
    * Set the MAM loading state for the target.

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useChatStore, useConnectionStore } from '../react/storeHooks'
-import type { MAMQueryState, Message } from '../core'
+import type { HistoryQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { useChatActions } from './useChatActions'
 
@@ -179,7 +179,7 @@ export function useChat() {
   })
 
   // Memoize the MAM state object to maintain stable reference
-  const activeMAMState = useMemo((): MAMQueryState | null => {
+  const activeHistoryState = useMemo((): HistoryQueryState | null => {
     if (!activeConversationId) return null
     return {
       isLoading: mamIsLoading,
@@ -209,7 +209,7 @@ export function useChat() {
       activeAnimation,
       // XEP-0313: MAM state
       supportsMAM,
-      activeMAMState,
+      activeHistoryState,
 
       // Actions (spread memoized actions)
       ...actions,
@@ -224,7 +224,7 @@ export function useChat() {
       activeTypingUsers,
       activeAnimation,
       supportsMAM,
-      activeMAMState,
+      activeHistoryState,
       actions,
     ]
   )

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -4,7 +4,7 @@ import { chatStore } from '../stores/chatStore'
 import { chatSelectors } from '../stores/chatSelectors'
 import { useChatStore, useConnectionStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
-import type { Conversation, MAMQueryState, Message } from '../core'
+import type { Conversation, HistoryQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { useChatActions } from './useChatActions'
 import { createContinueCatchUp } from './shared'
@@ -182,7 +182,7 @@ export function useChatActive() {
     return s.conversationGaps.get(s.activeConversationId)?.start
   })
 
-  const activeMAMState = useMemo((): MAMQueryState | null => {
+  const activeHistoryState = useMemo((): HistoryQueryState | null => {
     if (!activeConversationId) return null
     return {
       isLoading: mamIsLoading,
@@ -322,14 +322,14 @@ export function useChatActive() {
       activeAnimation,
       targetMessageId,
       supportsMAM,
-      activeMAMState,
+      activeHistoryState,
       windowAtLiveEdge: activeWindowAtLiveEdge,
       ...actions,
     }),
     [
       activeConversationId, activeConversation, activeFirstNewMessageId, activeFirstNewMessageIsProvisional,
       activeReadPointerId, activeMessages,
-      activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeMAMState,
+      activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeHistoryState,
       activeWindowAtLiveEdge, actions,
     ]
   )

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useRoomStore, useAdminStore } from '../react/storeHooks'
-import type { MAMQueryState } from '../core/types'
+import type { HistoryQueryState } from '../core/types'
 import { useRoomActions } from './useRoomActions'
 
 /**
@@ -133,7 +133,7 @@ export function useRoom() {
   })
 
   // Memoize the MAM state object to maintain stable reference
-  const activeMAMState = useMemo((): MAMQueryState | null => {
+  const activeHistoryState = useMemo((): HistoryQueryState | null => {
     if (!activeRoomJid) return null
     return {
       isLoading: mamIsLoading,
@@ -180,7 +180,7 @@ export function useRoom() {
       activeAnimation,
       drafts,
       mucServiceJid,
-      activeMAMState,
+      activeHistoryState,
 
       // Actions (spread memoized actions)
       ...actions,
@@ -201,7 +201,7 @@ export function useRoom() {
       activeAnimation,
       drafts,
       mucServiceJid,
-      activeMAMState,
+      activeHistoryState,
       actions,
     ]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -3,7 +3,7 @@ import { roomStore } from '../stores/roomStore'
 import { roomSelectors } from '../stores/roomSelectors'
 import { useRoomStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
-import type { Room, RoomMessage, ChatStateNotification, FileAttachment, MAMQueryState, RoomFeatures, SendMessageOptions, ReplyTarget } from '../core/types'
+import type { Room, RoomMessage, ChatStateNotification, FileAttachment, HistoryQueryState, RoomFeatures, SendMessageOptions, ReplyTarget } from '../core/types'
 import { createFetchOlderHistory, createContinueCatchUp, pickOldestArchiveId } from './shared'
 import { usePolls } from './usePolls'
 import { useRoomModeration } from './useRoomModeration'
@@ -158,7 +158,7 @@ export function useRoomActive() {
   })
 
   // Memoize the MAM state object to maintain stable reference
-  const activeMAMState = useMemo((): MAMQueryState | null => {
+  const activeHistoryState = useMemo((): HistoryQueryState | null => {
     if (!activeRoomJid) return null
     return {
       isLoading: mamIsLoading,
@@ -476,7 +476,7 @@ export function useRoomActive() {
       activeTypingUsers,
       activeAnimation,
       targetMessageId,
-      activeMAMState,
+      activeHistoryState,
       firstNewMessageId: activeFirstNewMessageId,
       firstNewMessageIsProvisional: activeFirstNewMessageIsProvisional,
       readPointerId: activeReadPointerId,
@@ -492,7 +492,7 @@ export function useRoomActive() {
       activeTypingUsers,
       activeAnimation,
       targetMessageId,
-      activeMAMState,
+      activeHistoryState,
       activeFirstNewMessageId,
       activeFirstNewMessageIsProvisional,
       activeReadPointerId,

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -354,9 +354,9 @@ export type {
   LastActivityEntry,
 
   // XEP-0313: Message Archive Management
-  MAMQueryOptions,
-  MAMResult,
-  MAMQueryState,
+  HistoryQueryOptions,
+  HistoryResult,
+  HistoryQueryState,
 } from './core/types'
 
 // Client construction options. Exported from `core/clientConfig` rather than
@@ -365,7 +365,7 @@ export type {
 export type { XMPPClientConfig } from './core/clientConfig'
 
 // Events types
-export type { SubscriptionRequest, StrangerMessage, MucInvitation, SystemNotification, SystemNotificationType } from './core/types'
+export type { SubscriptionRequest, StrangerMessage, RoomInvitation, SystemNotification, SystemNotificationType } from './core/types'
 
 // EventHook base class (Obsidian-inspired plugin pattern)
 export { EventHook } from './core/EventHook'
@@ -391,7 +391,7 @@ export type {
   ConnectionEvents,
   ChatEvents,
   RoomEvents,
-  RosterEvents,
+  ContactsEvents,
   NotificationEvents,
   BlockingEvents,
   AdminEvents,

--- a/packages/fluux-sdk/src/stores/chatSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { chatSelectors } from './chatSelectors'
 import type { ChatState } from './chatStore'
-import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState } from '../core/types'
+import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState } from '../core/types'
 
 /**
  * Create a minimal ChatState mock for testing selectors.
@@ -274,7 +274,7 @@ describe('chatSelectors', () => {
 
   describe('mamStateFor', () => {
     it('should return MAM state for conversation', () => {
-      const mamState: MAMQueryState = {
+      const mamState: HistoryQueryState = {
         isLoading: true,
         hasQueried: false,
         error: null,
@@ -289,7 +289,7 @@ describe('chatSelectors', () => {
 
   describe('isMAMLoading', () => {
     it('should return true when loading', () => {
-      const mamQueryStates = new Map<string, MAMQueryState>([['user@example.com', {
+      const mamQueryStates = new Map<string, HistoryQueryState>([['user@example.com', {
         isLoading: true,
         hasQueried: false,
         error: null,

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -21,7 +21,7 @@
  */
 
 import type { ChatState } from './chatStore'
-import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState } from '../core/types'
+import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState } from '../core/types'
 
 /**
  * Stable empty references to prevent infinite re-renders.
@@ -175,7 +175,7 @@ export const chatSelectors = {
   /**
    * Get MAM query state for a specific conversation.
    */
-  mamStateFor: (conversationId: string) => (state: ChatState): MAMQueryState | undefined => {
+  mamStateFor: (conversationId: string) => (state: ChatState): HistoryQueryState | undefined => {
     return state.mamQueryStates.get(conversationId)
   },
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
-import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core/types'
+import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, RSMResponse } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -8,7 +8,7 @@ import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
-import type { MAMQueryDirection } from './shared/mamState'
+import type { HistoryQueryDirection } from './shared/mamState'
 import { syncGapAfterArchiveMerge, messagePageExtent, newestMessageStanzaId, type GapInterval } from './shared/mamGap'
 import {
   syncCoverageAfterArchiveMerge,
@@ -281,7 +281,7 @@ interface ChatState {
   // Message drafts per conversation (persisted to localStorage)
   drafts: Map<string, string>
   // XEP-0313: MAM query state per conversation (ephemeral, not persisted)
-  mamQueryStates: Map<string, MAMQueryState>
+  mamQueryStates: Map<string, HistoryQueryState>
   // Persisted history-gap intervals per conversation (in the account-scoped chat
   // blob; drives the gap marker). Parity with roomStore.roomGaps.
   conversationGaps: Map<string, GapInterval>
@@ -475,7 +475,7 @@ interface ChatState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
   /**
    * Strip a purged archive id from the persisted gap anchor (`startId`),
    * keeping the `start` timestamp so the next catch-up resume uses the
@@ -489,7 +489,7 @@ interface ChatState {
   /** Drop the coverage record; with `ifBottomId`, only when it matches
    *  `bottomId` (purge-event guard — the anchor is known gone). */
   clearConversationCoverage: (conversationId: string, ifBottomId?: string) => void
-  getMAMQueryState: (conversationId: string) => MAMQueryState
+  getMAMQueryState: (conversationId: string) => HistoryQueryState
   resetMAMStates: () => void
   /**
    * Update only the lastMessage preview for a conversation without affecting the messages array.
@@ -2606,7 +2606,7 @@ export const chatStore = createStore<ChatState>()(
 
         // --- Coverage gate: every uncertain branch defers -
         const mam = mamState.getMAMQueryState(get().mamQueryStates, conversationId)
-        if (!isCaughtUpForCounting(mam)) return defer('mam-not-caught-up')
+        if (!isCaughtUpForCounting(mam)) return defer('history-not-caught-up')
 
         const record = get().conversationCoverage.get(conversationId)
         const bottom = await resolveCoverageBottom(conversationId, record, false)

--- a/packages/fluux-sdk/src/stores/eventsStore.ts
+++ b/packages/fluux-sdk/src/stores/eventsStore.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla'
-import type { SubscriptionRequest, StrangerMessage, MucInvitation, SystemNotification, SystemNotificationType } from '../core/types'
+import type { SubscriptionRequest, StrangerMessage, RoomInvitation, SystemNotification, SystemNotificationType } from '../core/types'
 import { generateUUID } from '../utils/uuid'
 
 /**
@@ -35,7 +35,7 @@ import { generateUUID } from '../utils/uuid'
 interface EventsState {
   subscriptionRequests: SubscriptionRequest[]
   strangerMessages: StrangerMessage[]
-  mucInvitations: MucInvitation[]
+  mucInvitations: RoomInvitation[]
   systemNotifications: SystemNotification[]
 
   // Actions
@@ -54,7 +54,7 @@ interface EventsState {
 const initialState = {
   subscriptionRequests: [] as SubscriptionRequest[],
   strangerMessages: [] as StrangerMessage[],
-  mucInvitations: [] as MucInvitation[],
+  mucInvitations: [] as RoomInvitation[],
   systemNotifications: [] as SystemNotification[],
 }
 

--- a/packages/fluux-sdk/src/stores/index.ts
+++ b/packages/fluux-sdk/src/stores/index.ts
@@ -56,7 +56,7 @@ export { eventsStore } from './eventsStore'
 export type { EventsState } from './eventsStore'
 // Re-exported from the concrete module, not the '../core/types' barrel: that barrel
 // pulls in core/types/client.ts, which would put this barrel back inside a cycle.
-export type { SubscriptionRequest, StrangerMessage, MucInvitation } from '../core/types/events'
+export type { SubscriptionRequest, StrangerMessage, RoomInvitation } from '../core/types/events'
 
 export { roomStore } from './roomStore'
 export type { RoomState } from './roomStore'

--- a/packages/fluux-sdk/src/stores/roomSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { roomSelectors, roomActivityTone } from './roomSelectors'
 import type { RoomState } from './roomStore'
-import type { Room, RoomEntity, RoomMetadata, RoomRuntime, RoomOccupant, RoomMessage, MAMQueryState } from '../core/types'
+import type { Room, RoomEntity, RoomMetadata, RoomRuntime, RoomOccupant, RoomMessage, HistoryQueryState } from '../core/types'
 
 /**
  * Create a minimal RoomState mock for testing selectors.
@@ -365,7 +365,7 @@ describe('roomSelectors', () => {
 
   describe('mamStateFor', () => {
     it('should return MAM state for room', () => {
-      const mamState: MAMQueryState = {
+      const mamState: HistoryQueryState = {
         isLoading: true,
         hasQueried: false,
         error: null,
@@ -380,7 +380,7 @@ describe('roomSelectors', () => {
 
   describe('isMAMLoading', () => {
     it('should return true when loading', () => {
-      const mamQueryStates = new Map<string, MAMQueryState>([['room@conference.example.com', {
+      const mamQueryStates = new Map<string, HistoryQueryState>([['room@conference.example.com', {
         isLoading: true,
         hasQueried: false,
         error: null,

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -21,7 +21,7 @@
  */
 
 import type { RoomState } from './roomStore'
-import type { Room, RoomEntity, RoomMetadata, RoomRuntime, RoomOccupant, RoomMessage, MAMQueryState } from '../core/types'
+import type { Room, RoomEntity, RoomMetadata, RoomRuntime, RoomOccupant, RoomMessage, HistoryQueryState } from '../core/types'
 
 /**
  * Stable empty references to prevent infinite re-renders.
@@ -207,7 +207,7 @@ export const roomSelectors = {
   /**
    * Get MAM query state for a specific room.
    */
-  mamStateFor: (roomJid: string) => (state: RoomState): MAMQueryState | undefined => {
+  mamStateFor: (roomJid: string) => (state: RoomState): HistoryQueryState | undefined => {
     return state.mamQueryStates.get(roomJid)
   },
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -9,7 +9,7 @@ import type {
   RoomAffiliation,
   RoomMember,
   RoomMessage,
-  MAMQueryState,
+  HistoryQueryState,
   RSMResponse,
 } from '../core/types'
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
@@ -22,7 +22,7 @@ import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
 import * as mamState from './shared/mamState'
-import type { MAMQueryDirection } from './shared/mamState'
+import type { HistoryQueryDirection } from './shared/mamState'
 import { syncGapAfterArchiveMerge, messagePageExtent, newestMessageStanzaId, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import {
   syncCoverageAfterArchiveMerge,
@@ -800,7 +800,7 @@ export interface RoomState {
   votedPollIds: Map<string, Set<string>>
   dismissedPollIds: Map<string, Set<string>>
   // MAM query states per room (for rooms with MAM enabled)
-  mamQueryStates: Map<string, MAMQueryState>
+  mamQueryStates: Map<string, HistoryQueryState>
   // Persisted history-gap intervals per room (survives reload; drives the gap marker)
   roomGaps: Map<string, GapInterval>
   // Persisted contiguous-with-live coverage per room (positive twin of roomGaps;
@@ -1033,7 +1033,7 @@ export interface RoomState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
   /**
    * Strip a purged archive id from the persisted gap anchor (`startId`),
    * keeping the `start` timestamp so the next catch-up resume uses the
@@ -1047,7 +1047,7 @@ export interface RoomState {
   /** Drop the coverage record; with `ifBottomId`, only when it matches
    *  `bottomId` (purge-event guard — the anchor is known gone). */
   clearRoomCoverage: (roomJid: string, ifBottomId?: string) => void
-  getRoomMAMQueryState: (roomJid: string) => MAMQueryState
+  getRoomMAMQueryState: (roomJid: string) => HistoryQueryState
   resetRoomMAMStates: () => void
   /** Update only the lastMessage preview without affecting message history */
   updateLastMessagePreview: (roomJid: string, lastMessage: RoomMessage) => void
@@ -2422,7 +2422,7 @@ export const roomStore = createStore<RoomState>()(
 
     // --- Coverage gate: every uncertain branch defers -
     const mam = mamState.getMAMQueryState(get().mamQueryStates, roomJid)
-    if (!isCaughtUpForCounting(mam)) return defer('mam-not-caught-up')
+    if (!isCaughtUpForCounting(mam)) return defer('history-not-caught-up')
 
     const record = get().roomCoverage.get(roomJid)
     const bottom = await resolveCoverageBottom(roomJid, record, true)

--- a/packages/fluux-sdk/src/stores/shared/mamState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.test.ts
@@ -6,7 +6,7 @@ import {
   setMAMError,
   setMAMQueryCompleted,
 } from './mamState'
-import type { MAMQueryState } from '../../core/types'
+import type { HistoryQueryState } from '../../core/types'
 
 describe('mamState utilities', () => {
   describe('DEFAULT_MAM_STATE', () => {
@@ -23,13 +23,13 @@ describe('mamState utilities', () => {
 
   describe('getMAMQueryState', () => {
     it('returns default state when id not found', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = getMAMQueryState(states, 'unknown-id')
       expect(result).toEqual(DEFAULT_MAM_STATE)
     })
 
     it('returns existing state when id is found', () => {
-      const existingState: MAMQueryState = {
+      const existingState: HistoryQueryState = {
         isLoading: true,
         error: null,
         hasQueried: true,
@@ -37,7 +37,7 @@ describe('mamState utilities', () => {
         isCaughtUpToLive: false,
         oldestFetchedId: 'msg-123',
       }
-      const states = new Map<string, MAMQueryState>([['conv-1', existingState]])
+      const states = new Map<string, HistoryQueryState>([['conv-1', existingState]])
       const result = getMAMQueryState(states, 'conv-1')
       expect(result).toEqual(existingState)
     })
@@ -45,7 +45,7 @@ describe('mamState utilities', () => {
 
   describe('setMAMLoading', () => {
     it('creates new state with loading=true for new id', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMLoading(states, 'conv-1', true)
 
       expect(result.get('conv-1')).toEqual({
@@ -57,7 +57,7 @@ describe('mamState utilities', () => {
     })
 
     it('updates existing state with loading=true', () => {
-      const existingState: MAMQueryState = {
+      const existingState: HistoryQueryState = {
         isLoading: false,
         error: 'previous error',
         hasQueried: true,
@@ -65,7 +65,7 @@ describe('mamState utilities', () => {
         isCaughtUpToLive: false,
         oldestFetchedId: 'msg-123',
       }
-      const states = new Map<string, MAMQueryState>([['conv-1', existingState]])
+      const states = new Map<string, HistoryQueryState>([['conv-1', existingState]])
       const result = setMAMLoading(states, 'conv-1', true)
 
       expect(result.get('conv-1')).toEqual({
@@ -75,21 +75,21 @@ describe('mamState utilities', () => {
     })
 
     it('sets loading=false', () => {
-      const existingState: MAMQueryState = {
+      const existingState: HistoryQueryState = {
         isLoading: true,
         error: null,
         hasQueried: false,
         isHistoryComplete: false,
         isCaughtUpToLive: false,
       }
-      const states = new Map<string, MAMQueryState>([['conv-1', existingState]])
+      const states = new Map<string, HistoryQueryState>([['conv-1', existingState]])
       const result = setMAMLoading(states, 'conv-1', false)
 
       expect(result.get('conv-1')?.isLoading).toBe(false)
     })
 
     it('does not mutate the original map', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMLoading(states, 'conv-1', true)
 
       expect(result).not.toBe(states)
@@ -99,14 +99,14 @@ describe('mamState utilities', () => {
 
   describe('setMAMError', () => {
     it('sets error and clears loading state', () => {
-      const existingState: MAMQueryState = {
+      const existingState: HistoryQueryState = {
         isLoading: true,
         error: null,
         hasQueried: false,
         isHistoryComplete: false,
         isCaughtUpToLive: false,
       }
-      const states = new Map<string, MAMQueryState>([['conv-1', existingState]])
+      const states = new Map<string, HistoryQueryState>([['conv-1', existingState]])
       const result = setMAMError(states, 'conv-1', 'Network error')
 
       expect(result.get('conv-1')).toEqual({
@@ -117,21 +117,21 @@ describe('mamState utilities', () => {
     })
 
     it('clears error when set to null', () => {
-      const existingState: MAMQueryState = {
+      const existingState: HistoryQueryState = {
         isLoading: false,
         error: 'Previous error',
         hasQueried: true,
         isHistoryComplete: false,
         isCaughtUpToLive: false,
       }
-      const states = new Map<string, MAMQueryState>([['conv-1', existingState]])
+      const states = new Map<string, HistoryQueryState>([['conv-1', existingState]])
       const result = setMAMError(states, 'conv-1', null)
 
       expect(result.get('conv-1')?.error).toBeNull()
     })
 
     it('creates new state for unknown id', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMError(states, 'conv-1', 'Error')
 
       expect(result.get('conv-1')).toEqual({
@@ -142,7 +142,7 @@ describe('mamState utilities', () => {
     })
 
     it('does not mutate the original map', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMError(states, 'conv-1', 'Error')
 
       expect(result).not.toBe(states)
@@ -152,7 +152,7 @@ describe('mamState utilities', () => {
 
   describe('setMAMQueryCompleted', () => {
     it('sets completed state with oldestFetchedId for backward query', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', true, 'backward', 'msg-oldest')
 
       expect(result.get('conv-1')).toEqual({
@@ -167,7 +167,7 @@ describe('mamState utilities', () => {
     })
 
     it('sets isCaughtUpToLive for forward query', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', true, 'forward', 'msg-newest')
 
       expect(result.get('conv-1')).toEqual({
@@ -182,7 +182,7 @@ describe('mamState utilities', () => {
     })
 
     it('clears an existing forwardGapTimestamp on a completing forward query (default)', () => {
-      const states = new Map<string, MAMQueryState>([
+      const states = new Map<string, HistoryQueryState>([
         ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
       ])
       const result = setMAMQueryCompleted(states, 'room-1', true, 'forward')
@@ -192,7 +192,7 @@ describe('mamState utilities', () => {
     it('preserveGapMarker keeps an existing forwardGapTimestamp on a completing forward query', () => {
       // A bounded force repair must NOT hide a real gap marker just because its
       // own (windowed) forward query happened to complete.
-      const states = new Map<string, MAMQueryState>([
+      const states = new Map<string, HistoryQueryState>([
         ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
       ])
       const result = setMAMQueryCompleted(states, 'room-1', true, 'forward', undefined, undefined, true)
@@ -201,7 +201,7 @@ describe('mamState utilities', () => {
     })
 
     it('preserveGapMarker does not overwrite forwardGapTimestamp on an incomplete forward query', () => {
-      const states = new Map<string, MAMQueryState>([
+      const states = new Map<string, HistoryQueryState>([
         ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
       ])
       // Without preserve this would set forwardGapTimestamp = 5000 (this page's newest).
@@ -210,7 +210,7 @@ describe('mamState utilities', () => {
     })
 
     it('sets isHistoryComplete=false for incomplete backward query', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', false, 'backward', 'msg-123')
 
       expect(result.get('conv-1')?.isHistoryComplete).toBe(false)
@@ -218,14 +218,14 @@ describe('mamState utilities', () => {
     })
 
     it('handles undefined oldestFetchedId', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', true, 'backward')
 
       expect(result.get('conv-1')?.oldestFetchedId).toBeUndefined()
     })
 
     it('does not mutate the original map', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', true, 'backward', 'msg-123')
 
       expect(result).not.toBe(states)
@@ -233,7 +233,7 @@ describe('mamState utilities', () => {
     })
 
     it('preserves existing isHistoryComplete when doing forward query', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       // First, complete backward history
       const afterBackward = setMAMQueryCompleted(states, 'conv-1', true, 'backward', 'msg-oldest')
       expect(afterBackward.get('conv-1')?.isHistoryComplete).toBe(true)
@@ -245,7 +245,7 @@ describe('mamState utilities', () => {
     })
 
     it('preserves existing isCaughtUpToLive when doing backward query', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       // First, catch up to live
       const afterForward = setMAMQueryCompleted(states, 'conv-1', true, 'forward')
       expect(afterForward.get('conv-1')?.isCaughtUpToLive).toBe(true)
@@ -257,7 +257,7 @@ describe('mamState utilities', () => {
     })
 
     it('sets forwardGapTimestamp when forward catch-up is incomplete', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const gapTs = Date.now() - 60_000
       const result = setMAMQueryCompleted(states, 'room-1', false, 'forward', undefined, gapTs)
 
@@ -266,7 +266,7 @@ describe('mamState utilities', () => {
     })
 
     it('clears forwardGapTimestamp when forward catch-up completes', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       // First: incomplete catch-up sets the gap
       const withGap = setMAMQueryCompleted(states, 'room-1', false, 'forward', undefined, Date.now())
       expect(withGap.get('room-1')?.forwardGapTimestamp).toBeDefined()
@@ -278,7 +278,7 @@ describe('mamState utilities', () => {
     })
 
     it('preserves forwardGapTimestamp during backward queries', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const gapTs = Date.now() - 60_000
       const withGap = setMAMQueryCompleted(states, 'room-1', false, 'forward', undefined, gapTs)
 
@@ -288,7 +288,7 @@ describe('mamState utilities', () => {
     })
 
     it('does not set forwardGapTimestamp when no timestamp is provided', () => {
-      const states = new Map<string, MAMQueryState>()
+      const states = new Map<string, HistoryQueryState>()
       const result = setMAMQueryCompleted(states, 'room-1', false, 'forward')
 
       expect(result.get('room-1')?.forwardGapTimestamp).toBeUndefined()
@@ -299,7 +299,7 @@ describe('mamState utilities', () => {
       // A signal-only page (reactions/receipts only — zero displayable
       // messages) yields no newestFetchedTimestamp. It proves nothing about
       // the hole, so it must not erase the recorded marker.
-      const states = new Map<string, MAMQueryState>([
+      const states = new Map<string, HistoryQueryState>([
         ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
       ])
       const result = setMAMQueryCompleted(states, 'room-1', false, 'forward', undefined, undefined)

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -13,12 +13,12 @@
  * - `isCaughtUpToLive`: Synced with real-time (no gap to present)
  */
 
-import type { MAMQueryDirection, MAMQueryState } from '../../core/types'
+import type { HistoryQueryDirection, HistoryQueryState } from '../../core/types'
 
 /**
  * Default MAM query state for conversations/rooms that haven't been queried yet.
  */
-export const DEFAULT_MAM_STATE: MAMQueryState = {
+export const DEFAULT_MAM_STATE: HistoryQueryState = {
   isLoading: false,
   error: null,
   hasQueried: false,
@@ -30,9 +30,9 @@ export const DEFAULT_MAM_STATE: MAMQueryState = {
  * Get MAM query state for a conversation/room, returning default if not found.
  */
 export function getMAMQueryState(
-  states: Map<string, MAMQueryState>,
+  states: Map<string, HistoryQueryState>,
   id: string
-): MAMQueryState {
+): HistoryQueryState {
   return states.get(id) || DEFAULT_MAM_STATE
 }
 
@@ -40,10 +40,10 @@ export function getMAMQueryState(
  * Create a new MAM states map with loading state updated.
  */
 export function setMAMLoading(
-  states: Map<string, MAMQueryState>,
+  states: Map<string, HistoryQueryState>,
   id: string,
   isLoading: boolean
-): Map<string, MAMQueryState> {
+): Map<string, HistoryQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
   newStates.set(id, { ...current, isLoading })
@@ -54,10 +54,10 @@ export function setMAMLoading(
  * Create a new MAM states map with error state updated.
  */
 export function setMAMError(
-  states: Map<string, MAMQueryState>,
+  states: Map<string, HistoryQueryState>,
   id: string,
   error: string | null
-): Map<string, MAMQueryState> {
+): Map<string, HistoryQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
   newStates.set(id, { ...current, error, isLoading: false })
@@ -76,10 +76,10 @@ export function setMAMError(
  * unchanged rather than rebuilding it from scratch.
  */
 export function setCoverageBottomUnproven(
-  states: Map<string, MAMQueryState>,
+  states: Map<string, HistoryQueryState>,
   id: string,
   value: boolean
-): Map<string, MAMQueryState> {
+): Map<string, HistoryQueryState> {
   const current = states.get(id) || DEFAULT_MAM_STATE
   if (!!current.coverageBottomUnproven === value) return states
   const newStates = new Map(states)
@@ -91,7 +91,7 @@ export function setCoverageBottomUnproven(
  * Query direction for MAM queries. Declared in `core/types/pagination.ts` and
  * re-exported here, where the helpers that consume it live.
  */
-export type { MAMQueryDirection } from '../../core/types'
+export type { HistoryQueryDirection } from '../../core/types'
 
 /**
  * Newest fetched message timestamp (epoch ms), for gap marker positioning by
@@ -102,7 +102,7 @@ export type { MAMQueryDirection } from '../../core/types'
  */
 export function computeNewestFetchedTimestamp(
   fetched: Array<{ timestamp?: Date }>,
-  direction: MAMQueryDirection
+  direction: HistoryQueryDirection
 ): number | undefined {
   return direction === 'forward' && fetched.length > 0
     ? Math.max(...fetched.map(m => m.timestamp?.getTime() ?? 0))
@@ -155,16 +155,16 @@ export function isDisjointFromResidentWindow(
  *   the archive bottom, not the user's visible timeline.
  */
 export function setMAMQueryCompleted(
-  states: Map<string, MAMQueryState>,
+  states: Map<string, HistoryQueryState>,
   id: string,
   complete: boolean,
-  direction: MAMQueryDirection,
+  direction: HistoryQueryDirection,
   oldestFetchedId?: string,
   newestFetchedTimestamp?: number,
   preserveGapMarker = false,
   isFetchLatest = false,
   disjointFromResidentWindow = false
-): Map<string, MAMQueryState> {
+): Map<string, HistoryQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
 

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
@@ -38,10 +38,10 @@ describe('recountDiagnostics', () => {
   })
 
   it('is cumulative, leaving windowing to the reader', () => {
-    recordRecountDeferral('room', 'mam-not-caught-up')
-    expect(readRecountDeferrals()['room:mam-not-caught-up']).toBe(1)
-    recordRecountDeferral('room', 'mam-not-caught-up')
-    expect(readRecountDeferrals()['room:mam-not-caught-up']).toBe(2)
+    recordRecountDeferral('room', 'history-not-caught-up')
+    expect(readRecountDeferrals()['room:history-not-caught-up']).toBe(1)
+    recordRecountDeferral('room', 'history-not-caught-up')
+    expect(readRecountDeferrals()['room:history-not-caught-up']).toBe(2)
   })
 
   it('returns a copy, so a reader cannot mutate the tallies', () => {

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
@@ -38,8 +38,8 @@ export type RecountDeferralReason =
   | 'pending-remote-displayed'
   /** Neither a read pointer nor a history floor to count from. */
   | 'no-floor'
-  /** MAM has not caught up, so any count would be derived from partial history. */
-  | 'mam-not-caught-up'
+  /** History has not caught up, so any count would be derived from partial history. */
+  | 'history-not-caught-up'
   /** Cache epoch or storage scope moved under this recount. */
   | 'context-changed'
   /** No coverage record for the entity, so the archive bottom is unknown. */


### PR DESCRIPTION
Found while measuring where to surface archive failures: the persistent marker would have been built on `chat:mam-error` and `MAMQueryState`, and the toast on `roster:presence-error` — the exact vocabulary the client dropped in #1271. Renaming first, so the error work is not written against names we already decided against.

The client's modules stopped naming XEPs, but the bus it hands a consumer still did. `chat:mam-error` says which specification failed, not that the conversation's history could not be fetched. `roster:` was a whole domain prefix for what the client now calls `contacts`.

## What changes

Twenty-three event names, among them:

| Before | After |
|---|---|
| `chat:mam-error`, `room:mam-error` | `chat:history-error`, `room:history-error` |
| `chat:mam-loading`, `chat:mam-messages`, … | `chat:history-loading`, `chat:history-messages`, … |
| `connection:mam-fulltext-search` | `connection:history-search` |
| `roster:*` (8 events) | `contacts:*` |
| `events:muc-invitation` | `events:room-invitation` |
| `admin:muc-service` | `admin:room-service` |
| `connection:own-vcard` | `connection:own-profile` |

And the public types that travel with them: `MAMQueryState` → `HistoryQueryState`, `MAMResult` → `HistoryResult`, `MucInvitation` → `RoomInvitation`, `RosterEvents` → `ContactsEvents`, the hooks' `activeMAMState` → `activeHistoryState`, and the one public diagnostic reason still reading `mam-not-caught-up`.

Classes and files keep their protocol names, as agreed: `MAM.ts` implements XEP-0313 and says so. Only what a consumer types changes.

## Verification

`build:sdk`, `typecheck` 0 errors, `check:examples` 183 compiled, `check:comments` clean, `lint` 0 errors, `npm test` green (SDK 240 files / 6060 tests, app 455 / 6047), and `npm run test:scroll` 98/98 — run because this renames string literals, which the compiler follows in typed positions but not in the e2e harness. A sweep outside `src/` found no remaining occurrences.