### PR TITLE
feat(sdk): state why a room join failed in the caller's terms

### DIFF
--- a/apps/fluux/src/components/BrowseRoomsModal.test.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.test.tsx
@@ -10,15 +10,33 @@ const mockSetActiveRoom = vi.fn()
 const mockSetActiveConversation = vi.fn()
 
 const { RoomJoinError } = vi.hoisted(() => {
+  // Mirrors the SDK's own condition-to-reason resolution. Kept local because
+  // these suites mock the SDK barrel wholesale rather than importing it.
+  const REASONS: Record<string, string> = {
+    conflict: 'nickname-taken',
+    'registration-required': 'members-only',
+    forbidden: 'banned',
+    'service-unavailable': 'room-full',
+    'not-acceptable': 'registered-nickname-required',
+    'item-not-found': 'room-not-found',
+    timeout: 'timed-out',
+  }
+
   class RoomJoinError extends Error {
+    readonly reason: string
     constructor(
       public roomJid: string,
       public condition: string,
       public errorType?: string,
       public text?: string,
+      options?: { passwordSent?: boolean },
     ) {
       super(text || `Room join failed: ${condition}`)
       this.name = 'RoomJoinError'
+      this.reason =
+        condition === 'not-authorized'
+          ? options?.passwordSent ? 'wrong-password' : 'password-required'
+          : REASONS[condition] ?? 'unknown'
     }
   }
   return { RoomJoinError }

--- a/apps/fluux/src/components/JoinRoomModal.test.tsx
+++ b/apps/fluux/src/components/JoinRoomModal.test.tsx
@@ -12,15 +12,33 @@ const { mockJoinRoom, mockJoinResult, mockSetActiveRoom, mockSetActiveConversati
 
   // Minimal stand-in for the SDK's RoomJoinError so `instanceof` works in the
   // component (which imports it from the mocked '@fluux/sdk').
+  // Mirrors the SDK's own condition-to-reason resolution. Kept local because
+  // these suites mock the SDK barrel wholesale rather than importing it.
+  const REASONS: Record<string, string> = {
+    conflict: 'nickname-taken',
+    'registration-required': 'members-only',
+    forbidden: 'banned',
+    'service-unavailable': 'room-full',
+    'not-acceptable': 'registered-nickname-required',
+    'item-not-found': 'room-not-found',
+    timeout: 'timed-out',
+  }
+
   class RoomJoinError extends Error {
+    readonly reason: string
     constructor(
       public roomJid: string,
       public condition: string,
       public errorType?: string,
       public text?: string,
+      options?: { passwordSent?: boolean },
     ) {
       super(text || `Room join failed: ${condition}`)
       this.name = 'RoomJoinError'
+      this.reason =
+        condition === 'not-authorized'
+          ? options?.passwordSent ? 'wrong-password' : 'password-required'
+          : REASONS[condition] ?? 'unknown'
     }
   }
 
@@ -328,8 +346,12 @@ describe('JoinRoomModal', () => {
       expect(mockOnClose).not.toHaveBeenCalled()
     })
 
-    it('shows "incorrect password" when a password was already supplied', async () => {
-      mockJoinResult.mockRejectedValue(new RoomJoinError('room@conference.example.com', 'not-authorized', 'auth'))
+    // The SDK decides this, not the form: the error carries `wrong-password`
+    // only because the join it refused actually carried one.
+    it('shows "incorrect password" when the refused join carried a password', async () => {
+      mockJoinResult.mockRejectedValue(
+        new RoomJoinError('room@conference.example.com', 'not-authorized', 'auth', undefined, { passwordSent: true })
+      )
       render(<JoinRoomModal onClose={mockOnClose} />)
       fillRoom()
 

--- a/apps/fluux/src/components/JoinRoomModal.tsx
+++ b/apps/fluux/src/components/JoinRoomModal.tsx
@@ -48,17 +48,17 @@ export function JoinRoomModal({ onClose }: JoinRoomModalProps) {
     if (focusTarget) setFocusTarget(null)
   }, [focusTarget])
 
-  const showJoinError = (err: unknown, passwordWasSent: boolean) => {
+  const showJoinError = (err: unknown) => {
     // Field side-effects stay here; the message text comes from the shared helper.
     if (err instanceof RoomJoinError) {
-      if (err.condition === 'not-authorized') {
+      if (err.reason === 'password-required' || err.reason === 'wrong-password') {
         setShowPassword(true)
         setFocusTarget('password')
-      } else if (err.condition === 'conflict') {
+      } else if (err.reason === 'nickname-taken') {
         setFocusTarget('nickname')
       }
     }
-    setError(getRoomJoinErrorMessage(t, err, { passwordWasSent }))
+    setError(getRoomJoinErrorMessage(t, err))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -86,18 +86,17 @@ export function JoinRoomModal({ onClose }: JoinRoomModalProps) {
 
     // Room passwords are opaque XMPP strings — do not trim (preserve any
     // intentional surrounding whitespace).
-    const passwordWasSent = password.length > 0
     setJoining(true)
     try {
       // Issue #37: warn before joining a room that would expose the user's real JID.
       if (!(await confirmJoin(trimmedRoomJid))) return
-      await joinRoom(trimmedRoomJid, trimmedNickname, passwordWasSent ? { password } : undefined)
+      await joinRoom(trimmedRoomJid, trimmedNickname, password.length > 0 ? { password } : undefined)
       await joinResult(trimmedRoomJid)
       void setActiveConversation(null)
       void setActiveRoom(trimmedRoomJid)
       onClose()
     } catch (err) {
-      showJoinError(err, passwordWasSent)
+      showJoinError(err)
     } finally {
       setJoining(false)
     }

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -16,15 +16,33 @@ import { RoomView } from './RoomView'
 import type { RoomMessage, Room, RoomOccupant, Contact } from '@fluux/sdk'
 
 const { RoomJoinError } = vi.hoisted(() => {
+  // Mirrors the SDK's own condition-to-reason resolution. Kept local because
+  // these suites mock the SDK barrel wholesale rather than importing it.
+  const REASONS: Record<string, string> = {
+    conflict: 'nickname-taken',
+    'registration-required': 'members-only',
+    forbidden: 'banned',
+    'service-unavailable': 'room-full',
+    'not-acceptable': 'registered-nickname-required',
+    'item-not-found': 'room-not-found',
+    timeout: 'timed-out',
+  }
+
   class RoomJoinError extends Error {
+    readonly reason: string
     constructor(
       public roomJid: string,
       public condition: string,
       public errorType?: string,
       public text?: string,
+      options?: { passwordSent?: boolean },
     ) {
       super(text || `Room join failed: ${condition}`)
       this.name = 'RoomJoinError'
+      this.reason =
+        condition === 'not-authorized'
+          ? options?.passwordSent ? 'wrong-password' : 'password-required'
+          : REASONS[condition] ?? 'unknown'
     }
   }
   return { RoomJoinError }

--- a/apps/fluux/src/hooks/useDeepLink.test.tsx
+++ b/apps/fluux/src/hooks/useDeepLink.test.tsx
@@ -13,15 +13,33 @@ const mockJoinResult = vi.fn()
 const mockHasConversation = vi.fn()
 
 const { RoomJoinError } = vi.hoisted(() => {
+  // Mirrors the SDK's own condition-to-reason resolution. Kept local because
+  // these suites mock the SDK barrel wholesale rather than importing it.
+  const REASONS: Record<string, string> = {
+    conflict: 'nickname-taken',
+    'registration-required': 'members-only',
+    forbidden: 'banned',
+    'service-unavailable': 'room-full',
+    'not-acceptable': 'registered-nickname-required',
+    'item-not-found': 'room-not-found',
+    timeout: 'timed-out',
+  }
+
   class RoomJoinError extends Error {
+    readonly reason: string
     constructor(
       public roomJid: string,
       public condition: string,
       public errorType?: string,
       public text?: string,
+      options?: { passwordSent?: boolean },
     ) {
       super(text || `Room join failed: ${condition}`)
       this.name = 'RoomJoinError'
+      this.reason =
+        condition === 'not-authorized'
+          ? options?.passwordSent ? 'wrong-password' : 'password-required'
+          : REASONS[condition] ?? 'unknown'
     }
   }
   return { RoomJoinError }

--- a/apps/fluux/src/hooks/useDeepLink.ts
+++ b/apps/fluux/src/hooks/useDeepLink.ts
@@ -89,9 +89,7 @@ export function useDeepLink() {
         await joinRoom(roomJid, nickname, Object.keys(joinOptions).length > 0 ? joinOptions : undefined)
         await joinResult(roomJid)
       } catch (err) {
-        // A deep link can carry a password, so distinguish "incorrect password"
-        // from "password required" when the server rejects with not-authorized.
-        addToast('error', getRoomJoinErrorMessage(t, err, { passwordWasSent: !!password }))
+        addToast('error', getRoomJoinErrorMessage(t, err))
       }
 
       // Navigate to the room regardless of outcome: on failure the user lands on

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
@@ -68,7 +68,8 @@ export function useRoomPasswordPrompt() {
   const withPasswordPrompt = useCallback(
     async (attempt: (password?: string) => Promise<void>): Promise<boolean> => {
       const isPasswordRefusal = (err: unknown) =>
-        err instanceof RoomJoinError && err.condition === 'not-authorized'
+        err instanceof RoomJoinError &&
+        (err.reason === 'password-required' || err.reason === 'wrong-password')
 
       try {
         await attempt()

--- a/apps/fluux/src/hooks/useSDKErrorToasts.test.ts
+++ b/apps/fluux/src/hooks/useSDKErrorToasts.test.ts
@@ -72,12 +72,13 @@ describe('useSDKErrorToasts', () => {
     )
   })
 
-  it('should translate the condition of a failed rejoin', () => {
+  it('should translate the reason of a failed rejoin', () => {
     renderHook(() => useSDKErrorToasts())
 
     const callback = mockSubscribe.mock.calls.find(([name]) => name === 'room:autojoin-error')![1]
     callback({
       roomJid: 'team@conference.example.com',
+      reason: 'nickname-taken',
       error: 'Room join failed: conflict',
       condition: 'conflict',
     })
@@ -85,12 +86,13 @@ describe('useSDKErrorToasts', () => {
     expect(mockAddToast).toHaveBeenCalledWith('error', 'Could not rejoin team: Nickname already in use')
   })
 
-  it('should fall back to the server text on an unrecognized condition', () => {
+  it('should fall back to the server text on an unrecognized reason', () => {
     renderHook(() => useSDKErrorToasts())
 
     const callback = mockSubscribe.mock.calls.find(([name]) => name === 'room:autojoin-error')![1]
     callback({
       roomJid: 'team@conference.example.com',
+      reason: 'unknown',
       error: 'The service is going down for maintenance',
       condition: 'system-shutdown',
     })

--- a/apps/fluux/src/hooks/useSDKErrorToasts.ts
+++ b/apps/fluux/src/hooks/useSDKErrorToasts.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useXMPP, getLocalPart } from '@fluux/sdk'
 import { useToastStore } from '@/stores/toastStore'
-import { getRoomJoinConditionMessage } from '@/utils/roomJoinError'
+import { getRoomJoinReasonMessage } from '@/utils/roomJoinError'
 
 /**
  * Surfaces an SDK error event as a toast when no better place exists to show it.
@@ -26,10 +26,10 @@ export function useSDKErrorToasts(): void {
       client.subscribe('room:invite-error', ({ error }) => {
         addToast('error', t('rooms.inviteRejected', { error }))
       }),
-      client.subscribe('room:autojoin-error', ({ roomJid, condition, error }) => {
+      client.subscribe('room:autojoin-error', ({ roomJid, reason, error }) => {
         addToast('error', t('rooms.couldNotRejoin', {
           room: getLocalPart(roomJid) || roomJid,
-          reason: getRoomJoinConditionMessage(t, condition, error),
+          reason: getRoomJoinReasonMessage(t, reason, error),
         }))
       }),
     ]

--- a/apps/fluux/src/utils/roomJoinError.test.ts
+++ b/apps/fluux/src/utils/roomJoinError.test.ts
@@ -5,8 +5,8 @@ import { getRoomJoinErrorMessage } from './roomJoinError'
 // Identity translate fn: returns the key so assertions read as i18n keys.
 const t = (key: string) => key
 
-const err = (condition: string, text?: string) =>
-  new RoomJoinError('room@conference.example.com', condition, undefined, text)
+const err = (condition: string, text?: string, passwordSent?: boolean) =>
+  new RoomJoinError('room@conference.example.com', condition, undefined, text, { passwordSent })
 
 describe('getRoomJoinErrorMessage', () => {
   it('maps not-authorized to passwordRequired when no password was sent', () => {
@@ -14,7 +14,7 @@ describe('getRoomJoinErrorMessage', () => {
   })
 
   it('maps not-authorized to incorrectPassword when a password was sent', () => {
-    expect(getRoomJoinErrorMessage(t, err('not-authorized'), { passwordWasSent: true })).toBe(
+    expect(getRoomJoinErrorMessage(t, err('not-authorized', undefined, true))).toBe(
       'rooms.incorrectPassword',
     )
   })

--- a/apps/fluux/src/utils/roomJoinError.ts
+++ b/apps/fluux/src/utils/roomJoinError.ts
@@ -1,40 +1,41 @@
-import { RoomJoinError } from '@fluux/sdk'
+import { RoomJoinError, type RoomJoinReason } from '@fluux/sdk'
 
 // Matches the TranslateFn convention in messagePreviewText.ts.
 type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 /**
- * Map an RFC 6120 condition from a room-join failure to a localized message.
+ * Map a room-join reason to its localized, user-facing message.
  *
- * Takes the condition rather than the error object so the SDK's
+ * Takes the reason rather than the error object so the SDK's
  * `room:autojoin-error` event, which carries plain data, resolves its wording
- * through the same table as the thrown {@link RoomJoinError}.
+ * through the same table as a thrown {@link RoomJoinError}.
  *
- * @param condition - Condition reported by the server, or the synthetic 'timeout'.
- * @param text - Server-supplied text, used when the condition is unrecognized.
- * @param opts.passwordWasSent see {@link getRoomJoinErrorMessage}
+ * @param text - Server-supplied text, shown when the reason is `unknown`.
  */
-export function getRoomJoinConditionMessage(
+export function getRoomJoinReasonMessage(
   t: TranslateFn,
-  condition: string,
+  reason: RoomJoinReason,
   text?: string,
-  opts?: { passwordWasSent?: boolean },
 ): string {
-  switch (condition) {
-    case 'not-authorized':
-      return t(opts?.passwordWasSent ? 'rooms.incorrectPassword' : 'rooms.passwordRequired')
-    case 'conflict':
+  switch (reason) {
+    case 'password-required':
+      return t('rooms.passwordRequired')
+    case 'wrong-password':
+      return t('rooms.incorrectPassword')
+    case 'nickname-taken':
       return t('rooms.nicknameInUse')
-    case 'registration-required':
+    case 'members-only':
       return t('rooms.membersOnly')
-    case 'forbidden':
+    case 'banned':
       return t('rooms.bannedFromRoom')
-    case 'service-unavailable':
+    case 'room-full':
       return t('rooms.roomFull')
-    case 'not-acceptable':
+    case 'registered-nickname-required':
       return t('rooms.registeredNicknameRequired')
-    case 'item-not-found':
+    case 'room-not-found':
       return t('rooms.roomNotFound')
+    // `not-in-room`, `timed-out` and `unknown` carry nothing an app-specific
+    // wording would add, so they read the server's own text when there is one.
     default:
       return text || t('rooms.failedToJoinRoom')
   }
@@ -46,18 +47,10 @@ export function getRoomJoinConditionMessage(
  * RoomsList, BrowseRoomsModal, deep link) so the wording stays in sync. Field
  * side effects (revealing the password input, focusing the nickname) stay in
  * the modal — this resolves message text only.
- *
- * @param opts.passwordWasSent disambiguates the two `not-authorized` cases:
- *   false → "password required", true → "incorrect password". Secondary paths
- *   never send a password, so they omit it (defaults to false).
  */
-export function getRoomJoinErrorMessage(
-  t: TranslateFn,
-  err: unknown,
-  opts?: { passwordWasSent?: boolean },
-): string {
+export function getRoomJoinErrorMessage(t: TranslateFn, err: unknown): string {
   if (err instanceof RoomJoinError) {
-    return getRoomJoinConditionMessage(t, err.condition, err.text, opts)
+    return getRoomJoinReasonMessage(t, err.reason, err.text)
   }
   return err instanceof Error ? err.message : t('rooms.failedToJoinRoom')
 }

--- a/packages/fluux-sdk/src/core/errors.test.ts
+++ b/packages/fluux-sdk/src/core/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { RoomJoinError } from './errors'
+import { RoomJoinError, roomJoinReasonFor } from './errors'
 
 describe('RoomJoinError', () => {
   it('carries roomJid, condition, errorType, and text', () => {
@@ -20,5 +20,33 @@ describe('RoomJoinError', () => {
   it('uses server text as the message when present, else a condition fallback', () => {
     expect(new RoomJoinError('r@x', 'forbidden', 'auth', 'You are banned').message).toBe('You are banned')
     expect(new RoomJoinError('r@x', 'timeout').message).toBe('Room join failed: timeout')
+  })
+})
+
+describe('roomJoinReasonFor', () => {
+  it.each([
+    ['conflict', 'nickname-taken'],
+    ['registration-required', 'members-only'],
+    ['forbidden', 'banned'],
+    ['service-unavailable', 'room-full'],
+    ['not-acceptable', 'registered-nickname-required'],
+    ['item-not-found', 'room-not-found'],
+    ['not-joined', 'not-in-room'],
+    ['timeout', 'timed-out'],
+  ])('resolves %s to %s', (condition, reason) => {
+    expect(roomJoinReasonFor(condition)).toBe(reason)
+  })
+
+  it('separates the two not-authorized cases by whether a password was sent', () => {
+    expect(roomJoinReasonFor('not-authorized')).toBe('password-required')
+    expect(roomJoinReasonFor('not-authorized', true)).toBe('wrong-password')
+  })
+
+  it('reads a condition it does not know as unknown', () => {
+    expect(roomJoinReasonFor('resource-constraint')).toBe('unknown')
+  })
+
+  it('only lets the password flag change not-authorized', () => {
+    expect(roomJoinReasonFor('conflict', true)).toBe('nickname-taken')
   })
 })

--- a/packages/fluux-sdk/src/core/errors.ts
+++ b/packages/fluux-sdk/src/core/errors.ts
@@ -1,17 +1,84 @@
 import type { XMPPErrorType } from '../utils/xmppError'
 
 /**
+ * Why a room join failed, in terms of what the user has to do about it.
+ *
+ * The wire condition alone does not answer that: `not-authorized` means "ask
+ * for a password" or "that password was wrong" depending on whether one was
+ * sent, and `not-acceptable` means "this room only admits your registered
+ * nickname". Resolving that is the SDK's job, not each caller's.
+ *
+ * - `password-required` — the room is locked and no password was sent
+ * - `wrong-password` — a password was sent and the room refused it
+ * - `nickname-taken` — the nickname is in use by another occupant
+ * - `members-only` — the room admits registered members only
+ * - `banned` — this account is banned from the room
+ * - `room-full` — the room reached its occupancy limit
+ * - `registered-nickname-required` — the room only admits a reserved nickname
+ * - `room-not-found` — no such room, and it was not created
+ * - `not-in-room` — the operation needs an occupancy this client does not have
+ * - `timed-out` — no response before the retry budget ran out
+ * - `unknown` — the server gave a condition this list does not cover; read
+ *   {@link RoomJoinError.condition} and {@link RoomJoinError.text} for detail
+ */
+export type RoomJoinReason =
+  | 'password-required'
+  | 'wrong-password'
+  | 'nickname-taken'
+  | 'members-only'
+  | 'banned'
+  | 'room-full'
+  | 'registered-nickname-required'
+  | 'room-not-found'
+  | 'not-in-room'
+  | 'timed-out'
+  | 'unknown'
+
+/**
+ * Resolve an XEP-0045 §7.2 join failure to the reason a caller can act on.
+ *
+ * @param condition - RFC 6120 condition from the error presence, or one of the
+ *   SDK's synthetic conditions (`'timeout'`, `'not-joined'`).
+ * @param passwordSent - Whether the refused join carried a password. Only
+ *   `not-authorized` reads it, to tell a missing password from a wrong one.
+ */
+export function roomJoinReasonFor(condition: string, passwordSent = false): RoomJoinReason {
+  switch (condition) {
+    case 'not-authorized':
+      return passwordSent ? 'wrong-password' : 'password-required'
+    case 'conflict':
+      return 'nickname-taken'
+    case 'registration-required':
+      return 'members-only'
+    case 'forbidden':
+      return 'banned'
+    case 'service-unavailable':
+      return 'room-full'
+    case 'not-acceptable':
+      return 'registered-nickname-required'
+    case 'item-not-found':
+      return 'room-not-found'
+    case 'not-joined':
+      return 'not-in-room'
+    case 'timeout':
+      return 'timed-out'
+    default:
+      return 'unknown'
+  }
+}
+
+/**
  * Error surfaced by {@link MUC.joinResult} when joining a MUC room fails.
  *
- * Carries the RFC 6120 §8.3 error condition so callers can react specifically:
- * prompt for a password on `not-authorized`, re-prompt the nickname on
- * `conflict`, explain `registration-required` / `forbidden`, etc.
- *
- * The synthetic condition `'timeout'` is used when the join receives no
- * response after the retry budget is exhausted (no server condition available).
+ * Read {@link RoomJoinError.reason} to decide what to do: it states the failure
+ * in the application's terms and already resolves the cases the wire condition
+ * leaves ambiguous. {@link RoomJoinError.condition} carries the underlying
+ * RFC 6120 §8.3 condition for callers that want the protocol detail.
  */
 export class RoomJoinError extends Error {
   readonly roomJid: string
+  /** What the caller can act on. See {@link RoomJoinReason}. */
+  readonly reason: RoomJoinReason
   /** RFC 6120 defined condition, e.g. 'not-authorized', 'conflict', or the synthetic 'timeout'. */
   readonly condition: string
   /** RFC 6120 error type, e.g. 'auth' | 'cancel' | 'modify' | 'wait', when available. */
@@ -19,11 +86,23 @@ export class RoomJoinError extends Error {
   /** Optional human-readable server text. */
   readonly text?: string
 
-  constructor(roomJid: string, condition: string, errorType?: XMPPErrorType, text?: string) {
+  /**
+   * @param options.passwordSent - Whether the refused join carried a password.
+   *   Set by the join path so `not-authorized` resolves to `wrong-password`
+   *   rather than `password-required`.
+   */
+  constructor(
+    roomJid: string,
+    condition: string,
+    errorType?: XMPPErrorType,
+    text?: string,
+    options?: { passwordSent?: boolean },
+  ) {
     super(text || `Room join failed: ${condition}`)
     this.name = 'RoomJoinError'
     this.roomJid = roomJid
     this.condition = condition
+    this.reason = roomJoinReasonFor(condition, options?.passwordSent)
     this.errorType = errorType
     this.text = text
     // Preserve the prototype chain so `instanceof RoomJoinError` works after

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -955,6 +955,41 @@ describe('MUC Module', () => {
         updates: expect.objectContaining({ password: expect.anything() }),
       })
     })
+
+    // The refusal reads the same on the wire either way; only the join knows
+    // whether it sent a password, and it must be read before the pending join
+    // is cleared.
+    const refuse = () =>
+      muc.handle(createMockElement('presence', { from: `${ROOM}/mynick`, type: 'error' }, [
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc' } },
+        {
+          name: 'error',
+          attrs: { type: 'auth' },
+          children: [{ name: 'not-authorized', attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } }],
+        },
+      ]))
+
+    it('reports a refused password as wrong-password', async () => {
+      mockStores.room.getRoom.mockReturnValue(storedRoom())
+      mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+      await muc.joinRoom(ROOM, 'mynick', { password: 'wrong' })
+      const result = muc.joinResult(ROOM)
+      refuse()
+
+      await expect(result).rejects.toMatchObject({ reason: 'wrong-password' })
+    })
+
+    it('reports a locked room joined without a password as password-required', async () => {
+      mockStores.room.getRoom.mockReturnValue(storedRoom())
+      mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+      await muc.joinRoom(ROOM, 'mynick')
+      const result = muc.joinResult(ROOM)
+      refuse()
+
+      await expect(result).rejects.toMatchObject({ reason: 'password-required' })
+    })
   })
 
   describe('removeBookmark', () => {
@@ -2833,6 +2868,7 @@ describe('MUC Module', () => {
 
       expect(mockEmitSDK).toHaveBeenCalledWith('room:autojoin-error', {
         roomJid: ROOM,
+        reason: 'nickname-taken',
         error: 'Nickname is taken',
         condition: 'conflict',
         errorType: 'cancel',

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -552,18 +552,21 @@ export class MUC extends BaseModule {
    */
   private failJoin(stanza: Element, roomJid: string): void {
     const error = parseXMPPError(stanza)
-    const reason = error ? formatXMPPError(error) : 'unknown'
-    console.error(`[MUC] Room error for ${roomJid}: ${reason}`)
+    const summary = error ? formatXMPPError(error) : 'unknown'
+    console.error(`[MUC] Room error for ${roomJid}: ${summary}`)
+    // Read before clearPendingJoin drops it: whether the refused join carried a
+    // password is what separates "asks for one" from "that one was wrong".
+    const passwordSent = Boolean(this.pendingJoins.get(roomJid)?.options?.password)
     // Surface in the exportable XMPP console as an at-a-glance error event
     // (the raw error stanza is already logged, this is the readable summary).
-    this.deps.emitSDK('console:event', { message: `Failed to join ${roomJid}: ${reason}`, category: 'error' })
+    this.deps.emitSDK('console:event', { message: `Failed to join ${roomJid}: ${summary}`, category: 'error' })
     this.clearPendingJoin(roomJid) // stops the retry on terminal errors
     this.pendingOccupants.delete(roomJid)
     // SDK event only - binding calls store.updateRoom
     this.deps.emitSDK('room:updated', { roomJid, updates: { joined: false, isJoining: false } })
     this.settleJoinError(
       roomJid,
-      new RoomJoinError(roomJid, error?.condition ?? 'undefined-condition', error?.type, error?.text)
+      new RoomJoinError(roomJid, error?.condition ?? 'undefined-condition', error?.type, error?.text, { passwordSent })
     )
   }
 
@@ -591,6 +594,7 @@ export class MUC extends BaseModule {
       const joinError = err instanceof RoomJoinError ? err : null
       this.deps.emitSDK('room:autojoin-error', {
         roomJid,
+        reason: joinError?.reason ?? 'unknown',
         error: err instanceof Error ? err.message : String(err),
         condition: joinError?.condition ?? 'undefined-condition',
         errorType: joinError?.errorType,

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -13,6 +13,7 @@ import type { Message, Conversation } from './chat'
 import type { StoredMessage, StoredRoomMessage } from './message-internal'
 import type { Contact, PresenceShow, VCardInfo } from './roster'
 import type { Room, RoomOccupant, RoomMember, RoomMessage, RoomAffiliation, RoomRole } from './room'
+import type { RoomJoinReason } from '../errors'
 import type { ServerInfo } from './discovery'
 import type { HttpUploadService } from './upload'
 import type { WebPushService, WebPushStatus } from './webpush'
@@ -472,6 +473,8 @@ export interface RoomEvents {
    */
   'room:autojoin-error': {
     roomJid: string
+    /** What the caller can act on, already resolved from the wire condition */
+    reason: RoomJoinReason
     /** Human-readable error message (prefers server text, falls back to the condition) */
     error: string
     /** RFC 6120 error condition, or the synthetic 'timeout' (e.g. 'conflict', 'forbidden') */

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -607,6 +607,10 @@ export type { ConnectionErrorKind } from './core/modules/transportErrors'
 
 // MUC join failure error (rejected by client.rooms.joinResult)
 export { RoomJoinError, WhisperCounterpartGoneError, HatCommandError, IQTimeoutError } from './core/errors'
+// The reason a join failed, stated in the application's terms. Exported with
+// its resolver so a consumer can classify a condition it obtained elsewhere.
+export { roomJoinReasonFor } from './core/errors'
+export type { RoomJoinReason } from './core/errors'
 
 // XEP-0045: MUC Permission Utilities
 export { canSetAffiliation, canSetRole, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles } from './utils/mucPermissions'


### PR DESCRIPTION
`RoomJoinError` carried only the RFC 6120 condition, so every consumer had to re-derive what it meant. The reference app held that table, which meant any other client built on the SDK would have to write it again from the spec.

The error now carries `reason`: `password-required`, `wrong-password`, `nickname-taken`, `members-only`, `banned`, `room-full`, `registered-nickname-required`, `room-not-found`, `not-in-room`, `timed-out`, `unknown`. `condition` stays for callers that want the protocol detail, and `roomJoinReasonFor` is exported for a condition obtained elsewhere. `room:autojoin-error` carries the reason too.

It also moves one decision to the side that can make it. Telling "asks for a password" from "that password was wrong" needs to know whether the refused join carried one, and only the join path knows that. The app was inferring it from whatever its form state happened to hold, which a stored bookmark password or a retry could contradict; `failJoin` now reads it from the pending join, before clearing it.

The app keeps its i18n table but switches on the reason, and `passwordWasSent` disappears from the join modal, the deep-link handler and the shared helper.