### PR TITLE
refactor(scroll): give the seven executors one teardown order

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.leaseConformance.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.leaseConformance.test.ts
@@ -95,16 +95,26 @@ const entryFacts = {
   live: { syncedLiveEdge: false } satisfies EntryPositionFacts,
 }
 
-/** Collects the lease each executor is handed, and keeps the loop inert so no frame ever runs. */
+/**
+ * Collects the lease each executor is handed and keeps the loop inert so no frame ever runs.
+ *
+ * `abortedAtFinish` records what the abort signal read at the moment the loop was told to finish.
+ * Teardown must stop the loop before aborting, or a frame already scheduled runs against an
+ * execution whose lease has gone; the flag is the only way to observe that order from outside.
+ */
 function leaseCollector() {
   const leases: PositionExecutionLease[] = []
+  let abortedAtFinish: boolean | null = null
   const loop: PositionFrameLoop = {
     schedule: () => {},
     recordFrame: () => {},
-    finish: () => {},
+    finish: () => {
+      abortedAtFinish = leases.at(-1)?.signal.aborted ?? null
+    },
   }
   return {
     leases,
+    finishSawAbort: () => abortedAtFinish,
     beginLoop: (lease: PositionExecutionLease) => {
       leases.push(lease)
       return loop
@@ -115,6 +125,7 @@ function leaseCollector() {
 interface Started {
   lease: PositionExecutionLease
   generation: number
+  collector: ReturnType<typeof leaseCollector>
 }
 
 /**
@@ -282,7 +293,7 @@ function started(
   expect(request, 'the executor must accept its own entry point').not.toBeNull()
   const lease = collector.leases.at(-1)
   expect(lease, 'every executor must be handed a lease through beginLoop').toBeDefined()
-  return { lease: lease!, generation: request!.generation }
+  return { lease: lease!, generation: request!.generation, collector }
 }
 
 describe.each(EXECUTORS)('$name lease', ({ start }) => {
@@ -330,6 +341,22 @@ describe.each(EXECUTORS)('$name lease', ({ start }) => {
     })
 
     expect(lease.isCurrent()).toBe(false)
+  })
+
+  it('stops the frame loop before aborting the lease it authorised', () => {
+    // Teardown order, observed from outside: the loop is told to finish while the signal is still
+    // live. Aborting first would leave an already-scheduled frame to run against an execution whose
+    // lease has gone. Nothing else pins this — the order is otherwise only stated in a comment.
+    const controller = new PositioningController()
+    const { collector, generation } = start(controller)
+    expect(collector.finishSawAbort(), 'the loop must still be running before teardown').toBeNull()
+
+    controller.deactivate(conversationId, generation)
+
+    expect(
+      collector.finishSawAbort(),
+      'teardown must finish the loop before aborting, or not finish it at all',
+    ).toBe(false)
   })
 
   it('refuses to advance the phase once it is no longer current', () => {

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -2334,14 +2334,16 @@ export class PositioningController {
     execution: ResidentTopExecutionState,
     outcome: ResidentTopCompletion,
   ): void {
-    this.finishResidentTopLoop(execution)
-    execution.abortController?.abort()
-    runScrollShadowSafely({
-      event: 'resident-top-complete',
-      conversationId: execution.request.conversationId,
-      fallback: undefined,
-      observe: () => execution.executor.complete(execution.request, outcome),
-    })
+    this.teardownExecution(
+      execution,
+      (torn) => this.finishResidentTopLoop(torn),
+      (torn) => runScrollShadowSafely({
+        event: 'resident-top-complete',
+        conversationId: torn.request.conversationId,
+        fallback: undefined,
+        observe: () => torn.executor.complete(torn.request, outcome),
+      }),
+    )
     if (this.residentTopExecution === execution) {
       this.residentTopExecution = null
     }
@@ -3571,27 +3573,41 @@ export class PositioningController {
     this.cancelDirectionalHistoryExecution(outcome)
   }
 
+  /**
+   * Tear an execution down in the order every executor depends on: stop its frame loop, abort the
+   * work its lease authorised, then report the outcome to the executor that asked for it.
+   *
+   * The order is the point. Aborting before the loop is finished leaves a scheduled frame to run
+   * against a dead execution, and reporting before the abort hands the executor a completion whose
+   * signal is still live. Clearing the slot stays with each caller: most drop it unconditionally,
+   * resident top only when it still holds the execution being torn down.
+   */
+  private teardownExecution<T extends { abortController: AbortController | null }>(
+    execution: T | null,
+    finishLoop: (execution: T) => void,
+    reportOutcome?: (execution: T) => void,
+  ): void {
+    if (!execution) return
+    finishLoop(execution)
+    execution.abortController?.abort()
+    reportOutcome?.(execution)
+  }
+
   private cancelSavedExecution(): void {
-    if (this.savedExecution) {
-      this.finishSavedLoop(this.savedExecution)
-      this.savedExecution.abortController?.abort()
-    }
+    this.teardownExecution(this.savedExecution, (execution) => this.finishSavedLoop(execution))
     this.savedExecution = null
   }
 
   private cancelUnreadExecution(): void {
-    if (this.unreadExecution) {
-      this.finishUnreadLoop(this.unreadExecution)
-      this.unreadExecution.abortController?.abort()
-    }
+    this.teardownExecution(this.unreadExecution, (execution) => this.finishUnreadLoop(execution))
     this.unreadExecution = null
   }
 
   private cancelExplicitTargetExecution(): void {
-    if (this.explicitTargetExecution) {
-      this.finishExplicitTargetLoop(this.explicitTargetExecution)
-      this.explicitTargetExecution.abortController?.abort()
-    }
+    this.teardownExecution(
+      this.explicitTargetExecution,
+      (execution) => this.finishExplicitTargetLoop(execution),
+    )
     this.explicitTargetExecution = null
   }
 
@@ -3605,36 +3621,33 @@ export class PositioningController {
   }
 
   private cancelLiveEdgeExecution(outcome: LiveEdgeCompletion): void {
-    const execution = this.liveEdgeExecution
-    if (execution) {
-      this.finishLiveEdgeLoop(execution)
-      execution.abortController?.abort()
-      this.completeLiveEdge(execution, outcome)
-    }
+    this.teardownExecution(
+      this.liveEdgeExecution,
+      (execution) => this.finishLiveEdgeLoop(execution),
+      (execution) => this.completeLiveEdge(execution, outcome),
+    )
     this.liveEdgeExecution = null
   }
 
   private cancelAnchorPreservationExecution(
     outcome: AnchorPreservationCompletion,
   ): void {
-    const execution = this.anchorPreservationExecution
-    if (execution) {
-      this.finishAnchorPreservationLoop(execution)
-      execution.abortController?.abort()
-      this.completeAnchorPreservation(execution, outcome)
-    }
+    this.teardownExecution(
+      this.anchorPreservationExecution,
+      (execution) => this.finishAnchorPreservationLoop(execution),
+      (execution) => this.completeAnchorPreservation(execution, outcome),
+    )
     this.anchorPreservationExecution = null
   }
 
   private cancelDirectionalHistoryExecution(
     outcome: DirectionalHistoryCompletion,
   ): void {
-    const execution = this.directionalHistoryExecution
-    if (execution) {
-      this.finishDirectionalHistoryLoop(execution)
-      execution.abortController?.abort()
-      this.completeDirectionalHistory(execution, outcome)
-    }
+    this.teardownExecution(
+      this.directionalHistoryExecution,
+      (execution) => this.finishDirectionalHistoryLoop(execution),
+      (execution) => this.completeDirectionalHistory(execution, outcome),
+    )
     this.directionalHistoryExecution = null
   }
 }


### PR DESCRIPTION
The seven cancel paths were written in three shapes: three finished the loop and aborted, three did that and then reported an outcome, and resident top delegated the whole thing to its completion method. All three agreed on what teardown does; none of them said so in one place.

They now go through `teardownExecution(execution, finishLoop, reportOutcome?)`, which fixes the order: stop the frame loop, abort the work the lease authorised, then report. Aborting before the loop is finished leaves an already-scheduled frame to run against an execution whose lease has gone, and reporting before the abort hands the executor a completion whose signal is still live.

Clearing the slot stays with each caller, because it genuinely differs: six drop it unconditionally, resident top only when it still holds the execution being torn down.

This adds lines rather than removing them. The gain is one definition of the order, not size.

## The order had no test at all

Inverting it in either direction — aborting before finishing, or reporting before aborting — left all 98 controller tests green. The rationale existed only as a comment.

The conformance suite now records what the abort signal read at the moment the loop was told to finish, and all seven executors must see it still live. Inverting the order fails four of them. The comment no longer claims anything the suite does not hold.

## One note on the verification

An earlier full run of the scroll invariants reported seven failures, all preconditions in the *Insertion drift* family — an in-flight load that had already delivered, a demo answer that was no longer gateable. They did not reproduce: the machine was at a load average of 152 on 8 cores while macOS re-scanned binaries after a Node reinstall, and that run took 7.1 minutes against 4.8 for a clean one. Two subsequent full runs of the same code passed 98/98, the last of them in 4.8 minutes with nothing else running.

Recorded because the failure mode is worth recognising: these invariants gate on timing, so a saturated machine reads as a positioning regression.
