### PR TITLE
refactor(sdk): drop two protocol words from the curated entry

### DIFF
--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -124,6 +124,23 @@ describe('public API surface', () => {
     }
   })
 
+  it('names the timeout after the request, not after the stanza that carried it', () => {
+    // A caller has to handle "the server never answered". Making that reachable
+    // only through the word IQ would put a protocol term on a path everyone
+    // crosses.
+    expect(Object.keys(main)).toContain('RequestTimeoutError')
+    expect(Object.keys(main)).not.toContain('IQTimeoutError')
+  })
+
+  it('keeps raw extension shapes off the main entry', () => {
+    // Type-only exports leave no runtime key, so this reads the barrel itself.
+    // `OobInfo` is XEP-0066 as written on the wire; the attachment an app
+    // renders is `FileAttachment`, which stays.
+    const barrel = readFileSync(resolve(process.cwd(), 'src/index.ts'), 'utf8')
+    expect(barrel).not.toMatch(/^\s*OobInfo,\s*$/m)
+    expect(Object.keys(main)).toContain('formatXMPPError')
+  })
+
   it('does not hand the stanza builder back through a hook', () => {
     // A named export is not the only door: `useXMPP` used to return `xml`,
     // which would have made every assertion above true and meaningless. The

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -31,7 +31,7 @@ import { setupStoreSideEffects } from './sideEffects'
 import { defaultStores, type SDKStores } from '../stores/sdkStores'
 import { detectPlatform } from './platform'
 import { isDeadSocketError } from './modules/connectionUtils'
-import { IQTimeoutError } from './errors'
+import { RequestTimeoutError } from './errors'
 import { getBareJid, getDomain } from './jid'
 import { routeStanza } from './stanzaRouting'
 import { createE2EEDiagnosticLogger } from './e2eeDiagnosticLogger'
@@ -1810,7 +1810,7 @@ export class XMPPClient {
         return await Promise.race([
           request,
           new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new IQTimeoutError(timeoutMs)), timeoutMs)
+            setTimeout(() => reject(new RequestTimeoutError(timeoutMs)), timeoutMs)
           ),
         ])
       }

--- a/packages/fluux-sdk/src/core/errors.ts
+++ b/packages/fluux-sdk/src/core/errors.ts
@@ -131,21 +131,21 @@ export class WhisperCounterpartGoneError extends Error {
 }
 
 /**
- * Thrown when an IQ request passed an explicit `timeoutMs` receives no reply
- * within that budget.
+ * Thrown when a request given an explicit time budget receives no reply within
+ * it.
  *
- * The message is unchanged from the plain `Error` it replaces, so callers that
- * only inspect `err.message` keep working; the class exists so callers that
- * care can tell "the server never answered" apart from "the server said no".
+ * Exists so a caller can tell "the server never answered" apart from "the
+ * server said no": the first is worth retrying, the second is not.
  */
-export class IQTimeoutError extends Error {
+export class RequestTimeoutError extends Error {
+  /** The budget that elapsed, in milliseconds. */
   readonly timeoutMs: number
 
   constructor(timeoutMs: number) {
-    super(`IQ timeout after ${timeoutMs}ms`)
-    this.name = 'IQTimeoutError'
+    super(`Request timed out after ${timeoutMs}ms`)
+    this.name = 'RequestTimeoutError'
     this.timeoutMs = timeoutMs
-    Object.setPrototypeOf(this, IQTimeoutError.prototype)
+    Object.setPrototypeOf(this, RequestTimeoutError.prototype)
   }
 }
 

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -309,11 +309,11 @@ export type {
   WebPushRegistration,
   WebPushStatus,
 
-  // File attachment types (XEP-0066, XEP-0264, XEP-0454)
+  // File attachment types (XEP-0264, XEP-0454). `OobInfo` is the raw XEP-0066
+  // shape and no attachment field carries it, so it lives on `@fluux/sdk/xmpp`.
   FileAttachment,
   FileEncryption,
   ThumbnailInfo,
-  OobInfo,
 
   // Link preview types (XEP-0422 + OGP)
   LinkPreview,
@@ -605,8 +605,8 @@ export type { XMPPStanzaError, XMPPErrorType } from './utils/xmppError'
 export { classifyConnectionError, extractTransportErrorClass, humanizeTransportError } from './core/modules/transportErrors'
 export type { ConnectionErrorKind } from './core/modules/transportErrors'
 
-// MUC join failure error (rejected by client.rooms.joinResult)
-export { RoomJoinError, WhisperCounterpartGoneError, HatCommandError, IQTimeoutError } from './core/errors'
+// The failures a caller distinguishes by type rather than by message.
+export { RoomJoinError, WhisperCounterpartGoneError, HatCommandError, RequestTimeoutError } from './core/errors'
 // The reason a join failed, stated in the application's terms. Exported with
 // its resolver so a consumer can classify a condition it obtained elsewhere.
 export { roomJoinReasonFor } from './core/errors'

--- a/packages/fluux-sdk/src/utils/hatCommandError.ts
+++ b/packages/fluux-sdk/src/utils/hatCommandError.ts
@@ -5,7 +5,7 @@
  * Kept separate from `MUC` so the mapping is unit-testable on its own and can
  * be reused by any other ad-hoc command surface.
  */
-import { HatCommandError, IQTimeoutError } from '../core/errors'
+import { HatCommandError, RequestTimeoutError } from '../core/errors'
 import type { XMPPErrorType } from './xmppError'
 
 const VALID_ERROR_TYPES = new Set<string>(['cancel', 'continue', 'modify', 'auth', 'wait'])
@@ -39,7 +39,7 @@ function asNonEmptyString(value: unknown): string | undefined {
 export function toHatCommandError(err: unknown, roomJid: string, node: string): HatCommandError {
   if (err instanceof HatCommandError) return err
 
-  if (err instanceof IQTimeoutError) {
+  if (err instanceof RequestTimeoutError) {
     return new HatCommandError(roomJid, node, 'timeout', { cause: err })
   }
 

--- a/packages/fluux-sdk/src/xmpp/index.ts
+++ b/packages/fluux-sdk/src/xmpp/index.ts
@@ -44,6 +44,11 @@ export { parseDataForm, getFormFieldValue, getFormFieldValues, buildDataFormSubm
 // and `RSMResponse` shapes stay on the main entry for the same reason.
 export { parseRSMResponse, buildRSMElement } from '../utils/rsm'
 
+// XEP-0066: Out of Band Data. A URL and a description, as the extension puts
+// them on the wire. An attachment the SDK models is a `FileAttachment` on the
+// main entry; this is for reading or writing the raw element.
+export type { OobInfo } from '../core/types/upload'
+
 // XEP-0428: Fallback Indication — strip the fallback text a sending client
 // wrote for clients that cannot render the real payload.
 export { processFallback, getFallbackElement } from '../utils/fallbackUtils'


### PR DESCRIPTION
**`IQTimeoutError` → `RequestTimeoutError`.** Handling "the server never answered" is on the path of anyone who sends a request, and reaching it required naming the stanza kind. The message changes to match (`Request timed out after Nms`); nothing in the repository read that string, every consumer discriminates by type.

**`OobInfo` moves to `@fluux/sdk/xmpp`.** It is XEP-0066 as written on the wire. No field of `FileAttachment` carries it and nothing imported it, so it belongs with the raw shapes rather than on the curated entry.

Both boundaries are asserted in `barrelSurface.test.ts` rather than described. The second reads the barrel source, because a type-only export leaves no runtime key to inspect; I checked it fails when the export is put back.

This closes the sweep started in #1254. The other candidates I had listed turned out to be anchored: `DiscoResult` and `PEPItem` are named by `XMPPPrimitives` on the main entry, and `RSMRequest`/`RSMResponse` are fields of two public event payloads. What is left there is a naming question, not a placement one.