### PR TITLE
fix(sdk): make FAST authentication safe in Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Build SDK
         run: npm run build:sdk
 
+      - name: Run SDK in plain Node
+        run: npm run test:node --workspace=@fluux/sdk
+
       - name: Run tests
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Yes. By default, closing the main window minimizes Fluux to the system tray or m
 
 #### On the web version, why do I have to log in again after closing the tab?
 
-For security, credentials are only kept in the session context. Nothing sensitive is persisted to local storage. If your XMPP server supports [FAST](https://xmpp.org/extensions/xep-0484.html) authentication tokens (SASL2), reconnection across page reloads will work seamlessly, without ever storing your password. If it doesn't, your server likely doesn't yet support FAST.
+Fluux never persists your password to local storage. If your XMPP server supports [FAST](https://xmpp.org/extensions/xep-0484.html) authentication tokens (SASL2), Fluux stores a short-lived token in local storage so reconnection across page reloads works without storing the password. Without FAST support, the session credentials disappear when the tab closes and you must log in again.
 
 ## Contributing
 

--- a/SUPPORTED_XEPS.md
+++ b/SUPPORTED_XEPS.md
@@ -25,7 +25,7 @@ This document lists the XMPP Extension Protocols (XEPs) and related RFCs impleme
 | [XEP-0368](https://xmpp.org/extensions/xep-0368.html) | SRV Records for XMPP over TLS                   | ✅ Implemented | Desktop: SRV lookup for `_xmpps-client._tcp` (direct TLS) and `_xmpp-client._tcp` (STARTTLS) via Rust proxy |
 | [XEP-0386](https://xmpp.org/extensions/xep-0386.html) | Bind 2.0                                         | ✅ Implemented | Inline resource binding within SASL2, with Stream Management enabled inline                                  |
 | [XEP-0388](https://xmpp.org/extensions/xep-0388.html) | Extensible SASL Profile (SASL2)                  | ✅ Implemented | Modern authentication with inline features (bind2, FAST). Falls back to SASL1 if server doesn't support it  |
-| [XEP-0484](https://xmpp.org/extensions/xep-0484.html) | Fast Authentication Streamlining Tokens (FAST)   | ✅ Implemented | Token-based reconnection without password (web: 14-day localStorage persistence, HT-SHA-256-NONE mechanism) |
+| [XEP-0484](https://xmpp.org/extensions/xep-0484.html) | Fast Authentication Streamlining Tokens (FAST)   | ✅ Implemented | Token-based reconnection without password (14-day client cap; localStorage on web, injectable storage in Node; HT-SHA-256-NONE) |
 
 ## Service Discovery
 

--- a/apps/fluux/src/utils/performLogout.test.ts
+++ b/apps/fluux/src/utils/performLogout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { hasFastToken } from '@fluux/sdk'
 import { performLogout } from './performLogout'
 import { getReconnectIntent } from './reconnectIntent'
@@ -36,6 +36,10 @@ describe('performLogout', () => {
     mockReset.mockClear()
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   // ★ The ordering invariant: the intent must flip BEFORE any await, so a
   // disconnect that hangs (or a webview reload mid-logout) can't leave the app
   // in a reconnectable state.
@@ -59,6 +63,18 @@ describe('performLogout', () => {
     await performLogout({ disconnect, jid: JID, shouldCleanLocalData: false })
 
     expect(disconnect).toHaveBeenCalledWith({ invalidateFastToken: true })
+  })
+
+  it('warns when disconnect reports that the FAST token could not be removed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await performLogout({
+      disconnect: vi.fn().mockRejectedValue(new Error('FAST token removal failed')),
+      jid: JID,
+      shouldCleanLocalData: false,
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('disconnect failed'))
   })
 
   // Post-condition (keep-data logout): every local re-auth vector is gone AND

--- a/apps/fluux/src/utils/performLogout.ts
+++ b/apps/fluux/src/utils/performLogout.ts
@@ -54,6 +54,8 @@ export async function performLogout({ disconnect, jid, shouldCleanLocalData }: P
     console.warn(
       `[Fluux] Logout: disconnect timed out after ${LOGOUT_DISCONNECT_TIMEOUT_MS}ms, continuing cleanup`
     )
+  } else if (disconnectSettled === 'error') {
+    console.warn('[Fluux] Logout: disconnect failed; continuing credential cleanup')
   }
 
   // 3. Clear persisted session immediately so the UI can leave ChatLayout even

--- a/packages/fluux-sdk/README.md
+++ b/packages/fluux-sdk/README.md
@@ -157,6 +157,46 @@ const status = useConnectionStore.getState().status
 const conversations = useChatStore.getState().conversations
 ```
 
+FAST authentication tokens persist in `localStorage` in browsers and in
+process memory in Node. To keep tokens across Node process restarts, pass a
+synchronous `FastTokenStorageAdapter` when constructing the client and set
+`rememberSession: true` when connecting:
+
+```typescript
+import { XMPPClient, type FastTokenStorageAdapter } from '@fluux/sdk/core'
+
+const fastTokenStorage: FastTokenStorageAdapter = {
+  getToken: (jid) => persistentTokens.get(jid) ?? null,
+  setToken: (jid, token) => persistentTokens.set(jid, token),
+  deleteToken: (jid) => persistentTokens.delete(jid),
+}
+
+const userAgentId = persistentSettings.get('xmpp-user-agent-id') ?? crypto.randomUUID()
+persistentSettings.set('xmpp-user-agent-id', userAgentId)
+const client = new XMPPClient({ fastTokenStorage, userAgentId })
+
+await client.connect({
+  jid: 'bot@example.com',
+  password: 'secret',
+  server: 'example.com',
+  rememberSession: true,
+})
+```
+
+Here, `persistentTokens` is the application's synchronous database or
+key-value store. `userAgentId` must be the same UUID each time the process
+starts because the server binds FAST tokens to it. Use
+`createInMemoryFastTokenStorage()` when an isolated, non-persistent store is
+preferable to the shared Node default. Treat persisted tokens as credentials:
+restrict access to them and never include them in logs.
+
+For explicit logout, call `disconnect({ invalidateFastToken: true })`. The SDK
+removes the local token synchronously, requests server-side invalidation, and
+still disconnects if either operation fails. The promise rejects with
+`FastTokenLogoutError` only when neither operation succeeds, so callers can
+report that credential cleanup was not confirmed even though the connection
+is already closed.
+
 ## Installation
 
 ```bash

--- a/packages/fluux-sdk/examples/README.md
+++ b/packages/fluux-sdk/examples/README.md
@@ -4,8 +4,12 @@ Two runnable bots, headless: no React, no DOM, plain Node.
 
 They exist to be run against a real server. They are also the SDK's own check
 that `@fluux/sdk/core` stands on its own, so they are typechecked and linted
-with the package (`npm run typecheck`, `npm run lint`). An API change that
-breaks them breaks CI, which is the point.
+with the package and its built core bundle is executed in Node (`npm run
+typecheck`, `npm run lint`, `npm run test:node`). An API or runtime change that
+breaks headless use breaks CI, which is the point.
+
+See the SDK's [headless usage documentation](../README.md#headless-usage-bots-cli-non-react)
+for FAST token storage in Node.
 
 ## Running them
 

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -87,6 +87,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:node": "node --test test/node-runtime-smoke.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.bench.json && tsc --noEmit -p examples/tsconfig.json",
     "lint": "eslint src examples",
     "lint:fix": "eslint src examples --fix",

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -2,6 +2,7 @@ import { Client, Element } from '@xmpp/client'
 import { createActor, type Subscription, type Snapshot } from 'xstate'
 import type { EventHook } from './EventHook'
 import type { XMPPClientConfig } from './clientConfig'
+import type { FastTokenStorageAdapter } from './fastTokenStorage'
 import type {
   ConnectOptions,
   StoreBindings,
@@ -204,6 +205,8 @@ export interface InternalSurface {
 export class XMPPClient {
   protected currentJid: string | null = null
   private storageAdapter?: StorageAdapter
+  private fastTokenStorage?: FastTokenStorageAdapter
+  private userAgentId?: string
   private shouldAutoReconnect?: () => boolean
   private e2eeStorageBackend: StorageBackend = new InMemoryStorageBackend()
   private proxyAdapter?: ProxyAdapter
@@ -474,6 +477,8 @@ export class XMPPClient {
 
     // Store storage adapter for session persistence
     this.storageAdapter = config.storageAdapter
+    this.fastTokenStorage = config.fastTokenStorage
+    this.userAgentId = config.userAgentId
     this.shouldAutoReconnect = config.shouldAutoReconnect
     this.proxyAdapter = config.proxyAdapter
     // Store privacy options for avatar fetching behavior
@@ -674,6 +679,8 @@ export class XMPPClient {
       emitSDK: <K extends keyof SDKEvents>(event: K, payload: SDKEvents[K]) => this.emitSDK(event, payload),
       getXmpp: () => this.getXmpp(),
       storageAdapter: this.storageAdapter,
+      fastTokenStorage: this.fastTokenStorage,
+      userAgentId: this.userAgentId,
       proxyAdapter: this.proxyAdapter,
       registerMAMCollector: (queryId: string, collector: (stanza: Element) => void) => this.registerMAMCollector(queryId, collector),
       privacyOptions: this.privacyOptions,
@@ -1075,6 +1082,8 @@ export class XMPPClient {
    *   replayed from another device.
    *
    * @returns Promise that resolves when disconnected
+   * @throws {FastTokenLogoutError} After disconnecting when a requested FAST
+   *   token removal failed both locally and on the server.
    *
    * @example
    * ```typescript

--- a/packages/fluux-sdk/src/core/clientConfig.ts
+++ b/packages/fluux-sdk/src/core/clientConfig.ts
@@ -14,6 +14,7 @@ import type { SDKStores } from '../stores/sdkStores'
 import type { StorageAdapter } from './types/storage'
 import type { ProxyAdapter } from './types/proxy'
 import type { PresenceOptions, PrivacyOptions } from './types/client'
+import type { FastTokenStorageAdapter } from './fastTokenStorage'
 
 /**
  * XMPPClient configuration options.
@@ -75,6 +76,22 @@ export interface XMPPClientConfig {
    * ```
    */
   storageAdapter?: StorageAdapter
+  /**
+   * Storage for XEP-0484 FAST authentication tokens.
+   *
+   * Browsers default to localStorage. Headless runtimes default to memory. To
+   * survive a process restart, inject an adapter and persist {@link userAgentId}.
+   */
+  fastTokenStorage?: FastTokenStorageAdapter
+  /**
+   * Stable XEP-0388 user-agent UUID used to bind XEP-0484 FAST tokens.
+   *
+   * Headless runtimes keep a process-local default. Callers that persist FAST
+   * tokens across process restarts must persist and reuse this ID as well.
+   * An injected ID is caller-owned and is not changed by
+   * `clearUserAgentIdentity()`.
+   */
+  userAgentId?: string
   /**
    * Proxy adapter for WebSocket-to-TCP bridging.
    *

--- a/packages/fluux-sdk/src/core/errors.ts
+++ b/packages/fluux-sdk/src/core/errors.ts
@@ -1,6 +1,21 @@
 import type { XMPPErrorType } from '../utils/xmppError'
 
 /**
+ * Explicit logout completed its connection cleanup, but could not remove the
+ * FAST credential either from client storage or from the server.
+ */
+export class FastTokenLogoutError extends Error {
+  readonly jid: string
+
+  constructor(jid: string) {
+    super(`FAST token for ${jid} could not be removed locally or invalidated on the server`)
+    this.name = 'FastTokenLogoutError'
+    this.jid = jid
+    Object.setPrototypeOf(this, FastTokenLogoutError.prototype)
+  }
+}
+
+/**
  * Why a room join failed, in terms of what the user has to do about it.
  *
  * The wire condition alone does not answer that: `not-authorized` means "ask

--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
@@ -87,14 +87,21 @@ const createMockInstance = (): MockXmppInstance => {
   return inst
 }
 
-const { mockClientFactory, mockInstances } = vi.hoisted(() => {
+const { mockClientFactory, mockInstances, mockXmlFn } = vi.hoisted(() => {
   const instances: MockXmppInstance[] = []
   const factory = vi.fn()
-  return { mockClientFactory: factory, mockInstances: instances }
+  const xml = vi.fn((name: string, attrs?: Record<string, string>, ...children: unknown[]) => ({
+    name,
+    attrs: attrs || {},
+    children,
+    toString: () => `<${name}/>`
+  }))
+  return { mockClientFactory: factory, mockInstances: instances, mockXmlFn: xml }
 })
 
 vi.mock('@xmpp/client', () => ({
   client: mockClientFactory,
+  xml: mockXmlFn,
 }))
 
 vi.mock('@xmpp/debug', () => ({ default: vi.fn() }))
@@ -253,7 +260,42 @@ describe('invalidateFastTokenOnServer', () => {
     expect(fetched).toEqual(TOKEN)
   })
 
-  it('treats not-authorized as already-invalid (ok:true)', async () => {
+  it('passes the FAST-bound user-agent identity to authentication', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+    const authenticate = vi.fn().mockResolvedValue(undefined)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+      userAgentId: '11111111-2222-4333-8444-555555555555',
+    })
+    await Promise.resolve()
+
+    const config = mockClientFactory.mock.calls[0][0] as {
+      credentials: (
+        authenticateFn: typeof authenticate,
+        mechanisms: string[],
+        fast: unknown,
+      ) => Promise<void>
+    }
+    await config.credentials(authenticate, [TOKEN.mechanism], {})
+    inst._emit('online')
+    await p
+
+    expect(authenticate).toHaveBeenCalledWith(
+      expect.any(Object),
+      TOKEN.mechanism,
+      expect.objectContaining({
+        attrs: expect.objectContaining({
+          id: '11111111-2222-4333-8444-555555555555',
+        }),
+      }),
+    )
+  })
+
+  it('does not report not-authorized as confirmed invalidation', async () => {
     mockFetchFastToken.mockReturnValue(TOKEN)
     const inst = createMockInstance()
     mockClientFactory.mockImplementation(() => inst)
@@ -266,8 +308,7 @@ describe('invalidateFastTokenOnServer', () => {
     inst._emit('error', { condition: 'not-authorized', message: 'token rejected' })
 
     const result = await p
-    expect(result.ok).toBe(true)
-    expect(result.reason).toBe('already-invalid')
+    expect(result).toEqual({ ok: false, reason: 'not-authorized' })
   })
 
   it('resolves {ok:false} with the error message on unrelated errors', async () => {

--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
@@ -19,6 +19,7 @@ import { fetchFastToken, type FastToken } from './fastTokenStorage'
 import { getBareJid, getDomain, getLocalPart } from './jid'
 import { logInfo, logWarn } from './logger'
 import { FAST_TOKEN_INVALIDATION_TIMEOUT_MS } from './modules/connectionTimeouts'
+import { buildUserAgentElement } from './userAgent'
 
 export interface InvalidateFastTokenOptions {
   /** Full or bare JID of the account whose token should be invalidated */
@@ -27,11 +28,14 @@ export interface InvalidateFastTokenOptions {
   server: string
   /** Override the default invalidation timeout (ms) */
   timeoutMs?: number
+  /** Stable XEP-0388 identity used when the FAST token was issued */
+  userAgentId?: string
   /**
    * Pre-fetched token to use for the invalidation session. When provided,
-   * this function does not read localStorage — letting the caller delete the
-   * client-side token synchronously (e.g. before a webview reload) while still
-   * invalidating it server-side. Falls back to a localStorage lookup when omitted.
+   * this function does not read the runtime's default FAST storage — letting
+   * the caller delete the client-side token synchronously (e.g. before a
+   * webview reload) while still invalidating it server-side. Falls back to the
+   * default FAST storage when omitted.
    */
   token?: FastToken | null
 }
@@ -127,7 +131,11 @@ export async function invalidateFastTokenOnServer(
         domain,
         username,
         credentials: async (
-          authenticate: (creds: Record<string, unknown>, mechanism: string) => Promise<void>,
+          authenticate: (
+            creds: Record<string, unknown>,
+            mechanism: string,
+            userAgent: ReturnType<typeof buildUserAgentElement>,
+          ) => Promise<void>,
           mechanisms: string[],
           fast: unknown | null
         ) => {
@@ -138,7 +146,11 @@ export async function invalidateFastTokenOnServer(
           // needs to parse — it won't actually be used because fast.auth
           // will succeed (or fail and surface as an error).
           const mechanism = mechanisms[0] ?? token.mechanism
-          await authenticate({ username, token }, mechanism)
+          await authenticate(
+            { username, token },
+            mechanism,
+            buildUserAgentElement(options.userAgentId),
+          )
         },
       })
 
@@ -149,8 +161,8 @@ export async function invalidateFastTokenOnServer(
         return
       }
 
-      // Override token accessors so xmpp.js uses the token we have, and
-      // does not touch localStorage for this transient session.
+      // Override token accessors so xmpp.js uses the token we have and does
+      // not touch its own token store during this transient session.
       fastModule.fetchToken = async () => token
       fastModule.saveToken = () => {
         /* server MUST NOT issue a new token on invalidation (XEP-0484 §6) */
@@ -169,21 +181,8 @@ export async function invalidateFastTokenOnServer(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       xmppClient.on('error', (err: any) => {
         const msg = err?.message ?? String(err)
-        // A not-authorized / credentials-expired here means the server
-        // already considered the token invalid. Functionally the same
-        // outcome as a successful invalidation.
-        if (
-          err?.condition === 'not-authorized' ||
-          err?.condition === 'credentials-expired' ||
-          msg.includes('not-authorized') ||
-          msg.includes('credentials-expired')
-        ) {
-          logInfo(`FAST invalidation: token already invalid on server (${msg})`)
-          settle({ ok: true, reason: 'already-invalid' })
-          return
-        }
         logWarn(`FAST invalidation: failed (${msg})`)
-        settle({ ok: false, reason: msg })
+        settle({ ok: false, reason: err?.condition ?? msg })
       })
 
       xmppClient.start().catch((err: unknown) => {

--- a/packages/fluux-sdk/src/core/fastTokenStorage.test.ts
+++ b/packages/fluux-sdk/src/core/fastTokenStorage.test.ts
@@ -4,6 +4,8 @@ import {
   fetchFastToken,
   deleteFastToken,
   hasFastToken,
+  createInMemoryFastTokenStorage,
+  type FastTokenStorageAdapter,
 } from './fastTokenStorage'
 
 describe('fastTokenStorage', () => {
@@ -212,6 +214,56 @@ describe('fastTokenStorage', () => {
     it('returns false when token data is corrupted', () => {
       store[STORAGE_KEY] = 'garbage'
       expect(hasFastToken(JID)).toBe(false)
+    })
+  })
+
+  // ── Storage adapters ──
+
+  describe('storage adapters', () => {
+    it('uses an injected in-memory adapter without localStorage', () => {
+      const storage = createInMemoryFastTokenStorage()
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      })
+
+      saveFastToken(JID, validToken, storage)
+      expect(fetchFastToken(JID, storage)?.token).toBe(validToken.token)
+      deleteFastToken(JID, storage)
+      expect(hasFastToken(JID, storage)).toBe(false)
+    })
+
+    it('does not throw when an adapter fails during cleanup', () => {
+      const unavailableStorage: FastTokenStorageAdapter = {
+        getToken: () => { throw new Error('unavailable') },
+        setToken: () => { throw new Error('unavailable') },
+        deleteToken: () => { throw new Error('unavailable') },
+      }
+
+      expect(() => saveFastToken(JID, validToken, unavailableStorage)).not.toThrow()
+      expect(fetchFastToken(JID, unavailableStorage)).toBeNull()
+      expect(deleteFastToken(JID, unavailableStorage)).toBe(false)
+    })
+
+    it('reports whether deletion succeeded', () => {
+      const storage = createInMemoryFastTokenStorage()
+      saveFastToken(JID, validToken, storage)
+
+      expect(deleteFastToken(JID, storage)).toBe(true)
+      expect(fetchFastToken(JID, storage)).toBeNull()
+    })
+
+    it('does not delete a token when the adapter read fails', () => {
+      const deleteToken = vi.fn()
+      const unavailableStorage: FastTokenStorageAdapter = {
+        getToken: () => { throw new Error('temporarily unavailable') },
+        setToken: vi.fn(),
+        deleteToken,
+      }
+
+      expect(fetchFastToken(JID, unavailableStorage)).toBeNull()
+      expect(deleteToken).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/fluux-sdk/src/core/fastTokenStorage.ts
+++ b/packages/fluux-sdk/src/core/fastTokenStorage.ts
@@ -1,11 +1,8 @@
 /**
  * FAST Token Storage (XEP-0484)
  *
- * Provides localStorage-backed persistence for FAST authentication tokens.
- * Tokens allow password-less reconnection for up to 14 days on web.
- *
- * Storage key pattern: `fluux:fast-token:{bare-jid}`
- * Token format: { mechanism, token, expiry } as JSON
+ * Browser clients persist tokens in localStorage. Headless runtimes use a
+ * process-local in-memory adapter unless the caller injects another one.
  *
  * @see https://xmpp.org/extensions/xep-0484.html
  */
@@ -24,19 +21,80 @@ export interface FastToken {
   expiry: string
 }
 
+/**
+ * Synchronous persistence seam for XEP-0484 FAST tokens.
+ *
+ * Deletion is synchronous because explicit logout must remove the local token
+ * before any reconnect path can observe it.
+ */
+export interface FastTokenStorageAdapter {
+  getToken(jid: string): FastToken | null
+  setToken(jid: string, token: FastToken): void
+  deleteToken(jid: string): void
+}
+
 function storageKey(jid: string): string {
   return `${STORAGE_PREFIX}${jid}`
 }
 
+/** Create isolated, process-local FAST token storage. */
+export function createInMemoryFastTokenStorage(): FastTokenStorageAdapter {
+  const tokens = new Map<string, FastToken>()
+
+  return {
+    getToken: (jid) => tokens.get(jid) ?? null,
+    setToken: (jid, token) => { tokens.set(jid, token) },
+    deleteToken: (jid) => { tokens.delete(jid) },
+  }
+}
+
+const browserFastTokenStorage: FastTokenStorageAdapter = {
+  getToken(jid) {
+    const key = storageKey(jid)
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return null
+
+    try {
+      return JSON.parse(raw) as FastToken
+    } catch {
+      window.localStorage.removeItem(key)
+      return null
+    }
+  },
+  setToken(jid, token) {
+    window.localStorage.setItem(storageKey(jid), JSON.stringify(token))
+  },
+  deleteToken(jid) {
+    window.localStorage.removeItem(storageKey(jid))
+  },
+}
+
+const headlessFastTokenStorage = createInMemoryFastTokenStorage()
+
+function getDefaultFastTokenStorage(): FastTokenStorageAdapter {
+  return typeof window === 'undefined'
+    ? headlessFastTokenStorage
+    : browserFastTokenStorage
+}
+
+function removeInvalidToken(jid: string, storage: FastTokenStorageAdapter): void {
+  try {
+    storage.deleteToken(jid)
+  } catch {
+    // Storage is unavailable; there is nothing else to clean up.
+  }
+}
+
 /**
- * Save a FAST token to localStorage for the given JID.
+ * Save a FAST token for the given JID.
  *
- * The expiry is capped at 14 days from now. If the server provides
- * an earlier expiry, that is preserved.
+ * The expiry is capped at 14 days from now. If the server provides an earlier
+ * expiry, that is preserved.
  */
 export function saveFastToken(
   jid: string,
-  tokenData: { mechanism: string; token: string; expiry?: string }
+  tokenData: { mechanism: string; token: string; expiry?: string },
+  storage: FastTokenStorageAdapter = getDefaultFastTokenStorage(),
 ): void {
   const maxExpiry = new Date(Date.now() + MAX_TTL_MS).toISOString()
   let expiry = maxExpiry
@@ -55,58 +113,67 @@ export function saveFastToken(
   }
 
   try {
-    localStorage.setItem(storageKey(jid), JSON.stringify(stored))
+    storage.setToken(jid, stored)
   } catch {
-    // localStorage full or unavailable — token won't persist
+    // Storage is full or unavailable; authentication can continue without persistence.
   }
 }
 
 /**
- * Retrieve a FAST token from localStorage for the given JID.
+ * Retrieve a FAST token for the given JID.
  *
- * Returns null if no token exists or the token has expired.
- * Expired tokens are auto-deleted (lazy cleanup).
+ * Returns null if no token exists or the token has expired. Invalid and
+ * expired tokens are removed lazily.
  */
-export function fetchFastToken(jid: string): FastToken | null {
+export function fetchFastToken(
+  jid: string,
+  storage: FastTokenStorageAdapter = getDefaultFastTokenStorage(),
+): FastToken | null {
+  let stored: FastToken | null
+
   try {
-    const raw = localStorage.getItem(storageKey(jid))
-    if (!raw) return null
-
-    const stored: FastToken = JSON.parse(raw)
-
-    // Validate required fields
-    if (!stored.mechanism || !stored.token || !stored.expiry) {
-      localStorage.removeItem(storageKey(jid))
-      return null
-    }
-
-    // Check expiry
-    if (new Date(stored.expiry) <= new Date()) {
-      localStorage.removeItem(storageKey(jid))
-      return null
-    }
-
-    return stored
+    stored = storage.getToken(jid)
   } catch {
-    // Corrupted data — clean up
-    localStorage.removeItem(storageKey(jid))
     return null
   }
+
+  if (!stored) return null
+
+  if (!stored.mechanism || !stored.token || !stored.expiry) {
+    removeInvalidToken(jid, storage)
+    return null
+  }
+
+  if (new Date(stored.expiry) <= new Date()) {
+    removeInvalidToken(jid, storage)
+    return null
+  }
+
+  return stored
 }
 
 /**
- * Delete the FAST token for the given JID from localStorage.
- */
-export function deleteFastToken(jid: string): void {
-  localStorage.removeItem(storageKey(jid))
-}
-
-/**
- * Check whether a non-expired FAST token exists for the given JID.
+ * Delete the FAST token for the given JID.
  *
- * This only checks client-side token existence and expiry.
- * Server-side FAST support is verified during SASL2 negotiation by xmpp.js.
+ * Returns false when the adapter throws, allowing logout callers to combine
+ * local deletion with server-side invalidation without reporting false success.
  */
-export function hasFastToken(jid: string): boolean {
-  return fetchFastToken(jid) !== null
+export function deleteFastToken(
+  jid: string,
+  storage: FastTokenStorageAdapter = getDefaultFastTokenStorage(),
+): boolean {
+  try {
+    storage.deleteToken(jid)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Check whether a non-expired FAST token exists for the given JID. */
+export function hasFastToken(
+  jid: string,
+  storage: FastTokenStorageAdapter = getDefaultFastTokenStorage(),
+): boolean {
+  return fetchFastToken(jid, storage) !== null
 }

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -11,6 +11,9 @@ export { createDefaultStoreBindings } from './defaultStoreBindings'
 // Client construction options (carries the store bundle, so it lives outside
 // the leaf type layer).
 export type { XMPPClientConfig } from './clientConfig'
+export { createInMemoryFastTokenStorage, hasFastToken, deleteFastToken } from './fastTokenStorage'
+export type { FastToken, FastTokenStorageAdapter } from './fastTokenStorage'
+export { FastTokenLogoutError } from './errors'
 
 // Types
 export type {

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -2,6 +2,7 @@ import type { Client, Element } from '@xmpp/client'
 import type { StoreBindings, ClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
 import type { E2EEManager } from '../e2ee'
 import type { PresenceReader } from '../presenceReader'
+import type { FastTokenStorageAdapter } from '../fastTokenStorage'
 
 /**
  * Dependencies injected into each module by XMPPClient.
@@ -38,6 +39,10 @@ export interface ModuleDependencies {
    * Used by Connection module for SM state persistence.
    */
   storageAdapter?: StorageAdapter
+  /** Platform-specific persistence for XEP-0484 FAST authentication tokens. */
+  fastTokenStorage?: FastTokenStorageAdapter
+  /** Stable XEP-0388 identity used when authenticating and binding FAST tokens. */
+  userAgentId?: string
   /**
    * Proxy adapter for WebSocket-to-TCP bridging.
    * Used by Connection module for native TCP/TLS connections.

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { XMPPClient } from '../XMPPClient'
+import { FastTokenLogoutError } from '../errors'
 import {
   DIRECT_WEBSOCKET_PRECHECK_TIMEOUT_MS,
   RECONNECT_ATTEMPT_TIMEOUT_MS,
@@ -65,7 +66,7 @@ vi.mock('../../utils/websocketDiscovery', () => ({
 const { mockFetchFastToken, mockSaveFastToken, mockDeleteFastToken } = vi.hoisted(() => ({
   mockFetchFastToken: vi.fn().mockReturnValue(null),
   mockSaveFastToken: vi.fn(),
-  mockDeleteFastToken: vi.fn(),
+  mockDeleteFastToken: vi.fn().mockReturnValue(true),
 }))
 
 vi.mock('../fastTokenStorage', () => ({
@@ -99,6 +100,7 @@ describe('XMPPClient Connection', () => {
     // Reset WebSocket discovery mock to return null (discovery failed -> use fallback URL)
     mockDiscoverWebSocket.mockClear()
     mockDiscoverWebSocket.mockResolvedValue(null)
+    mockDeleteFastToken.mockReturnValue(true)
 
     mockStores = createMockStores()
     xmppClient = new XMPPClient({ debug: false })
@@ -449,6 +451,11 @@ describe('XMPPClient Connection', () => {
     })
 
     it('requests server-side FAST token invalidation when invalidateFastToken:true', async () => {
+      const stableUserAgentId = '11111111-2222-4333-8444-555555555555'
+      xmppClient.destroy()
+      xmppClient = new XMPPClient({ debug: false, userAgentId: stableUserAgentId })
+      xmppClient.bindStores(mockStores)
+
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
         password: 'secret',
@@ -478,6 +485,7 @@ describe('XMPPClient Connection', () => {
           jid: 'user@example.com',
           server: expect.stringContaining('example.com'),
           token: fakeToken,
+          userAgentId: stableUserAgentId,
         })
       )
       // Client-side token must also be removed so auto-reconnect paths
@@ -553,6 +561,62 @@ describe('XMPPClient Connection', () => {
       expect(mockDeleteFastToken).toHaveBeenCalledWith('user@example.com')
 
       mockFetchFastToken.mockReturnValue(null)
+    })
+
+    it('rejects after cleanup when local and server FAST token removal both fail', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      const fakeToken = {
+        mechanism: 'HT-SHA-256-NONE',
+        token: 'tok',
+        expiry: new Date(Date.now() + 86_400_000).toISOString(),
+      }
+      mockFetchFastToken.mockReturnValue(fakeToken)
+      mockDeleteFastToken.mockReturnValue(false)
+      mockInvalidateFastTokenOnServer.mockRejectedValueOnce(new Error('network down'))
+
+      await expect(
+        xmppClient.disconnect({ invalidateFastToken: true })
+      ).rejects.toBeInstanceOf(FastTokenLogoutError)
+
+      expect(mockXmppClientInstance.stop).toHaveBeenCalled()
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
+
+      mockFetchFastToken.mockReturnValue(null)
+      mockDeleteFastToken.mockReturnValue(true)
+    })
+
+    it('resolves when server invalidation succeeds after local deletion fails', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      mockFetchFastToken.mockReturnValue({
+        mechanism: 'HT-SHA-256-NONE',
+        token: 'tok',
+        expiry: new Date(Date.now() + 86_400_000).toISOString(),
+      })
+      mockDeleteFastToken.mockReturnValue(false)
+      mockInvalidateFastTokenOnServer.mockResolvedValueOnce({ ok: true })
+
+      await expect(
+        xmppClient.disconnect({ invalidateFastToken: true })
+      ).resolves.toBeUndefined()
+
+      mockFetchFastToken.mockReturnValue(null)
+      mockDeleteFastToken.mockReturnValue(true)
     })
 
     it('removes client-side FAST token when server returns not-ok result', async () => {
@@ -3811,6 +3875,92 @@ describe('XMPPClient Connection', () => {
       // Call the wired methods to verify they delegate to our mock
       fast.fetchToken()
       expect(mockFetchFastToken).toHaveBeenCalledWith('user@example.com')
+    })
+
+    it('should wire an injected FAST token storage adapter', async () => {
+      const fastTokenStorage = {
+        getToken: vi.fn().mockReturnValue(null),
+        setToken: vi.fn(),
+        deleteToken: vi.fn(),
+      }
+      const clientWithFastStorage = new XMPPClient({
+        debug: false,
+        fastTokenStorage,
+      })
+      clientWithFastStorage.bindStores(mockStores)
+      ;(mockXmppClientInstance as any).fast = {
+        fetchToken: vi.fn(),
+        saveToken: vi.fn(),
+        deleteToken: vi.fn(),
+      }
+
+      mockFetchFastToken.mockClear()
+      mockSaveFastToken.mockClear()
+      mockDeleteFastToken.mockClear()
+      mockFetchFastToken.mockReturnValue(null)
+
+      const connectPromise = clientWithFastStorage.connect({
+        jid: 'bot@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+        rememberSession: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      const fast = (mockXmppClientInstance as any).fast
+      fast.fetchToken()
+      fast.saveToken({ mechanism: 'HT-SHA-256-NONE', token: 'token' })
+      fast.deleteToken()
+
+      expect(mockFetchFastToken).toHaveBeenCalledWith('bot@example.com', fastTokenStorage)
+      expect(mockSaveFastToken).toHaveBeenCalledWith(
+        'bot@example.com',
+        expect.objectContaining({ token: 'token' }),
+        fastTokenStorage,
+      )
+      expect(mockDeleteFastToken).toHaveBeenCalledWith('bot@example.com', fastTokenStorage)
+
+      clientWithFastStorage.destroy()
+    })
+
+    it('should reuse an injected user-agent id across authentication attempts', async () => {
+      const stableUserAgentId = '11111111-2222-4333-8444-555555555555'
+
+      const authenticateOnce = async (): Promise<string> => {
+        mockXmppClientInstance = createMockXmppClient()
+        mockClientFactory._setInstance(mockXmppClientInstance)
+        const clientWithIdentity = new XMPPClient({
+          debug: false,
+          userAgentId: stableUserAgentId,
+        })
+        clientWithIdentity.bindStores(mockStores)
+
+        const connectPromise = clientWithIdentity.connect({
+          jid: 'bot@example.com',
+          password: 'secret',
+          server: 'example.com',
+          skipDiscovery: true,
+        })
+        mockXmppClientInstance._emit('online')
+        await connectPromise
+
+        const credentialsFn = getCredentialsCallback()
+        const authenticate = vi.fn().mockResolvedValue(undefined)
+        await credentialsFn(
+          authenticate,
+          ['SCRAM-SHA-256'],
+          { fetch: vi.fn().mockResolvedValue(null) },
+          { isSecure: () => true },
+        )
+        const userAgent = authenticate.mock.calls[0]?.[2] as { attrs: { id: string } }
+        clientWithIdentity.destroy()
+        return userAgent.attrs.id
+      }
+
+      expect(await authenticateOnce()).toBe(stableUserAgentId)
+      expect(await authenticateOnce()).toBe(stableUserAgentId)
     })
 
     it('should use password auth when no FAST token available', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -58,6 +58,7 @@ import { ProxyManager } from './proxyManager'
 import { isConnectionTraceEnabled } from './connectionDiagnostics'
 import { humanizeStreamError } from './streamErrors'
 import { humanizeTransportError } from './transportErrors'
+import { FastTokenLogoutError } from '../errors'
 
 // Dev-only error logging (checks Vite dev mode, excludes test mode)
 const isDev = (() => {
@@ -217,6 +218,30 @@ export class Connection extends BaseModule {
   protected get stores() { return this.deps.stores! }
   protected get emit() { return this.deps.emit }
   protected get storageAdapter() { return this.deps.storageAdapter }
+
+  private fetchStoredFastToken(jid: string) {
+    return this.deps.fastTokenStorage
+      ? fetchFastToken(jid, this.deps.fastTokenStorage)
+      : fetchFastToken(jid)
+  }
+
+  private saveStoredFastToken(
+    jid: string,
+    token: { mechanism: string; token: string; expiry?: string },
+  ): void {
+    if (this.deps.fastTokenStorage) {
+      saveFastToken(jid, token, this.deps.fastTokenStorage)
+    } else {
+      saveFastToken(jid, token)
+    }
+  }
+
+  private deleteStoredFastToken(jid: string): boolean {
+    if (this.deps.fastTokenStorage) {
+      return deleteFastToken(jid, this.deps.fastTokenStorage)
+    }
+    return deleteFastToken(jid)
+  }
 
   constructor(deps: ModuleDependencies) {
     super(deps)
@@ -706,7 +731,8 @@ export class Connection extends BaseModule {
    * @param options.invalidateFastToken - When true and a FAST token
    *   (XEP-0484) is stored for this account, open a short-lived SASL2
    *   session to invalidate the token on the server before teardown.
-   *   Best-effort: failures do not block the rest of the disconnect.
+   *   Failures do not block connection cleanup. Once cleanup completes, this
+   *   rejects when neither local deletion nor server invalidation succeeded.
    */
   async disconnect(options: { invalidateFastToken?: boolean } = {}): Promise<void> {
     const disconnectOp = ++this.disconnectOperationSeq
@@ -741,10 +767,16 @@ export class Connection extends BaseModule {
     // network-bound) server-side invalidation below can still use it.
     const bareJidForFastToken =
       shouldInvalidateFastToken && jidForSmCleanup ? getBareJid(jidForSmCleanup) : null
-    const capturedFastToken = bareJidForFastToken ? fetchFastToken(bareJidForFastToken) : null
+    const capturedFastToken = bareJidForFastToken
+      ? this.fetchStoredFastToken(bareJidForFastToken)
+      : null
+    const localFastTokenDeleted = bareJidForFastToken
+      ? this.deleteStoredFastToken(bareJidForFastToken)
+      : true
     if (bareJidForFastToken) {
-      deleteFastToken(bareJidForFastToken)
-      logDisconnect('FAST token removed from local storage (sync)')
+      logDisconnect(localFastTokenDeleted
+        ? 'FAST token removed from client storage (sync)'
+        : 'FAST token removal from client storage failed')
     }
 
     if (clientToStop) {
@@ -773,6 +805,7 @@ export class Connection extends BaseModule {
     // session can reach the server while we still have a network path. The
     // local token was already deleted synchronously above; we pass the
     // captured copy so this session can still authenticate to invalidate it.
+    let serverFastTokenInvalidated = false
     if (bareJidForFastToken && serverForInvalidation && capturedFastToken) {
       logDisconnect(`attempting FAST token invalidation for ${bareJidForFastToken}`)
       try {
@@ -780,8 +813,10 @@ export class Connection extends BaseModule {
           jid: bareJidForFastToken,
           server: serverForInvalidation,
           token: capturedFastToken,
+          userAgentId: this.deps.userAgentId,
         })
         if (result.ok) {
+          serverFastTokenInvalidated = true
           logDisconnect(`FAST token invalidated on server${result.reason ? ` (${result.reason})` : ''}`)
           this.stores.console.addEvent('FAST token invalidated on server', 'connection')
         } else {
@@ -861,6 +896,10 @@ export class Connection extends BaseModule {
     }
 
     logDisconnect('complete')
+
+    if (bareJidForFastToken && !localFastTokenDeleted && !serverFastTokenInvalidated) {
+      throw new FastTokenLogoutError(bareJidForFastToken)
+    }
   }
 
   /**
@@ -1560,7 +1599,7 @@ export class Connection extends BaseModule {
         logInfo(`Auth: ${authMethod} (SASL: ${mechanism}, offered: ${mechanisms.join(', ')})`)
         // XEP-0388 §2.2 / XEP-0484: FAST binds issued tokens to the user-agent
         // id, so we MUST include <user-agent/> for the server to issue tokens.
-        const userAgent = buildUserAgentElement()
+        const userAgent = buildUserAgentElement(this.deps.userAgentId)
         const saslStart = Date.now()
         let saslTimeoutId: ReturnType<typeof setTimeout> | undefined
         await Promise.race([
@@ -1578,28 +1617,27 @@ export class Connection extends BaseModule {
       },
     })
 
-    // Wire FAST token persistence to localStorage (XEP-0484)
-    // xmpp.js default storage is in-memory only — tokens would be lost on page reload.
-    // This enables password-less reconnection for up to 14 days on web.
+    // Wire FAST token persistence to the platform adapter (XEP-0484).
+    // Browsers default to localStorage; headless runtimes default to memory.
     // Token saving is gated on rememberSession — users must opt in via "Remember Me".
     const fastModule = xmppClient.fast
     if (fastModule) {
       const bareJid = getBareJid(jid)
-      fastModule.fetchToken = () => fetchFastToken(bareJid)
+      fastModule.fetchToken = () => this.fetchStoredFastToken(bareJid)
       fastModule.saveToken = options.rememberSession
         ? (t: { mechanism: string; token: string; expiry?: string }) => {
             logInfo(`FAST token saved (mechanism: ${t.mechanism}, expiry: ${t.expiry ?? 'none'})`)
-            saveFastToken(bareJid, t)
+            this.saveStoredFastToken(bareJid, t)
           }
         : () => { /* rememberSession disabled — do not persist FAST token */ }
       fastModule.deleteToken = () => {
         // xmpp.js calls deleteToken() whenever it takes the "invalid token" path,
         // including when no token existed (isTokenValid(undefined) === false).
         // Only log when a token was actually present to avoid spurious noise on first login.
-        if (fetchFastToken(bareJid) !== null) {
+        if (this.fetchStoredFastToken(bareJid) !== null) {
           logInfo('FAST token invalidated/deleted')
         }
-        deleteFastToken(bareJid)
+        this.deleteStoredFastToken(bareJid)
       }
     }
 
@@ -2406,12 +2444,14 @@ export class Connection extends BaseModule {
     }
 
     // Preflight: if there is no viable authentication credential (no password
-    // and no valid FAST token in localStorage), opening a connection would only
+    // and no valid FAST token in client storage), opening a connection would only
     // fail during SASL negotiation. Fail immediately so the machine transitions
     // to terminal.authFailed and the UI shows the login screen without burning
     // a reconnect attempt on a WebSocket round-trip.
     const hasPassword = !!this.credentials.password
-    const hasFastToken = fetchFastToken(getBareJid(this.credentials.jid)) !== null
+    const hasFastToken = this.fetchStoredFastToken(
+      getBareJid(this.credentials.jid),
+    ) !== null
     if (!hasPassword && !hasFastToken) {
       logInfo('attemptReconnect: no viable credentials (no password, no FAST token), transitioning to auth failure')
       this.stores.console.addEvent('Reconnect aborted: no credentials available', 'error')

--- a/packages/fluux-sdk/src/core/types/connection.ts
+++ b/packages/fluux-sdk/src/core/types/connection.ts
@@ -125,10 +125,11 @@ export interface ConnectOptions {
    */
   disableSmKeepalive?: boolean
   /**
-   * Persist FAST tokens (XEP-0484) to localStorage for password-less reconnection.
-   * When true, the SDK saves tokens received during SASL2 negotiation, enabling
-   * auto-login on subsequent sessions for up to 14 days without a password.
-   * When false (default), tokens are not persisted and each session requires a password.
+   * Save FAST tokens (XEP-0484) for password-less reconnection.
+   * When true, tokens received during SASL2 negotiation are saved for up to
+   * 14 days in the configured FAST token storage. Browsers default to
+   * localStorage; headless runtimes default to process memory.
+   * When false (default), newly received tokens are not saved.
    */
   rememberSession?: boolean
   /**

--- a/packages/fluux-sdk/src/core/userAgent.test.ts
+++ b/packages/fluux-sdk/src/core/userAgent.test.ts
@@ -51,6 +51,7 @@ describe('userAgent', () => {
 
   beforeEach(() => {
     store = installLocalStorageMock()
+    clearUserAgentIdentity()
   })
 
   afterEach(() => {
@@ -85,11 +86,11 @@ describe('userAgent', () => {
       expect(id).toMatch(UUID_V4_RE)
     })
 
-    it('returns different ids on each call when localStorage throws (not persisted)', () => {
+    it('returns the same process-local id when localStorage throws', () => {
       installThrowingLocalStorage()
       const id1 = getOrCreateUserAgentId()
       const id2 = getOrCreateUserAgentId()
-      expect(id1).not.toBe(id2)
+      expect(id2).toBe(id1)
     })
   })
 

--- a/packages/fluux-sdk/src/core/userAgent.ts
+++ b/packages/fluux-sdk/src/core/userAgent.ts
@@ -2,9 +2,10 @@
  * SASL2 User Agent (XEP-0388 §2.2)
  *
  * Builds the `<user-agent/>` element included in `<authenticate/>`.
- * The `id` attribute is a stable per-device UUIDv4 kept in localStorage;
- * FAST (XEP-0484) binds issued tokens to this id, so it MUST be stable
- * across sessions for token reuse to work.
+ * The `id` attribute is a stable per-device UUIDv4. Browsers keep it in
+ * localStorage, headless runtimes keep it for the process lifetime, and
+ * callers may inject one through XMPPClientConfig. FAST (XEP-0484) binds
+ * issued tokens to this id, so it MUST be stable across persisted sessions.
  *
  * The `<device/>` label is human-readable and shown in other clients'
  * connected-devices lists. It defaults to a platform-derived name
@@ -21,22 +22,28 @@ import { getCachedPlatform, type Platform } from './platform'
 
 const STORAGE_KEY_ID = 'fluux:user-agent-id'
 const STORAGE_KEY_DEVICE = 'fluux:user-agent-device'
+let fallbackUserAgentId: string | null = null
+
+function getOrCreateFallbackUserAgentId(): string {
+  fallbackUserAgentId ??= generateUUID()
+  return fallbackUserAgentId
+}
 
 /**
- * Get the persistent user-agent id for this installation,
- * generating one on first use.
+ * Get the stable user-agent id for this installation or process, generating
+ * one on first use.
  */
 export function getOrCreateUserAgentId(): string {
+  if (typeof window === 'undefined') return getOrCreateFallbackUserAgentId()
+
   try {
-    const existing = localStorage.getItem(STORAGE_KEY_ID)
+    const existing = window.localStorage.getItem(STORAGE_KEY_ID)
     if (existing) return existing
     const id = generateUUID()
-    localStorage.setItem(STORAGE_KEY_ID, id)
+    window.localStorage.setItem(STORAGE_KEY_ID, id)
     return id
   } catch {
-    // localStorage unavailable (SSR, private mode with quota=0, etc.)
-    // Return a fresh UUID; token persistence won't work but auth will.
-    return generateUUID()
+    return getOrCreateFallbackUserAgentId()
   }
 }
 
@@ -45,10 +52,12 @@ export function getOrCreateUserAgentId(): string {
  * Returns null if no id has been generated yet.
  */
 export function getUserAgentId(): string | null {
+  if (typeof window === 'undefined') return fallbackUserAgentId
+
   try {
-    return localStorage.getItem(STORAGE_KEY_ID)
+    return window.localStorage.getItem(STORAGE_KEY_ID)
   } catch {
-    return null
+    return fallbackUserAgentId
   }
 }
 
@@ -62,9 +71,12 @@ export function getUserAgentId(): string | null {
  * browser and may reconnect.
  */
 export function clearUserAgentIdentity(): void {
+  fallbackUserAgentId = null
+  if (typeof window === 'undefined') return
+
   try {
-    localStorage.removeItem(STORAGE_KEY_ID)
-    localStorage.removeItem(STORAGE_KEY_DEVICE)
+    window.localStorage.removeItem(STORAGE_KEY_ID)
+    window.localStorage.removeItem(STORAGE_KEY_DEVICE)
   } catch {
     // localStorage unavailable — nothing to clear.
   }
@@ -88,8 +100,10 @@ function defaultDeviceName(platform: Platform | null): string {
  * distinguish "user override" from "platform default".
  */
 export function getUserAgentDeviceName(): string | null {
+  if (typeof window === 'undefined') return null
+
   try {
-    const raw = localStorage.getItem(STORAGE_KEY_DEVICE)
+    const raw = window.localStorage.getItem(STORAGE_KEY_DEVICE)
     if (!raw) return null
     const trimmed = raw.trim()
     return trimmed.length > 0 ? trimmed : null
@@ -103,11 +117,13 @@ export function getUserAgentDeviceName(): string | null {
  * revert to the platform default.
  */
 export function setUserAgentDeviceName(name: string | null): void {
+  if (typeof window === 'undefined') return
+
   try {
     if (name && name.trim().length > 0) {
-      localStorage.setItem(STORAGE_KEY_DEVICE, name.trim())
+      window.localStorage.setItem(STORAGE_KEY_DEVICE, name.trim())
     } else {
-      localStorage.removeItem(STORAGE_KEY_DEVICE)
+      window.localStorage.removeItem(STORAGE_KEY_DEVICE)
     }
   } catch {
     // localStorage unavailable — silently ignore; auth still works with default.
@@ -128,8 +144,8 @@ export function getEffectiveDeviceName(): string {
  * Pass the returned element as the third argument of xmpp.js's
  * `authenticate(credentials, mechanism, userAgent)` callback.
  */
-export function buildUserAgentElement(): Element {
-  return xml('user-agent', { id: getOrCreateUserAgentId() }, [
+export function buildUserAgentElement(userAgentId = getOrCreateUserAgentId()): Element {
+  return xml('user-agent', { id: userAgentId }, [
     xml('software', {}, 'Fluux'),
     xml('device', {}, getEffectiveDeviceName()),
   ])

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -606,7 +606,7 @@ export { classifyConnectionError, extractTransportErrorClass, humanizeTransportE
 export type { ConnectionErrorKind } from './core/modules/transportErrors'
 
 // The failures a caller distinguishes by type rather than by message.
-export { RoomJoinError, WhisperCounterpartGoneError, HatCommandError, RequestTimeoutError } from './core/errors'
+export { FastTokenLogoutError, RoomJoinError, WhisperCounterpartGoneError, HatCommandError, RequestTimeoutError } from './core/errors'
 // The reason a join failed, stated in the application's terms. Exported with
 // its resolver so a consumer can classify a condition it obtained elsewhere.
 export { roomJoinReasonFor } from './core/errors'
@@ -624,7 +624,8 @@ export type { DiscoveryResult } from './utils/websocketDiscovery'
 // =============================================================================
 
 // FAST token utilities (XEP-0484)
-export { hasFastToken, deleteFastToken } from './core/fastTokenStorage'
+export { createInMemoryFastTokenStorage, hasFastToken, deleteFastToken } from './core/fastTokenStorage'
+export type { FastToken, FastTokenStorageAdapter } from './core/fastTokenStorage'
 
 // SASL2 user-agent identity (XEP-0388 §2.2)
 // - id: stable per-device UUID, bound to by FAST tokens

--- a/packages/fluux-sdk/test/node-runtime-smoke.mjs
+++ b/packages/fluux-sdk/test/node-runtime-smoke.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: undefined,
+  configurable: true,
+})
+
+const {
+  XMPPClient,
+  createInMemoryFastTokenStorage,
+  setLogSink,
+} = await import('../dist/core/index.js')
+
+setLogSink(() => {})
+
+function exerciseFastHooks(fastTokenStorage) {
+  const sdkClient = new XMPPClient({ fastTokenStorage })
+  const xmppClient = sdkClient.connection.createXmppClient({
+    jid: 'bot@example.com',
+    password: 'secret',
+    server: 'wss://example.com/ws',
+    rememberSession: true,
+  })
+
+  assert.equal(xmppClient.fast.fetchToken(), null)
+  xmppClient.fast.saveToken({
+    mechanism: 'HT-SHA-256-NONE',
+    token: 'node-token',
+  })
+  assert.equal(xmppClient.fast.fetchToken()?.token, 'node-token')
+  xmppClient.fast.deleteToken()
+  assert.equal(xmppClient.fast.fetchToken(), null)
+
+  sdkClient.destroy()
+}
+
+test('the core client FAST hooks run without browser globals', () => {
+  exerciseFastHooks(undefined)
+})
+
+test('the core client uses an injected FAST token storage adapter', () => {
+  exerciseFastHooks(createInMemoryFastTokenStorage())
+})


### PR DESCRIPTION
Make XEP-0484 FAST token handling safe in plain Node runtimes by introducing injectable token storage, a process-local default, and stable user-agent identity support.

Explicit logout now reports unconfirmed credential cleanup, server invalidation uses the token's original identity, and CI runs a built-SDK Node smoke test.
