### PR TITLE
fix: complete assistant replies and report token warm failures

### DIFF
--- a/apps/fluux/src/anomaly/recorder.test.ts
+++ b/apps/fluux/src/anomaly/recorder.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRecorder, type Recorder } from './recorder'
 import { resetSerializerCountersForTesting } from './serializer'
 import type { Sink } from './sinks/sink'
@@ -14,6 +14,8 @@ import {
   resetValuesForTesting,
   retainRef,
   TAG,
+  tokenSync,
+  tokenWarmFailureCount,
 } from './values'
 
 function fakeSink(): Sink & { lines: string[] } {
@@ -30,6 +32,10 @@ beforeEach(async () => {
   resetValuesForTesting()
   resetSerializerCountersForTesting()
   await initTokenizer()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 function make(sink: Sink, maxBytes?: () => number): Recorder {
@@ -162,6 +168,18 @@ describe('counters', () => {
     expect(first.counters['recorder/rejected-value']).toBe(2)
     // Cumulative would say 3 here; the window saw 1.
     expect(second.counters['recorder/rejected-value']).toBe(1)
+  })
+
+  it('reports rejected background token warms as recorder health', async () => {
+    const sink = fakeSink()
+    const rec = make(sink)
+    vi.spyOn(crypto.subtle, 'sign').mockRejectedValueOnce(new Error('subtle.sign failed'))
+
+    tokenSync('jid', 'failing-recorder@example.com')
+    await vi.waitFor(() => expect(tokenWarmFailureCount()).toBe(1))
+    rec.flushDigest(300_000)
+
+    expect(digests(sink)[0].counters['recorder/token-warm-failed']).toBe(1)
   })
 
   it('clears application counters after a successful flush', () => {

--- a/apps/fluux/src/anomaly/recorder.ts
+++ b/apps/fluux/src/anomaly/recorder.ts
@@ -23,6 +23,7 @@ import {
   retainOpaque,
   tokenKeyId,
   tokenUnresolvedCount,
+  tokenWarmFailureCount,
   type Opaque,
 } from './values'
 
@@ -311,6 +312,7 @@ export function createRecorder(opts: RecorderOptions): Recorder {
         [COUNTER.rejectedValue, rejectedValueCount()],
         [COUNTER.localRefOverflow, localRefOverflowCount()],
         [COUNTER.tokenUnresolved, tokenUnresolvedCount()],
+        [COUNTER.tokenWarmFailed, tokenWarmFailureCount()],
         [COUNTER.sinkWriteFailed, sink.failureCount()],
         [COUNTER.droppedNotReady, droppedNotReady],
       ]

--- a/apps/fluux/src/anomaly/values.test.ts
+++ b/apps/fluux/src/anomaly/values.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   COUNTER,
   CTX,
@@ -20,6 +20,7 @@ import {
   TAG,
   tokenKeyId,
   tokenSync,
+  tokenWarmFailureCount,
   tokenUnresolvedCount,
   warmToken,
 } from './values'
@@ -28,6 +29,10 @@ beforeEach(async () => {
   localStorage.clear()
   resetValuesForTesting()
   await initTokenizer()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('registries', () => {
@@ -213,6 +218,14 @@ describe('tokens', () => {
     const t = tokenSync('jid', 'cold@example.com')
     expect(t.s).toBe('c:unresolved')
     expect(tokenUnresolvedCount()).toBe(1)
+  })
+
+  it('counts a rejected background warm instead of leaving it unhandled', async () => {
+    vi.spyOn(crypto.subtle, 'sign').mockRejectedValueOnce(new Error('subtle.sign failed'))
+
+    expect(tokenSync('jid', 'failing@example.com').s).toBe('c:unresolved')
+
+    await vi.waitFor(() => expect(tokenWarmFailureCount()).toBe(1))
   })
 
   it('namespaces the preimage so one string in two roles differs', async () => {

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -156,6 +156,7 @@ export const COUNTER = Object.freeze({
   rejectedValue: mint('recorder/rejected-value', 'counter'),
   localRefOverflow: mint('recorder/localref-overflow', 'counter'),
   tokenUnresolved: mint('recorder/token-unresolved', 'counter'),
+  tokenWarmFailed: mint('recorder/token-warm-failed', 'counter'),
   sinkWriteFailed: mint('recorder/sink-write-failed', 'counter'),
   droppedNotReady: mint('recorder/dropped-not-ready', 'counter'),
 })
@@ -237,6 +238,7 @@ const tokens = new Map<string, Opaque>()
 let hmacKey: CryptoKey | null = null
 let keyId = 'unknown'
 let unresolved = 0
+let backgroundWarmFailures = 0
 
 function nsKey(ns: string, value: string): string {
   return `${ns}\u0000${value}` // U+0000: cannot occur in a JID or a stanza id
@@ -322,7 +324,9 @@ export function tokenSync(ns: TokenNs, value: string): Opaque {
     return hit
   }
   unresolved++
-  void warmToken(ns, value)
+  void warmToken(ns, value).catch(() => {
+    backgroundWarmFailures++
+  })
   return UNRESOLVED
 }
 
@@ -344,6 +348,10 @@ export function isTokenizerReady(): boolean {
 
 export function tokenUnresolvedCount(): number {
   return unresolved
+}
+
+export function tokenWarmFailureCount(): number {
+  return backgroundWarmFailures
 }
 
 // ---------------------------------------------------------------------------
@@ -449,6 +457,7 @@ export function resetValuesForTesting(): void {
   hmacKey = null
   keyId = 'unknown'
   unresolved = 0
+  backgroundWarmFailures = 0
   nextSeq = 0
   overflow = 0
 }

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -42,6 +42,7 @@ Counter names (digest only, not invariant ids):
 | `recorder/rejected-value` | A detector passed a value with the wrong provenance or category; the record was dropped | A detector bug. Nothing reached disk, but the evidence is lost |
 | `recorder/localref-overflow` | The 2 000-ref map was full and all refs pinned; a crumb was omitted | Usually a leak: something retains refs without releasing |
 | `recorder/token-unresolved` | A token was requested before it was warmed | Rare is fine. Sustained means the pre-warm is missing a lifecycle event |
+| `recorder/token-warm-failed` | A background token warm started by a synchronous lookup rejected | Check `recorder/entity-warm-failing` in the same session. Sustained failures mean `crypto.subtle.sign` is unavailable or failing |
 | `recorder/dropped-not-ready` | Records refused because the tokenizer had no key yet | A few at startup are normal. Sustained means the tokenizer never initialised — check `fluux.log` for the warning |
 | `recorder/sink-write-failed` | A sidecar append failed | Check `fluux.log` — failures mirror there, because a broken sink cannot report itself |
 

--- a/packages/fluux-sdk/examples/assistant.test.ts
+++ b/packages/fluux-sdk/examples/assistant.test.ts
@@ -1,0 +1,77 @@
+import type { RoomMessage, XMPPClient } from '@fluux/sdk/core'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  questionFromRoom,
+  respond,
+  respondInBackground,
+  type Question,
+} from './assistant'
+
+function createClient() {
+  const messages = {
+    sendReaction: vi.fn().mockResolvedValue(undefined),
+    sendChatState: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue('placeholder-id'),
+    sendCorrection: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return {
+    client: { messages } as unknown as XMPPClient,
+    messages,
+  }
+}
+
+const question: Question = {
+  to: 'room@conference.example.com',
+  messageId: 'question-id',
+  messageFrom: 'room@conference.example.com/alice',
+  text: '@assistant Can you help?',
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('assistant example', () => {
+  it('keeps the full room occupant JID needed by XEP-0461 replies', () => {
+    const message = {
+      id: 'question-id',
+      from: 'room@conference.example.com/alice',
+      roomJid: 'room@conference.example.com',
+      nick: 'alice',
+      body: '@assistant Can you help?',
+      isOutgoing: false,
+      isDelayed: false,
+    } as RoomMessage
+
+    expect(questionFromRoom(message, 'assistant')).toMatchObject({
+      messageFrom: message.from,
+    })
+  })
+
+  it('includes the original sender when replying to a room message', async () => {
+    vi.useFakeTimers()
+    const { client, messages } = createClient()
+
+    const response = respond(client, question)
+    await vi.runAllTimersAsync()
+    await response
+
+    expect(messages.sendMessage).toHaveBeenCalledWith(
+      question.to,
+      'Working on it…',
+      { replyTo: { id: question.messageId, to: question.messageFrom } },
+    )
+  })
+
+  it('reports initial response failures instead of rejecting in the background', async () => {
+    const { client, messages } = createClient()
+    const error = new Error('reaction failed')
+    messages.sendReaction.mockRejectedValue(error)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(respondInBackground(client, question)).resolves.toBeUndefined()
+    expect(consoleError).toHaveBeenCalledWith('Could not answer question-id: reaction failed')
+  })
+})

--- a/packages/fluux-sdk/examples/assistant.ts
+++ b/packages/fluux-sdk/examples/assistant.ts
@@ -17,14 +17,17 @@
 import { XMPPClient } from '@fluux/sdk/core'
 import type { Message, RoomMessage } from '@fluux/sdk/core'
 import { checkForMention, getBareJid, getLocalPart } from '@fluux/sdk/core'
+import { pathToFileURL } from 'node:url'
 import { loadConfig, routeSdkLogsToStderr } from './config'
 
 /** A question the bot has decided to answer, and everything needed to reply. */
-interface Question {
+export interface Question {
   /** Who to address the answer to: the room, or the person. */
   to: string
   /** The message being answered, for the acknowledgement and the reply. */
   messageId: string
+  /** Full sender address required by XEP-0461 reply metadata. */
+  messageFrom: string
   text: string
 }
 
@@ -44,13 +47,13 @@ async function answer(question: string): Promise<string> {
  * into the answer, instead of a placeholder followed by a second message that
  * pushes it out of view.
  */
-async function respond(client: XMPPClient, question: Question): Promise<void> {
+export async function respond(client: XMPPClient, question: Question): Promise<void> {
   // Tell the asker it landed, before anything slow starts.
   await client.messages.sendReaction(question.to, question.messageId, ['👀'])
   await client.messages.sendChatState(question.to, 'composing')
 
   const placeholderId = await client.messages.sendMessage(question.to, 'Working on it…', {
-    replyTo: { id: question.messageId },
+    replyTo: { id: question.messageId, to: question.messageFrom },
   })
 
   try {
@@ -65,6 +68,14 @@ async function respond(client: XMPPClient, question: Question): Promise<void> {
   }
 }
 
+/** Start answering without blocking the subscription callback, reporting failures. */
+export function respondInBackground(client: XMPPClient, question: Question): Promise<void> {
+  return respond(client, question).catch((error: unknown) => {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.error(`Could not answer ${question.messageId}: ${reason}`)
+  })
+}
+
 /**
  * Decide whether a one-to-one message is a question for us.
  *
@@ -72,13 +83,14 @@ async function respond(client: XMPPClient, question: Question): Promise<void> {
  * bot itself sent (carbons of its own replies would otherwise loop) and
  * archived ones replayed at startup, which are already answered.
  */
-function questionFromChat(message: Message): Question | null {
+export function questionFromChat(message: Message): Question | null {
   if (message.isOutgoing || message.isDelayed) return null
   if (!message.body.trim()) return null
 
   return {
     to: getBareJid(message.from),
     messageId: message.id,
+    messageFrom: message.from,
     text: message.body,
   }
 }
@@ -91,7 +103,7 @@ function questionFromChat(message: Message): Question | null {
  * here: on join, the service replays history in which our past messages are
  * indistinguishable from anyone else's, which is what `isDelayed` covers.
  */
-function questionFromRoom(message: RoomMessage, nickname: string): Question | null {
+export function questionFromRoom(message: RoomMessage, nickname: string): Question | null {
   if (message.isOutgoing || message.isDelayed) return null
   if (message.nick === nickname) return null
   if (!checkForMention(message.body, nickname)) return null
@@ -99,6 +111,7 @@ function questionFromRoom(message: RoomMessage, nickname: string): Question | nu
   return {
     to: message.roomJid,
     messageId: message.id,
+    messageFrom: message.from,
     text: message.body,
   }
 }
@@ -113,12 +126,12 @@ async function main(): Promise<void> {
 
   client.subscribe('chat:message', ({ message }) => {
     const question = questionFromChat(message)
-    if (question) void respond(client, question)
+    if (question) void respondInBackground(client, question)
   })
 
   client.subscribe('room:message', ({ message }) => {
     const question = questionFromRoom(message, nickname)
-    if (question) void respond(client, question)
+    if (question) void respondInBackground(client, question)
   })
 
   await client.connect(config)
@@ -138,7 +151,10 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => void stop())
 }
 
-main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : error)
-  process.exitCode = 1
-})
+const entryPoint = process.argv[1]
+if (entryPoint && import.meta.url === pathToFileURL(entryPoint).href) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/packages/fluux-sdk/vitest.config.ts
+++ b/packages/fluux-sdk/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     silent: true,
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'examples/**/*.test.ts'],
     setupFiles: ['./src/test-setup.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Fix two asynchronous correctness gaps. The assistant example now includes the originating MUC occupant JID in XEP-0461 reply metadata and reports response failures instead of leaving rejected promises unhandled.

The anomaly tokenizer now catches rejected background token warms and reports them through the recorder health digest. Fixes #1217.
