### PR TITLE
refactor(sdk): name pagination after the page, not after the extension

### DIFF
--- a/packages/fluux-sdk/src/barrelSurface.test.ts
+++ b/packages/fluux-sdk/src/barrelSurface.test.ts
@@ -160,6 +160,16 @@ describe('public API surface', () => {
     expect(Object.keys(main)).toContain('formatXMPPError')
   })
 
+  it('names pagination after the page, not after the extension that carries it', () => {
+    // The wire parsers keep their protocol names on the escape hatch: they take
+    // and return elements. The shapes a consumer reads do not.
+    const barrel = readFileSync(resolve(process.cwd(), 'src/index.ts'), 'utf8')
+    expect(barrel).toMatch(/^\s*PageRequest,\s*$/m)
+    expect(barrel).toMatch(/^\s*PageInfo,\s*$/m)
+    expect(barrel).not.toMatch(/\bRSMRequest\b|\bRSMResponse\b/)
+    expect(Object.keys(xmpp)).toContain('parseRSMResponse')
+  })
+
   it('does not hand the stanza builder back through a hook', () => {
     // A named export is not the only door: `useXMPP` used to return `xml`,
     // which would have made every assertion above true and meaningless. The

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -286,9 +286,9 @@ export function createStoreBindings(
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:history-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('chat:history-messages', ({ conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
-    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
+    stores.chat.mergeMAMMessages(conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // A purged id-exact anchor (item-not-found degrade): strip the matching
@@ -477,9 +477,9 @@ export function createStoreBindings(
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:history-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('room:history-messages', ({ roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
-    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
+    stores.room.mergeRoomMAMMessages(roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // Room twin of chat:mam-anchor-purged (see above).

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -38,7 +38,7 @@ export type {
   HistorySearchOptions,
   RoomHistorySearchOptions,
   HistoryPagingSearchOptions,
-  RSMResponse,
+  PageInfo,
   // Room types (separated for fine-grained subscriptions)
   Room,
   RoomEntity,

--- a/packages/fluux-sdk/src/core/modules/Admin.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.ts
@@ -22,8 +22,8 @@ import type {
   AdminCommandCategory,
   DataForm,
   AdminSession,
-  RSMRequest,
-  RSMResponse,
+  PageRequest,
+  PageInfo,
   AdminUser,
   AdminRoom,
   ServerStats,
@@ -693,11 +693,11 @@ export class Admin extends BaseModule {
   /**
    * Fetch paginated list of registered users via XEP-0133.
    * @param vhost - Virtual host to query (defaults to current domain)
-   * @param rsm - RSM pagination parameters
+   * @param page - RSM pagination parameters
    */
-  async fetchUserList(vhost?: string, rsm?: RSMRequest): Promise<{
+  async fetchUserList(vhost?: string, page?: PageRequest): Promise<{
     users: AdminUser[]
-    pagination: RSMResponse
+    pagination: PageInfo
   }> {
     const currentJid = this.deps.getCurrentJid()
     if (!currentJid) throw new Error('Not connected')
@@ -727,8 +727,8 @@ export class Admin extends BaseModule {
       const completeChildren: Element[] = [
         xml('x', { xmlns: NS_DATA_FORMS, type: 'submit' })
       ]
-      if (rsm) {
-        completeChildren.push(buildRSMElement(rsm))
+      if (page) {
+        completeChildren.push(buildRSMElement(page))
       }
 
       const completeIq = xml(
@@ -953,11 +953,11 @@ export class Admin extends BaseModule {
   /**
    * Fetch paginated list of public rooms from MUC service.
    * @param mucServiceJid - Optional MUC service JID. If not provided, uses auto-discovered service.
-   * @param rsm - RSM pagination parameters
+   * @param page - RSM pagination parameters
    */
-  async fetchRoomList(mucServiceJid?: string, rsm?: RSMRequest): Promise<{
+  async fetchRoomList(mucServiceJid?: string, page?: PageRequest): Promise<{
     rooms: AdminRoom[]
-    pagination: RSMResponse
+    pagination: PageInfo
   }> {
     const currentJid = this.deps.getCurrentJid()
     if (!currentJid) throw new Error('Not connected')
@@ -977,8 +977,8 @@ export class Admin extends BaseModule {
 
     // Build disco#items query with RSM
     const queryChildren: Element[] = []
-    if (rsm) {
-      queryChildren.push(buildRSMElement(rsm))
+    if (page) {
+      queryChildren.push(buildRSMElement(page))
     }
 
     const iq = xml(

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -316,7 +316,7 @@ describe('XMPPClient MAM', () => {
           const msg = createMockElement('message', { from: 'example.com' }, [
             {
               name: 'result',
-              attrs: { xmlns: 'urn:xmpp:mam:2', queryid: actualQueryId, id: 'archive-rsm-id' },
+              attrs: { xmlns: 'urn:xmpp:mam:2', queryid: actualQueryId, id: 'archive-page-id' },
               children: [
                 {
                   name: 'forwarded',
@@ -399,7 +399,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
-        rsm: expect.any(Object),
+        page: expect.any(Object),
         complete: true,
         direction: 'backward',
         isFetchLatest: true,
@@ -2619,7 +2619,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', {
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
-        rsm: expect.any(Object),
+        page: expect.any(Object),
         complete: true, // complete from server
         direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
         isFetchLatest: false, // forward queries are never fetch-latest candidates
@@ -2657,7 +2657,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-messages', expect.objectContaining({
         conversationId: 'alice@example.com',
         messages: expect.any(Array),
-        rsm: expect.any(Object),
+        page: expect.any(Object),
         complete: true, // complete from server
         direction: 'backward', // direction - store will set isHistoryComplete
         isFetchLatest: true, // before:'' fetch-latest candidate
@@ -2874,7 +2874,7 @@ describe('XMPPClient MAM', () => {
 
       const result = await xmppClient.messages.queryMAM({ with: 'alice@example.com', before: '' })
 
-      // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's rsm.first:
+      // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's page.first:
       // everything between topId and bottomId is already proven signal-only.
       expect(callCount).toBe(2)
       const secondQueryEl = capturedIqs[1].children?.find((c: any) => c.name === 'query')
@@ -2966,7 +2966,7 @@ describe('XMPPClient MAM', () => {
         // coverage (Codex r4 #2) — the flag blocks record formation.
         walkCarriedModifications: true,
       })
-      expect((mamEmits[0][1] as { rsm: { first?: string } }).rsm.first).toBe('p5-first')
+      expect((mamEmits[0][1] as { page: { first?: string } }).page.first).toBe('p5-first')
     })
 
     it('a floor purged AFTER the jump falls back to the pre-jump cursor and continues the walk (Codex r4 #6)', async () => {
@@ -3386,7 +3386,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid,
         messages: expect.any(Array),
-        rsm: expect.objectContaining({ first: 'first-id', last: 'last-id' }),
+        page: expect.objectContaining({ first: 'first-id', last: 'last-id' }),
         complete: true,
         direction: 'backward',
         isFetchLatest: true, // no before, no start = fetch-latest
@@ -3508,7 +3508,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', {
         roomJid,
         messages: expect.any(Array),
-        rsm: expect.any(Object),
+        page: expect.any(Object),
         complete: true, // complete from server
         direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
         isFetchLatest: false, // forward query, never a fetch-latest
@@ -3561,7 +3561,7 @@ describe('XMPPClient MAM', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('room:history-messages', expect.objectContaining({
         roomJid,
         messages: expect.any(Array),
-        rsm: expect.any(Object),
+        page: expect.any(Object),
         complete: true, // complete from server
         direction: 'backward', // direction - store will set isHistoryComplete
         isFetchLatest: false, // real pagination cursor ('some-stanza-id'), not a fetch-latest
@@ -3849,7 +3849,7 @@ describe('XMPPClient MAM', () => {
 
       const result = await xmppClient.messages.queryRoomMAM({ roomJid })
 
-      // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's rsm.first.
+      // Page 2's cursor must be the coverage BOTTOM (jump), not page 1's page.first.
       expect(callCount).toBe(2)
       const secondQueryEl = capturedIqs[1].children?.find((c: any) => c.name === 'query')
       const secondSetEl = secondQueryEl?.children?.find((c: any) => c.name === 'set')

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1609,10 +1609,10 @@ export class Chat extends BaseModule {
    * const initial = await client.messages.queryMAM({ with: 'user@example.com' })
    *
    * // Load more (older messages)
-   * if (!initial.complete && initial.rsm?.first) {
+   * if (!initial.complete && initial.page?.first) {
    *   const older = await client.messages.queryMAM({
    *     with: 'user@example.com',
-   *     before: initial.rsm.first
+   *     before: initial.page.first
    *   })
    * }
    * ```

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -434,7 +434,7 @@ describe('MAM Background Catch-Up', () => {
       ]
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
@@ -459,7 +459,7 @@ describe('MAM Background Catch-Up', () => {
       ]
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpAllConversations({ sessionStartTime })
       await waitForAsyncOps(20, 100)
@@ -483,7 +483,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(gapStart.getTime())
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
@@ -501,7 +501,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(undefined)
       vi.mocked(mockStores.chat.getConversationLastTimestamp!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: false, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: false, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
       await waitForAsyncOps(20, 100)
@@ -524,7 +524,7 @@ describe('MAM Background Catch-Up', () => {
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async () => {
         // The fetch-latest merge resolved the pointer (its message was in the page).
         vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -543,10 +543,10 @@ describe('MAM Background Catch-Up', () => {
         if (opts.before === 'page-1-first') {
           // Second backward page contained the pointer's message → resolved.
           vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'page-2-first' } }
+          return { messages: [], complete: false, page: { first: 'page-2-first' } }
         }
-        if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
-        return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
+        if (opts.before === '') return { messages: [], complete: false, page: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'page-1-first' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -561,8 +561,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
-        return { messages: [], complete: true, rsm: { first: 'page-1-first' } } // archive start
+        if (opts.before === '') return { messages: [], complete: false, page: { first: 'w-bottom' } }
+        return { messages: [], complete: true, page: { first: 'page-1-first' } } // archive start
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -577,7 +577,7 @@ describe('MAM Background Catch-Up', () => {
       let n = 0
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async () => {
         n++
-        return { messages: [], complete: false, rsm: { first: `page-${n}-first` } }
+        return { messages: [], complete: false, page: { first: `page-${n}-first` } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -595,7 +595,7 @@ describe('MAM Background Catch-Up', () => {
         calls.push(opts)
         // Every page — including the fetch-latest — returns the SAME cursor:
         // the archive has nothing further to offer this walk.
-        return { messages: [], complete: false, rsm: { first: 'stuck' } }
+        return { messages: [], complete: false, page: { first: 'stuck' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -612,7 +612,7 @@ describe('MAM Background Catch-Up', () => {
       // Default loadMessagesFromCache mock resolves [] — the cache-bottom probe is unavailable.
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive')
-        .mockResolvedValue({ messages: [], complete: false, rsm: {} })
+        .mockResolvedValue({ messages: [], complete: false, page: {} })
 
       await expect(
         getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -629,7 +629,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat('mds-ptr')
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive')
-        .mockResolvedValue({ messages: [], complete: false, rsm: { first: 'w-bottom' } })
+        .mockResolvedValue({ messages: [], complete: false, page: { first: 'w-bottom' } })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [])
 
@@ -641,7 +641,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat(undefined)
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive')
-        .mockResolvedValue({ messages: [], complete: true, rsm: {} })
+        .mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
@@ -658,7 +658,7 @@ describe('MAM Background Catch-Up', () => {
       setupChat(undefined)
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive')
-        .mockResolvedValue({ messages: [], complete: true, rsm: {} })
+        .mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
@@ -676,8 +676,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start) return { messages: [], complete: false, rsm: { last: 'x' } }
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        if (opts.start) return { messages: [], complete: false, page: { last: 'x' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
@@ -706,13 +706,13 @@ describe('MAM Background Catch-Up', () => {
         calls.push(opts)
         // Phase A forward from the coverage edge completes in one page —
         // no fetch-latest, so windowBottom would stay unset.
-        if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
+        if (opts.after === 'new-9') return { messages: [], complete: true, page: {} }
         if (opts.before === 'bottom-1') {
           // First backward page below prior coverage resolved the pointer.
           vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'older-0' } }
+          return { messages: [], complete: false, page: { first: 'older-0' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'x' } }
+        return { messages: [], complete: false, page: { first: 'x' } }
       })
 
       const cached = [
@@ -750,8 +750,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
-        return { messages: [], complete: false, rsm: { first: 'p1' } }
+        if (opts.start || opts.after) return { messages: [], complete: true, page: {} } // Phase A done
+        return { messages: [], complete: false, page: { first: 'p1' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com',
@@ -778,8 +778,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
-        return { messages: [], complete: false, rsm: { first: 'p1' } }
+        if (opts.start || opts.after) return { messages: [], complete: true, page: {} } // Phase A done
+        return { messages: [], complete: false, page: { first: 'p1' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com',
@@ -808,8 +808,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
-        return { messages: [], complete: false, rsm: { first: 'p1' } }
+        if (opts.start || opts.after) return { messages: [], complete: true, page: {} } // Phase A done
+        return { messages: [], complete: false, page: { first: 'p1' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com',
@@ -829,12 +829,12 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
+        if (opts.after === 'new-9') return { messages: [], complete: true, page: {} }
         if (opts.before === 'old-1') {
           vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'older-0' } }
+          return { messages: [], complete: false, page: { first: 'older-0' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'x' } }
+        return { messages: [], complete: false, page: { first: 'x' } }
       })
 
       const cached = [
@@ -861,9 +861,9 @@ describe('MAM Background Catch-Up', () => {
         if (opts.before === 'w-bottom') {
           // The user opened the conversation while this backward page was in flight.
           vi.mocked(mockStores.chat.getActiveConversationId!).mockReturnValue('alice@example.com')
-          return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
+          return { messages: [], complete: false, page: { first: 'page-1-first' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -880,7 +880,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
       vi.mocked(mockStores.chat.getConversationGapStartId!).mockReturnValue('gap-edge-7')
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
 
@@ -924,11 +924,11 @@ describe('MAM Background Catch-Up', () => {
           // Phase A's forward query already degraded internally (purged
           // after-anchor) and returned a fetch-latest page — NOT a second
           // `before: ''` bail query should follow.
-          return { messages: [], complete: false, degradedToFetchLatest: true, rsm: { first: 'w-bottom' } }
+          return { messages: [], complete: false, degradedToFetchLatest: true, page: { first: 'w-bottom' } }
         }
         // The pointer's own message is in the backward page seeded from 'w-bottom'.
         vi.mocked(mockStores.chat.getConversationPendingStanzaId!).mockReturnValue(undefined)
-        return { messages: [], complete: false, rsm: { first: 'older' } }
+        return { messages: [], complete: false, page: { first: 'older' } }
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
@@ -939,7 +939,7 @@ describe('MAM Background Catch-Up', () => {
 
       // No second `before: ''` bail query — the degraded initial IS the fetch-latest.
       expect(calls.some((c) => c.before === '')).toBe(false)
-      // Phase B seeds its first backward page from the degraded result's rsm.first.
+      // Phase B seeds its first backward page from the degraded result's page.first.
       expect(calls[1]).toMatchObject({ before: 'w-bottom' })
       expect(calls).toHaveLength(2)
     })
@@ -952,7 +952,7 @@ describe('MAM Background Catch-Up', () => {
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
         // Empty cache: Phase A's own query IS the fetch-latest (before: '').
-        return { messages: [], complete: true, rsm: { first: 'w-bottom' } }
+        return { messages: [], complete: true, page: { first: 'w-bottom' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpConversationHistory('alice@example.com', [], { stitchReadPointer: true })
@@ -978,7 +978,7 @@ describe('MAM Background Catch-Up', () => {
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async () => {
         vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
@@ -996,10 +996,10 @@ describe('MAM Background Catch-Up', () => {
         calls.push(opts)
         if (opts.before === 'page-1-first') {
           vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'page-2-first' } }
+          return { messages: [], complete: false, page: { first: 'page-2-first' } }
         }
-        if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
-        return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
+        if (opts.before === '') return { messages: [], complete: false, page: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'page-1-first' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
@@ -1014,8 +1014,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start) return { messages: [], complete: false, rsm: { last: 'x' } }
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        if (opts.start) return { messages: [], complete: false, page: { last: 'x' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
@@ -1042,12 +1042,12 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
+        if (opts.after === 'new-9') return { messages: [], complete: true, page: {} }
         if (opts.before === 'bottom-1') {
           vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'older-0' } }
+          return { messages: [], complete: false, page: { first: 'older-0' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'x' } }
+        return { messages: [], complete: false, page: { first: 'x' } }
       })
 
       const cached = [
@@ -1082,8 +1082,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
-        return { messages: [], complete: false, rsm: { first: 'p1' } }
+        if (opts.start || opts.after) return { messages: [], complete: true, page: {} } // Phase A done
+        return { messages: [], complete: false, page: { first: 'p1' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid,
@@ -1107,8 +1107,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.start || opts.after) return { messages: [], complete: true, rsm: {} } // Phase A done
-        return { messages: [], complete: false, rsm: { first: 'p1' } }
+        if (opts.start || opts.after) return { messages: [], complete: true, page: {} } // Phase A done
+        return { messages: [], complete: false, page: { first: 'p1' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid,
@@ -1130,12 +1130,12 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.after === 'new-9') return { messages: [], complete: true, rsm: {} }
+        if (opts.after === 'new-9') return { messages: [], complete: true, page: {} }
         if (opts.before === 'old-1') {
           vi.mocked(mockStores.room.getRoomPendingStanzaId!).mockReturnValue(undefined)
-          return { messages: [], complete: false, rsm: { first: 'older-0' } }
+          return { messages: [], complete: false, page: { first: 'older-0' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'x' } }
+        return { messages: [], complete: false, page: { first: 'x' } }
       })
 
       const cached = [
@@ -1162,9 +1162,9 @@ describe('MAM Background Catch-Up', () => {
         if (opts.before === 'w-bottom') {
           // The user opened the room while this backward page was in flight.
           vi.mocked(mockStores.room.getActiveRoomJid).mockReturnValue(roomJid)
-          return { messages: [], complete: false, rsm: { first: 'page-1-first' } }
+          return { messages: [], complete: false, page: { first: 'page-1-first' } }
         }
-        return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
+        return { messages: [], complete: false, page: { first: 'w-bottom' } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
@@ -1179,8 +1179,8 @@ describe('MAM Background Catch-Up', () => {
       const calls: any[] = []
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async (opts: any) => {
         calls.push(opts)
-        if (opts.before === '') return { messages: [], complete: false, rsm: { first: 'w-bottom' } }
-        return { messages: [], complete: true, rsm: { first: 'page-1-first' } } // archive start
+        if (opts.before === '') return { messages: [], complete: false, page: { first: 'w-bottom' } }
+        return { messages: [], complete: true, page: { first: 'page-1-first' } } // archive start
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
@@ -1195,7 +1195,7 @@ describe('MAM Background Catch-Up', () => {
       let n = 0
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockImplementation(async () => {
         n++
-        return { messages: [], complete: false, rsm: { first: `page-${n}-first` } }
+        return { messages: [], complete: false, page: { first: `page-${n}-first` } }
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [], { stitchReadPointer: true })
@@ -1209,7 +1209,7 @@ describe('MAM Background Catch-Up', () => {
       setupRoom('mds-ptr')
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive')
-        .mockResolvedValue({ messages: [], complete: false, rsm: { first: 'w-bottom' } })
+        .mockResolvedValue({ messages: [], complete: false, page: { first: 'w-bottom' } })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [])
 
@@ -1221,7 +1221,7 @@ describe('MAM Background Catch-Up', () => {
       setupRoom(undefined)
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive')
-        .mockResolvedValue({ messages: [], complete: true, rsm: {} })
+        .mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z'), stanzaId: 'cov-42' }]
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
@@ -1238,7 +1238,7 @@ describe('MAM Background Catch-Up', () => {
       setupRoom(undefined)
 
       const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive')
-        .mockResolvedValue({ messages: [], complete: true, rsm: {} })
+        .mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const cached = [{ timestamp: new Date('2026-05-14T09:00:00.000Z') }]
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, cached, { sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
@@ -1255,7 +1255,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.getRoomGapStart!).mockReturnValue(new Date('2026-05-14T09:00:00Z').getTime())
       vi.mocked(mockStores.room.getRoomGapStartId!).mockReturnValue('gap-edge-7')
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       await getInternalSurfaceForTesting(xmppClient).mam.catchUpRoomHistory(roomJid, [{ timestamp: new Date('2026-06-01T12:00:00Z'), stanzaId: 'newer' }])
 
@@ -1353,7 +1353,7 @@ describe('MAM Background Catch-Up', () => {
 
       // Cursor source = pure cache peek (catchUpRoom uses the return value).
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpRoom('room1@conference.example.com', sessionStartTime)
       await waitForAsyncOps(20, 100)
@@ -1378,7 +1378,7 @@ describe('MAM Background Catch-Up', () => {
 
       // Cursor source = pure cache peek (catchUpRoom uses the return value).
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
@@ -1527,7 +1527,7 @@ describe('MAM Background Catch-Up', () => {
       ] as any)
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
 
-      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+      const querySpy = vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, page: {} })
 
       const catchUpPromise = getInternalSurfaceForTesting(xmppClient).mam.forceCatchUpAllRooms()
       await waitForAsyncOps(20, 100)
@@ -1581,7 +1581,7 @@ describe('MAM Background Catch-Up', () => {
     it('emits a console event when a 1:1 forward catch-up ends incomplete (a gap remains)', async () => {
       await connectClient()
 
-      // complete=false, no rsm cursor → forward pagination stops with isComplete=false
+      // complete=false, no page cursor → forward pagination stops with isComplete=false
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
 
       const queryPromise = getInternalSurfaceForTesting(xmppClient).mam.queryArchive({
@@ -1605,7 +1605,7 @@ describe('MAM Background Catch-Up', () => {
       await connectClient()
 
       vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
-      // complete=false, no rsm cursor → forward pagination stops with isComplete=false
+      // complete=false, no page cursor → forward pagination stops with isComplete=false
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
 
       const queryPromise = getInternalSurfaceForTesting(xmppClient).mam.queryRoomArchive({
@@ -1760,7 +1760,7 @@ describe('MAM Background Catch-Up', () => {
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({
         messages: [fakeMessage] as any,
         complete: true,
-        rsm: {},
+        page: {},
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.discoverNewConversationsFromRoster()
@@ -1789,7 +1789,7 @@ describe('MAM Background Catch-Up', () => {
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({
         messages: [],
         complete: true,
-        rsm: {},
+        page: {},
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.discoverNewConversationsFromRoster()
@@ -1810,7 +1810,7 @@ describe('MAM Background Catch-Up', () => {
       vi.spyOn(getInternalSurfaceForTesting(xmppClient).mam, 'queryArchive').mockResolvedValue({
         messages: [fakeMessage] as any,
         complete: true,
-        rsm: {},
+        page: {},
       })
 
       await getInternalSurfaceForTesting(xmppClient).mam.discoverNewConversationsFromRoster()

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -78,7 +78,7 @@ import type {
   HistoryResult,
   RoomHistoryQueryOptions,
   RoomHistoryResult,
-  RSMResponse,
+  PageInfo,
   HistorySearchOptions,
   RoomHistorySearchOptions,
   HistoryPagingSearchOptions,
@@ -160,10 +160,10 @@ interface UnresolvedModifications {
  * })
  *
  * // Load older messages
- * if (!initial.complete && initial.rsm?.first) {
+ * if (!initial.complete && initial.page?.first) {
  *   const older = await client.messages.queryRoomMAM({
  *     roomJid: 'room@conference.example.com',
- *     before: initial.rsm.first
+ *     before: initial.page.first
  *   })
  * }
  * ```
@@ -218,11 +218,11 @@ export class MAM extends BaseModule {
     // The pointer-seed catch-up starts the FIRST page from the given `after`
     // cursor; a plain `start`-anchored catch-up has no initial cursor (the
     // timestamp filter alone selects the first page) and only acquires one
-    // from `rsm.last` after that first page.
+    // from `pageInfo.last` after that first page.
     let currentAfter: string | undefined = after
     let isComplete = false
-    let lastRsm: RSMResponse = {}
-    // rsm.last of the FIRST backward page — the newest archive entry seen by
+    let lastPage: PageInfo = {}
+    // pageInfo.last of the FIRST backward page — the newest archive entry seen by
     // this walk; stamped as the coverage record's topId (mamCoverage.ts).
     let fetchLatestTopId: string | undefined
     // Persisted coverage record (Codex r3 #4): floor for the signal-only walk
@@ -331,7 +331,7 @@ export class MAM extends BaseModule {
             }
             throw iqError
           }
-          const { complete, rsm } = this.parseMAMResponse(response)
+          const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
           // Drain the buffer: E2EE decrypt first (so modification bodies are
           // plaintext, not fallback hints), then modification detection, then parse.
@@ -350,8 +350,8 @@ export class MAM extends BaseModule {
           // page's correction/reaction can still land on an earlier page's message.
           allMessages.push(...collectedMessages)
           isComplete = complete
-          lastRsm = rsm
-          if (page === 0 && !isForwardPaginate) fetchLatestTopId = rsm.last
+          lastPage = pageInfo
+          if (page === 0 && !isForwardPaginate) fetchLatestTopId = pageInfo.last
           if (coverageRecord?.topId && rawEntries.some((e) => e.archiveId === coverageRecord.topId)) {
             sawCoverageTop = true
           }
@@ -359,8 +359,8 @@ export class MAM extends BaseModule {
           if (isForwardPaginate) {
             // Forward catch-up: accumulate every page, advance via `after` until complete.
             if (complete) break
-            if (rsm.last) {
-              currentAfter = rsm.last
+            if (pageInfo.last) {
+              currentAfter = pageInfo.last
             } else {
               break
             }
@@ -371,7 +371,7 @@ export class MAM extends BaseModule {
             }
             // No displayable messages but archive has more - continue with next page
             // Use the 'first' ID as the 'before' cursor for backward pagination
-            if (rsm.first) {
+            if (pageInfo.first) {
               // Known signal-only floor (persisted coverage): once this walk
               // re-enters previously-covered territory (the page contains the
               // record's top entry), everything down to the record's bottom is
@@ -379,11 +379,11 @@ export class MAM extends BaseModule {
               // successive sessions descend instead of re-walking the same
               // newest pages (Codex r3 #4).
               if (canJumpToFloor && coverageRecord && sawCoverageTop && !jumpedToFloor) {
-                preJumpCursor = rsm.first
+                preJumpCursor = pageInfo.first
                 currentBefore = coverageRecord.bottomId
                 jumpedToFloor = true
               } else {
-                currentBefore = rsm.first
+                currentBefore = pageInfo.first
               }
               this.deps.emitSDK('console:event', {
                 message: `Page ${page + 1} had no displayable messages, fetching older...`,
@@ -422,7 +422,7 @@ export class MAM extends BaseModule {
       this.deps.emitSDK('chat:history-messages', {
         conversationId,
         messages: allMessages,
-        rsm: lastRsm,
+        page: lastPage,
         complete: isComplete,
         direction,
         preserveGapMarker,
@@ -453,7 +453,7 @@ export class MAM extends BaseModule {
         })
       }
 
-      return { messages: allMessages, complete: isComplete, rsm: lastRsm }
+      return { messages: allMessages, complete: isComplete, page: lastPage }
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error'
       if (isConnectionError(error)) {
@@ -495,8 +495,8 @@ export class MAM extends BaseModule {
     const maxAutoPages = isForward ? (maxAutoPagesOpt ?? MAM_ROOM_FORWARD_MAX_PAGES) : MAM_BACKWARD_SIGNAL_RETRY_PAGES
     const allMessages: RoomMessage[] = []
     let isComplete = false
-    let lastRsm: RSMResponse = {}
-    // rsm.last of the FIRST backward page — the newest archive entry seen by
+    let lastPage: PageInfo = {}
+    // pageInfo.last of the FIRST backward page — the newest archive entry seen by
     // this walk; stamped as the coverage record's topId (mamCoverage.ts).
     let fetchLatestTopId: string | undefined
     // Persisted coverage record (Codex r3 #4): floor for the signal-only walk
@@ -612,7 +612,7 @@ export class MAM extends BaseModule {
             }
             throw iqError
           }
-          const { complete, rsm } = this.parseMAMResponse(response)
+          const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
           // Drain buffer: E2EE decrypt first, then modification detection, then parse.
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
@@ -645,7 +645,7 @@ export class MAM extends BaseModule {
             this.deps.emitSDK('room:history-messages', {
               roomJid,
               messages: collectedMessages,
-              rsm,
+              page: pageInfo,
               complete,
               direction: 'forward',
               preserveGapMarker,
@@ -659,8 +659,8 @@ export class MAM extends BaseModule {
 
           allMessages.push(...collectedMessages)
           isComplete = complete
-          lastRsm = rsm
-          if (page === 0 && !isForward) fetchLatestTopId = rsm.last
+          lastPage = pageInfo
+          if (page === 0 && !isForward) fetchLatestTopId = pageInfo.last
           if (coverageRecord?.topId && rawEntries.some((e) => e.archiveId === coverageRecord.topId)) {
             sawCoverageTop = true
           }
@@ -672,8 +672,8 @@ export class MAM extends BaseModule {
 
           if (isForward) {
             // Forward pagination: use `last` as the next `after` cursor
-            if (rsm.last) {
-              currentAfter = rsm.last
+            if (pageInfo.last) {
+              currentAfter = pageInfo.last
             } else {
               break
             }
@@ -686,15 +686,15 @@ export class MAM extends BaseModule {
             if (allMessages.length > 0) {
               break
             }
-            if (rsm.first) {
+            if (pageInfo.first) {
               // Known signal-only floor (persisted coverage) — jump below
               // covered territory; see the 1:1 twin in queryArchive.
               if (canJumpToFloor && coverageRecord && sawCoverageTop && !jumpedToFloor) {
-                preJumpCursor = rsm.first
+                preJumpCursor = pageInfo.first
                 currentBefore = coverageRecord.bottomId
                 jumpedToFloor = true
               } else {
-                currentBefore = rsm.first
+                currentBefore = pageInfo.first
               }
               this.deps.emitSDK('console:event', {
                 message: `Page ${page + 1} had no displayable messages, fetching older...`,
@@ -726,7 +726,7 @@ export class MAM extends BaseModule {
         this.deps.emitSDK('room:history-messages', {
           roomJid,
           messages: allMessages,
-          rsm: lastRsm,
+          page: lastPage,
           complete: isComplete,
           direction: 'backward',
           preserveGapMarker,
@@ -753,7 +753,7 @@ export class MAM extends BaseModule {
         })
       }
 
-      return { messages: allMessages, complete: isComplete, rsm: lastRsm }
+      return { messages: allMessages, complete: isComplete, page: lastPage }
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error'
       if (isConnectionError(error)) {
@@ -818,7 +818,7 @@ export class MAM extends BaseModule {
     try {
       logInfo(`MAM search: query="${query}"${withJid ? `, with=${getBareJid(withJid)}` : ''}, max=${max}`)
       const response = await this.deps.sendIQ(iq)
-      const { complete, rsm } = this.parseMAMResponse(response)
+      const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
       const currentJid = this.deps.getCurrentJid()
       const ownBareJid = currentJid ? getBareJid(currentJid) : ''
@@ -839,7 +839,7 @@ export class MAM extends BaseModule {
       this.applyModifications(collectedMessages, modifications, (msg, from) => msg.from === from)
 
       logInfo(`MAM search result: ${collectedMessages.length} msg(s), complete=${complete}`)
-      return { messages: collectedMessages, complete, rsm }
+      return { messages: collectedMessages, complete, page: pageInfo }
     } finally {
       unregister()
     }
@@ -886,7 +886,7 @@ export class MAM extends BaseModule {
     try {
       logInfo(`Room MAM search: query="${query}", room=${roomJid}, max=${max}`)
       const response = await this.deps.sendIQ(iq)
-      const { complete, rsm } = this.parseMAMResponse(response)
+      const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
         const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
@@ -901,7 +901,7 @@ export class MAM extends BaseModule {
       this.applyModifications(collectedMessages, modifications, (msg, from) => msg.from === from)
 
       logInfo(`Room MAM search result: ${collectedMessages.length} msg(s), complete=${complete}`)
-      return { messages: collectedMessages, complete, rsm }
+      return { messages: collectedMessages, complete, page: pageInfo }
     } finally {
       unregister()
     }
@@ -926,13 +926,13 @@ export class MAM extends BaseModule {
     const phraseTokens = parsed.phrases.flatMap((p) => tokenize(p))
     const allTokens = [...new Set([...parsed.terms, ...phraseTokens])]
     if (allTokens.length === 0 && parsed.phrases.length === 0) {
-      return { messages: [], complete: true, rsm: {} }
+      return { messages: [], complete: true, page: {} }
     }
 
     const matches: Message[] = []
     let beforeCursor: string | undefined
     let isComplete = false
-    let lastRsm: RSMResponse = {}
+    let lastPage: PageInfo = {}
 
     logInfo(`MAM paging search: query="${query}", with=${withJid}, maxPages=${maxPages}`)
 
@@ -948,7 +948,7 @@ export class MAM extends BaseModule {
       })
 
       isComplete = result.complete
-      lastRsm = result.rsm
+      lastPage = result.page
 
       // Match messages client-side
       for (const msg of result.messages) {
@@ -958,15 +958,15 @@ export class MAM extends BaseModule {
         }
       }
 
-      if (isComplete || !result.rsm.first) break
-      beforeCursor = result.rsm.first
+      if (isComplete || !result.page.first) break
+      beforeCursor = result.page.first
 
       // Small delay between pages to avoid overwhelming the server
       await new Promise(resolve => setTimeout(resolve, 100))
     }
 
     logInfo(`MAM paging search result: scanned to find ${matches.length} match(es), complete=${isComplete}`)
-    return { messages: matches, complete: isComplete, rsm: lastRsm }
+    return { messages: matches, complete: isComplete, page: lastPage }
   }
 
   /**
@@ -1423,7 +1423,7 @@ export class MAM extends BaseModule {
         after?: string
         start?: string
         maxAutoPages?: number
-      }) => Promise<{ complete: boolean; rsm: { first?: string }; degradedToFetchLatest?: boolean }>
+      }) => Promise<{ complete: boolean; page: { first?: string }; degradedToFetchLatest?: boolean }>
     },
   ): Promise<void> {
     const { sessionStartTime, stitchReadPointer = false } = options
@@ -1453,14 +1453,14 @@ export class MAM extends BaseModule {
       // before:'' fetch-latest — `initial` IS that fetch-latest page. Treat
       // it as the fetch-latest phase directly instead of issuing a second,
       // fully-deduped `before: ''` bail query.
-      windowBottom = initial.rsm.first
+      windowBottom = initial.page.first
       windowBottomComplete = initial.complete
     } else if (isForward && !initial.complete) {
       const latest = await io.query({ max: MAM_CATCHUP_BACKWARD_MAX, before: '' })
-      windowBottom = latest.rsm.first
+      windowBottom = latest.page.first
       windowBottomComplete = latest.complete
     } else if (!isForward) {
-      windowBottom = initial.rsm.first
+      windowBottom = initial.page.first
       windowBottomComplete = initial.complete
     }
     // (forward && complete → contiguous to live over the cache; a pending
@@ -1523,8 +1523,8 @@ export class MAM extends BaseModule {
         max: MAM_CATCHUP_FORWARD_MAX,
       })
       if (res.complete) return // archive start reached — a still-pending pointer is purged
-      if (!res.rsm.first || res.rsm.first === windowBottom) return
-      windowBottom = res.rsm.first
+      if (!res.page.first || res.page.first === windowBottom) return
+      windowBottom = res.page.first
     }
   }
 
@@ -2167,11 +2167,11 @@ export class MAM extends BaseModule {
   /**
    * Parse MAM response to extract completion status and RSM info.
    */
-  private parseMAMResponse(response: Element): { complete: boolean; rsm: RSMResponse } {
+  private parseMAMResponse(response: Element): { complete: boolean; page: PageInfo } {
     const fin = response.getChild('fin', NS_MAM)
     const complete = fin?.attrs.complete === 'true'
-    const rsm = parseRSMResponse(fin?.getChild('set', NS_RSM))
-    return { complete, rsm }
+    const pageInfo = parseRSMResponse(fin?.getChild('set', NS_RSM))
+    return { complete, page: pageInfo }
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -39,8 +39,8 @@ import type {
   RoomRole,
   Hat,
   PresenceShow,
-  RSMRequest,
-  RSMResponse,
+  PageRequest,
+  PageInfo,
   AdminRoom,
   RoomFeatures,
   RoomMessage,
@@ -2186,7 +2186,7 @@ export class MUC extends BaseModule {
    * on the specified MUC service. Supports pagination via RSM.
    *
    * @param mucServiceJid - The MUC service JID (e.g., 'conference.example.com')
-   * @param rsm - Optional pagination parameters
+   * @param page - Optional pagination parameters
    * @returns List of rooms and pagination info
    *
    * @example
@@ -2203,13 +2203,13 @@ export class MUC extends BaseModule {
    * }
    * ```
    */
-  async fetchRoomList(mucServiceJid: string, rsm?: RSMRequest): Promise<{ rooms: AdminRoom[]; pagination?: RSMResponse }> {
+  async fetchRoomList(mucServiceJid: string, page?: PageRequest): Promise<{ rooms: AdminRoom[]; pagination?: PageInfo }> {
     const iq = xml('iq', { type: 'get', to: mucServiceJid, id: `disco_items_${generateUUID()}` },
       xml('query', { xmlns: NS_DISCO_ITEMS },
-        rsm ? xml('set', { xmlns: NS_RSM },
-          rsm.max ? xml('max', {}, String(rsm.max)) : undefined,
-          rsm.after ? xml('after', {}, rsm.after) : undefined,
-          rsm.before ? xml('before', {}, rsm.before) : undefined
+        page ? xml('set', { xmlns: NS_RSM },
+          page.max ? xml('max', {}, String(page.max)) : undefined,
+          page.after ? xml('after', {}, page.after) : undefined,
+          page.before ? xml('before', {}, page.before) : undefined
         ) : undefined
       )
     )
@@ -2228,7 +2228,7 @@ export class MUC extends BaseModule {
     }
 
     const rsmEl = query?.getChild('set', NS_RSM)
-    const pagination: RSMResponse | undefined = rsmEl ? {
+    const pagination: PageInfo | undefined = rsmEl ? {
       first: rsmEl.getChildText('first') || undefined,
       last: rsmEl.getChildText('last') || undefined,
       count: rsmEl.getChildText('count') ? parseInt(rsmEl.getChildText('count')!, 10) : undefined,

--- a/packages/fluux-sdk/src/core/types/admin.ts
+++ b/packages/fluux-sdk/src/core/types/admin.ts
@@ -5,7 +5,7 @@
  * @module Types/Admin
  */
 
-import type { RSMResponse } from './pagination'
+import type { PageInfo } from './pagination'
 
 // ============================================================================
 // Admin Types (XEP-0133 Service Administration)
@@ -243,7 +243,7 @@ export interface EntityListState<T> {
   /** List items */
   items: T[]
   /** Pagination info */
-  pagination: RSMResponse
+  pagination: PageInfo
   /** True while loading */
   isLoading: boolean
   /** Error message if failed */

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -98,8 +98,8 @@ export type { LinkPreview } from './media'
 
 // Pagination types
 export type {
-  RSMRequest,
-  RSMResponse,
+  PageRequest,
+  PageInfo,
   HistoryQueryOptions,
   HistoryResult,
   HistoryQueryState,

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -9,34 +9,44 @@ import type { Message } from './chat'
 import type { RoomMessage } from './room'
 
 /**
- * Pagination request parameters (XEP-0059).
+ * The page to ask a server for.
+ *
+ * A page is addressed by the item it sits next to, not by an offset: pass the
+ * id of the item to read forward from, or the one to read backward from. Ids
+ * come from the {@link PageInfo} of a previous page.
+ *
+ * Carried over XEP-0059 Result Set Management.
  *
  * @category Pagination
  */
-export interface RSMRequest {
+export interface PageRequest {
   /** Maximum items per page (default 50) */
   max?: number
-  /** Item ID for forward pagination (get items after this) */
+  /** Read forward from this item id */
   after?: string
-  /** Item ID for backward pagination (get items before this) */
+  /** Read backward from this item id */
   before?: string
-  /** Start index (some servers support this) */
+  /** Start index, where the server supports offset addressing */
   index?: number
 }
 
 /**
- * Pagination response from server (XEP-0059).
+ * Where the page that came back sits in the whole set.
+ *
+ * Every field is optional because a server reports only what it chooses to:
+ * `count` in particular is an estimate on many servers, and absent on others,
+ * so it must not be treated as a reliable total.
  *
  * @category Pagination
  */
-export interface RSMResponse {
-  /** ID of first item in result set */
+export interface PageInfo {
+  /** Id of the first item, the cursor to read backward from */
   first?: string
-  /** Index of first item */
+  /** Index of the first item, where the server reports one */
   firstIndex?: number
-  /** ID of last item (use with `after` for next page) */
+  /** Id of the last item, the cursor to read forward from */
   last?: string
-  /** Total count of items (if server provides) */
+  /** Total items in the whole set, where the server reports one */
   count?: number
 }
 
@@ -88,7 +98,7 @@ export interface HistoryResult {
   /** True if no more messages before this batch */
   complete: boolean
   /** Pagination info for next query */
-  rsm: RSMResponse
+  page: PageInfo
   /**
    * Set when a purged `after`-anchored cursor (item-not-found) degraded this
    * query to a `before:''` fetch-latest — the result IS that fetch-latest
@@ -138,7 +148,7 @@ export interface RoomHistoryResult {
   /** True if no more messages before this batch */
   complete: boolean
   /** Pagination info for next query */
-  rsm: RSMResponse
+  page: PageInfo
   /**
    * Set when a purged `after`-anchored cursor (item-not-found) degraded this
    * query to a `before:''` fetch-latest — the result IS that fetch-latest
@@ -231,7 +241,7 @@ export interface HistoryQueryState {
    * Also set after initial load with `before=""` since that fetches latest messages.
    */
   isCaughtUpToLive: boolean
-  /** ID of oldest fetched message (rsm.first) - use as 'before' cursor for pagination */
+  /** ID of oldest fetched message (page.first) - use as 'before' cursor for pagination */
   oldestFetchedId?: string
   /**
    * Epoch ms of the newest message from an incomplete forward catch-up.
@@ -285,7 +295,7 @@ export interface CoverageRecord {
   /** Archive id of the OLDEST entry proven contiguous with the live edge. */
   bottomId: string
   /** Archive id of the NEWEST entry seen by the fetch-latest walk that
-   *  established this record (page-1 rsm.last). */
+   *  established this record (page-1 page.last). */
   topId?: string
 }
 
@@ -297,7 +307,7 @@ export interface CoverageRecord {
 export interface MergeArchiveExtras {
   /** The `before` cursor the query was started with ('' = fetch-latest). */
   initialBefore?: string
-  /** rsm.last of the FIRST page of a backward walk (newest covered entry). */
+  /** page.last of the FIRST page of a backward walk (newest covered entry). */
   fetchLatestTopId?: string
   /** The walk contained the existing coverage record's top entry — the only
    *  accepted proof of contiguity with the record (Codex r4 #3). */

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -18,7 +18,7 @@ import type { ServerInfo } from './discovery'
 import type { HttpUploadService } from './upload'
 import type { WebPushService, WebPushStatus } from './webpush'
 import type { AdminCommand, AdminSession, ServerStats } from './admin'
-import type { RSMResponse } from './pagination'
+import type { PageInfo } from './pagination'
 import type { HistoryQueryDirection } from './pagination'
 import type { SystemNotificationType } from './events'
 import type { XMPPErrorType, XMPPStanzaError } from '../../utils/xmppError'
@@ -223,7 +223,7 @@ export interface ChatEvents {
   'chat:history-messages': {
     conversationId: string
     messages: Message[]
-    rsm: RSMResponse
+    page: PageInfo
     complete: boolean
     direction: HistoryQueryDirection
     /** When true, leave the gap marker untouched (bounded windowed context queries). */
@@ -233,7 +233,7 @@ export interface ChatEvents {
     /** The `before` cursor the query started from ('' = fetch-latest) — anchors
      *  the persisted coverage-record extension (mamCoverage.ts). */
     initialBefore?: string
-    /** rsm.last of the FIRST page of a backward walk (newest covered entry) —
+    /** page.last of the FIRST page of a backward walk (newest covered entry) —
      *  the coverage record's `topId`. */
     fetchLatestTopId?: string
     /** The walk contained the existing coverage record's top entry (id-exact
@@ -487,7 +487,7 @@ export interface RoomEvents {
   'room:history-messages': {
     roomJid: string
     messages: RoomMessage[]
-    rsm: RSMResponse
+    page: PageInfo
     complete: boolean
     direction: HistoryQueryDirection
     /** When true, leave the gap marker untouched (bounded force-repair queries). */
@@ -497,7 +497,7 @@ export interface RoomEvents {
     /** The `before` cursor the query started from ('' = fetch-latest) — anchors
      *  the persisted coverage-record extension (mamCoverage.ts). */
     initialBefore?: string
-    /** rsm.last of the FIRST page of a backward walk (newest covered entry) —
+    /** page.last of the FIRST page of a backward walk (newest covered entry) —
      *  the coverage record's `topId`. */
     fetchLatestTopId?: string
     /** The walk contained the existing coverage record's top entry (id-exact

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -31,7 +31,7 @@ import type {
   HistoryQueryDirection,
   CoverageRecord,
   MergeArchiveExtras,
-  RSMResponse,
+  PageInfo,
 } from './pagination'
 import type { GetMessagesOptions } from '../../utils/messageCache'
 
@@ -153,11 +153,11 @@ export interface ChatBindings {
    * Merge MAM messages into conversation and update query state.
    * @param conversationId - Conversation JID
    * @param messages - Messages from MAM query
-   * @param rsm - RSM pagination response
+   * @param page - RSM pagination response
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
+  mergeMAMMessages: (conversationId: string, messages: Message[], page: PageInfo, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
   getMAMQueryState: (conversationId: string) => HistoryQueryState
   resetMAMStates: () => void
 
@@ -430,11 +430,11 @@ export interface RoomBindings {
    * Merge MAM messages into room and update query state.
    * @param roomJid - Room JID
    * @param messages - Messages from MAM query
-   * @param rsm - RSM pagination response
+   * @param page - RSM pagination response
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], page: PageInfo, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
   getRoomMAMQueryState: (roomJid: string) => HistoryQueryState
   resetRoomMAMStates: () => void
 

--- a/packages/fluux-sdk/src/hooks/useAdmin.ts
+++ b/packages/fluux-sdk/src/hooks/useAdmin.ts
@@ -3,7 +3,7 @@ import { adminStore } from '../stores/adminStore'
 import { LastActivityQueue } from '../core/admin/lastActivityQueue'
 import { useAdminStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
-import type { AdminCommand, AdminCommandCategory, AdminCategory, RSMRequest } from '../core/types'
+import type { AdminCommand, AdminCommandCategory, AdminCategory, PageRequest } from '../core/types'
 import { USER_COMMANDS } from './adminCommands'
 
 /**
@@ -321,15 +321,15 @@ export function useAdmin() {
 
   // Fetch user list with pagination
   const fetchUsers = useCallback(
-    async (rsm?: RSMRequest) => {
+    async (page?: PageRequest) => {
       const store = adminStore.getState()
       store.setUserList({ isLoading: true, error: null })
 
       try {
         // Use selected vhost or fall back to default
         const vhost = store.selectedVhost || undefined
-        const result = await client.admin.fetchUserList(vhost, rsm)
-        if (rsm?.after) {
+        const result = await client.admin.fetchUserList(vhost, page)
+        if (page?.after) {
           // Appending to existing list
           store.appendUserList(result.users, result.pagination)
         } else {
@@ -379,13 +379,13 @@ export function useAdmin() {
 
   // Fetch room list with pagination
   const fetchRooms = useCallback(
-    async (rsm?: RSMRequest) => {
+    async (page?: PageRequest) => {
       const store = adminStore.getState()
       store.setRoomList({ isLoading: true, error: null })
 
       try {
-        const result = await client.admin.fetchRoomList(undefined, rsm)
-        if (rsm?.after) {
+        const result = await client.admin.fetchRoomList(undefined, page)
+        if (page?.after) {
           // Appending to existing list
           store.appendRoomList(result.rooms, result.pagination)
         } else {

--- a/packages/fluux-sdk/src/hooks/useRoomManagement.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomManagement.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useXMPPContext } from '../provider'
-import type { RSMRequest, AdminRoom, RSMResponse } from '../core/types'
+import type { PageRequest, AdminRoom, PageInfo } from '../core/types'
 
 /**
  * Focused hook for MUC room lifecycle & settings: create/destroy a room,
@@ -101,8 +101,8 @@ export function useRoomManagement() {
   )
 
   const browsePublicRooms = useCallback(
-    async (mucServiceJid?: string, rsm?: RSMRequest): Promise<{ rooms: AdminRoom[]; pagination: RSMResponse }> => {
-      return client.admin.fetchRoomList(mucServiceJid, rsm)
+    async (mucServiceJid?: string, page?: PageRequest): Promise<{ rooms: AdminRoom[]; pagination: PageInfo }> => {
+      return client.admin.fetchRoomList(mucServiceJid, page)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -341,8 +341,8 @@ export type {
   DataFormFieldOption,
 
   // Admin entity list types (XEP-0059 RSM)
-  RSMRequest,
-  RSMResponse,
+  PageRequest,
+  PageInfo,
   AdminUser,
   AdminRoom,
   EntityListState,

--- a/packages/fluux-sdk/src/stores/adminStore.ts
+++ b/packages/fluux-sdk/src/stores/adminStore.ts
@@ -5,7 +5,7 @@ import type {
   AdminUser,
   AdminRoom,
   EntityListState,
-  RSMResponse,
+  PageInfo,
   AdminCategory,
   ServerStats,
   LastActivityEntry,
@@ -121,10 +121,10 @@ export interface AdminState {
   // Entity list actions
   setActiveCategory: (category: AdminCategory | null) => void
   setUserList: (state: Partial<EntityListState<AdminUser>>) => void
-  appendUserList: (items: AdminUser[], pagination: RSMResponse) => void
+  appendUserList: (items: AdminUser[], pagination: PageInfo) => void
   resetUserList: () => void
   setRoomList: (state: Partial<EntityListState<AdminRoom>>) => void
-  appendRoomList: (items: AdminRoom[], pagination: RSMResponse) => void
+  appendRoomList: (items: AdminRoom[], pagination: PageInfo) => void
   resetRoomList: () => void
   setMucServiceJid: (jid: string | null) => void
   setOnlineJids: (jids: Set<string>) => void

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -517,9 +517,9 @@ describe('chatStore', () => {
     })
 
     it('forward ADVANCE of an existing gap is deferred until the page is durably cached', async () => {
-      // Codex r3 #1: the advance (startId → rsm.last) was persisted
+      // Codex r3 #1: the advance (startId → page.last) was persisted
       // synchronously while the IndexedDB write was still in flight — a crash
-      // in between resumes `after: rsm.last` and skips the page forever.
+      // in between resumes `after: page.last` and skips the page forever.
       chatStore.getState().addConversation(createConversation(cid))
       chatStore.setState({ conversationGaps: new Map([[cid, {
         start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -532,7 +532,7 @@ describe('chatStore', () => {
       )
 
       const m = { ...createMessage(cid, 'fwd'), id: 'fwd', timestamp: new Date('2026-07-07T00:00:00Z') }
-      // Incomplete forward page: gap start moves up and startId advances to rsm.last.
+      // Incomplete forward page: gap start moves up and startId advances to page.last.
       chatStore.getState().mergeMAMMessages(cid, [m], { last: 'new-cursor' }, false, 'forward')
 
       // Advance must NOT be visible while the write is pending.
@@ -563,8 +563,8 @@ describe('chatStore', () => {
       expect(chatStore.getState().conversationGaps.get(cid)?.startId).toBe('old-cursor')
     })
 
-    it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s rsm.last)', async () => {
-      // Codex r4 #1: a formed forward gap carries rsm.last as startId — a
+    it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s page.last)', async () => {
+      // Codex r4 #1: a formed forward gap carries page.last as startId — a
       // cursor INTO this very page. Publishing it before the write commits
       // has exactly the deletion/advance crash window: resume `after: startId`
       // skips the never-stored page. So formation defers as well; on a crash
@@ -764,7 +764,7 @@ describe('chatStore', () => {
 
     it('a signal-only incomplete forward page preserves the persisted gap and advances its coverage cursor', () => {
       // All pages of a forward catch-up were signals (reactions/receipts): the
-      // merge carries zero displayable messages but rsm.last IS set. The gap
+      // merge carries zero displayable messages but page.last IS set. The gap
       // must survive (the page proves nothing about the hole) with startId
       // advanced to the last fetched archive id (coverage progress).
       chatStore.getState().addConversation(createConversation(cid))

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
-import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, RSMResponse } from '../core/types'
+import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, PageInfo } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -471,11 +471,11 @@ interface ChatState {
    * Merge MAM messages into conversation and update query state.
    * @param conversationId - Conversation JID
    * @param messages - Messages from MAM query
-   * @param rsm - RSM pagination response
+   * @param page - RSM pagination response
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
+  mergeMAMMessages: (conversationId: string, messages: Message[], page: PageInfo, complete: boolean, direction: HistoryQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean, extras?: MergeArchiveExtras) => void
   /**
    * Strip a purged archive id from the persisted gap anchor (`startId`),
    * keeping the `start` timestamp so the next catch-up resume uses the
@@ -2784,7 +2784,7 @@ export const chatStore = createStore<ChatState>()(
         }))
       },
 
-      mergeMAMMessages: (conversationId, archivePage, rsm, complete, direction, isFetchLatest = false, preserveGapMarker = false, extras = undefined) => {
+      mergeMAMMessages: (conversationId, archivePage, page, complete, direction, isFetchLatest = false, preserveGapMarker = false, extras = undefined) => {
         bumpChatUnreadInputVersion(conversationId)
 
         // XEP-0424: a retraction recorded earlier can target a message arriving in
@@ -2837,7 +2837,7 @@ export const chatStore = createStore<ChatState>()(
             conversationId,
             complete,
             direction,
-            rsm.first, // Pagination cursor for fetching older messages
+            page.first, // Pagination cursor for fetching older messages
             newestFetchedTimestamp,
             preserveGapMarker,
             isFetchLatest,
@@ -2871,7 +2871,7 @@ export const chatStore = createStore<ChatState>()(
             // flagged below instead (finding 10).
             newestHeldBelowTs: residentNewestTs,
             newestHeldBelowId: newestMessageStanzaId(rawExisting),
-            lastFetchedArchiveId: rsm.last,
+            lastFetchedArchiveId: page.last,
             preserveGapMarker,
           })
 
@@ -2901,7 +2901,7 @@ export const chatStore = createStore<ChatState>()(
           // the page forever: the resume cursor would point past data that
           // was never stored. That covers deletion, forward startId advance,
           // backward end/endId shrink AND formation (a formed forward gap
-          // carries this page's rsm.last as startId). So EVERY gap transition
+          // carries this page's page.last as startId). So EVERY gap transition
           // defers until the durable write reports success when the merge
           // carries persistable messages; with nothing persistable there is
           // no crash window and the transition applies immediately.
@@ -2925,7 +2925,7 @@ export const chatStore = createStore<ChatState>()(
             direction,
             isFetchLatest,
             preserveGapMarker,
-            rsmFirst: rsm.first,
+            rsmFirst: page.first,
             fetchLatestTopId: extras?.fetchLatestTopId,
             initialBefore: extras?.initialBefore,
             sawCoverageTop: extras?.sawCoverageTop ?? false,

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -346,7 +346,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
     roomStore.getState().mergeRoomMAMMessages(
       ROOM,
       [rmsg('m2', 's2', 2), rmsg('m5', 's5', 5)],
-      {}, // RSMResponse — all fields optional, empty is valid
+      {}, // PageInfo — all fields optional, empty is valid
       true,
       'forward'
     )

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2938,9 +2938,9 @@ describe('roomStore', () => {
     })
 
     it('forward ADVANCE of an existing gap is deferred until the page is durably cached', async () => {
-      // Codex r3 #1: the advance (startId → rsm.last) was persisted
+      // Codex r3 #1: the advance (startId → page.last) was persisted
       // synchronously while the IndexedDB write was still in flight — a crash
-      // in between resumes `after: rsm.last` and skips the page forever.
+      // in between resumes `after: page.last` and skips the page forever.
       roomStore.getState().addRoom(createRoom(jid))
       roomStore.setState({ roomGaps: new Map([[jid, {
         start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -2956,7 +2956,7 @@ describe('roomStore', () => {
         type: 'groupchat', id: 'fwd', roomJid: jid, from: `${jid}/a`, nick: 'a',
         body: 'fwd', timestamp: new Date('2026-07-07T00:00:00Z'), isOutgoing: false,
       }
-      // Incomplete forward page: gap start moves up and startId advances to rsm.last.
+      // Incomplete forward page: gap start moves up and startId advances to page.last.
       roomStore.getState().mergeRoomMAMMessages(jid, [m], { last: 'new-cursor' }, false, 'forward')
 
       // Advance must NOT be visible while the write is pending.
@@ -2990,8 +2990,8 @@ describe('roomStore', () => {
       expect(roomStore.getState().roomGaps.get(jid)?.startId).toBe('old-cursor')
     })
 
-    it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s rsm.last)', async () => {
-      // Codex r4 #1: a formed forward gap carries rsm.last as startId — a
+    it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s page.last)', async () => {
+      // Codex r4 #1: a formed forward gap carries page.last as startId — a
       // cursor INTO this very page. Publishing it before the write commits
       // has exactly the deletion/advance crash window.
       roomStore.getState().addRoom(createRoom(jid))
@@ -3248,7 +3248,7 @@ describe('roomStore', () => {
 
     it('a signal-only incomplete forward page preserves the persisted gap and advances its coverage cursor', () => {
       // All-signal page (reactions/receipts only): zero displayable messages
-      // but rsm.last IS set. The gap must survive (the page proves nothing
+      // but page.last IS set. The gap must survive (the page proves nothing
       // about the hole) with startId advanced to the last fetched archive id.
       roomStore.getState().addRoom(createRoom(jid))
       const start = new Date('2026-07-06T00:00:00Z').getTime()

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -10,7 +10,7 @@ import type {
   RoomMember,
   RoomMessage,
   HistoryQueryState,
-  RSMResponse,
+  PageInfo,
 } from '../core/types'
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
@@ -1029,11 +1029,11 @@ export interface RoomState {
    * Merge MAM messages into room and update query state.
    * @param roomJid - Room JID
    * @param messages - Messages from MAM query
-   * @param rsm - RSM pagination response
+   * @param page - RSM pagination response
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], page: PageInfo, complete: boolean, direction: HistoryQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean, extras?: MergeArchiveExtras) => void
   /**
    * Strip a purged archive id from the persisted gap anchor (`startId`),
    * keeping the `start` timestamp so the next catch-up resume uses the
@@ -3768,7 +3768,7 @@ export const roomStore = createStore<RoomState>()(
     }))
   },
 
-  mergeRoomMAMMessages: (roomJid, archivePage, rsm, complete, direction, preserveGapMarker = false, isFetchLatest = false, extras = undefined) => {
+  mergeRoomMAMMessages: (roomJid, archivePage, page, complete, direction, preserveGapMarker = false, isFetchLatest = false, extras = undefined) => {
     bumpRoomUnreadInputVersion(roomJid)
 
     // XEP-0424: a retraction recorded earlier can target a message arriving in
@@ -3829,7 +3829,7 @@ export const roomStore = createStore<RoomState>()(
         roomJid,
         complete,
         direction,
-        rsm.first, // Pagination cursor for fetching older messages
+        page.first, // Pagination cursor for fetching older messages
         newestFetchedTimestamp,
         preserveGapMarker,
         isFetchLatest,
@@ -3865,7 +3865,7 @@ export const roomStore = createStore<RoomState>()(
         // flagged below instead (finding 10).
         newestHeldBelowTs: residentNewestTs,
         newestHeldBelowId: newestMessageStanzaId(existingMessages),
-        lastFetchedArchiveId: rsm.last,
+        lastFetchedArchiveId: page.last,
         preserveGapMarker,
       })
 
@@ -3893,7 +3893,7 @@ export const roomStore = createStore<RoomState>()(
       // crash — or a silently failed write — skip the page forever: the
       // resume cursor would point past data that was never stored. That
       // covers deletion, forward startId advance, backward end/endId shrink
-      // AND formation (a formed forward gap carries this page's rsm.last as
+      // AND formation (a formed forward gap carries this page's page.last as
       // startId). So EVERY gap transition defers until the durable write
       // reports success when the merge carries persistable messages; with
       // nothing persistable there is no crash window and the transition
@@ -3918,7 +3918,7 @@ export const roomStore = createStore<RoomState>()(
         direction,
         isFetchLatest,
         preserveGapMarker,
-        rsmFirst: rsm.first,
+        rsmFirst: page.first,
         fetchLatestTopId: extras?.fetchLatestTopId,
         initialBefore: extras?.initialBefore,
         sawCoverageTop: extras?.sawCoverageTop ?? false,

--- a/packages/fluux-sdk/src/stores/searchStore.test.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.test.ts
@@ -1002,17 +1002,17 @@ function createMockMAMClient(opts?: {
             isDelayed: true,
           })),
           complete: true,
-          rsm: {},
+          page: {},
         }),
         searchRoomMessages: vi.fn().mockResolvedValue({
           messages: [],
           complete: true,
-          rsm: {},
+          page: {},
         }),
         searchConversationHistory: vi.fn().mockResolvedValue({
           messages: [],
           complete: true,
-          rsm: {},
+          page: {},
         }),
     },
   }

--- a/packages/fluux-sdk/src/stores/searchStore.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.ts
@@ -432,7 +432,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
           })
           newResults = result.messages.map(m => roomMessageToSearchResult(m, scope, query, phrases))
           hasMore = !result.complete
-          mamRsmCursor = result.rsm.first
+          mamRsmCursor = result.page.first
         } else {
           const result = await clientRef.messages.searchMessages({
             query,
@@ -442,7 +442,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
           })
           newResults = result.messages.map(m => messageToSearchResult(m, query, phrases))
           hasMore = !result.complete
-          mamRsmCursor = result.rsm.first
+          mamRsmCursor = result.page.first
         }
       } else if (!isRoom) {
         // Paging search (1:1 conversations only, no fulltext required)
@@ -479,7 +479,7 @@ async function executeMAMSearch(append: boolean): Promise<void> {
       })
       newResults = result.messages.map(m => messageToSearchResult(m, query, phrases))
       hasMore = !result.complete
-      mamRsmCursor = result.rsm.first
+      mamRsmCursor = result.page.first
     }
 
     // Check generation — discard if query changed

--- a/packages/fluux-sdk/src/stores/shared/durableMapPersist.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/durableMapPersist.test.ts
@@ -374,7 +374,7 @@ describe('durableMapPersist — the gap boundary is structural, the end is not',
   })
 
   /** `startId` alone can move while `start` stands still — an incomplete forward
-   *  page whose `rsm.last` advances the id-exact cursor. Same class, same rule. */
+   *  page whose `page.last` advances the id-exact cursor. Same class, same rule. */
   it('force-flushes a startId-only advance', () => {
     write({ gaps: gaps({ a: { start: 1000, startId: 'arc-1' } }) }, 'baseline')
     write({ gaps: gaps({ a: { start: 1000, end: 900, startId: 'arc-1' } }) }, 'opener')

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -32,7 +32,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     expect(out.coverage.get('a@b')).toEqual({ bottomId: 'deep', topId: 'top' })
   })
 
-  it('signal-only give-up (zero messages, rsm.first set) still establishes the record', () => {
+  it('signal-only give-up (zero messages, page.first set) still establishes the record', () => {
     // Codex r3 #4: the walked window IS proven contiguous coverage even with
     // zero displayable messages — this is the durable resume for the cap.
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'page5-first', fetchLatestTopId: 'page1-last' }))
@@ -162,7 +162,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     })
   })
 
-  it('empty fetch-latest with no rsm.first (empty archive) is a no-op', () => {
+  it('empty fetch-latest with no page.first (empty archive) is a no-op', () => {
     const coverage = new Map<string, CoverageRecord>()
     expect(syncCoverageAfterArchiveMerge(base({ coverage })).coverage).toBe(coverage)
   })

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -82,7 +82,7 @@ export interface ArchiveMergeCoverageInput {
   initialAfter?: string
   /** Bounded windowed query — proves nothing about live contiguity. */
   preserveGapMarker: boolean
-  /** rsm.first of the merge's LAST page (deepest entry seen, signals included). */
+  /** page.first of the merge's LAST page (deepest entry seen, signals included). */
   rsmFirst?: string
   fetchLatestTopId?: string
   initialBefore?: string

--- a/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
@@ -232,14 +232,14 @@ describe('syncGapAfterArchiveMerge', () => {
     expect(out.get(id)).toEqual({ start: ts('2026-07-10T00:00:00Z'), end, startId: 's2', endId: 'e1' })
   })
 
-  it('forward resync: preserves startId when the merge has no lastFetchedArchiveId (rsm.last)', () => {
+  it('forward resync: preserves startId when the merge has no lastFetchedArchiveId (page.last)', () => {
     const start = ts('2026-07-01T00:00:00Z')
     const end = ts('2026-07-14T00:00:00Z')
     const gaps = new Map([[id, { start, end, startId: 's1', endId: 'e1' }]])
     const merged = [msg('2026-07-14T00:00:00Z')]
     const out = syncGapAfterArchiveMerge(base({
       direction: 'forward', gaps, forwardGapTimestamp: start, merged,
-      // No lastFetchedArchiveId — an incomplete forward merge without rsm.last.
+      // No lastFetchedArchiveId — an incomplete forward merge without page.last.
     }))
     expect(out.get(id)).toEqual({ start, end, startId: 's1', endId: 'e1' })
   })

--- a/packages/fluux-sdk/src/stores/shared/mamGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.ts
@@ -279,7 +279,7 @@ export interface ArchiveMergeGapInput {
    *  `newestHeldBelowTs`) — stamped as a formed backward seam's `startId`. */
   newestHeldBelowId?: string
   /** Archive id of the last fetched message for an incomplete forward
-   *  catch-up (the merge's `rsm.last`) — stamped as the forward gap's `startId`. */
+   *  catch-up (the merge's `page.last`) — stamped as the forward gap's `startId`. */
   lastFetchedArchiveId?: string
   /** Bounded force-repair: leave the marker untouched (neither set nor cleared). */
   preserveGapMarker: boolean
@@ -316,12 +316,12 @@ export function syncGapAfterArchiveMerge(input: ArchiveMergeGapInput): Map<strin
     // (forwardGapTimestamp) normally carries the gap through this mirror, but
     // on a fresh session mamQueryStates are empty while the gap map is
     // persisted: preserve the recorded interval verbatim and only advance the
-    // id-exact coverage cursor (rsm.last IS set for signal-only pages).
+    // id-exact coverage cursor (page.last IS set for signal-only pages).
     if (existing && !complete && fetched.length === 0 && forwardGapTimestamp === undefined) {
       return syncGap(gaps, id, existing.start, existing.end, lastFetchedArchiveId ?? existing.startId, existing.endId)
     }
     const gapEnd = forwardGapTimestamp !== undefined ? computeGapEnd(merged, forwardGapTimestamp) : undefined
-    // startId: prefer this merge's rsm.last; an incomplete forward merge
+    // startId: prefer this merge's page.last; an incomplete forward merge
     // without one (no new page fetched) carries the existing cursor forward.
     const startId = lastFetchedArchiveId ?? existing?.startId
     // endId: only survives when the end edge hasn't moved — once `end`

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -204,7 +204,7 @@ export function setMAMQueryCompleted(
   // marker — such a page proves nothing about the hole, and clearing the
   // marker here would let the persisted-gap mirror (syncGapAfterArchiveMerge)
   // delete the recorded GapInterval: a permanent silent hole. Coverage still
-  // advances id-exactly via the gap's startId (rsm.last IS set for
+  // advances id-exactly via the gap's startId (page.last IS set for
   // signal-only pages; see mamGap.ts).
   const forwardGapTimestamp = preserveGapMarker
     ? current.forwardGapTimestamp

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1375,7 +1375,7 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
 }
 
 /**
- * Resolve an archive id — a MAM `rsm.first`/`rsm.last` value, which is what a
+ * Resolve an archive id — a MAM `page.first`/`page.last` value, which is what a
  * {@link CoverageRecord}'s `bottomId` names — to its position in archive
  * order. `parseArchiveMessage`/`parseRoomArchiveMessage` (`MAM.ts`) store this
  * id as the row's `stanzaId` (`stanzaId = parsed.stanzaId || archiveId`), so

--- a/packages/fluux-sdk/src/utils/rsm.ts
+++ b/packages/fluux-sdk/src/utils/rsm.ts
@@ -1,14 +1,14 @@
 import { xml, Element } from '@xmpp/client'
-import type { RSMRequest, RSMResponse } from '../core/types'
+import type { PageRequest, PageInfo } from '../core/types'
 import { NS_RSM } from '../core/namespaces'
 
 /**
  * Parse RSM response from XML element (XEP-0059).
  */
-export function parseRSMResponse(setElement: Element | undefined): RSMResponse {
+export function parseRSMResponse(setElement: Element | undefined): PageInfo {
   if (!setElement) return {}
 
-  const response: RSMResponse = {}
+  const response: PageInfo = {}
 
   const firstEl = setElement.getChild('first')
   if (firstEl) {
@@ -38,23 +38,23 @@ export function parseRSMResponse(setElement: Element | undefined): RSMResponse {
 /**
  * Build RSM request XML element (XEP-0059).
  */
-export function buildRSMElement(rsm: RSMRequest): Element {
+export function buildRSMElement(page: PageRequest): Element {
   const children: Element[] = []
 
-  if (rsm.max !== undefined) {
-    children.push(xml('max', {}, String(rsm.max)))
+  if (page.max !== undefined) {
+    children.push(xml('max', {}, String(page.max)))
   }
 
-  if (rsm.after !== undefined) {
-    children.push(xml('after', {}, rsm.after))
+  if (page.after !== undefined) {
+    children.push(xml('after', {}, page.after))
   }
 
-  if (rsm.before !== undefined) {
-    children.push(xml('before', {}, rsm.before))
+  if (page.before !== undefined) {
+    children.push(xml('before', {}, page.before))
   }
 
-  if (rsm.index !== undefined) {
-    children.push(xml('index', {}, String(rsm.index)))
+  if (page.index !== undefined) {
+    children.push(xml('index', {}, String(page.index)))
   }
 
   return xml('set', { xmlns: NS_RSM }, ...children)

--- a/packages/fluux-sdk/src/xmpp/index.ts
+++ b/packages/fluux-sdk/src/xmpp/index.ts
@@ -40,8 +40,8 @@ export type { PEPItem } from '../core/e2ee'
 // admin forms without ever touching the wire.
 export { parseDataForm, getFormFieldValue, getFormFieldValues, buildDataFormSubmit } from '../utils/dataForm'
 
-// XEP-0059: Result Set Management — pagination on the wire. The `RSMRequest`
-// and `RSMResponse` shapes stay on the main entry for the same reason.
+// XEP-0059: Result Set Management — pagination on the wire. The `PageRequest`
+// and `PageInfo` shapes stay on the main entry for the same reason.
 export { parseRSMResponse, buildRSMElement } from '../utils/rsm'
 
 // XEP-0066: Out of Band Data. A URL and a description, as the extension puts


### PR DESCRIPTION
Reading a page of history meant knowing what RSM stands for: the result carried an `rsm` field typed `RSMResponse`, and asking for the next page meant building an `RSMRequest`.

`RSMRequest` becomes `PageRequest`, `RSMResponse` becomes `PageInfo`, and the field they travel in becomes `page` — on `HistoryResult`, `RoomHistoryResult`, the `chat:history-messages` and `room:history-messages` payloads, and the archive bindings. The admin list already named its own field `pagination`, which is what made the type the last holdout.

The wire keeps the protocol word: `parseRSMResponse` and `buildRSMElement` take and return elements, so they stay named for the extension they implement and stay on `@fluux/sdk/xmpp`. They now speak in pages. `barrelSurface.test.ts` pins both halves of that boundary.

The docs on the two shapes now state what a caller has to know rather than restating the field names: a page is addressed by a neighbouring item id rather than an offset, and `count` is an estimate on many servers and absent on others.

Nothing persisted changes — the cache stores coverage as `bottomId`/`topId` and never held this field.