### PR TITLE
fix(sdk): retry keepalive after scheduler suspension

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1139,7 +1139,8 @@ export class XMPPClient {
   }
 
   /**
-   * Verify the connection is alive by sending an XMPP ping (XEP-0199).
+   * Verify the connection is alive with a Stream Management acknowledgment,
+   * falling back to an XMPP ping (XEP-0199) when SM is unavailable.
    *
    * @returns Promise that resolves to true if the server responds, false otherwise
    *
@@ -1158,11 +1159,14 @@ export class XMPPClient {
   /**
    * Lightweight connection health check for routine keepalive.
    *
-   * Unlike {@link verifyConnection}, this does NOT change connection status
-   * or trigger presence events. Suitable for periodic health checks where
-   * the connection is expected to be healthy.
+   * Unlike {@link verifyConnection}, this does not enter the transient
+   * `verifying` status or trigger presence events. Concurrent calls share one
+   * probe. If JavaScript scheduling delays the probe timeout, the SDK requires
+   * a fresh Stream Management acknowledgment or ping result before deciding
+   * that the connection is dead. Confirmed failures trigger reconnection.
    *
-   * @returns Promise that resolves to true if healthy, false if dead
+   * @returns Promise that resolves to true if healthy, false if unavailable
+   *   or confirmed dead
    */
   async verifyConnectionHealth(): Promise<boolean> {
     return this.connection.verifyConnectionHealth()
@@ -1174,7 +1178,8 @@ export class XMPPClient {
    * The SDK routes the tick internally based on connection state and the
    * display-power signal: nudges a stalled reconnect loop, runs a health
    * check when connected, or no-ops. When `displayActive` is `false` the
-   * tick does no network work and only informs the state machine.
+   * tick does no network work and only informs the state machine. Connected
+   * ticks that overlap share the current health probe.
    *
    * @param displayActive Primary-display power state (undefined = legacy
    *   payload, treated as active / fail-open).

--- a/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
@@ -228,9 +228,15 @@ describe('Connection race conditions', () => {
     it('should not trigger double reconnect from concurrent wake events', async () => {
       await connectAndGoOnline(xmppClient, mockXmppClientInstance)
 
-      // Make verify fail: IQ ping hangs (simulates dead socket after sleep)
+      // Make verify fail: IQ ping times out (simulates dead socket after sleep)
       mockXmppClientInstance.iqCaller.request.mockImplementation(
-        () => new Promise(() => {}) // Never resolves — simulates dead socket
+        (_stanza: unknown, timeoutMs: number) => new Promise((_, reject) => {
+          setTimeout(() => {
+            const error = new Error('IQ request timed out')
+            error.name = 'TimeoutError'
+            reject(error)
+          }, timeoutMs)
+        })
       )
 
       // Both WAKEs fire almost simultaneously (as happens with Tauri + heartbeat)

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -9,6 +9,7 @@ import { FastTokenLogoutError } from '../errors'
 import {
   DIRECT_WEBSOCKET_PRECHECK_TIMEOUT_MS,
   RECONNECT_ATTEMPT_TIMEOUT_MS,
+  VERIFY_CONNECTION_TIMEOUT_MS,
   XMPP_STREAM_OPEN_TIMEOUT_MS,
 } from './connectionTimeouts'
 import { SM_SESSION_TIMEOUT_MS } from '../connectionMachine'
@@ -4209,6 +4210,31 @@ describe('XMPPClient Connection', () => {
       expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
     })
 
+    it('restarts the SM probe when suspension delays the keepalive timeout', async () => {
+      mockXmppClientInstance.send.mockClear()
+      mockXmppClientInstance.send.mockResolvedValue(undefined)
+      vi.setSystemTime(new Date(0))
+
+      const healthPromise = xmppClient.verifyConnectionHealth()
+
+      expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
+
+      // Advancing wall time without advancing timers models a suspended JS
+      // runtime: the callback runs long after the timeout's deadline.
+      vi.setSystemTime(new Date(16_000))
+      await vi.advanceTimersByTimeAsync(VERIFY_CONNECTION_TIMEOUT_MS)
+
+      expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
+      expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
+
+      mockXmppClientInstance._emit(
+        'nonza',
+        createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
+      )
+
+      await expect(healthPromise).resolves.toBe(true)
+    })
+
     // #515: with SM disabled, the keepalive probe falls back to an IQ ping to
     // the account domain. A misconfigured server (Openfire answering bare-domain
     // IQs with <remote-server-not-found/>) rejects that ping with an IQ ERROR on
@@ -4226,6 +4252,64 @@ describe('XMPPClient Connection', () => {
       const healthy = await xmppClient.verifyConnectionHealth()
 
       expect(healthy).toBe(true)
+      expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
+    })
+
+    it('retires each delayed ping before starting its replacement', async () => {
+      mockXmppClientInstance.streamManagement = { id: null, enabled: false, inbound: 0, outbound: 0, on: vi.fn() }
+      mockXmppClientInstance.iqCaller.request.mockReset()
+      let requestCount = 0
+      let activeRequests = 0
+      let maxActiveRequests = 0
+      mockXmppClientInstance.iqCaller.request.mockImplementation((...args: unknown[]) => {
+        const requestTimeoutMs = args[1] as number
+        requestCount += 1
+        activeRequests += 1
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
+
+        if (requestCount > 2) {
+          activeRequests -= 1
+          return Promise.resolve(undefined)
+        }
+
+        return new Promise((_, reject) => {
+          setTimeout(() => {
+            activeRequests -= 1
+            const error = new Error('IQ request timed out')
+            error.name = 'TimeoutError'
+            reject(error)
+          }, requestTimeoutMs)
+        })
+      })
+      vi.setSystemTime(new Date(0))
+
+      const healthPromise = xmppClient.verifyConnectionHealth()
+
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(1)
+
+      vi.setSystemTime(new Date(Date.now() + 16_000))
+      await vi.advanceTimersByTimeAsync(VERIFY_CONNECTION_TIMEOUT_MS)
+
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(2)
+      expect(activeRequests).toBe(1)
+
+      vi.setSystemTime(new Date(Date.now() + 16_000))
+      await vi.advanceTimersByTimeAsync(VERIFY_CONNECTION_TIMEOUT_MS)
+
+      await expect(healthPromise).resolves.toBe(true)
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenCalledTimes(3)
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        VERIFY_CONNECTION_TIMEOUT_MS
+      )
+      expect(mockXmppClientInstance.iqCaller.request).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        VERIFY_CONNECTION_TIMEOUT_MS
+      )
+      expect(maxActiveRequests).toBe(1)
+      expect(activeRequests).toBe(0)
       expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
     })
 
@@ -4303,7 +4387,7 @@ describe('XMPPClient Connection', () => {
         expect(mockClientFactory.mock.calls.length).toBe(clientsBefore + 1)
       })
 
-      it('is safe to tick repeatedly (no dedup)', async () => {
+      it('coalesces repeated ticks while a health check is in flight', async () => {
         mockXmppClientInstance.send.mockImplementation(() => {
           setTimeout(() => {
             const ackNonza = createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
@@ -4311,14 +4395,18 @@ describe('XMPPClient Connection', () => {
           }, 50)
           return Promise.resolve()
         })
+        mockXmppClientInstance.send.mockClear()
 
         xmppClient.handleKeepaliveTick()
         xmppClient.handleKeepaliveTick()
         xmppClient.handleKeepaliveTick()
 
         await vi.advanceTimersByTimeAsync(100)
-        // Each tick triggers a health check — at least 3 SM <r/> requests sent
-        expect(mockXmppClientInstance.send.mock.calls.length).toBeGreaterThanOrEqual(3)
+        expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(1)
+
+        xmppClient.handleKeepaliveTick()
+        await vi.advanceTimersByTimeAsync(100)
+        expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
       })
 
       it('swallows health check rejections', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -77,6 +77,8 @@ const logError = (...args: unknown[]) => {
   }
 }
 
+type ConnectionProbeLabel = 'verify' | 'keepalive'
+
 // Stream/SASL auth failures are terminal and should not be retried.
 // Keep this list explicit to avoid classifying generic stanza `type="auth"`
 // errors (e.g. PEP/pubsub permissions) as account authentication failures.
@@ -185,6 +187,10 @@ export class Connection extends BaseModule {
   // into a single in-flight promise prevents the render storm that causes the
   // webview to hang after wake.
   private handleAwakeInFlight: Promise<void> | null = null
+
+  // Native ticks can bunch up when the webview resumes. Keep one routine
+  // health probe active so delayed timers cannot accumulate listeners and IQs.
+  private healthCheckInFlight: Promise<boolean> | null = null
 
   // Timestamp of last wake-from-sleep event. Used by attemptReconnect to add a
   // short settle delay — navigator.onLine goes true before the network path is
@@ -996,14 +1002,25 @@ export class Connection extends BaseModule {
    * to `connected.verifying`. It silently sends an SM `<r/>` request and waits
    * for an `<a/>` acknowledgment. If the check passes, nothing happens (no
    * status change, no logging). If it fails, {@link handleDeadSocket} triggers
-   * reconnection.
+   * reconnection. Concurrent checks share one probe. When scheduler suspension
+   * delays a timeout, the probe restarts with a fresh deadline before deciding
+   * that the socket is dead.
    *
    * Use this for periodic health checks (e.g., Rust-driven keepalive) where the
    * connection is expected to be healthy.
    */
-  async verifyConnectionHealth(timeoutMs = VERIFY_CONNECTION_TIMEOUT_MS): Promise<boolean> {
-    if (!this.xmpp || !this.isInConnectedState()) return false
+  verifyConnectionHealth(timeoutMs = VERIFY_CONNECTION_TIMEOUT_MS): Promise<boolean> {
+    if (!this.xmpp || !this.isInConnectedState()) return Promise.resolve(false)
+    if (this.healthCheckInFlight) return this.healthCheckInFlight
 
+    const healthCheck = this.runConnectionHealthCheck(timeoutMs).finally(() => {
+      if (this.healthCheckInFlight === healthCheck) this.healthCheckInFlight = null
+    })
+    this.healthCheckInFlight = healthCheck
+    return healthCheck
+  }
+
+  private async runConnectionHealthCheck(timeoutMs: number): Promise<boolean> {
     const result = await this.probeConnection(timeoutMs, 'keepalive')
 
     if (result === 'healthy') return true
@@ -1075,7 +1092,7 @@ export class Connection extends BaseModule {
    */
   private async probeConnection(
     timeoutMs: number,
-    label: string
+    label: ConnectionProbeLabel
   ): Promise<'healthy' | 'dead' | 'stale'> {
     const clientAtStart = this.xmpp
     if (!clientAtStart) return 'dead'
@@ -1088,12 +1105,19 @@ export class Connection extends BaseModule {
     try {
       const sm = clientAtStart.streamManagement
       if (sm?.enabled) {
-        const ackReceived = await this.waitForSmAck(timeoutMs)
-        if (this.xmpp && this.xmpp !== clientAtStart) {
-          logInfo(`${label}: client replaced during await, ignoring stale result`)
-          return 'stale'
-        }
-        if (!ackReceived) {
+        while (true) {
+          const ackResult = await this.waitForSmAck(timeoutMs)
+          if (this.xmpp && this.xmpp !== clientAtStart) {
+            logInfo(`${label}: client replaced during await, ignoring stale result`)
+            return 'stale'
+          }
+          if (ackResult.status === 'acknowledged') break
+          if (
+            ackResult.status === 'timeout' &&
+            this.shouldRetryDelayedKeepalive(label, ackResult.elapsedMs, timeoutMs)
+          ) {
+            continue
+          }
           logWarn(`${label} probe failed (sm-ack): no <a/> within ${timeoutMs}ms`)
           return 'dead'
         }
@@ -1106,17 +1130,27 @@ export class Connection extends BaseModule {
         probeMode = 'ping'
         const iqCaller = clientAtStart.iqCaller
         if (iqCaller) {
-          const ping = xml(
-            'iq',
-            { type: 'get', id: `${label}_${Date.now()}` },
-            xml('ping', { xmlns: NS_PING })
-          )
-          await Promise.race([
-            iqCaller.request(ping),
-            new Promise((_, reject) =>
-              setTimeout(() => reject(new Error('Ping timeout')), timeoutMs)
-            ),
-          ])
+          while (true) {
+            const ping = xml(
+              'iq',
+              { type: 'get', id: `${label}_${Date.now()}` },
+              xml('ping', { xmlns: NS_PING })
+            )
+            const startedAt = Date.now()
+            try {
+              await iqCaller.request(ping, timeoutMs)
+              break
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                error.name === 'TimeoutError' &&
+                this.shouldRetryDelayedKeepalive(label, Date.now() - startedAt, timeoutMs)
+              ) {
+                continue
+              }
+              throw error
+            }
+          }
         } else {
           // No iqCaller available — fire-and-forget ping
           const ping = xml(
@@ -1152,7 +1186,11 @@ export class Connection extends BaseModule {
    * Wait for a Stream Management acknowledgment (<a/>) with timeout.
    * @internal
    */
-  private waitForSmAck(timeoutMs: number): Promise<boolean> {
+  private waitForSmAck(timeoutMs: number): Promise<
+    | { status: 'acknowledged' }
+    | { status: 'failed' }
+    | { status: 'timeout'; elapsedMs: number }
+  > {
     return new Promise((resolve) => {
       // Capture the client reference at call time. If the client is swapped
       // (reconnect), we must not act on the stale timeout — forceDestroyClient
@@ -1160,11 +1198,12 @@ export class Connection extends BaseModule {
       // only exit path for orphaned waits.
       const client = this.xmpp
       if (!client) {
-        resolve(false)
+        resolve({ status: 'failed' })
         return
       }
 
       let resolved = false
+      const startedAt = Date.now()
 
       // Cleanup helper
       const cleanup = (timeoutId: ReturnType<typeof setTimeout>) => {
@@ -1178,7 +1217,7 @@ export class Connection extends BaseModule {
         if (nonza.is('a', 'urn:xmpp:sm:3') && !resolved) {
           resolved = true
           cleanup(timeoutId)
-          resolve(true)
+          resolve({ status: 'acknowledged' })
         }
       }
 
@@ -1187,7 +1226,7 @@ export class Connection extends BaseModule {
         if (!resolved) {
           resolved = true
           cleanup(timeoutId)
-          resolve(false)
+          resolve({ status: 'failed' })
         }
       }
 
@@ -1200,7 +1239,7 @@ export class Connection extends BaseModule {
           resolved = true
           client?.off?.('nonza', handleNonza)
           client?.off?.('disconnect', handleDisconnect)
-          resolve(false)
+          resolve({ status: 'timeout', elapsedMs: Date.now() - startedAt })
         }
       }, timeoutMs)
 
@@ -1209,10 +1248,22 @@ export class Connection extends BaseModule {
         if (!resolved) {
           resolved = true
           cleanup(timeoutId)
-          resolve(false)
+          resolve({ status: 'failed' })
         }
       })
     })
+  }
+
+  private shouldRetryDelayedKeepalive(
+    label: ConnectionProbeLabel,
+    elapsedMs: number,
+    timeoutMs: number
+  ): boolean {
+    if (label !== 'keepalive' || !didTimerSleepThrough(elapsedMs, timeoutMs)) return false
+    logWarn(
+      `${label} probe timer delayed (${elapsedMs}ms for ${timeoutMs}ms timeout); retrying before reconnect`
+    )
+    return true
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/connectionUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionUtils.ts
@@ -88,8 +88,8 @@ export function computePostWakeSettleMs(
 }
 
 /**
- * Decide whether a connection-attempt timer firing `elapsedMs` after it was
- * scheduled should be treated as evidence that the system slept through it.
+ * Decide whether a timer firing `elapsedMs` after it was scheduled should be
+ * treated as evidence that the system slept through it.
  *
  * `setTimeout` freezes while macOS sleeps; when the app wakes, the timer
  * fires immediately regardless of how long the sleep lasted. An elapsed


### PR DESCRIPTION
Routine keepalive checks now treat timers that fire late after scheduler suspension as stale evidence and require a fresh Stream Management acknowledgement or ping before reconnecting. Concurrent ticks share one in-flight probe, and ping retries use xmpp.js request timeouts so each previous IQ handler is retired before its replacement starts.

This avoids false reconnects after App Nap or heavy load while retaining prompt recovery for genuine disconnects and on-time failures. Regression coverage exercises delayed SM and ping paths, bounded IQ ownership, and tick coalescing. The full monorepo tests, typecheck, and lint passed before the gate; the no-mistakes gate then reviewed the final behavior, fixed IQ ownership, reran focused tests, and passed documentation and lint checks.
