### PR TITLE
refactor(scroll): name the drift question the four loops all ask

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -2495,6 +2495,27 @@ describe('positioning controller anchor-preservation ownership', () => {
     expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
   })
 
+  it('counts a frame exactly on the drift bound as still, and one past it as movement', () => {
+    // ANCHOR_PRESERVATION_DRIFT_PX is 8, and the window is inclusive: a row settling by exactly 8px
+    // per frame has stopped moving for positioning purposes. Nothing else pins that boundary, so a
+    // stricter comparison would pass every other test here while never letting a slow settle finish.
+    const stepBy = (px: number) => {
+      let scrollTop = 0
+      const harness = anchorHarness(() => ({
+        kind: 'positioned',
+        scrollTop: (scrollTop += px),
+        reassert: true,
+      }))
+      const controller = new PositioningController()
+      beginMedia(controller, harness)
+      for (let i = 0; i < 8 + 1; i++) harness.runFrame()
+      return harness
+    }
+
+    expect(stepBy(8).complete).toHaveBeenCalledWith(expect.anything(), 'settled')
+    expect(stepBy(9).complete).not.toHaveBeenCalled()
+  })
+
   it('ends best-effort when the anchor stops being reachable', () => {
     let available = true
     const harness = anchorHarness(() =>

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -379,6 +379,22 @@ interface DirectionalHistoryExecutionState {
   applied: boolean
 }
 
+/**
+ * Whether a frame landed close enough to the previous one to count as still. A run's first frame has
+ * no previous landing and is never still, which is what the null check says: without it, a fresh
+ * execution would count its opening write as one stable frame it never measured.
+ *
+ * Each executor decides for itself what to do with the answer — how many still frames settle it,
+ * whether the settling frame is recorded — so only the question is shared, not the accounting.
+ */
+function heldWithinDrift(
+  landedTarget: number | null,
+  scrollTop: number,
+  driftPx: number,
+): boolean {
+  return landedTarget !== null && Math.abs(scrollTop - landedTarget) <= driftPx
+}
+
 const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
@@ -1839,11 +1855,7 @@ export class PositioningController {
       return
     }
     let wrote = false
-    if (
-      execution.landedTarget !== null &&
-      Math.abs(result.scrollTop - execution.landedTarget) <=
-        ANCHOR_PRESERVATION_DRIFT_PX
-    ) {
+    if (heldWithinDrift(execution.landedTarget, result.scrollTop, ANCHOR_PRESERVATION_DRIFT_PX)) {
       execution.stableFrames += 1
     } else {
       wrote = true
@@ -2613,11 +2625,7 @@ export class PositioningController {
     lease.markApplied()
     if (!lease.isCurrent()) return
 
-    if (
-      execution.landedTarget !== null &&
-      Math.abs(result.scrollTop - execution.landedTarget) <=
-        EXPLICIT_TARGET_DRIFT_PX
-    ) {
+    if (heldWithinDrift(execution.landedTarget, result.scrollTop, EXPLICIT_TARGET_DRIFT_PX)) {
       execution.stableFrames += 1
       if (execution.stableFrames >= EXPLICIT_TARGET_STABLE_FRAMES) {
         this.recordExplicitTargetFrame(execution, result.wrote)
@@ -2877,11 +2885,7 @@ export class PositioningController {
     execution.resolvedAtLiveEdge ||= result.atLiveEdge
 
     let wrote = false
-    if (
-      execution.landedTarget !== null &&
-      Math.abs(result.scrollTop - execution.landedTarget) <=
-        UNREAD_MARKER_DRIFT_PX
-    ) {
+    if (heldWithinDrift(execution.landedTarget, result.scrollTop, UNREAD_MARKER_DRIFT_PX)) {
       execution.stableFrames += 1
       if (execution.stableFrames >= UNREAD_MARKER_STABLE_FRAMES) {
         if (execution.resolvedAtLiveEdge) {
@@ -3211,11 +3215,7 @@ export class PositioningController {
     }
 
     let wrote = false
-    if (
-      execution.landedTarget !== null &&
-      Math.abs(result.scrollTop - execution.landedTarget) <=
-        SAVED_POSITION_DRIFT_PX
-    ) {
+    if (heldWithinDrift(execution.landedTarget, result.scrollTop, SAVED_POSITION_DRIFT_PX)) {
       execution.stableFrames += 1
       if (execution.stableFrames >= SAVED_POSITION_STABLE_FRAMES) {
         this.settleSavedPosition(execution, lease, 'settled')


### PR DESCRIPTION
Four frame loops each restated the same comparison: has this frame landed close enough to the previous one to count as still. It now has a name, `heldWithinDrift`, and one definition.

Only the question is shared, not the accounting around it — which is why this is narrower than a unified loop. Saved position, explicit target and unread marker test their stability threshold inside the still branch; anchor preservation tests it after recording. Three derive a local `wrote` from the comparison, explicit target takes `result.wrote` from its executor, and resident top passes literals with no drift notion at all. Those differences stay exactly where they are.

The null guard is the part worth naming. A run's first frame has no previous landing and is never still; without the guard a fresh execution would count its opening write as one stable frame it never measured. That subtlety was restated four times and explained none.

## What naming it exposed

Nothing pinned the boundary. Changing `<=` to `<` left every test green — so a stricter comparison would have passed the whole suite while preventing a slow settle from ever finishing, since a row converging by exactly the drift constant per frame would never be counted still.

The anchor-preservation ownership block now covers it: a row settling by exactly 8px per frame is still, 9px is movement. That mutation now fails one test, and only that one.

Two other mutations of the predicate were already caught — removing the null guard fails four tests, inverting the comparison fails seven.

## Scope

The frame loop itself is deliberately not unified. Seven loops, two driving modes, one executor with no stability threshold at all, and `wrote` coming from three different sources — a parameterisation wide enough to cover them would read worse than seven explicit loops. That assessment is recorded here rather than attempted.
