### PR TITLE
feat(diagnostics): enrich XMPP console health export

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 ### Power User Tools
 - **Command Palette** - Keyboard-accessible launcher for conversations, contacts, rooms, and actions
 - **Keyboard Shortcuts** - Comprehensive shortcut system with a categorized help overlay and AZERTY support
-- **Built-in XMPP Console** - Live stanza inspector and debug interface
+- **Built-in XMPP Console** - Live stanza inspector with exportable connection-health diagnostics for scheduler suspension, sleep, and reconnection troubleshooting
 - **Server Administration** - Manage users, rooms, and server commands right from the client (for admins)
 - **User Profiles** - Rich user info popovers with vCard details, connected devices, timezone, and last seen status
 

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -10,6 +10,7 @@ import { TextInput, TextArea } from './ui/TextInput'
 import { Tooltip } from './Tooltip'
 import { ModalOverlay } from './ModalOverlay'
 import { platform } from '@/platform'
+import { buildXmppConsoleExport } from '@/utils/xmppConsoleExport'
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
@@ -179,7 +180,7 @@ export function XmppConsole() {
   const status = useConnectionStore((s) => s.status)
   const serverInfo = useConnectionStore((s) => s.serverInfo)
   const connectionMethod = useConnectionStore((s) => s.connectionMethod)
-  const { sendRawXml } = useXMPP()
+  const { client, sendRawXml } = useXMPP()
   const [inputXml, setInputXml] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [autoScroll, setAutoScroll] = useState(true)
@@ -426,53 +427,36 @@ export function XmppConsole() {
   }
 
   const handleExport = useCallback(async () => {
-    // Snapshot current entries at export time to avoid stale closure issues
-    const currentEntries = entries
-    const currentConnectionMethod = connectionMethod
-    const currentServerInfo = serverInfo
-
-    // Build header with version info
-    const exportDate = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
-    const header = [
-      '================================================================================',
-      `Fluux XMPP Console Log`,
-      `Version: ${__APP_VERSION__} (${__GIT_COMMIT__})`,
-      `Connection: ${currentConnectionMethod?.toUpperCase() ?? 'Unknown'}`,
-      `Exported: ${exportDate}`,
-      '================================================================================',
-    ]
-
-    // Add server info section if available
-    const serverSection: string[] = []
-    if (currentServerInfo) {
-      serverSection.push('')
-      serverSection.push(`Server: ${currentServerInfo.domain}`)
-      if (currentServerInfo.identities.length > 0) {
-        const identity = currentServerInfo.identities[0]
-        serverSection.push(`Identity: ${identity.name || 'Unknown'} (${identity.category}/${identity.type})`)
-      }
-      serverSection.push(`Features (${currentServerInfo.features.length}):`)
-      for (const feature of currentServerInfo.features) {
-        serverSection.push(`  - ${feature}`)
-      }
-      serverSection.push('')
-      serverSection.push('================================================================================')
-    }
-
-    serverSection.push('')
-
-    // Format entries as a readable log
-    const lines = currentEntries.map((entry) => {
-      const timestamp = format(entry.timestamp, 'yyyy-MM-dd HH:mm:ss.SSS')
-      if (entry.type === 'event') {
-        return `[${timestamp}] EVENT: ${entry.content}`
-      }
-      const direction = entry.type === 'incoming' ? 'IN ' : 'OUT'
-      return `[${timestamp}] ${direction}: ${entry.content}`
+    const exportedAt = new Date()
+    const machineSnapshot = client.connectionActor.getSnapshot()
+    const machineContext = machineSnapshot.context
+    const streamManagement = client.getStreamManagementState()
+    const content = buildXmppConsoleExport({
+      entries,
+      appVersion: __APP_VERSION__,
+      gitCommit: __GIT_COMMIT__,
+      exportedAt,
+      connectionMethod,
+      serverInfo,
+      health: {
+        status,
+        machineState: machineSnapshot.value,
+        reconnectAttempt: machineContext.reconnectAttempt,
+        nextRetryDelayMs: machineContext.nextRetryDelayMs,
+        reconnectTargetTime: machineContext.reconnectTargetTime,
+        smResumeViable: machineContext.smResumeViable,
+        displayAsleep: machineContext.displayAsleep,
+        browserOnline: typeof navigator === 'undefined' ? null : navigator.onLine,
+        visibilityState: typeof document === 'undefined' ? null : document.visibilityState,
+        focused: typeof document === 'undefined' || typeof document.hasFocus !== 'function'
+          ? null
+          : document.hasFocus(),
+        streamManagement: streamManagement
+          ? { inbound: streamManagement.inbound, outbound: streamManagement.outbound }
+          : null,
+      },
     })
-
-    const content = [...header, ...serverSection, ...lines].join('\n')
-    const defaultFilename = `xmpp-log-${format(new Date(), 'yyyy-MM-dd-HHmmss')}.txt`
+    const defaultFilename = `xmpp-log-${format(exportedAt, 'yyyy-MM-dd-HHmmss')}.txt`
 
     // Use native save dialog in Tauri, fallback to blob download for web
     if (platform().nativeDownloads) {
@@ -496,7 +480,7 @@ export function XmppConsole() {
     } else {
       downloadAsBlob(content, defaultFilename)
     }
-  }, [entries, connectionMethod, serverInfo])
+  }, [client, connectionMethod, entries, serverInfo, status])
 
   if (!isOpen) return null
 

--- a/apps/fluux/src/utils/xmppConsoleExport.test.ts
+++ b/apps/fluux/src/utils/xmppConsoleExport.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { XmppPacket } from '@fluux/sdk'
+import { buildXmppConsoleExport } from './xmppConsoleExport'
+
+describe('buildXmppConsoleExport', () => {
+  it('includes a privacy-safe connection health snapshot and recent traffic', () => {
+    const exportedAt = new Date('2026-08-18T12:00:10.000Z')
+    const entries: XmppPacket[] = [
+      {
+        id: 'outgoing',
+        type: 'outgoing',
+        content: '<r xmlns="urn:xmpp:sm:3"/>',
+        timestamp: new Date('2026-08-18T12:00:04.000Z'),
+      },
+      {
+        id: 'incoming',
+        type: 'incoming',
+        content: '<a xmlns="urn:xmpp:sm:3" h="42"/>',
+        timestamp: new Date('2026-08-18T12:00:06.500Z'),
+      },
+      {
+        id: 'health',
+        type: 'event',
+        content: '[health] probe-recovered generation=3 mode=sm-ack elapsedMs=275 lastSmAckAgeMs=0 bufferedAmount=0',
+        eventCategory: 'connection',
+        timestamp: new Date('2026-08-18T12:00:06.500Z'),
+      },
+    ]
+
+    const output = buildXmppConsoleExport({
+      entries,
+      appVersion: '0.18.0',
+      gitCommit: 'abcdef0',
+      exportedAt,
+      connectionMethod: 'websocket',
+      serverInfo: null,
+      health: {
+        status: 'online',
+        machineState: { connected: 'healthy' },
+        reconnectAttempt: 0,
+        nextRetryDelayMs: 0,
+        reconnectTargetTime: null,
+        smResumeViable: true,
+        displayAsleep: false,
+        browserOnline: true,
+        visibilityState: 'hidden',
+        focused: false,
+        streamManagement: { inbound: 42, outbound: 39 },
+      },
+    })
+
+    expect(output).toContain('Connection health')
+    expect(output).toContain('Store status: online')
+    expect(output).toContain('Machine state: connected.healthy')
+    expect(output).toContain('Reconnect: attempt=0 nextRetryDelayMs=0 target=none')
+    expect(output).toContain('Stream management: inbound=42 outbound=39')
+    expect(output).toContain('Last SM acknowledgment: 2026-08-18T12:00:06.500Z (ageMs=3500)')
+    expect(output).toContain('Browser: network=online visibility=hidden focused=false')
+    expect(output).toContain('Last outgoing traffic: 2026-08-18T12:00:04.000Z (ageMs=6000)')
+    expect(output).toContain('Last incoming traffic: 2026-08-18T12:00:06.500Z (ageMs=3500)')
+    expect(output).toContain('Latest health event: 2026-08-18T12:00:06.500Z [health] probe-recovered')
+    expect(output).not.toContain('sm-session-secret')
+  })
+
+  it('uses explicit unavailable markers when runtime signals do not exist', () => {
+    const output = buildXmppConsoleExport({
+      entries: [],
+      appVersion: '0.18.0',
+      gitCommit: 'abcdef0',
+      exportedAt: new Date('2026-08-18T12:00:10.000Z'),
+      connectionMethod: null,
+      serverInfo: null,
+      health: {
+        status: 'disconnected',
+        machineState: 'disconnected',
+        reconnectAttempt: 0,
+        nextRetryDelayMs: 0,
+        reconnectTargetTime: null,
+        smResumeViable: true,
+        displayAsleep: false,
+        browserOnline: null,
+        visibilityState: null,
+        focused: null,
+        streamManagement: null,
+      },
+    })
+
+    expect(output).toContain('Browser: network=unknown visibility=unknown focused=unknown')
+    expect(output).toContain('Stream management: unavailable')
+    expect(output).toContain('Last incoming traffic: unavailable')
+    expect(output).toContain('Latest health event: unavailable')
+  })
+})

--- a/apps/fluux/src/utils/xmppConsoleExport.ts
+++ b/apps/fluux/src/utils/xmppConsoleExport.ts
@@ -1,0 +1,157 @@
+import { format } from 'date-fns'
+import type {
+  ConnectionMethod,
+  ConnectionStateValue,
+  ConnectionStatus,
+  ServerInfo,
+  XmppPacket,
+} from '@fluux/sdk'
+
+export interface XmppConsoleHealthSnapshot {
+  status: ConnectionStatus
+  machineState: ConnectionStateValue
+  reconnectAttempt: number
+  nextRetryDelayMs: number
+  reconnectTargetTime: number | null
+  smResumeViable: boolean
+  displayAsleep: boolean
+  browserOnline: boolean | null
+  visibilityState: string | null
+  focused: boolean | null
+  streamManagement: { inbound: number; outbound: number } | null
+}
+
+interface XmppConsoleExportOptions {
+  entries: XmppPacket[]
+  appVersion: string
+  gitCommit: string
+  exportedAt: Date
+  connectionMethod: ConnectionMethod | null
+  serverInfo: ServerInfo | null
+  health: XmppConsoleHealthSnapshot
+}
+
+function formatMachineState(state: ConnectionStateValue): string {
+  if (typeof state === 'string') return state
+  const [parent, child] = Object.entries(state)[0] ?? ['unknown', 'unknown']
+  return `${parent}.${child}`
+}
+
+function formatOptionalBoolean(value: boolean | null): string {
+  return value === null ? 'unknown' : String(value)
+}
+
+function formatTraffic(
+  entries: XmppPacket[],
+  direction: 'incoming' | 'outgoing',
+  exportedAt: Date
+): string {
+  const entry = findLastEntry(entries, (candidate) => candidate.type === direction)
+  if (!entry) return 'unavailable'
+  const ageMs = Math.max(0, exportedAt.getTime() - entry.timestamp.getTime())
+  return `${entry.timestamp.toISOString()} (ageMs=${ageMs})`
+}
+
+function findLastEntry(
+  entries: XmppPacket[],
+  predicate: (entry: XmppPacket) => boolean
+): XmppPacket | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (predicate(entries[index])) return entries[index]
+  }
+  return undefined
+}
+
+function buildHealthSection(
+  entries: XmppPacket[],
+  health: XmppConsoleHealthSnapshot,
+  exportedAt: Date
+): string[] {
+  const latestHealthEvent = findLastEntry(
+    entries,
+    (entry) => entry.type === 'event' && entry.content.startsWith('[health] ')
+  )
+  const latestSmAck = findLastEntry(
+    entries,
+    (entry) => entry.type === 'incoming' &&
+      /^<a(?:\s|>)/.test(entry.content.trim()) &&
+      entry.content.includes('urn:xmpp:sm:3')
+  )
+  const reconnectTarget = health.reconnectTargetTime === null
+    ? 'none'
+    : new Date(health.reconnectTargetTime).toISOString()
+
+  return [
+    '',
+    'Connection health',
+    `  Store status: ${health.status}`,
+    `  Machine state: ${formatMachineState(health.machineState)}`,
+    `  Reconnect: attempt=${health.reconnectAttempt} nextRetryDelayMs=${health.nextRetryDelayMs} target=${reconnectTarget}`,
+    `  Resume policy: smResumeViable=${health.smResumeViable} displayAsleep=${health.displayAsleep}`,
+    `  Browser: network=${health.browserOnline === null ? 'unknown' : health.browserOnline ? 'online' : 'offline'} visibility=${health.visibilityState ?? 'unknown'} focused=${formatOptionalBoolean(health.focused)}`,
+    health.streamManagement
+      ? `  Stream management: inbound=${health.streamManagement.inbound} outbound=${health.streamManagement.outbound}`
+      : '  Stream management: unavailable',
+    latestSmAck
+      ? `  Last SM acknowledgment: ${latestSmAck.timestamp.toISOString()} (ageMs=${Math.max(0, exportedAt.getTime() - latestSmAck.timestamp.getTime())})`
+      : '  Last SM acknowledgment: unavailable',
+    `  Last incoming traffic: ${formatTraffic(entries, 'incoming', exportedAt)}`,
+    `  Last outgoing traffic: ${formatTraffic(entries, 'outgoing', exportedAt)}`,
+    latestHealthEvent
+      ? `  Latest health event: ${latestHealthEvent.timestamp.toISOString()} ${latestHealthEvent.content}`
+      : '  Latest health event: unavailable',
+    '',
+    '================================================================================',
+  ]
+}
+
+export function buildXmppConsoleExport(options: XmppConsoleExportOptions): string {
+  const {
+    entries,
+    appVersion,
+    gitCommit,
+    exportedAt,
+    connectionMethod,
+    serverInfo,
+    health,
+  } = options
+  const header = [
+    '================================================================================',
+    'Fluux XMPP Console Log',
+    `Version: ${appVersion} (${gitCommit})`,
+    `Connection: ${connectionMethod?.toUpperCase() ?? 'Unknown'}`,
+    `Exported: ${format(exportedAt, 'yyyy-MM-dd HH:mm:ss')}`,
+    '================================================================================',
+  ]
+
+  const serverSection: string[] = []
+  if (serverInfo) {
+    serverSection.push('')
+    serverSection.push(`Server: ${serverInfo.domain}`)
+    if (serverInfo.identities.length > 0) {
+      const identity = serverInfo.identities[0]
+      serverSection.push(`Identity: ${identity.name || 'Unknown'} (${identity.category}/${identity.type})`)
+    }
+    serverSection.push(`Features (${serverInfo.features.length}):`)
+    for (const feature of serverInfo.features) {
+      serverSection.push(`  - ${feature}`)
+    }
+  }
+
+  const lines = entries.map((entry) => {
+    const timestamp = format(entry.timestamp, 'yyyy-MM-dd HH:mm:ss.SSS')
+    if (entry.type === 'event') {
+      return `[${timestamp}] EVENT: ${entry.content}`
+    }
+    const direction = entry.type === 'incoming' ? 'IN ' : 'OUT'
+    return `[${timestamp}] ${direction}: ${entry.content}`
+  })
+
+  return [
+    ...header,
+    ...serverSection,
+    ...buildHealthSection(entries, health, exportedAt),
+    '',
+    ...lines,
+  ].join('\n')
+}

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -4213,6 +4213,10 @@ describe('XMPPClient Connection', () => {
     it('restarts the SM probe when suspension delays the keepalive timeout', async () => {
       mockXmppClientInstance.send.mockClear()
       mockXmppClientInstance.send.mockResolvedValue(undefined)
+      mockXmppClientInstance.socket = {
+        writable: true,
+        socket: { bufferedAmount: 4096 },
+      } as MockXmppClient['socket']
       vi.setSystemTime(new Date(0))
 
       const healthPromise = xmppClient.verifyConnectionHealth()
@@ -4226,6 +4230,12 @@ describe('XMPPClient Connection', () => {
 
       expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
       expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
+      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\[health\] probe-delayed generation=1 mode=sm-ack elapsedMs=26000 timeoutMs=10000 .*bufferedAmount=4096$/
+        ),
+        'connection'
+      )
 
       mockXmppClientInstance._emit(
         'nonza',
@@ -4233,6 +4243,31 @@ describe('XMPPClient Connection', () => {
       )
 
       await expect(healthPromise).resolves.toBe(true)
+    })
+
+    it('records a sleep-gap tick with the display and transport state', () => {
+      mockXmppClientInstance.socket = {
+        writable: true,
+        socket: { bufferedAmount: 2048 },
+      } as MockXmppClient['socket']
+
+      xmppClient.handleKeepaliveTick(false, 180_000)
+
+      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\[health\] keepalive-wake generation=1 display=inactive sleptMs=180000 .*bufferedAmount=2048$/
+        ),
+        'connection'
+      )
+    })
+
+    it('does not record a steady keepalive tick as a wake', () => {
+      xmppClient.handleKeepaliveTick(false, 30_000)
+
+      expect(mockStores.console.addEvent).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^\[health\] keepalive-wake /),
+        'connection'
+      )
     })
 
     // #515: with SM disabled, the keepalive probe falls back to an IQ ping to
@@ -4321,6 +4356,14 @@ describe('XMPPClient Connection', () => {
 
       expect(healthy).toBe(false)
       expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
+      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
+        expect.stringMatching(/^\[health\] probe-failed .*reason="WebSocket ECONNERROR" /),
+        'connection'
+      )
+      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
+        expect.stringMatching(/^\[health\] reconnect-decision .*source=keepalive-failed /),
+        'connection'
+      )
     })
 
     it('should not trigger reconnect when concurrent verifyConnection and verifyConnectionHealth race', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -78,6 +78,7 @@ const logError = (...args: unknown[]) => {
 }
 
 type ConnectionProbeLabel = 'verify' | 'keepalive'
+const KEEPALIVE_WAKE_THRESHOLD_MS = 180_000
 
 // Stream/SASL auth failures are terminal and should not be retried.
 // Keep this list explicit to avoid classifying generic stanza `type="auth"`
@@ -191,6 +192,16 @@ export class Connection extends BaseModule {
   // Native ticks can bunch up when the webview resumes. Keep one routine
   // health probe active so delayed timers cannot accumulate listeners and IQs.
   private healthCheckInFlight: Promise<boolean> | null = null
+
+  // Monotonic identity for each xmpp.js client owned by this module. Health
+  // events use it to distinguish stale callbacks from the active transport.
+  private connectionGeneration = 0
+
+  // Wall-clock time of the latest XEP-0198 acknowledgment observed by a
+  // health probe. The value is diagnostic only and is never persisted.
+  private lastSmAckTimestamp = 0
+  private lastIncomingTimestamp = 0
+  private lastOutgoingTimestamp = 0
 
   // Timestamp of last wake-from-sleep event. Used by attemptReconnect to add a
   // short settle delay — navigator.onLine goes true before the network path is
@@ -385,6 +396,56 @@ export class Connection extends BaseModule {
     if (!isConnectionTraceEnabled()) return
     this.stores.console.addEvent(message, 'connection')
     logInfo(message)
+  }
+
+  private getWebSocketBufferedAmount(): number | null {
+    const socketWrapper = (this.xmpp as unknown as {
+      socket?: {
+        bufferedAmount?: unknown
+        socket?: { bufferedAmount?: unknown } | null
+      } | null
+    } | null)?.socket
+    const value = socketWrapper?.socket?.bufferedAmount ?? socketWrapper?.bufferedAmount
+    return typeof value === 'number' && Number.isFinite(value) ? value : null
+  }
+
+  private logHealthEvent(
+    event: string,
+    fields: ReadonlyArray<readonly [name: string, value: string | number | boolean]> = []
+  ): void {
+    const now = Date.now()
+    const lastSmAckAgeMs = this.lastSmAckTimestamp > 0
+      ? Math.max(0, now - this.lastSmAckTimestamp)
+      : 'unknown'
+    const lastIncomingAgeMs = this.lastIncomingTimestamp > 0
+      ? Math.max(0, now - this.lastIncomingTimestamp)
+      : 'unknown'
+    const lastOutgoingAgeMs = this.lastOutgoingTimestamp > 0
+      ? Math.max(0, now - this.lastOutgoingTimestamp)
+      : 'unknown'
+    const bufferedAmount = this.getWebSocketBufferedAmount() ?? 'unknown'
+    const fieldText = fields.map(([name, value]) => {
+      const text = String(value)
+      const formatted = /^[A-Za-z0-9._:-]+$/.test(text) ? text : JSON.stringify(text)
+      return `${name}=${formatted}`
+    })
+    const machineState = this.getMachineState()
+    const state = typeof machineState === 'string'
+      ? machineState
+      : Object.entries(machineState).map(([parent, child]) => `${parent}.${child}`).join('.')
+    this.stores.console.addEvent(
+      [
+        `[health] ${event}`,
+        `generation=${this.connectionGeneration}`,
+        ...fieldText,
+        `state=${state}`,
+        `lastSmAckAgeMs=${lastSmAckAgeMs}`,
+        `lastIncomingAgeMs=${lastIncomingAgeMs}`,
+        `lastOutgoingAgeMs=${lastOutgoingAgeMs}`,
+        `bufferedAmount=${bufferedAmount}`,
+      ].join(' '),
+      'connection'
+    )
   }
 
   /**
@@ -582,7 +643,7 @@ export class Connection extends BaseModule {
     const attemptConnection = async (resolvedServer: string, connectionMethod: ConnectionMethod): Promise<void> => {
       this.stores.connection.setConnectionMethod(connectionMethod)
       this.credentials = { jid, password, server: resolvedServer, resource, lang, disableSmKeepalive, rememberSession }
-      this.xmpp = this.createXmppClient({ jid, password, server: resolvedServer, resource, lang, rememberSession })
+      this.installXmppClient({ jid, password, server: resolvedServer, resource, lang, rememberSession })
       this.hydrateStreamManagement(effectiveSmState)
       this.setupHandlers()
 
@@ -1049,6 +1110,13 @@ export class Connection extends BaseModule {
    *   gap indicates the machine slept; used to send an immediate wake kick.
    */
   handleKeepaliveTick(displayActive?: boolean, sleptMs?: number): void {
+    if ((sleptMs ?? 0) >= KEEPALIVE_WAKE_THRESHOLD_MS) {
+      this.logHealthEvent('keepalive-wake', [
+        ['display', displayActive === false ? 'inactive' : displayActive === true ? 'active' : 'unknown'],
+        ['sleptMs', sleptMs!],
+      ])
+    }
+
     if (displayActive === false) {
       // Display off: zero outbound work; just release/hold the ladder.
       this.sendMachineEvent({ type: 'DISPLAY_INACTIVE' }, 'keepalive:display-inactive')
@@ -1101,6 +1169,7 @@ export class Connection extends BaseModule {
     // delayed because the file never said the keepalive was failing, let
     // alone how (the console event is in-app only).
     let probeMode = 'sm-ack'
+    let retriedAfterDelayedTimer = false
 
     try {
       const sm = clientAtStart.streamManagement
@@ -1114,11 +1183,18 @@ export class Connection extends BaseModule {
           if (ackResult.status === 'acknowledged') break
           if (
             ackResult.status === 'timeout' &&
-            this.shouldRetryDelayedKeepalive(label, ackResult.elapsedMs, timeoutMs)
+            this.shouldRetryDelayedKeepalive(label, probeMode, ackResult.elapsedMs, timeoutMs)
           ) {
+            retriedAfterDelayedTimer = true
             continue
           }
           logWarn(`${label} probe failed (sm-ack): no <a/> within ${timeoutMs}ms`)
+          this.logHealthEvent('probe-failed', [
+            ['probe', label],
+            ['mode', probeMode],
+            ['timeoutMs', timeoutMs],
+            ['reason', ackResult.status],
+          ])
           return 'dead'
         }
       } else {
@@ -1144,8 +1220,9 @@ export class Connection extends BaseModule {
               if (
                 error instanceof Error &&
                 error.name === 'TimeoutError' &&
-                this.shouldRetryDelayedKeepalive(label, Date.now() - startedAt, timeoutMs)
+                this.shouldRetryDelayedKeepalive(label, probeMode, Date.now() - startedAt, timeoutMs)
               ) {
+                retriedAfterDelayedTimer = true
                 continue
               }
               throw error
@@ -1164,6 +1241,12 @@ export class Connection extends BaseModule {
 
       // If client was replaced during the await, treat as stale
       if (this.xmpp && this.xmpp !== clientAtStart) return 'stale'
+      if (retriedAfterDelayedTimer) {
+        this.logHealthEvent('probe-recovered', [
+          ['probe', label],
+          ['mode', probeMode],
+        ])
+      }
       return 'healthy'
     } catch (err) {
       if (this.xmpp && this.xmpp !== clientAtStart) return 'stale'
@@ -1178,6 +1261,11 @@ export class Connection extends BaseModule {
         return 'healthy'
       }
       logWarn(`${label} probe failed (${probeMode}): ${errorMessage}`)
+      this.logHealthEvent('probe-failed', [
+        ['probe', label],
+        ['mode', probeMode],
+        ['reason', errorMessage || 'unknown'],
+      ])
       return 'dead'
     }
   }
@@ -1216,6 +1304,7 @@ export class Connection extends BaseModule {
       const handleNonza = (nonza: Element) => {
         if (nonza.is('a', 'urn:xmpp:sm:3') && !resolved) {
           resolved = true
+          if (this.xmpp === client) this.lastSmAckTimestamp = Date.now()
           cleanup(timeoutId)
           resolve({ status: 'acknowledged' })
         }
@@ -1256,6 +1345,7 @@ export class Connection extends BaseModule {
 
   private shouldRetryDelayedKeepalive(
     label: ConnectionProbeLabel,
+    mode: string,
     elapsedMs: number,
     timeoutMs: number
   ): boolean {
@@ -1263,6 +1353,11 @@ export class Connection extends BaseModule {
     logWarn(
       `${label} probe timer delayed (${elapsedMs}ms for ${timeoutMs}ms timeout); retrying before reconnect`
     )
+    this.logHealthEvent('probe-delayed', [
+      ['mode', mode],
+      ['elapsedMs', elapsedMs],
+      ['timeoutMs', timeoutMs],
+    ])
     return true
   }
 
@@ -1291,6 +1386,11 @@ export class Connection extends BaseModule {
       )
       return
     }
+
+    this.logHealthEvent('reconnect-decision', [
+      ['source', source],
+      ['immediate', immediateReconnect],
+    ])
 
     // Signal to setupConnectionHandlers' error handler that recovery is already
     // in progress. Must be set BEFORE cleanupClient/nudgeReconnect so the
@@ -1765,6 +1865,16 @@ export class Connection extends BaseModule {
     return xmppClient
   }
 
+  private installXmppClient(options: ConnectOptions): Client {
+    const nextClient = this.createXmppClient(options)
+    this.xmpp = nextClient
+    this.connectionGeneration += 1
+    this.lastSmAckTimestamp = 0
+    this.lastIncomingTimestamp = 0
+    this.lastOutgoingTimestamp = 0
+    return nextClient
+  }
+
   /**
    * Disable xmpp.js built-in auto-reconnect (@xmpp/reconnect module).
    *
@@ -2093,9 +2203,11 @@ export class Connection extends BaseModule {
 
     // Log all incoming/outgoing XML to console store
     this.xmpp.on('element', (element: Element) => {
+      this.lastIncomingTimestamp = Date.now()
       this.stores?.console.addPacket('incoming', element.toString())
     })
     this.xmpp.on('send', (element: Element) => {
+      this.lastOutgoingTimestamp = Date.now()
       this.stores?.console.addPacket('outgoing', element.toString())
     })
 
@@ -2593,7 +2705,7 @@ export class Connection extends BaseModule {
 
       const connectWithOptions = async (options: ConnectOptions): Promise<void> => {
         this.deadSocketRecoveryInProgress = false
-        this.xmpp = this.createXmppClient(options)
+        this.installXmppClient(options)
         clientCreatedByThisAttempt = this.xmpp
         this.hydrateStreamManagement(smState ?? undefined)
         this.setupHandlers()


### PR DESCRIPTION
Enriches the existing XMPP console export with a connection-health snapshot covering connection state, reconnect backoff, Stream Management counters and acknowledgments, recent traffic, and browser visibility.

Adds bounded health events for suspension gaps, delayed and recovered probes, transport failures, and reconnect decisions, including WebSocket buffering and connection-generation context. Steady keepalive ticks stay out of the diagnostic history so incident evidence remains available.
