### PR TITLE
fix(scroll): scale the non-converging threshold to each loop's frame budget

### DIFF
--- a/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/directionalHistoryBrowserAdapter.test.ts
@@ -83,6 +83,7 @@ function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
     conversationId: 'room-a',
     generation: 7,
     operation: 1,
+    frameBudget: 60,
     signal: controller.signal,
     isCurrent,
     markApplied: () => true,

--- a/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
@@ -65,6 +65,7 @@ function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
     conversationId: 'room-a',
     generation: 7,
     operation: 1,
+    frameBudget: 60,
     signal: new AbortController().signal,
     isCurrent,
     markApplied: () => true,

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
@@ -92,6 +92,7 @@ function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
     conversationId: 'room-a',
     generation: 7,
     operation: 1,
+    frameBudget: 60,
     signal: new AbortController().signal,
     isCurrent,
     markApplied: () => true,

--- a/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/messageTargetBrowserAdapters.test.ts
@@ -108,6 +108,7 @@ function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
     conversationId: 'room-a',
     generation: 7,
     operation: 1,
+    frameBudget: 60,
     signal: controller.signal,
     isCurrent,
     markApplied: () => true,

--- a/apps/fluux/src/components/conversation/positioningController.leaseConformance.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.leaseConformance.test.ts
@@ -359,6 +359,16 @@ describe.each(EXECUTORS)('$name lease', ({ start }) => {
     ).toBe(false)
   })
 
+  it('tells the monitor what budget it was given', () => {
+    // The non-converging threshold is a fraction of the budget, so a lease that misreports it —
+    // or omits it — silently moves the line at which a loop is called non-converging.
+    const controller = new PositioningController()
+    const { lease } = start(controller)
+
+    expect(Number.isInteger(lease.frameBudget)).toBe(true)
+    expect(lease.frameBudget).toBeGreaterThan(0)
+  })
+
   it('refuses to advance the phase once it is no longer current', () => {
     // The lease is the authority a frame checks before writing. A superseded one that still
     // reported success would let a finished executor move the phase of its successor.

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -1615,7 +1615,10 @@ describe('positioning controller saved-position ownership', () => {
     for (let frame = 0; frame < 9; frame += 1) harness.runFrame()
 
     expect(harness.positionFrame).toHaveBeenCalledTimes(10)
-    expect(harness.recordFrame).toHaveBeenCalledTimes(8)
+    // Nine, not eight: the frame that reaches the threshold is reported like every other, so the
+    // loop monitor gets one last overlap sample at the moment this loop ends — which is when a
+    // second loop starting is most likely. Every executor now settles that way.
+    expect(harness.recordFrame).toHaveBeenCalledTimes(9)
     expect(harness.recordFrame).toHaveBeenNthCalledWith(1, true)
     expect(harness.finish).toHaveBeenCalledTimes(1)
     expect(harness.complete).toHaveBeenLastCalledWith(

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -52,6 +52,12 @@ export interface PositionExecutionLease {
   conversationId: string
   generation: number
   operation: number
+  /**
+   * Frames this run may take before it gives up. The loop monitor derives its non-converging
+   * threshold from it, so a run must report the budget it was actually given: understating it
+   * calls a healthy loop non-converging, overstating it never calls anything.
+   */
+  frameBudget: number
   signal: AbortSignal
   isCurrent: () => boolean
   markApplied: () => boolean
@@ -1743,6 +1749,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -1994,6 +2001,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -2196,6 +2204,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -2390,6 +2399,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -2708,6 +2718,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -2887,23 +2898,23 @@ export class PositioningController {
     let wrote = false
     if (heldWithinDrift(execution.landedTarget, result.scrollTop, UNREAD_MARKER_DRIFT_PX)) {
       execution.stableFrames += 1
-      if (execution.stableFrames >= UNREAD_MARKER_STABLE_FRAMES) {
-        if (execution.resolvedAtLiveEdge) {
-          this.promoteUnreadFallback(
-            execution,
-            'unread-marker-resolved-at-live-edge',
-          )
-        } else {
-          this.finishUnreadExecution(execution, true)
-        }
-        return
-      }
     } else {
       wrote = true
       execution.stableFrames = 0
     }
     execution.landedTarget = result.scrollTop
     this.recordUnreadMarkerFrame(execution, wrote)
+    if (execution.stableFrames >= UNREAD_MARKER_STABLE_FRAMES) {
+      if (execution.resolvedAtLiveEdge) {
+        this.promoteUnreadFallback(
+          execution,
+          'unread-marker-resolved-at-live-edge',
+        )
+      } else {
+        this.finishUnreadExecution(execution, true)
+      }
+      return
+    }
     this.scheduleUnreadMarkerFrame(execution, lease)
   }
 
@@ -3019,6 +3030,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),
@@ -3217,16 +3229,16 @@ export class PositioningController {
     let wrote = false
     if (heldWithinDrift(execution.landedTarget, result.scrollTop, SAVED_POSITION_DRIFT_PX)) {
       execution.stableFrames += 1
-      if (execution.stableFrames >= SAVED_POSITION_STABLE_FRAMES) {
-        this.settleSavedPosition(execution, lease, 'settled')
-        return
-      }
     } else {
       wrote = true
       execution.stableFrames = 0
     }
     execution.landedTarget = result.scrollTop
     this.recordSavedPositionFrame(execution, wrote)
+    if (execution.stableFrames >= SAVED_POSITION_STABLE_FRAMES) {
+      this.settleSavedPosition(execution, lease, 'settled')
+      return
+    }
     this.scheduleSavedPositionFrame(execution, lease)
   }
 
@@ -3503,6 +3515,7 @@ export class PositioningController {
       conversationId,
       generation,
       operation,
+      frameBudget: execution.framesLeft,
       signal: abortController.signal,
       isCurrent,
       markApplied: () => advance({ kind: 'position-applied' }),

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.test.ts
@@ -145,3 +145,33 @@ describe('reassertLoopSignal', () => {
     expect(JSON.stringify(signal)).not.toContain('ScrollReassertLoop')
   })
 })
+
+describe('non-converging threshold derived from the frame budget', () => {
+  const writesOver = (frameBudget: number, writes: number) => {
+    const m = createReassertLoopMonitor()
+    const h = m.begin('marker', 0, frameBudget)
+    let warned = false
+    for (let i = 0; i < writes; i++) warned ||= h.frame(i, true)?.reason === 'non-converging'
+    return warned
+  }
+
+  it('scales the line with the budget instead of applying one flat count', () => {
+    // A third of the budget. A flat 40 was unreachable for the 30-frame explicit-target loop —
+    // it would have had to write 41 times in 30 frames — and lenient for the 120-frame ones.
+    expect(writesOver(30, 10)).toBe(false)
+    expect(writesOver(30, 11)).toBe(true)
+    expect(writesOver(90, 30)).toBe(false)
+    expect(writesOver(90, 31)).toBe(true)
+  })
+
+  it('keeps the long-standing line for the budget it was tuned against', () => {
+    // 120 frames was the case the flat 40 described, so that case must not move.
+    expect(writesOver(120, 40)).toBe(false)
+    expect(writesOver(120, 41)).toBe(true)
+  })
+
+  it('falls back to the flat threshold when no budget is given', () => {
+    expect(writesOver(undefined as unknown as number, 40)).toBe(false)
+    expect(writesOver(undefined as unknown as number, 41)).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -90,8 +90,19 @@ export interface ReassertLoopHandle {
 }
 
 export interface ReassertLoopMonitor {
-  /** Register the start of a re-assert loop; `label` names the loop kind. */
-  begin(label: ReassertLoopLabel, now: number): ReassertLoopHandle
+  /**
+   * Register the start of a re-assert loop; `label` names the loop kind.
+   *
+   * `frameBudget` is how many frames this loop may run before it gives up. The
+   * non-converging threshold is derived from it, because a fixed count cannot
+   * mean the same thing to a loop bounded at 30 frames and one bounded at 120.
+   * Omit it and the flat `writeThreshold` applies.
+   */
+  begin(
+    label: ReassertLoopLabel,
+    now: number,
+    frameBudget?: number,
+  ): ReassertLoopHandle
   /** Labels of the currently-active loops (for tests/diagnostics). */
   activeLabels(): string[]
 }
@@ -105,14 +116,25 @@ export interface ReassertLoopMonitorOptions {
   cooldownMs?: number
 }
 
+/**
+ * A loop writing on more than this fraction of its frame budget is not converging.
+ * One third reproduces the long-standing 40 for the 120-frame loops it was tuned
+ * against, and carries the same meaning to the shorter ones.
+ */
+const WRITES_PER_FRAME_BUDGET = 3
+
 export function createReassertLoopMonitor(
   opts: ReassertLoopMonitorOptions = {},
 ): ReassertLoopMonitor {
-  // Defaults: 2 concurrent loops is already an overlap (they fight over
-  // scrollTop). A healthy loop writes only a few times before it settles, so >40
-  // cumulative writes (it runs at most ~120 frames) means it never converged.
+  // 2 concurrent loops is already an overlap (they fight over scrollTop).
+  //
+  // Non-converging is a RATIO, not a count: a healthy loop writes a few times and
+  // then idles out its budget, so writing on more than a third of the frames it
+  // was given means it never converged. A flat count could not say that for every
+  // loop — the frame budgets span 30 to 120, so 40 was unreachable for the
+  // 30-frame explicit-target loop and lenient for the 120-frame ones.
   const overlapThreshold = opts.overlapThreshold ?? 2
-  const writeThreshold = opts.writeThreshold ?? 40
+  const flatWriteThreshold = opts.writeThreshold ?? 40
   const cooldownMs = opts.cooldownMs ?? 5000
 
   // Active loops by monotonically-increasing id, so two loops sharing a label
@@ -123,7 +145,15 @@ export function createReassertLoopMonitor(
   let lastOverlapWarnAt = Number.NEGATIVE_INFINITY
 
   return {
-    begin(label: ReassertLoopLabel, _now: number): ReassertLoopHandle {
+    begin(
+      label: ReassertLoopLabel,
+      _now: number,
+      frameBudget?: number,
+    ): ReassertLoopHandle {
+      const writeThreshold =
+        frameBudget === undefined
+          ? flatWriteThreshold
+          : Math.max(1, Math.ceil(frameBudget / WRITES_PER_FRAME_BUDGET))
       const id = nextId++
       active.set(id, label)
       let writeCount = 0

--- a/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/savedPositionBrowserAdapter.test.ts
@@ -137,6 +137,7 @@ function lease(isCurrent: () => boolean = () => true): SavedPositionExecutionLea
     conversationId: 'room-a',
     generation: 7,
     operation: 1,
+    frameBudget: 60,
     signal: controller.signal,
     isCurrent,
     markApplied: () => true,

--- a/apps/fluux/src/components/conversation/useScrollExecutors.test.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.test.ts
@@ -3,6 +3,16 @@ import { renderHook } from '@testing-library/react'
 import type { ControllerFrameLoopRegistration } from './controllerFrameLoop'
 import type { PinLoopClaim } from './pinLoopClaim'
 import type { DirectionalHistoryWindowCoordinator } from './directionalHistoryWindowCoordinator'
+const monitorBegin = vi.fn((_label: string, _now: number, _frameBudget?: number) => ({
+  frame: () => null,
+  end: () => {},
+  label: 'marker' as const,
+}))
+vi.mock('./reassertLoopMonitor', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./reassertLoopMonitor')>()),
+  createReassertLoopMonitor: () => ({ begin: monitorBegin, activeCount: () => 0 }),
+}))
+
 import {
   useScrollExecutors,
   type ScrollExecutorPorts,
@@ -213,6 +223,7 @@ describe('useScrollExecutors adapter ownership', () => {
       conversationId: 'room-a',
       generation: 1,
       operation: 1,
+      frameBudget: 60,
       signal: new AbortController().signal,
       isCurrent: () => true,
       markApplied: () => true,
@@ -297,5 +308,32 @@ describe('useScrollExecutors adapter ownership', () => {
     result.current.disposeDirectionalHistoryBrowser()
     // A rebuild after disposal must hand out a fresh adapter, not the disposed one.
     expect(result.current.getDirectionalHistoryBrowser()).not.toBe(browser)
+  })
+})
+
+describe('useScrollExecutors monitor wiring', () => {
+  it("hands the monitor the lease's frame budget", () => {
+    // The non-converging threshold is a fraction of the budget. Drop the budget here and every
+    // loop silently reverts to the flat threshold — unreachable for the short loops — with
+    // nothing else in the codebase noticing.
+    monitorBegin.mockClear()
+    const { ports } = portsHarness()
+    const { result } = renderHook(
+      (input: UseScrollExecutorsInput) => useScrollExecutors(input),
+      { initialProps: baseInput(ports) },
+    )
+    result.current.buildUnreadMarkerExecutor().beginLoop({
+      conversationId: 'room-a',
+      generation: 1,
+      operation: 1,
+      frameBudget: 30,
+      signal: new AbortController().signal,
+      isCurrent: () => true,
+      markApplied: () => true,
+      settle: () => true,
+    })
+
+    expect(monitorBegin).toHaveBeenCalledTimes(1)
+    expect(monitorBegin.mock.calls[0]?.[2]).toBe(30)
   })
 })

--- a/apps/fluux/src/components/conversation/useScrollExecutors.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.ts
@@ -197,7 +197,7 @@ export function useScrollExecutors({
       lease,
       supersede: supersedeReassertLoopRef.current,
       beginHandle: () => (reassertMonitorRef.current ??=
-        createReassertLoopMonitor()).begin(label, performance.now()),
+        createReassertLoopMonitor()).begin(label, performance.now(), lease.frameBudget),
       registry: portsRef.current.reassertLoopRegistry,
       // Native WebKit/Chromium scheduler methods require Window as their receiver. Keep them behind
       // closures when passing into the extracted adapter; an unbound method throws before the first


### PR DESCRIPTION
The re-assert loop monitor warned when a positioning loop had written more than a flat 40 times. Frame budgets across the seven executors span 30 to 120 frames, so one number could not mean the same thing to all of them: the 30-frame explicit-target loop would have had to write 41 times in 30 frames to reach it, while the 120-frame loops could write on a third of their frames and stay quiet.

The threshold is now a fraction of the budget the run was given. One third reproduces the previous 40 for the 120-frame loops it was tuned against, and carries the same meaning to the shorter ones — which get a reachable line for the first time. The budget travels on the execution lease, the one thing the seven executors already share.

Two loops also settled before reporting the frame that settled them, so the monitor lost its last overlap sample exactly at the moment a loop ended. Four already reported it; the six that converge on a drift threshold now agree.

Resident top is unchanged and correct as it stands: its frame only reads `scrollTop`, so reporting no write is exact.