### PR TITLE
fix(sdk): preserve unread recount convergence

### DIFF
--- a/docs/2026-07-17-mam-catchup-roadmap.md
+++ b/docs/2026-07-17-mam-catchup-roadmap.md
@@ -38,7 +38,7 @@ This document is the backlog *beyond* those — what to improve next, prioritize
 
 ### R3. Exact unread badge while the pointer is still pending
 
-**Problem.** #1029's fix wave made the badge recount from the full cache when the pointer resolves during Phase B (finding fixed). But *while the pointer is still pending* (deep backlog mid-walk), the badge shows a lower bound (loaded-so-far), converging to exact only once the pointer's message loads. The async recount also has a documented benign race (a live message landing between the cache read and the apply is missed by that one recount, corrected on the next merge/activation).
+**Problem.** #1029's fix wave made the badge recount from the full cache when the pointer resolves during Phase B (finding fixed). But *while the pointer is still pending* (deep backlog mid-walk), the badge shows a lower bound (loaded-so-far), converging to exact only once the pointer's message loads.
 
 **Impact.** Cosmetic during the (usually brief) walk window; self-corrects. Only visible for genuinely deep backlogs.
 

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -70,7 +70,7 @@ badge; recounts for other entities in the same window can contribute to the tall
 | `pointerless-defer` | No read position ever established; a bare zero cannot be trusted |
 | `pending-remote-displayed` | A remote XEP-0490 position is still resolving |
 | `no-floor` | Neither a read pointer nor a history floor to count from |
-| `mam-not-caught-up` | History is partial, so any count would under-report |
+| `history-not-caught-up` | History is partial, so any count would under-report |
 | `context-changed` | Cache epoch or storage scope moved underneath |
 | `coverage-missing` | No coverage record, so the archive bottom is unknown |
 | `coverage-unresolvable` | The coverage bottom no longer resolves in the archive |
@@ -81,9 +81,11 @@ badge; recounts for other entities in the same window can contribute to the tall
 | `pointer-changed` | The read pointer moved while the recount was in flight |
 
 `input-version-changed` is the one to watch for #1211: `addMessage` bumps that version
-on **every** arrival, so an active room that keeps receiving can invalidate each recount
-with the traffic that made it necessary. A high tally during the affected window
-supports that attribution; a high `coverage-missing` points elsewhere entirely.
+on **every** arrival, so live traffic can invalidate an in-flight recount. The store
+keeps the stale-snapshot guard and schedules at most one coalesced trailing recount,
+waiting until pending cache writes and archive catch-up are durably ready. A high tally
+during the affected window supports that attribution; a high `coverage-missing` points
+elsewhere entirely.
 
 ## Detector families
 

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -20,6 +20,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Prevent IndexedDB operations triggered by chatStore.addMessage / updateMessage
 vi.mock('../utils/messageCache', () => ({
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),
@@ -41,6 +42,7 @@ vi.mock('../utils/messageCache', () => ({
   isMessageCacheAvailable: vi.fn().mockReturnValue(false),
   getOldestMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -27,6 +28,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
@@ -18,6 +18,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -26,6 +27,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/chatSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.test.ts
@@ -16,6 +16,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -24,6 +25,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -27,6 +28,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/networkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/networkScenarios.test.ts
@@ -18,6 +18,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -26,6 +27,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/core/roomSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.test.ts
@@ -17,6 +17,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 // Mock messageCache to prevent IndexedDB operations
 vi.mock('../utils/messageCache', () => ({
+  saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
   saveRoomMessage: vi.fn().mockResolvedValue(undefined),
   saveRoomMessages: vi.fn().mockResolvedValue(undefined),
   getRoomMessages: vi.fn().mockResolvedValue([]),
@@ -25,6 +26,7 @@ vi.mock('../utils/messageCache', () => ({
   updateRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessage: vi.fn().mockResolvedValue(undefined),
   deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+  saveMessageWithResult: vi.fn().mockResolvedValue(true),
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/hooks/useChat.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChat.test.tsx
@@ -15,12 +15,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe('useChat hook', () => {
   beforeEach(() => {
-    // Reset store state before each test
-    chatStore.setState({
-      conversations: new Map(),
-      messages: new Map(),
-      activeConversationId: null,
-    })
+    chatStore.getState().reset()
   })
 
   describe('composed action surface (useChat = state + useChatActions)', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -27,10 +27,16 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     // order (vi.fn.mockImplementationOnce) without disabling the real cursor.
     getMessages: vi.fn(actual.getMessages),
     countUnreadInArchive: vi.fn(actual.countUnreadInArchive),
+    saveMessageWithResult: vi.fn(actual.saveMessageWithResult),
+    saveMessages: vi.fn(actual.saveMessages),
   }
 })
 import * as messageCache from '../utils/messageCache'
 import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
+
+const countUnreadInArchiveImplementation = vi.mocked(messageCache.countUnreadInArchive).getMockImplementation()!
+const saveMessageWithResultImplementation = vi.mocked(messageCache.saveMessageWithResult).getMockImplementation()!
+const saveMessagesImplementation = vi.mocked(messageCache.saveMessages).getMockImplementation()!
 
 /**
  * A transient entry's position.
@@ -113,10 +119,15 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     chatStore.getState().reset()
     resetRecountDeferralsForTesting()
     chatStore.getState().addConversation(createConversation(CID))
-    // mockClear() only resets call history, never the base implementation set
-    // by vi.fn(actual.countUnreadInArchive) above, so it stays real by default.
+    // Reset queued one-shot implementations as well as call history so a
+    // deliberately failing race test cannot contaminate the next test.
     vi.mocked(messageCache.getMessages).mockClear()
-    vi.mocked(messageCache.countUnreadInArchive).mockClear()
+    vi.mocked(messageCache.countUnreadInArchive).mockReset()
+    vi.mocked(messageCache.countUnreadInArchive).mockImplementation(countUnreadInArchiveImplementation)
+    vi.mocked(messageCache.saveMessageWithResult).mockReset()
+    vi.mocked(messageCache.saveMessageWithResult).mockImplementation(saveMessageWithResultImplementation)
+    vi.mocked(messageCache.saveMessages).mockReset()
+    vi.mocked(messageCache.saveMessages).mockImplementation(saveMessagesImplementation)
     // The transient overlay is a module-level singleton (never cleared on
     // deactivation by design) — reset it between tests explicitly.
     clearTransientScope(getStorageScopeJid() ?? '')
@@ -657,7 +668,9 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // lets 'a-msg' get appended last, wrongly advances the pointer TO
     // 'a-msg', and 'z-msg' — already-confirmed-seen — then archive-sorts
     // AFTER it and gets wrongly counted as unread.
-    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    })
   })
 
   // ---------------------------------------------------------------------
@@ -755,7 +768,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     expect(readRecountDeferrals()['chat:context-changed']).toBeUndefined()
   })
 
-  it('discards a recount whose archive snapshot predates a live arrival', async () => {
+  it('holds an invalidated active recount until forward catch-up durably completes', async () => {
     await messageCache.saveMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
       archiveMsg('p0', 1000),
@@ -767,23 +780,144 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     seedCoverage('anchor-stanza')
 
     let releaseCount!: (v: { unread: number }) => void
-    vi.mocked(messageCache.countUnreadInArchive).mockImplementationOnce(
-      () => new Promise((resolve) => { releaseCount = resolve })
-    )
+    vi.mocked(messageCache.countUnreadInArchive)
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseCount = resolve }))
+      .mockImplementationOnce(async () => ({ unread: 7 }))
 
-    const stale = chatStore.getState().recomputeUnreadForConversation(CID)
+    chatStore.setState({ activeConversationId: CID })
+    const stale = chatStore.getState().recomputeUnreadForConversation(CID, { allowActive: true })
     await vi.waitFor(() => expect(releaseCount).toBeDefined())
 
     chatStore.getState().addMessage(archiveMsg('live', 2000))
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
+    chatStore.getState().mergeMAMMessages(
+      CID,
+      [archiveMsg('catchup-1', 2100)],
+      { first: 'catchup-1', last: 'catchup-1' },
+      false,
+      'forward'
+    )
 
     releaseCount({ unread: 3 })
     await stale
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(1)
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
-    expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(6)
+
+    chatStore.getState().mergeMAMMessages(
+      CID,
+      [archiveMsg('catchup-2', 2200)],
+      { first: 'catchup-2', last: 'catchup-2' },
+      true,
+      'forward'
+    )
+
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(7)
+    })
+    expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(7)
+    expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(2)
     expect(readRecountDeferrals()['chat:input-version-changed']).toBe(1)
     expect(readRecountDeferrals()['chat:context-changed']).toBeUndefined()
+  })
+
+  it('retains a failed live cache write in the unread recount overlay', async () => {
+    await messageCache.saveMessages([
+      archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('p0', 1000),
+      ...Array.from({ length: 5 }, (_, index) => archiveMsg(`u${index + 1}`, 1100 + index)),
+    ])
+    setMeta({
+      unreadCount: 5,
+      readPointer: { order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
+    })
+    seedCoverage('anchor-stanza')
+    chatStore.setState({ activeConversationId: CID })
+
+    let releaseCount!: (v: { unread: number }) => void
+    vi.mocked(messageCache.countUnreadInArchive).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseCount = resolve })
+    )
+    vi.mocked(messageCache.saveMessageWithResult).mockResolvedValueOnce(false)
+
+    const stale = chatStore.getState().recomputeUnreadForConversation(CID, { allowActive: true })
+    await vi.waitFor(() => expect(releaseCount).toBeDefined())
+    chatStore.getState().addMessage(archiveMsg('live-write-failed', 2000))
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
+
+    releaseCount({ unread: 5 })
+    await stale
+
+    await vi.waitFor(() => {
+      expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(2)
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(6)
+    })
+    expect(transientCounts(scopeKey(), undefined).unread).toBe(1)
+  })
+
+  it('resumes a held active recount after a backward archive write commits', async () => {
+    await messageCache.saveMessages([
+      archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('older', 700),
+      archiveMsg('p0', 1000),
+    ])
+    setMeta({
+      unreadCount: 5,
+      readPointer: { order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'chat', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
+    })
+    seedCoverage('anchor-stanza')
+    chatStore.setState({ activeConversationId: CID })
+
+    let releaseCount!: (v: { unread: number }) => void
+    vi.mocked(messageCache.countUnreadInArchive)
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseCount = resolve }))
+      .mockImplementationOnce(async () => ({ unread: 7 }))
+    let releaseSave!: (committed: boolean) => void
+    vi.mocked(messageCache.saveMessages).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseSave = resolve })
+    )
+
+    const stale = chatStore.getState().recomputeUnreadForConversation(CID, { allowActive: true })
+    await vi.waitFor(() => expect(releaseCount).toBeDefined())
+    chatStore.getState().mergeMAMMessages(
+      CID,
+      [archiveMsg('older', 700)],
+      { first: 'older', last: 'older' },
+      true,
+      'backward'
+    )
+    releaseCount({ unread: 3 })
+    await stale
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(1)
+    releaseSave(true)
+
+    await vi.waitFor(() => {
+      expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(2)
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(7)
+    })
+  })
+
+  it('settles a live write when an unrelated conversation is deleted', async () => {
+    const otherId = 'other@example.com'
+    chatStore.getState().addConversation(createConversation(otherId))
+    chatStore.setState({ activeConversationId: CID })
+    let releaseSave!: (committed: boolean) => void
+    vi.mocked(messageCache.saveMessageWithResult).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseSave = resolve })
+    )
+
+    chatStore.getState().addMessage(archiveMsg('pending-live', 2000))
+    expect(transientCounts(scopeKey(), undefined).unread).toBe(1)
+
+    chatStore.getState().deleteConversation(otherId)
+    releaseSave(true)
+
+    await vi.waitFor(() => {
+      expect(transientCounts(scopeKey(), undefined).unread).toBe(0)
+    })
   })
 
   // Was 'rejects a guard-pass pointer write after the account scope changes',

--- a/packages/fluux-sdk/src/stores/chatStore.compatMap.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.compatMap.test.ts
@@ -40,6 +40,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
     deleteConversationMessagesBefore: vi.fn().mockResolvedValue(undefined),
     saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessageWithResult: vi.fn().mockResolvedValue(true),
     saveMessages: vi.fn().mockResolvedValue(true),
     getMessages: vi.fn().mockResolvedValue([]),
     getMessagesAround: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -28,6 +28,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     isMessageCacheAvailable: vi.fn().mockReturnValue(true),
     saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessageWithResult: vi.fn().mockResolvedValue(true),
     saveMessages: vi.fn().mockResolvedValue(undefined),
     getMessages: vi.fn().mockResolvedValue([]),
     getMessagesAround: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -46,6 +46,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
     saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessageWithResult: vi.fn().mockResolvedValue(true),
     saveMessages: vi.fn().mockResolvedValue(true),
     getMessages: vi.fn().mockResolvedValue([]),
     getMessagesAround: vi.fn().mockResolvedValue([]),
@@ -1584,7 +1585,7 @@ describe('chatStore', () => {
 
       chatStore.getState().addMessage(msg)
 
-      expect(messageCache.saveMessage).toHaveBeenCalledWith(msg)
+      expect(messageCache.saveMessageWithResult).toHaveBeenCalledWith(msg)
     })
 
     it('should not save message to IndexedDB when noLocalStore is true (XEP-0334)', () => {
@@ -1593,7 +1594,7 @@ describe('chatStore', () => {
 
       chatStore.getState().addMessage(msg)
 
-      expect(messageCache.saveMessage).not.toHaveBeenCalled()
+      expect(messageCache.saveMessageWithResult).not.toHaveBeenCalled()
     })
 
     it('should still add noLocalStore message to in-memory store', () => {
@@ -4535,7 +4536,7 @@ describe('chatStore', () => {
 
     beforeEach(() => {
       vi.mocked(messageCache.getMessages).mockReset()
-      vi.mocked(messageCache.saveMessage).mockClear()
+      vi.mocked(messageCache.saveMessageWithResult).mockClear()
       chatStore.getState().addConversation(createConversation(conversationId))
     })
 
@@ -4590,7 +4591,7 @@ describe('chatStore', () => {
       await chatStore.getState().loadOlderMessagesFromCache(conversationId, 50)
       expect(chatStore.getState().windowAtLiveEdge.get(conversationId)).toBe(false)
 
-      vi.mocked(messageCache.saveMessage).mockClear()
+      vi.mocked(messageCache.saveMessageWithResult).mockClear()
       const before = chatStore.getState().messages.get(conversationId)!
       const live = chatMsgAt('live-1', 10000)
       chatStore.getState().addMessage(live)
@@ -4601,7 +4602,7 @@ describe('chatStore', () => {
       expect(messages.length).toBe(before.length)
       expect(messages[messages.length - 1].id).toBe(before[before.length - 1].id)
       // ...but the message is still persisted to IndexedDB...
-      expect(messageCache.saveMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 'live-1' }))
+      expect(messageCache.saveMessageWithResult).toHaveBeenCalledWith(expect.objectContaining({ id: 'live-1' }))
       // ...and meta (sidebar preview + unread badge) still update.
       expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.id).toBe('live-1')
       expect(chatStore.getState().conversationMeta.get(conversationId)?.unreadCount).toBe(1)
@@ -5174,7 +5175,7 @@ describe('chatStore delayed live arrivals (#1176)', () => {
     ] as const) {
       chatStore.getState().addMessage(arrival(id, iso))
     }
-    vi.mocked(messageCache.saveMessage).mockClear()
+    vi.mocked(messageCache.saveMessageWithResult).mockClear()
 
     // Offline replay: reaches the live path now, stamped BEFORE the window's
     // oldest resident message.
@@ -5187,8 +5188,8 @@ describe('chatStore delayed live arrivals (#1176)', () => {
     expect(resident.some((m) => m.id === 'offline-replay')).toBe(false)
     // ...yet it WAS written to IndexedDB, so it is durable-only: invisible in
     // the timeline until a cache slice pages it back in.
-    expect(messageCache.saveMessage).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(messageCache.saveMessage).mock.calls[0][0]).toMatchObject({ id: 'offline-replay' })
+    expect(messageCache.saveMessageWithResult).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(messageCache.saveMessageWithResult).mock.calls[0][0]).toMatchObject({ id: 'offline-replay' })
   })
 
   it('positions a delayed arrival inside the resident window in timestamp order', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -32,6 +32,7 @@ import {
   pruneTransient,
   removeTransient,
   clearTransientScope,
+  clearTransientEntity,
   transientIdentity,
   transientAliases,
   type ScopeKey as TransientScopeKey,
@@ -64,6 +65,8 @@ import {
   recordRecountDeferral,
   type RecountDeferralReason,
 } from './shared/recountDiagnostics'
+import { createRecountRetryScheduler } from './shared/recountRetry'
+import { createPendingEntityWrites } from './shared/pendingEntityWrites'
 import { flushKey, flush as flushThrottledStorage } from './shared/throttledStorage'
 import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per conversation; rest live in IndexedDB + MAM).
@@ -561,6 +564,11 @@ const conversationArchiveSaves = createArchiveSaveChain()
 // write (the recompute also re-checks `conversationMeta` under the same key).
 const chatRecountVersion = new Map<string, number>()
 const chatUnreadInputVersion = new Map<string, number>()
+const chatPendingUnreadWrites = createPendingEntityWrites()
+const chatEntityEpoch = new Map<string, number>()
+const chatRecountRetry = createRecountRetryScheduler((error) => {
+  console.warn('Unread recount retry failed for a conversation:', error)
+})
 
 function bumpChatRecountVersion(conversationId: string): number {
   const next = (chatRecountVersion.get(conversationId) ?? 0) + 1
@@ -572,11 +580,17 @@ function bumpChatUnreadInputVersion(conversationId: string): void {
   chatUnreadInputVersion.set(conversationId, (chatUnreadInputVersion.get(conversationId) ?? 0) + 1)
 }
 
-// Cache epoch (Codex r4 #5): bumped whenever the chat cache lifecycle resets
-// (logout reset, account switch, conversation deletion). Deferred
-// gap/coverage commits capture the epoch at merge time and no-op when it
-// moved — a gate already in flight when the state was torn down must not
-// resurrect entries.
+function chatRecountReady(conversationId: string): boolean {
+  const mam = mamState.getMAMQueryState(chatStore.getState().mamQueryStates, conversationId)
+  return !chatPendingUnreadWrites.has(conversationId) &&
+    !conversationArchiveSaves.has(conversationId) &&
+    isCaughtUpForCounting(mam)
+}
+
+function currentChatEntityEpoch(conversationId: string): number {
+  return chatEntityEpoch.get(conversationId) ?? 0
+}
+
 let chatCacheEpoch = 0
 
 /**
@@ -664,6 +678,16 @@ const unmigratedLegacyReadState = new Map<string, Map<string, LegacyReadState>>(
  */
 function chatTransientScopeKey(conversationId: string): TransientScopeKey {
   return { accountScope: getStorageScopeJid() ?? '', kind: 'chat', entityId: conversationId }
+}
+
+function invalidateChatEntity(conversationId: string): void {
+  chatEntityEpoch.set(conversationId, currentChatEntityEpoch(conversationId) + 1)
+  conversationArchiveSaves.cancel(conversationId)
+  chatPendingUnreadWrites.cancel(conversationId)
+  chatRecountRetry.cancel(conversationId)
+  chatRecountVersion.delete(conversationId)
+  chatUnreadInputVersion.delete(conversationId)
+  clearTransientEntity(chatTransientScopeKey(conversationId))
 }
 
 /**
@@ -1597,7 +1621,7 @@ export const chatStore = createStore<ChatState>()(
         // r4 #5): drop them with the cache, and invalidate in-flight deferred
         // commits so one can't resurrect an entry for the deleted
         // conversation.
-        chatCacheEpoch++
+        invalidateChatEntity(id)
 
         set((state) => {
           // Remove from all three conversation maps
@@ -1643,9 +1667,9 @@ export const chatStore = createStore<ChatState>()(
         const msg = arrival.messages[0]
         if (arrival.pendingRetractions) set({ pendingRetractions: arrival.pendingRetractions })
 
-        // `noLocalStore` messages (Quick Chat) are never archived, so
-        // the transient overlay is their ONLY source of unread truth —
-        // computed once, here, before the state update below, so
+        // Unread messages that are not yet durable use the transient overlay:
+        // permanently for `noLocalStore`, and until a live cache write commits
+        // for ordinary messages. It is computed once here, before the state update, so
         // `noteTransient` (a side-effecting Map mutation) runs exactly once
         // per arrival. Gated on `isUnseenIncomingMessage` so we never note an
         // outgoing/seen/historical arrival that `onMessageReceived` would not
@@ -1672,9 +1696,10 @@ export const chatStore = createStore<ChatState>()(
           },
           { treatDelayedAsNew: true }
         )
-        const noteAsTransient = unseen && isNoLocalStore(msg) && isRenderableStoredMessage(msg)
+        const noteAsTransient = unseen && isRenderableStoredMessage(msg)
         let overlayUnreadDelta = 0
         let overlayRequiresRecount = false
+        let acceptedMessage = false
         if (noteAsTransient && priorMeta) {
           const scopeKey = chatTransientScopeKey(msg.conversationId)
           // No boundary here: `isUnseenIncomingMessage` above already
@@ -1733,15 +1758,7 @@ export const chatStore = createStore<ChatState>()(
             patchedMap.set(msg.conversationId, append.messages)
             return { messages: patchedMap }
           }
-
-          // Save to IndexedDB + search index only if the message is locally persistable.
-          // This runs regardless of the live-edge gate: a gated message is still
-          // durable in the cache (and the meta/preview/unread updates below still
-          // run); it reloads on jump-to-latest.
-          if (!isNoLocalStore(msg)) {
-            void messageCache.saveMessage(msg)
-            searchIndex.indexMessage(msg).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
-          }
+          acceptedMessage = true
 
           const newMessages = new Map(state.messages)
           newMessages.set(
@@ -1857,6 +1874,31 @@ export const chatStore = createStore<ChatState>()(
 
           return { messages: newMessages, lastArrivedMessage: newArrived, ...interiorPlacementPatch }
         })
+
+        if (!acceptedMessage && overlayUnreadDelta > 0) {
+          removeTransient(chatTransientScopeKey(msg.conversationId), transientIdentity({ id: msg.id }, 'chat'))
+        }
+
+        if (acceptedMessage && !isNoLocalStore(msg)) {
+          const scopeAtSave = getStorageScopeJid()
+          const writeToken = chatPendingUnreadWrites.begin(msg.conversationId)
+          const save = 'saveMessageWithResult' in messageCache
+            ? messageCache.saveMessageWithResult(msg)
+            : messageCache.saveMessage(msg).then(() => true)
+          void save.then((committed) => {
+            const owned = chatPendingUnreadWrites.finish(msg.conversationId, writeToken)
+            if (!owned || getStorageScopeJid() !== scopeAtSave) return
+            if (committed && noteAsTransient) {
+              const removed = removeTransient(
+                chatTransientScopeKey(msg.conversationId),
+                transientIdentity({ id: msg.id }, 'chat')
+              )
+              if (removed.removed) bumpChatUnreadInputVersion(msg.conversationId)
+            }
+            chatRecountRetry.resume(msg.conversationId)
+          })
+          searchIndex.indexMessage(msg).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
+        }
 
         // See `noteTransient`'s doc on `requiresRecount`: only the
         // archive-derived recompute can fold this change back into the stored
@@ -2515,10 +2557,18 @@ export const chatStore = createStore<ChatState>()(
       },
 
       recomputeUnreadForConversation: async (conversationId, options) => {
-        // Passive diagnostic — see the room twin and #1211.
-        const defer = (reason: RecountDeferralReason): void =>
-          recordRecountDeferral('chat', reason)
         const allowActive = options?.allowActive ?? false
+        const defer = (reason: RecountDeferralReason): void => {
+          recordRecountDeferral('chat', reason)
+          if (reason === 'input-version-changed') {
+            chatRecountRetry.schedule(
+              conversationId,
+              allowActive,
+              (retryOptions) => get().recomputeUnreadForConversation(conversationId, retryOptions),
+              () => chatRecountReady(conversationId)
+            )
+          }
+        }
         // Active conversation counts are usually reconciled by their own
         // synchronous path (the live-edge convergence) — skip here to
         // avoid a redundant race, UNLESS the caller explicitly opted in
@@ -2581,10 +2631,11 @@ export const chatStore = createStore<ChatState>()(
         // overwriting the newer (correct) result.
         const version = bumpChatRecountVersion(conversationId)
         const cacheEpochAtStart = chatCacheEpoch
+        const entityEpochAtStart = currentChatEntityEpoch(conversationId)
         const storageScopeAtStart = getStorageScopeJid()
         const unreadInputVersionAtStart = chatUnreadInputVersion.get(conversationId) ?? 0
         const recountContextDeferral = (): RecountDeferralReason | undefined => {
-          if (chatCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
+          if (chatCacheEpoch !== cacheEpochAtStart || currentChatEntityEpoch(conversationId) !== entityEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
             return 'context-changed'
           }
           if (chatRecountVersion.get(conversationId) !== version) return 'recount-superseded'
@@ -2594,10 +2645,9 @@ export const chatStore = createStore<ChatState>()(
           return undefined
         }
 
-        // final-fix-2: snapshot the pointer identity the archive-derived
-        // count below is computed AGAINST. Re-checked at the final commit
-        // (see that guard's comment) to close a race the new allowActive
-        // trigger (advanceReadPointer) makes materially more likely.
+        // Snapshot the pointer identity the archive-derived count below is
+        // computed against. Re-check it at the final commit because an
+        // allowActive recount can race advanceReadPointer.
         const pointerIdAtCompute = metaNow.readPointer?.identity.messageId
         const unreadInputVersionAtCompute = chatUnreadInputVersion.get(conversationId) ?? 0
 
@@ -2664,7 +2714,7 @@ export const chatStore = createStore<ChatState>()(
           const meta = state.conversationMeta.get(conversationId)
           if (!meta) { defer('no-meta'); return state }
 
-          // final-fix-2: `res.unread` was derived against `pointerIdAtCompute`
+          // `res.unread` was derived against `pointerIdAtCompute`
           // (metaNow.readPointer, captured before the coverage-bottom and
           // countUnreadInArchive awaits). chatRecountVersion only orders this
           // recompute against ANOTHER recompute for the same entity — it does
@@ -2675,9 +2725,8 @@ export const chatStore = createStore<ChatState>()(
           // still active) can therefore be in flight exactly when that direct
           // write lands. Re-reading the pointer here and bailing if it moved
           // means a result computed against a now-stale pointer never clobbers
-          // the newer, correct value — worst case this recompute under-acts
-          // once; the next trigger (another arrival, deactivation, or
-          // activation) re-derives it.
+          // the newer, correct value. An input change queues the bounded
+          // trailing retry; a direct pointer advance launches its own recount.
           if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) {
             defer('pointer-changed')
             return state
@@ -2786,6 +2835,9 @@ export const chatStore = createStore<ChatState>()(
 
       mergeMAMMessages: (conversationId, archivePage, page, complete, direction, isFetchLatest = false, preserveGapMarker = false, extras = undefined) => {
         bumpChatUnreadInputVersion(conversationId)
+        const cacheEpochAtMerge = chatCacheEpoch
+        const entityEpochAtMerge = currentChatEntityEpoch(conversationId)
+        const storageScopeAtMerge = getStorageScopeJid()
 
         // XEP-0424: a retraction recorded earlier can target a message arriving in
         // THIS page (the live pass missed it because nothing was resident). Patch
@@ -2806,6 +2858,8 @@ export const chatStore = createStore<ChatState>()(
         // NON-active conversation — the archive-derived recount runs after
         // set() returns (see bottom of this action).
         let shouldRecountAfterMerge = false
+        let archiveCommitGate: Promise<boolean> | undefined
+        let durableMessages: Message[] = []
         set((state) => {
           // Get existing messages for this conversation
           const rawExisting = state.messages.get(conversationId) || []
@@ -2907,6 +2961,7 @@ export const chatStore = createStore<ChatState>()(
           // no crash window and the transition applies immediately.
           const prevGap = state.conversationGaps.get(conversationId)
           const persistableMessages = newMessages.filter(msg => !isNoLocalStore(msg))
+          durableMessages = persistableMessages
           // A merge with nothing persistable still defers when earlier pages
           // of this conversation are in flight (or failed): its cursor must
           // not leap them.
@@ -2954,7 +3009,7 @@ export const chatStore = createStore<ChatState>()(
           const scheduleDeferredCommit = (gate: Promise<boolean>) => {
             void gate.then((committed) => {
               if (!committed) return
-              if (chatCacheEpoch !== epochAtMerge) return
+              if (chatCacheEpoch !== epochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge) return
               set((s) => {
                 // State may have moved on (a later merge advanced or
                 // re-planted the gap/record): only transition the exact
@@ -2996,7 +3051,8 @@ export const chatStore = createStore<ChatState>()(
             // still gate this merge's transitions: chain a no-op save so the
             // transition applies (or is dropped) with the same ordering rules.
             if (deferGapCommit || deferCoverageCommit) {
-              scheduleDeferredCommit(conversationArchiveSaves.chain(conversationId, Promise.resolve(true)))
+              archiveCommitGate = conversationArchiveSaves.chain(conversationId, Promise.resolve(true))
+              scheduleDeferredCommit(archiveCommitGate)
             }
             if (patched.length === 0 || !isActive) {
               return { mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge }
@@ -3013,6 +3069,7 @@ export const chatStore = createStore<ChatState>()(
             // true only when THIS page and every earlier in-flight page
             // committed.
             const commitGate = conversationArchiveSaves.chain(conversationId, savePromise)
+            archiveCommitGate = commitGate
             if (deferGapCommit || deferCoverageCommit) {
               scheduleDeferredCommit(commitGate)
             }
@@ -3085,6 +3142,21 @@ export const chatStore = createStore<ChatState>()(
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
 
+        if (archiveCommitGate) {
+          void archiveCommitGate.then((committed) => {
+            if (!committed || chatCacheEpoch !== cacheEpochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+            let removed = false
+            for (const message of durableMessages) {
+              removed = removeTransient(
+                chatTransientScopeKey(conversationId),
+                transientIdentity({ id: message.id }, 'chat')
+              ).removed || removed
+            }
+            if (removed) bumpChatUnreadInputVersion(conversationId)
+            chatRecountRetry.resume(conversationId)
+          })
+        }
+
         // XEP-0490: a pending marker was not orderable in an earlier slice.
         // Retry against the merged messages; applyRemoteDisplayed clears
         // pendingRemoteDisplayedStanzaId only when the comparison resolves.
@@ -3099,6 +3171,17 @@ export const chatStore = createStore<ChatState>()(
         // the badge from the archive rather than trusting this page alone.
         if (shouldRecountAfterMerge) {
           void get().recomputeUnreadForConversation(conversationId)
+        }
+        if (direction === 'forward' && complete) {
+          if (!archiveCommitGate && conversationArchiveSaves.has(conversationId)) {
+            archiveCommitGate = conversationArchiveSaves.chain(conversationId, Promise.resolve(true))
+          }
+          const resume = () => {
+            if (chatCacheEpoch !== cacheEpochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+            chatRecountRetry.resume(conversationId)
+          }
+          if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
+          else resume()
         }
       },
 
@@ -3358,6 +3441,9 @@ export const chatStore = createStore<ChatState>()(
         chatCacheEpoch++
         chatRecountVersion.clear()
         chatUnreadInputVersion.clear()
+        chatPendingUnreadWrites.clear()
+        chatEntityEpoch.clear()
+        chatRecountRetry.clear()
         // Tear down the OUTGOING account's transient overlay entries
         // before adopting the new scope — see lastChatTransientScope's doc for
         // why this can't just read getStorageScopeJid() here.
@@ -3376,6 +3462,9 @@ export const chatStore = createStore<ChatState>()(
         chatCacheEpoch++
         chatRecountVersion.clear()
         chatUnreadInputVersion.clear()
+        chatPendingUnreadWrites.clear()
+        chatEntityEpoch.clear()
+        chatRecountRetry.clear()
         // Logout tears down this account's transient overlay too.
         // Unlike switchAccount, nothing flips the global scope before reset()
         // runs (clearLocalData calls it directly), so getStorageScopeJid()

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1882,9 +1882,7 @@ export const chatStore = createStore<ChatState>()(
         if (acceptedMessage && !isNoLocalStore(msg)) {
           const scopeAtSave = getStorageScopeJid()
           const writeToken = chatPendingUnreadWrites.begin(msg.conversationId)
-          const save = 'saveMessageWithResult' in messageCache
-            ? messageCache.saveMessageWithResult(msg)
-            : messageCache.saveMessage(msg).then(() => true)
+          const save = messageCache.saveMessageWithResult(msg)
           void save.then((committed) => {
             const owned = chatPendingUnreadWrites.finish(msg.conversationId, writeToken)
             if (!owned || getStorageScopeJid() !== scopeAtSave) return

--- a/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.viewportGate.test.ts
@@ -35,6 +35,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
   return {
     ...actual,
     saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessageWithResult: vi.fn().mockResolvedValue(true),
     saveMessages: vi.fn().mockResolvedValue(true),
     getMessages: vi.fn().mockResolvedValue([]),
     getMessagesAround: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -30,10 +30,16 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     // order (vi.fn.mockImplementationOnce) without disabling the real cursor.
     getRoomMessages: vi.fn(actual.getRoomMessages),
     countRoomUnreadInArchive: vi.fn(actual.countRoomUnreadInArchive),
+    saveRoomMessageWithResult: vi.fn(actual.saveRoomMessageWithResult),
+    saveRoomMessages: vi.fn(actual.saveRoomMessages),
   }
 })
 import * as messageCache from '../utils/messageCache'
 import { makeCacheOrderKey, type ExactPosition } from './shared/readState'
+
+const countRoomUnreadInArchiveImplementation = vi.mocked(messageCache.countRoomUnreadInArchive).getMockImplementation()!
+const saveRoomMessageWithResultImplementation = vi.mocked(messageCache.saveRoomMessageWithResult).getMockImplementation()!
+const saveRoomMessagesImplementation = vi.mocked(messageCache.saveRoomMessages).getMockImplementation()!
 
 /**
  * A transient entry's position.
@@ -131,10 +137,15 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     _resetRoomReadStateForTesting()
     resetRecountDeferralsForTesting()
     roomStore.getState().addRoom(createRoom(ROOM))
-    // mockClear() only resets call history, never the base implementation set
-    // by vi.fn(actual.countRoomUnreadInArchive) above, so it stays real by default.
+    // Reset queued one-shot implementations as well as call history so a
+    // deliberately failing race test cannot contaminate the next test.
     vi.mocked(messageCache.getRoomMessages).mockClear()
-    vi.mocked(messageCache.countRoomUnreadInArchive).mockClear()
+    vi.mocked(messageCache.countRoomUnreadInArchive).mockReset()
+    vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementation(countRoomUnreadInArchiveImplementation)
+    vi.mocked(messageCache.saveRoomMessageWithResult).mockReset()
+    vi.mocked(messageCache.saveRoomMessageWithResult).mockImplementation(saveRoomMessageWithResultImplementation)
+    vi.mocked(messageCache.saveRoomMessages).mockReset()
+    vi.mocked(messageCache.saveRoomMessages).mockImplementation(saveRoomMessagesImplementation)
     // The transient overlay is a module-level singleton (never cleared on
     // deactivation by design) — reset it between tests explicitly.
     clearTransientScope(getStorageScopeJid() ?? '')
@@ -562,7 +573,9 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // lets alice's message get appended last, wrongly advances the pointer TO
     // it, and zulu's message — already-confirmed-seen — then archive-sorts
     // AFTER it and gets wrongly counted as unread.
-    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    })
   })
 
   // ---------------------------------------------------------------------
@@ -656,11 +669,21 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     expect(readRecountDeferrals()['room:context-changed']).toBeUndefined()
   })
 
-  it('discards a recount whose archive snapshot predates a live arrival', async () => {
+  it('holds an invalidated active pointer recount until forward catch-up durably completes', async () => {
+    const p0 = archiveMsg('p0', 1000)
+    const p1 = archiveMsg('p1', 1500)
     await messageCache.saveRoomMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
-      archiveMsg('p0', 1000),
+      p0,
+      p1,
     ])
+    roomStore.setState((state) => {
+      const rooms = new Map(state.rooms)
+      rooms.set(ROOM, { ...rooms.get(ROOM)!, messages: [p0, p1] })
+      const roomRuntime = new Map(state.roomRuntime)
+      roomRuntime.set(ROOM, { ...roomRuntime.get(ROOM)!, messages: [p0, p1] })
+      return { rooms, roomRuntime }
+    })
     setMeta({
       unreadCount: 5,
       readPointer: { order: { role: 'exact', timestamp: new Date(1000).getTime(), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
@@ -668,23 +691,144 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     seedCoverage('anchor-stanza')
 
     let releaseCount!: (v: { unread: number }) => void
-    vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementationOnce(
-      () => new Promise((resolve) => { releaseCount = resolve })
-    )
+    vi.mocked(messageCache.countRoomUnreadInArchive)
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseCount = resolve }))
+      .mockImplementationOnce(async () => ({ unread: 7 }))
 
-    const stale = roomStore.getState().recomputeUnreadForRoom(ROOM)
+    roomStore.setState({ activeRoomJid: ROOM })
+    roomStore.getState().advanceReadPointer(ROOM, 'p1')
     await vi.waitFor(() => expect(releaseCount).toBeDefined())
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p1')
 
     roomStore.getState().addMessage(ROOM, archiveMsg('live', 2000))
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [archiveMsg('catchup-1', 2100)],
+      { first: 'catchup-1', last: 'catchup-1' },
+      false,
+      'forward'
+    )
 
     releaseCount({ unread: 3 })
-    await stale
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(1)
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
-    expect(roomStore.getState().rooms.get(ROOM)?.unreadCount).toBe(6)
+
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [archiveMsg('catchup-2', 2200)],
+      { first: 'catchup-2', last: 'catchup-2' },
+      true,
+      'forward'
+    )
+
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(7)
+    })
+    expect(roomStore.getState().rooms.get(ROOM)?.unreadCount).toBe(7)
+    expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(2)
     expect(readRecountDeferrals()['room:input-version-changed']).toBe(1)
     expect(readRecountDeferrals()['room:context-changed']).toBeUndefined()
+  })
+
+  it('retains a failed live cache write in the unread recount overlay', async () => {
+    await messageCache.saveRoomMessages([
+      archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('p0', 1000),
+      ...Array.from({ length: 5 }, (_, index) => archiveMsg(`u${index + 1}`, 1100 + index)),
+    ])
+    setMeta({
+      unreadCount: 5,
+      readPointer: { order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
+    })
+    seedCoverage('anchor-stanza')
+    roomStore.setState({ activeRoomJid: ROOM })
+
+    let releaseCount!: (v: { unread: number }) => void
+    vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseCount = resolve })
+    )
+    vi.mocked(messageCache.saveRoomMessageWithResult).mockResolvedValueOnce(false)
+
+    const stale = roomStore.getState().recomputeUnreadForRoom(ROOM, { allowActive: true })
+    await vi.waitFor(() => expect(releaseCount).toBeDefined())
+    roomStore.getState().addMessage(ROOM, archiveMsg('live-write-failed', 2000))
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
+
+    releaseCount({ unread: 5 })
+    await stale
+
+    await vi.waitFor(() => {
+      expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(2)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(6)
+    })
+    expect(transientCounts(scopeKey(), undefined).unread).toBe(1)
+  })
+
+  it('resumes a held active recount after a backward archive write commits', async () => {
+    await messageCache.saveRoomMessages([
+      archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+      archiveMsg('older', 700),
+      archiveMsg('p0', 1000),
+    ])
+    setMeta({
+      unreadCount: 5,
+      readPointer: { order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'p0' } }, identity: { state: 'local', messageId: 'p0' } },
+    })
+    seedCoverage('anchor-stanza')
+    roomStore.setState({ activeRoomJid: ROOM })
+
+    let releaseCount!: (v: { unread: number }) => void
+    vi.mocked(messageCache.countRoomUnreadInArchive)
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseCount = resolve }))
+      .mockImplementationOnce(async () => ({ unread: 7 }))
+    let releaseSave!: (committed: boolean) => void
+    vi.mocked(messageCache.saveRoomMessages).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseSave = resolve })
+    )
+
+    const stale = roomStore.getState().recomputeUnreadForRoom(ROOM, { allowActive: true })
+    await vi.waitFor(() => expect(releaseCount).toBeDefined())
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [archiveMsg('older', 700)],
+      { first: 'older', last: 'older' },
+      true,
+      'backward'
+    )
+    releaseCount({ unread: 3 })
+    await stale
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(1)
+    releaseSave(true)
+
+    await vi.waitFor(() => {
+      expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(2)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(7)
+    })
+  })
+
+  it('settles a live write when an unrelated room is removed', async () => {
+    const otherRoom = 'other@conference.example.com'
+    roomStore.getState().addRoom(createRoom(otherRoom))
+    roomStore.setState({ activeRoomJid: ROOM })
+    let releaseSave!: (committed: boolean) => void
+    vi.mocked(messageCache.saveRoomMessageWithResult).mockImplementationOnce(
+      () => new Promise((resolve) => { releaseSave = resolve })
+    )
+
+    roomStore.getState().addMessage(ROOM, archiveMsg('pending-live', 2000))
+    expect(transientCounts(scopeKey(), undefined).unread).toBe(1)
+
+    roomStore.getState().removeRoom(otherRoom)
+    releaseSave(true)
+
+    await vi.waitFor(() => {
+      expect(transientCounts(scopeKey(), undefined).unread).toBe(0)
+    })
   })
 
   // Was 'rejects a guard-pass pointer write after the account scope changes',

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -42,6 +42,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     isMessageCacheAvailable: vi.fn().mockReturnValue(true),
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
+    saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
     saveRoomMessages: vi.fn().mockResolvedValue(true),
     getRoomMessages: vi.fn().mockResolvedValue([]),
     getRoomMessagesAround: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
@@ -22,6 +22,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
+    saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
     getRoomMessages: vi.fn().mockResolvedValue([]),
   }
 })

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -51,6 +51,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     isMessageCacheAvailable: vi.fn().mockReturnValue(true),
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
+    saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
     saveRoomMessages: vi.fn().mockResolvedValue(true),
     getRoomMessages: vi.fn().mockResolvedValue([]),
     getRoomMessagesAround: vi.fn().mockResolvedValue([]),
@@ -1485,7 +1486,7 @@ describe('roomStore', () => {
 
       roomStore.getState().addMessage('test@conference.example.com', message)
 
-      expect(messageCache.saveRoomMessage).toHaveBeenCalled()
+      expect(messageCache.saveRoomMessageWithResult).toHaveBeenCalled()
     })
 
     it('should not save message to IndexedDB when noLocalStore is true (XEP-0334)', () => {
@@ -1494,7 +1495,7 @@ describe('roomStore', () => {
 
       roomStore.getState().addMessage('test@conference.example.com', message)
 
-      expect(messageCache.saveRoomMessage).not.toHaveBeenCalled()
+      expect(messageCache.saveRoomMessageWithResult).not.toHaveBeenCalled()
     })
 
     it('should set noLocalStore=true on messages for Quick Chat rooms', () => {
@@ -1504,7 +1505,7 @@ describe('roomStore', () => {
       roomStore.getState().addMessage('quickchat@conference.example.com', message)
 
       // Message should not be saved to IndexedDB
-      expect(messageCache.saveRoomMessage).not.toHaveBeenCalled()
+      expect(messageCache.saveRoomMessageWithResult).not.toHaveBeenCalled()
 
       // But message should still be in memory with noLocalStore flag
       const room = roomStore.getState().rooms.get('quickchat@conference.example.com')
@@ -5384,7 +5385,7 @@ describe('roomStore', () => {
     beforeEach(() => {
       roomStore.getState().reset()
       vi.mocked(messageCache.getRoomMessages).mockReset()
-      vi.mocked(messageCache.saveRoomMessage).mockClear()
+      vi.mocked(messageCache.saveRoomMessageWithResult).mockClear()
       roomStore.getState().addRoom({
         jid: roomJid,
         name: 'Test Room',
@@ -5461,7 +5462,7 @@ describe('roomStore', () => {
       await roomStore.getState().loadOlderMessagesFromCache(roomJid, 50)
       expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
 
-      vi.mocked(messageCache.saveRoomMessage).mockClear()
+      vi.mocked(messageCache.saveRoomMessageWithResult).mockClear()
       const before = roomStore.getState().getRoom(roomJid)!.messages
       const live = roomMsgAt('live-1', 10000)
       roomStore.getState().addMessage(roomJid, live)
@@ -5472,7 +5473,7 @@ describe('roomStore', () => {
       expect(room.messages.length).toBe(before.length)
       expect(room.messages[room.messages.length - 1].id).toBe(before[before.length - 1].id)
       // ...but the message is still persisted to IndexedDB...
-      expect(messageCache.saveRoomMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 'live-1' }))
+      expect(messageCache.saveRoomMessageWithResult).toHaveBeenCalledWith(expect.objectContaining({ id: 'live-1' }))
       // ...and meta (sidebar preview + unread badge) still update.
       expect(room.lastMessage?.id).toBe('live-1')
       expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.id).toBe('live-1')

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2156,9 +2156,7 @@ export const roomStore = createStore<RoomState>()(
     if (acceptedMessage && !isNoLocalStore(messageToAdd)) {
       const scopeAtSave = getStorageScopeJid()
       const writeToken = roomPendingUnreadWrites.begin(roomJid)
-      const save = 'saveRoomMessageWithResult' in messageCache
-        ? messageCache.saveRoomMessageWithResult(messageToAdd)
-        : messageCache.saveRoomMessage(messageToAdd).then(() => true)
+      const save = messageCache.saveRoomMessageWithResult(messageToAdd)
       void save.then((committed) => {
         const owned = roomPendingUnreadWrites.finish(roomJid, writeToken)
         if (!owned || getStorageScopeJid() !== scopeAtSave) return

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -49,6 +49,7 @@ import {
   pruneTransient,
   removeTransient,
   clearTransientScope,
+  clearTransientEntity,
   transientIdentity,
   transientAliases,
   type ScopeKey as TransientScopeKey,
@@ -78,6 +79,8 @@ import {
   recordRecountDeferral,
   type RecountDeferralReason,
 } from './shared/recountDiagnostics'
+import { createRecountRetryScheduler } from './shared/recountRetry'
+import { createPendingEntityWrites } from './shared/pendingEntityWrites'
 import { schedule, flush as flushThrottledStorage } from './shared/throttledStorage'
 import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per room; rest live in IndexedDB + MAM). Read via
@@ -386,7 +389,7 @@ function savePendingRetractionsToStorage(pending: Map<string, PendingRetraction[
 const roomArchiveSaves = createArchiveSaveChain()
 
 // Cache epoch (Codex r4 #5): bumped whenever the room cache lifecycle resets
-// (logout reset, account switch, room removal). Deferred gap/coverage commits
+// (logout reset or account switch). Deferred gap/coverage commits
 // capture the epoch at merge time and no-op when it moved — a gate that was
 // already in flight when the state was torn down must not resurrect entries.
 let roomCacheEpoch = 0
@@ -415,6 +418,11 @@ export function _resetRoomArchiveSavesForTesting(): void {
 // under the same key).
 const roomRecountVersion = new Map<string, number>()
 const roomUnreadInputVersion = new Map<string, number>()
+const roomPendingUnreadWrites = createPendingEntityWrites()
+const roomEntityEpoch = new Map<string, number>()
+const roomRecountRetry = createRecountRetryScheduler((error) => {
+  console.warn('Unread recount retry failed for a room:', error)
+})
 
 function bumpRoomRecountVersion(roomJid: string): number {
   const next = (roomRecountVersion.get(roomJid) ?? 0) + 1
@@ -426,6 +434,17 @@ function bumpRoomUnreadInputVersion(roomJid: string): void {
   roomUnreadInputVersion.set(roomJid, (roomUnreadInputVersion.get(roomJid) ?? 0) + 1)
 }
 
+function roomRecountReady(roomJid: string): boolean {
+  const mam = mamState.getMAMQueryState(roomStore.getState().mamQueryStates, roomJid)
+  return !roomPendingUnreadWrites.has(roomJid) &&
+    !roomArchiveSaves.has(roomJid) &&
+    isCaughtUpForCounting(mam)
+}
+
+function currentRoomEntityEpoch(roomJid: string): number {
+  return roomEntityEpoch.get(roomJid) ?? 0
+}
+
 /**
  * The transient-overlay scope key for a room. `accountScope` mirrors
  * chatStore's `chatTransientScopeKey` — a bare room JID can collide across
@@ -433,6 +452,16 @@ function bumpRoomUnreadInputVersion(roomJid: string): void {
  */
 function roomTransientScopeKey(roomJid: string): TransientScopeKey {
   return { accountScope: getStorageScopeJid() ?? '', kind: 'room', entityId: roomJid }
+}
+
+function invalidateRoomEntity(roomJid: string): void {
+  roomEntityEpoch.set(roomJid, currentRoomEntityEpoch(roomJid) + 1)
+  roomArchiveSaves.cancel(roomJid)
+  roomPendingUnreadWrites.cancel(roomJid)
+  roomRecountRetry.cancel(roomJid)
+  roomRecountVersion.delete(roomJid)
+  roomUnreadInputVersion.delete(roomJid)
+  clearTransientEntity(roomTransientScopeKey(roomJid))
 }
 
 /**
@@ -1216,7 +1245,7 @@ export const roomStore = createStore<RoomState>()(
     // The durable cursors describe messages that no longer exist (Codex r4
     // #5): drop them with the cache, and invalidate in-flight deferred
     // commits so one can't resurrect an entry for the removed room.
-    roomCacheEpoch++
+    invalidateRoomEntity(roomJid)
 
     set((state) => {
       const newRooms = new Map(state.rooms)
@@ -1764,6 +1793,9 @@ export const roomStore = createStore<RoomState>()(
     roomCacheEpoch++
     roomRecountVersion.clear()
     roomUnreadInputVersion.clear()
+    roomPendingUnreadWrites.clear()
+    roomEntityEpoch.clear()
+    roomRecountRetry.clear()
     // Tear down the OUTGOING account's transient overlay entries
     // before adopting the new scope — see lastRoomTransientScope's doc for
     // why this can't just read getStorageScopeJid() here.
@@ -1787,6 +1819,9 @@ export const roomStore = createStore<RoomState>()(
     roomCacheEpoch++
     roomRecountVersion.clear()
     roomUnreadInputVersion.clear()
+    roomPendingUnreadWrites.clear()
+    roomEntityEpoch.clear()
+    roomRecountRetry.clear()
     // Logout tears down this account's transient overlay too.
     // Unlike switchAccount, nothing flips the global scope before reset()
     // runs (clearLocalData calls it directly), so getStorageScopeJid() here
@@ -1850,15 +1885,9 @@ export const roomStore = createStore<RoomState>()(
     const messageToAdd = arrival.messages[0]
     if (arrival.pendingRetractions) set({ pendingRetractions: arrival.pendingRetractions })
 
-    // Save to IndexedDB only if the message is locally persistable
-    if (!isNoLocalStore(messageToAdd)) {
-      void messageCache.saveRoomMessage(messageToAdd)
-      searchIndex.indexMessage(messageToAdd).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
-    }
-
-    // `noLocalStore` messages (Quick Chat rooms, MUC ephemera) are
-    // never archived, so the transient overlay is their ONLY source of
-    // unread truth — computed once, here, before the state update below, so
+    // Unread messages that are not yet durable use the transient overlay:
+    // permanently for `noLocalStore`, and until a live cache write commits
+    // for ordinary messages. It is computed once here, before the state update, so
     // `noteTransient` (a side-effecting Map mutation) runs exactly once per
     // arrival. Gated on `isUnseenIncomingMessage` so we never note an
     // outgoing/seen/historical arrival that `onMessageReceived` would not
@@ -1881,9 +1910,10 @@ export const roomStore = createStore<RoomState>()(
       windowVisible: connectionStore.getState().windowVisible,
       viewportAtLiveEdge: viewportAtLiveEdgeForNote,
     })
-    const noteAsTransient = incrementUnread && unseen && isNoLocalStore(messageToAdd) && isRenderableStoredMessage(messageToAdd)
+    const noteAsTransient = incrementUnread && unseen && isRenderableStoredMessage(messageToAdd)
     let overlayUnreadDelta = 0
     let overlayRequiresRecount = false
+    let acceptedMessage = false
     if (noteAsTransient && priorMeta) {
       const scopeKey = roomTransientScopeKey(roomJid)
       // No boundary here: `isUnseenIncomingMessage` above already establishes
@@ -1954,6 +1984,7 @@ export const roomStore = createStore<RoomState>()(
         }
         return { rooms: newRooms, roomRuntime: patchedRuntime }
       }
+      acceptedMessage = true
 
       // The appended set is also the basis for the newest-message preview even
       // when the append was gated (the preview must still advance to the
@@ -2109,6 +2140,36 @@ export const roomStore = createStore<RoomState>()(
 
       return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers, ...interiorPlacementPatch }
     })
+
+    const transientMessageIdentity = () => transientIdentity({
+      roomJid,
+      from: messageToAdd.from,
+      id: messageToAdd.id,
+      stanzaId: messageToAdd.stanzaId,
+      originId: messageToAdd.originId,
+    }, 'room')
+
+    if (!acceptedMessage && overlayUnreadDelta > 0) {
+      removeTransient(roomTransientScopeKey(roomJid), transientMessageIdentity())
+    }
+
+    if (acceptedMessage && !isNoLocalStore(messageToAdd)) {
+      const scopeAtSave = getStorageScopeJid()
+      const writeToken = roomPendingUnreadWrites.begin(roomJid)
+      const save = 'saveRoomMessageWithResult' in messageCache
+        ? messageCache.saveRoomMessageWithResult(messageToAdd)
+        : messageCache.saveRoomMessage(messageToAdd).then(() => true)
+      void save.then((committed) => {
+        const owned = roomPendingUnreadWrites.finish(roomJid, writeToken)
+        if (!owned || getStorageScopeJid() !== scopeAtSave) return
+        if (committed && noteAsTransient) {
+          const removed = removeTransient(roomTransientScopeKey(roomJid), transientMessageIdentity())
+          if (removed.removed) bumpRoomUnreadInputVersion(roomJid)
+        }
+        roomRecountRetry.resume(roomJid)
+      })
+      searchIndex.indexMessage(messageToAdd).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
+    }
 
     // See `noteTransient`'s doc on `requiresRecount`: only the archive-derived
     // recompute can fold this change back into the stored count. No-ops for
@@ -2333,9 +2394,17 @@ export const roomStore = createStore<RoomState>()(
 
   recomputeUnreadForRoom: async (roomJid, options) => {
     const allowActive = options?.allowActive ?? false
-    // Passive diagnostic: every guard below declines to COUNT, and from outside the
-    // store they are indistinguishable — the badge just keeps its old value. See #1211.
-    const defer = (reason: RecountDeferralReason): void => recordRecountDeferral('room', reason)
+    const defer = (reason: RecountDeferralReason): void => {
+      recordRecountDeferral('room', reason)
+      if (reason === 'input-version-changed') {
+        roomRecountRetry.schedule(
+          roomJid,
+          allowActive,
+          (retryOptions) => get().recomputeUnreadForRoom(roomJid, retryOptions),
+          () => roomRecountReady(roomJid)
+        )
+      }
+    }
     // Active room counts are usually reconciled by their own synchronous path
     // (the live-edge convergence) — skip here to avoid a redundant
     // race, UNLESS the caller explicitly opted in (a remote XEP-0490
@@ -2397,10 +2466,11 @@ export const roomStore = createStore<RoomState>()(
     // room is discarded instead of overwriting the newer (correct) result.
     const version = bumpRoomRecountVersion(roomJid)
     const cacheEpochAtStart = roomCacheEpoch
+    const entityEpochAtStart = currentRoomEntityEpoch(roomJid)
     const storageScopeAtStart = getStorageScopeJid()
     const unreadInputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
     const recountContextDeferral = (): RecountDeferralReason | undefined => {
-      if (roomCacheEpoch !== cacheEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
+      if (roomCacheEpoch !== cacheEpochAtStart || currentRoomEntityEpoch(roomJid) !== entityEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
         return 'context-changed'
       }
       if (roomRecountVersion.get(roomJid) !== version) return 'recount-superseded'
@@ -2410,10 +2480,9 @@ export const roomStore = createStore<RoomState>()(
       return undefined
     }
 
-    // final-fix-2: snapshot the pointer identity the archive-derived count
-    // below is computed AGAINST. Re-checked at the final commit (see that
-    // guard's comment) to close a race the new allowActive trigger
-    // (advanceReadPointer) makes materially more likely.
+    // Snapshot the pointer identity the archive-derived count below is
+    // computed against. Re-check it at the final commit because an
+    // allowActive recount can race advanceReadPointer.
     const pointerIdAtCompute = metaNow.readPointer?.identity.messageId
     const unreadInputVersionAtCompute = roomUnreadInputVersion.get(roomJid) ?? 0
 
@@ -2482,7 +2551,7 @@ export const roomStore = createStore<RoomState>()(
       const meta = state.roomMeta.get(roomJid)
       if (!meta) { defer('no-meta'); return state }
 
-      // final-fix-2: `res.unread` was derived against `pointerIdAtCompute`
+      // `res.unread` was derived against `pointerIdAtCompute`
       // (metaNow.readPointer, captured before the coverage-bottom and
       // countRoomUnreadInArchive awaits). roomRecountVersion only orders this
       // recompute against ANOTHER recompute for the same room — it does NOT
@@ -2493,9 +2562,8 @@ export const roomStore = createStore<RoomState>()(
       // still active) can therefore be in flight exactly when that direct
       // write lands. Re-reading the pointer here and bailing if it moved
       // means a result computed against a now-stale pointer never clobbers
-      // the newer, correct value — worst case this recompute under-acts
-      // once; the next trigger (another arrival, deactivation, or
-      // activation) re-derives it.
+      // the newer, correct value. An input change queues the bounded trailing
+      // retry; a direct pointer advance launches its own recount.
       if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) {
         defer('pointer-changed')
         return state
@@ -3770,6 +3838,9 @@ export const roomStore = createStore<RoomState>()(
 
   mergeRoomMAMMessages: (roomJid, archivePage, page, complete, direction, preserveGapMarker = false, isFetchLatest = false, extras = undefined) => {
     bumpRoomUnreadInputVersion(roomJid)
+    const cacheEpochAtMerge = roomCacheEpoch
+    const entityEpochAtMerge = currentRoomEntityEpoch(roomJid)
+    const storageScopeAtMerge = getStorageScopeJid()
 
     // XEP-0424: a retraction recorded earlier can target a message arriving in
     // THIS page (the live pass missed it because nothing was resident). Patch
@@ -3793,6 +3864,8 @@ export const roomStore = createStore<RoomState>()(
     // contiguous history past the read pointer with new messages — triggers
     // the archive-derived recount after this set().
     let shouldRecountAfterMerge = false
+    let archiveCommitGate: Promise<boolean> | undefined
+    let durableMessages: RoomMessage[] = []
     set((state) => {
       const room = state.rooms.get(roomJid)
       if (!room) return state
@@ -3900,6 +3973,7 @@ export const roomStore = createStore<RoomState>()(
       // applies immediately.
       const prevGap = state.roomGaps.get(roomJid)
       const persistableMessages = newFromMAM.filter(msg => !isNoLocalStore(msg))
+      durableMessages = persistableMessages
       // A merge with nothing persistable still defers when earlier pages of
       // this room are in flight (or failed): its cursor must not leap them.
       const mustGateOnChain = persistableMessages.length > 0 || roomArchiveSaves.has(roomJid)
@@ -3943,7 +4017,7 @@ export const roomStore = createStore<RoomState>()(
       const scheduleDeferredCommit = (gate: Promise<boolean>) => {
         void gate.then((committed) => {
           if (!committed) return
-          if (roomCacheEpoch !== epochAtMerge) return
+          if (roomCacheEpoch !== epochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge) return
           set((s) => {
             // State may have moved on (a later merge advanced or re-planted
             // the gap/record): only transition the exact value this merge
@@ -3984,7 +4058,8 @@ export const roomStore = createStore<RoomState>()(
         // still gate this merge's transitions: chain a no-op save so the
         // transition applies (or is dropped) with the same ordering rules.
         if (deferGapCommit || deferCoverageCommit) {
-          scheduleDeferredCommit(roomArchiveSaves.chain(roomJid, Promise.resolve(true)))
+          archiveCommitGate = roomArchiveSaves.chain(roomJid, Promise.resolve(true))
+          scheduleDeferredCommit(archiveCommitGate)
         }
         if (patched.length === 0 || state.activeRoomJid !== roomJid) {
           return { mamQueryStates: newStates, roomGaps: gapsAfterMerge, roomCoverage: coverageAfterMerge }
@@ -4006,6 +4081,7 @@ export const roomStore = createStore<RoomState>()(
         // Serialize through the per-room chain: the gate resolves true only
         // when THIS page and every earlier in-flight page committed.
         const commitGate = roomArchiveSaves.chain(roomJid, savePromise)
+        archiveCommitGate = commitGate
         if (deferGapCommit || deferCoverageCommit) {
           scheduleDeferredCommit(commitGate)
         }
@@ -4082,6 +4158,30 @@ export const roomStore = createStore<RoomState>()(
       return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
+    if (archiveCommitGate) {
+      void archiveCommitGate.then((committed) => {
+        if (!committed || roomCacheEpoch !== cacheEpochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+        let removed = false
+        for (const message of durableMessages) {
+          const aliases = transientAliases({
+            roomJid,
+            from: message.from,
+            id: message.id,
+            stanzaId: message.stanzaId,
+            originId: message.originId,
+          }, 'room')
+          for (const alias of aliases) {
+            if (removeTransient(roomTransientScopeKey(roomJid), alias).removed) {
+              removed = true
+              break
+            }
+          }
+        }
+        if (removed) bumpRoomUnreadInputVersion(roomJid)
+        roomRecountRetry.resume(roomJid)
+      })
+    }
+
     // XEP-0490: a pending marker was not orderable in an earlier slice.
     // Retry against the merged messages; the shared resolver clears it only
     // when the comparison resolves.
@@ -4096,6 +4196,17 @@ export const roomStore = createStore<RoomState>()(
     // badge from the archive rather than trusting this page alone.
     if (shouldRecountAfterMerge) {
       void get().recomputeUnreadForRoom(roomJid)
+    }
+    if (direction === 'forward' && complete) {
+      if (!archiveCommitGate && roomArchiveSaves.has(roomJid)) {
+        archiveCommitGate = roomArchiveSaves.chain(roomJid, Promise.resolve(true))
+      }
+      const resume = () => {
+        if (roomCacheEpoch !== cacheEpochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+        roomRecountRetry.resume(roomJid)
+      }
+      if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
+      else resume()
     }
   },
 

--- a/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
@@ -43,6 +43,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     ...actual,
     isMessageCacheAvailable: vi.fn().mockReturnValue(true),
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
+    saveRoomMessageWithResult: vi.fn().mockResolvedValue(true),
     saveRoomMessages: vi.fn().mockResolvedValue(true),
     getRoomMessages: vi.fn().mockResolvedValue([]),
     getRoomMessagesAround: vi.fn().mockResolvedValue([]),

--- a/packages/fluux-sdk/src/stores/shared/archiveSaveChain.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveSaveChain.ts
@@ -22,6 +22,7 @@ export interface ArchiveSaveChain {
   chain: (id: string, save: Promise<boolean>) => Promise<boolean>
   /** True when `id` has an in-flight (or poisoned) chain entry. */
   has: (id: string) => boolean
+  cancel: (id: string) => void
   /** Drop all entries (store reset / account switch). */
   clear: () => void
 }
@@ -42,6 +43,9 @@ export function createArchiveSaveChain(): ArchiveSaveChain {
     },
     has(id) {
       return chains.has(id)
+    },
+    cancel(id) {
+      chains.delete(id)
     },
     clear() {
       chains.clear()

--- a/packages/fluux-sdk/src/stores/shared/pendingEntityWrites.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingEntityWrites.ts
@@ -1,0 +1,28 @@
+export interface PendingEntityWriteToken {
+  readonly value: symbol
+}
+
+export function createPendingEntityWrites() {
+  const writes = new Map<string, Set<symbol>>()
+
+  const begin = (entityId: string): PendingEntityWriteToken => {
+    const value = Symbol(entityId)
+    const pending = writes.get(entityId) ?? new Set<symbol>()
+    pending.add(value)
+    writes.set(entityId, pending)
+    return { value }
+  }
+
+  const finish = (entityId: string, token: PendingEntityWriteToken): boolean => {
+    const pending = writes.get(entityId)
+    if (!pending?.delete(token.value)) return false
+    if (pending.size === 0) writes.delete(entityId)
+    return true
+  }
+
+  const has = (entityId: string): boolean => writes.has(entityId)
+  const cancel = (entityId: string): void => { writes.delete(entityId) }
+  const clear = (): void => { writes.clear() }
+
+  return { begin, finish, has, cancel, clear }
+}

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
@@ -56,9 +56,8 @@ export type RecountDeferralReason =
    * Message inputs changed while this recount was awaiting, so its result describes
    * a state that no longer exists.
    *
-   * The interesting one for #1211: `addMessage` bumps this version on EVERY
-   * arrival, so an active room that keeps receiving can invalidate each recount
-   * with the traffic that made it necessary.
+   * `addMessage` bumps this version on every arrival, so a snapshot computed
+   * before live traffic cannot commit after that traffic changes its inputs.
    */
   | 'input-version-changed'
   /** The read pointer moved while the recount was in flight. */

--- a/packages/fluux-sdk/src/stores/shared/recountRetry.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountRetry.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRecountRetryScheduler } from './recountRetry'
+
+describe('createRecountRetryScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces an invalidation burst and preserves allowActive', async () => {
+    const retry = vi.fn(async () => {})
+    const scheduler = createRecountRetryScheduler(vi.fn())
+
+    scheduler.schedule('room@example.com', false, retry)
+    scheduler.schedule('room@example.com', true, retry)
+    scheduler.schedule('room@example.com', false, retry)
+
+    await vi.runAllTimersAsync()
+
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(retry).toHaveBeenCalledWith({ allowActive: true })
+  })
+
+  it('does not reschedule a retry invalidated while it is running', async () => {
+    const scheduler = createRecountRetryScheduler(vi.fn())
+    const retry = vi.fn(async () => {
+      scheduler.schedule('room@example.com', true, retry)
+    })
+
+    scheduler.schedule('room@example.com', true, retry)
+    await vi.runAllTimersAsync()
+    await vi.runAllTimersAsync()
+
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds the coalesced retry until its durable boundary is ready', async () => {
+    let ready = false
+    const retry = vi.fn(async () => {})
+    const scheduler = createRecountRetryScheduler(vi.fn())
+
+    scheduler.schedule('room@example.com', true, retry, () => ready)
+    await vi.runAllTimersAsync()
+
+    expect(retry).not.toHaveBeenCalled()
+
+    ready = true
+    scheduler.resume('room@example.com')
+    await vi.runAllTimersAsync()
+
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(retry).toHaveBeenCalledWith({ allowActive: true })
+  })
+
+  it('cancels pending retries when its session is cleared', async () => {
+    const retry = vi.fn(async () => {})
+    const scheduler = createRecountRetryScheduler(vi.fn())
+
+    scheduler.schedule('room@example.com', false, retry)
+    scheduler.clear()
+    await vi.runAllTimersAsync()
+
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it('keeps recreated entity retry ownership when a cancelled retry settles', async () => {
+    let releaseFirst!: () => void
+    let releaseSecond!: () => void
+    const retry = vi.fn<() => Promise<void>>()
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseFirst = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseSecond = resolve }))
+      .mockImplementation(async () => {})
+    const scheduler = createRecountRetryScheduler(vi.fn())
+
+    scheduler.schedule('room@example.com', true, retry)
+    await vi.runAllTimersAsync()
+    expect(retry).toHaveBeenCalledTimes(1)
+
+    scheduler.cancel('room@example.com')
+    scheduler.schedule('room@example.com', true, retry)
+    await vi.runAllTimersAsync()
+    expect(retry).toHaveBeenCalledTimes(2)
+
+    releaseFirst()
+    await vi.runAllTimersAsync()
+
+    scheduler.schedule('room@example.com', true, retry)
+    await vi.runAllTimersAsync()
+    expect(retry).toHaveBeenCalledTimes(2)
+
+    releaseSecond()
+    await vi.runAllTimersAsync()
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/recountRetry.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountRetry.ts
@@ -1,0 +1,89 @@
+export interface RecountRetryOptions {
+  allowActive: boolean
+}
+
+type Retry = (options: RecountRetryOptions) => Promise<void>
+type Ready = () => boolean
+
+interface PendingRetry {
+  allowActive: boolean
+  retry: Retry
+  ready: Ready
+  timer?: ReturnType<typeof setTimeout>
+  generation: number
+}
+
+/**
+ * Schedules one trailing retry after an unread recount observes changing input.
+ * A retry that is itself invalidated must not schedule another retry: sustained
+ * message traffic must never turn archive recounting into a timer loop.
+ */
+export function createRecountRetryScheduler(onError: (error: unknown) => void) {
+  const pending = new Map<string, PendingRetry>()
+  const running = new Map<string, PendingRetry>()
+  let generation = 0
+
+  const dispatch = (entityId: string, request: PendingRetry): void => {
+    if (generation !== request.generation || pending.get(entityId) !== request) return
+    request.timer = undefined
+    if (!request.ready()) return
+
+    pending.delete(entityId)
+    running.set(entityId, request)
+    void request.retry({ allowActive: request.allowActive })
+      .catch(onError)
+      .finally(() => {
+        if (running.get(entityId) === request) {
+          running.delete(entityId)
+        }
+      })
+  }
+
+  const arm = (entityId: string, request: PendingRetry): void => {
+    if (request.timer !== undefined) return
+    request.timer = setTimeout(() => dispatch(entityId, request), 0)
+  }
+
+  const schedule = (entityId: string, allowActive: boolean, retry: Retry, ready: Ready = () => true): void => {
+    if (running.get(entityId)?.generation === generation) return
+
+    const existing = pending.get(entityId)
+    if (existing?.generation === generation) {
+      existing.allowActive ||= allowActive
+      return
+    }
+
+    const scheduledGeneration = generation
+    const request: PendingRetry = {
+      allowActive,
+      retry,
+      ready,
+      generation: scheduledGeneration,
+    }
+    pending.set(entityId, request)
+    arm(entityId, request)
+  }
+
+  const resume = (entityId: string): void => {
+    const request = pending.get(entityId)
+    if (!request || request.generation !== generation || !request.ready()) return
+    arm(entityId, request)
+  }
+
+  const clear = (): void => {
+    generation++
+    for (const request of pending.values()) {
+      if (request.timer !== undefined) clearTimeout(request.timer)
+    }
+    pending.clear()
+  }
+
+  const cancel = (entityId: string): void => {
+    const request = pending.get(entityId)
+    if (request?.timer !== undefined) clearTimeout(request.timer)
+    pending.delete(entityId)
+    running.delete(entityId)
+  }
+
+  return { schedule, resume, cancel, clear }
+}

--- a/packages/fluux-sdk/src/stores/shared/transientUnread.ts
+++ b/packages/fluux-sdk/src/stores/shared/transientUnread.ts
@@ -2,12 +2,12 @@ import { compareExact, isAfterBoundary, type ExactPosition, type PointerOrder } 
 import { roomCanonicalKey, roomIdentityKeys, type RoomIdentityFields } from '../../utils/roomMessageIdentity'
 
 /**
- * Transient overlay for `noLocalStore` messages (MUC ephemera, Quick Chat):
- * messages that are never written to IndexedDB but must still count as
- * unread. `unreadCount` is derived from the archive (see `readState.ts`),
- * but an archive-only count silently erases these messages — they have no
- * row to scan. This overlay holds them in memory, position-aware, so Tasks
- * 7/8 can add its contribution on top of the archive-derived count:
+ * Transient overlay for unread messages that have no durable IndexedDB row:
+ * permanently for `noLocalStore` messages, and while an ordinary live write
+ * is pending or after it fails. `unreadCount` is derived from the archive (see
+ * `readState.ts`), but an archive-only count silently erases these messages.
+ * This overlay holds them in memory, position-aware, so callers can add its
+ * contribution on top of the archive-derived count:
  * `unread = min(999, archive.unread + transient.unread)`.
  *
  * Scoped by `{accountScope, kind, entityId}` (never a bare `entityId` — that
@@ -24,8 +24,8 @@ import { roomCanonicalKey, roomIdentityKeys, type RoomIdentityFields } from '../
  * Entries are NEVER cleared on deactivation: clearing when the user
  * switches away (while scrolled up) would silently drop unread. An entry
  * leaves only when the read pointer passes it ({@link pruneTransient}), the
- * message is retracted/removed ({@link removeTransient}), or the account is
- * torn down ({@link clearTransientScope}). Because {@link transientCounts}
+ * message becomes durable or is retracted/removed ({@link removeTransient}),
+ * or the account is torn down ({@link clearTransientScope}). Because {@link transientCounts}
  * compares each entry against the *current* boundary, a partial pointer
  * advance reduces the count correctly with no clearing at all — pruning is
  * a memory bound, not a correctness mechanism.
@@ -119,7 +119,7 @@ export function transientAliases(msg: RoomIdentityFields | { id: string }, kind:
 }
 
 /**
- * Note a transient (never-archived) message. Resolves every supplied alias
+ * Note a message that is not yet represented by a durable archive row. Resolves every supplied alias
  * through `canonicalByAlias`:
  *
  * - none resolve → brand-new logical entry, stored under `identity`.
@@ -251,6 +251,10 @@ export function clearTransientScope(accountScope: string): void {
   for (const k of scopes.keys()) {
     if (k.startsWith(prefix)) scopes.delete(k)
   }
+}
+
+export function clearTransientEntity(key: ScopeKey): void {
+  scopes.delete(scopeKeyString(key))
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, expectTypeOf, beforeEach, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
 import { openDB } from 'idb'
@@ -9,6 +9,7 @@ import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
 
 // Must import after fake-indexeddb/auto
 import * as messageCache from './messageCache'
+import * as cacheApi from '../cache'
 import { mergeRoomRows, _contentProjectionForTesting } from './messageCache'
 import type { StoredRoomMessage } from './messageCache'
 
@@ -46,6 +47,11 @@ function createMockRoomMessage(roomJid: string, overrides: Partial<RoomMessage> 
 }
 
 describe('messageCache', () => {
+  it('preserves public single-message save return types', () => {
+    expectTypeOf(cacheApi.saveMessage).returns.toEqualTypeOf<Promise<void>>()
+    expectTypeOf(cacheApi.saveRoomMessage).returns.toEqualTypeOf<Promise<void>>()
+  })
+
   beforeEach(async () => {
     _resetStorageScopeForTesting()
     // Reset IndexedDB completely before each test
@@ -93,7 +99,7 @@ describe('messageCache', () => {
       it('should save a message to IndexedDB', async () => {
         const message = createMockMessage(conversationId, { id: 'msg-1' })
 
-        await messageCache.saveMessage(message)
+        await expect(messageCache.saveMessage(message)).resolves.toBeUndefined()
 
         const retrieved = await messageCache.getMessage('msg-1')
         expect(retrieved).not.toBeNull()
@@ -107,7 +113,7 @@ describe('messageCache', () => {
           stanzaId: 'stanza-123',
         })
 
-        await messageCache.saveMessage(message)
+        await expect(messageCache.saveMessage(message)).resolves.toBeUndefined()
 
         const byStanzaId = await messageCache.getMessageByStanzaId('stanza-123')
         expect(byStanzaId).not.toBeNull()
@@ -508,7 +514,7 @@ describe('messageCache', () => {
       it('should save a room message to IndexedDB', async () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-1' })
 
-        await messageCache.saveRoomMessage(message)
+        await expect(messageCache.saveRoomMessage(message)).resolves.toBeUndefined()
 
         const retrieved = await messageCache.getRoomMessage(roomJid, 'room-1')
         expect(retrieved).not.toBeNull()
@@ -521,7 +527,7 @@ describe('messageCache', () => {
           stanzaId: 'room-stanza-123',
         })
 
-        await messageCache.saveRoomMessage(message)
+        await expect(messageCache.saveRoomMessage(message)).resolves.toBeUndefined()
 
         const byStanzaId = await messageCache.getRoomMessageByStanzaId(roomJid, 'room-stanza-123')
         expect(byStanzaId).not.toBeNull()

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -545,17 +545,23 @@ async function putChatMessageGuarded(
  * Upserts - will overwrite if message with same ID exists, EXCEPT it never
  * degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  */
-export async function saveMessage(message: Message): Promise<void> {
+export async function saveMessageWithResult(message: Message): Promise<boolean> {
   try {
     const db = await getDB(getStorageScopeJid())
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
     await putChatMessageGuarded(tx.store, message)
     await tx.done
+    return true
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to save message:', error)
     }
+    return false
   }
+}
+
+export async function saveMessage(message: Message): Promise<void> {
+  await saveMessageWithResult(message)
 }
 
 /**
@@ -1117,8 +1123,12 @@ export async function deleteConversationMessages(conversationId: string): Promis
  * catch-up cursor may skip past it. Batched writes for history replay
  * should use {@link saveRoomMessages} instead.
  */
+export async function saveRoomMessageWithResult(message: RoomMessage): Promise<boolean> {
+  return saveRoomMessages([message])
+}
+
 export async function saveRoomMessage(message: RoomMessage): Promise<void> {
-  await saveRoomMessages([message])
+  await saveRoomMessageWithResult(message)
 }
 
 /**


### PR DESCRIPTION
Fixes #1211.

Unread archive recounts now schedule a single coalesced retry when live traffic invalidates their input snapshot. Retries wait for pending cache writes and MAM catch-up to reach a durable boundary, preserve active-entity authorization, and are canceled on entity or session teardown.

Failed live cache writes remain represented in transient unread state so badges cannot silently undercount, while the public single-message cache APIs retain their existing `Promise<void>` contract.
