### PR TITLE
refactor(scroll): end an orphaned frame loop the same way in all seven runs

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -518,6 +518,29 @@ function positionFrameInShadow<Request extends { conversationId: string }, Resul
   })
 }
 
+/**
+ * Discard a loop whose lease went stale while it was being built.
+ *
+ * `beginLoop` can outlive the ownership that authorised it, and the orphaned loop is nobody else's
+ * to end. Ending it is an adapter call like any other, so it runs inside the shadow — the seven runs
+ * reach this point by different paths and must not differ in whether a failing adapter throws out of
+ * one of them. No public entry point is known to reach this branch; it is depth, kept uniform so a
+ * reader does not have to work out which runs have it.
+ */
+function finishStaleLoopInShadow(
+  run: { request: { conversationId: string } },
+  event: string,
+  loop: PositionFrameLoop | null,
+): void {
+  if (!loop) return
+  runScrollShadowSafely({
+    event,
+    conversationId: run.request.conversationId,
+    fallback: undefined,
+    observe: () => loop.finish(),
+  })
+}
+
 const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
@@ -1699,7 +1722,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'live-edge-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -1927,7 +1950,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'anchor-preservation-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2119,7 +2142,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'directional-history-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2282,14 +2305,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'resident-top-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'resident-top-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2570,14 +2586,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'explicit-target-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'explicit-target-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2836,14 +2845,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'unread-marker-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'unread-marker-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -3193,14 +3195,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'saved-position-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'saved-position-loop-stale-finish', loop)
       return
     }
     if (!loop) {


### PR DESCRIPTION
A frame loop can be built and then find that the ownership that authorised it is gone, which leaves it orphaned: nobody else will end it, so the run that built it must. Four runs did that inside the scroll shadow; live edge, anchor preservation and directional history called `finish()` bare. All seven now go through one step.

This is uniformity on an error path rather than a bug fix, and the code says so. No public entry point is known to reach the branch: deactivation cancels executions from inside its own shadow, so an adapter that fails while being discarded is already absorbed there, and an attempt to drive a run into the branch did not reach it — a probe on all three bare sites counted zero passes. The value is that the next reader no longer has to work out which runs carry the guard, or whether the difference meant something.