### PR TITLE
refactor(scroll): mint every run's lease through one step

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -1264,6 +1264,32 @@ describe('positioning controller saved-position ownership', () => {
     }
   }
 
+  it('keeps a settled entry settled when a later frame reports the position applied', () => {
+    // A saved-position run can be driven a second time — an around-load or a recenter re-enters it
+    // with a fresh request — and the first pass may already have settled. Reporting "applied" then
+    // would walk the phase backwards, and a phase that goes back from settled is read by the rest
+    // of the app as positioning still in progress.
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+    const lease = harness.leases.at(-1)
+    expect(lease).toBeDefined()
+
+    expect(lease!.settle()).toBe(true)
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'settled',
+    })
+
+    expect(lease!.markApplied()).toBe(true)
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'settled',
+    })
+  })
+
   it('loads an off-window anchor exactly once and resumes when that load settles', async () => {
     let anchorAvailable = false
     let resolveLoad!: () => void

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -433,6 +433,14 @@ function advanceDriftConvergence(
   return { moved, settles: execution.stableFrames >= stableFramesToSettle }
 }
 
+/** What a run exposes to the step that mints its lease. */
+interface ExecutionOperationState {
+  request: { conversationId: string; generation: number }
+  abortController: AbortController | null
+  operation: number
+  framesLeft: number
+}
+
 /**
  * What every positioning run exposes to the shadow-wrapped frame steps below.
  *
@@ -1841,8 +1849,21 @@ export class PositioningController {
     })
   }
 
-  private beginLiveEdgeOperation(
-    execution: LiveEdgeExecutionState,
+  /**
+   * Mint the lease that authorises one operation of a run, superseding whatever it was doing.
+   *
+   * A lease answers one question — does this run still own the position — and ownership can be lost
+   * three ways, minted at three different moments: the abort signal fires, the controller's slot
+   * stops pointing at this execution, or a newer operation supersedes this one. A newer generation
+   * of the conversation is the fourth, and lives in the model rather than on the execution.
+   *
+   * `ownsSlot` is the only part a run states for itself, because the slot is a named field per run.
+   * `alreadySatisfied` lets a run treat a phase as reached without touching the model.
+   */
+  private beginExecutionOperation(
+    execution: ExecutionOperationState,
+    ownsSlot: () => boolean,
+    alreadySatisfied?: (phase: PositioningPhase) => boolean,
   ): PositionExecutionLease {
     execution.abortController?.abort()
     const abortController = new AbortController()
@@ -1851,11 +1872,12 @@ export class PositioningController {
     const { conversationId, generation } = execution.request
     const isCurrent = () =>
       !abortController.signal.aborted &&
-      this.liveEdgeExecution === execution &&
+      ownsSlot() &&
       execution.operation === operation &&
       isCurrentGeneration(this.model, conversationId, generation)
     const advance = (phase: PositioningPhase) => {
       if (!isCurrent()) return false
+      if (alreadySatisfied?.(phase)) return true
       this.model = advancePhaseIfCurrent(
         this.model,
         conversationId,
@@ -1874,6 +1896,15 @@ export class PositioningController {
       markApplied: () => advance({ kind: 'position-applied' }),
       settle: () => advance({ kind: 'settled' }),
     }
+  }
+
+  private beginLiveEdgeOperation(
+    execution: LiveEdgeExecutionState,
+  ): PositionExecutionLease {
+    return this.beginExecutionOperation(
+      execution,
+      () => this.liveEdgeExecution === execution,
+    )
   }
 
   /**
@@ -2071,36 +2102,10 @@ export class PositioningController {
   private beginAnchorPreservationOperation(
     execution: AnchorPreservationExecutionState,
   ): PositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.anchorPreservationExecution === execution &&
-      execution.operation === operation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+    return this.beginExecutionOperation(
+      execution,
+      () => this.anchorPreservationExecution === execution,
+    )
   }
 
   private isAnchorPreservationExecutionCurrent(execution: AnchorPreservationExecutionState): boolean {
@@ -2253,36 +2258,10 @@ export class PositioningController {
   private beginDirectionalHistoryOperation(
     execution: DirectionalHistoryExecutionState,
   ): PositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.directionalHistoryExecution === execution &&
-      execution.operation === operation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+    return this.beginExecutionOperation(
+      execution,
+      () => this.directionalHistoryExecution === execution,
+    )
   }
 
   private isDirectionalHistoryExecutionCurrent(execution: DirectionalHistoryExecutionState): boolean {
@@ -2428,38 +2407,10 @@ export class PositioningController {
   private beginResidentTopOperation(
     execution: ResidentTopExecutionState,
   ): PositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.residentTopExecution === execution &&
-      execution.operation === operation &&
-      execution.request.conversationId === conversationId &&
-      execution.request.generation === generation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+    return this.beginExecutionOperation(
+      execution,
+      () => this.residentTopExecution === execution,
+    )
   }
 
   private isResidentTopExecutionCurrent(execution: ResidentTopExecutionState): boolean {
@@ -2727,38 +2678,10 @@ export class PositioningController {
   private beginExplicitTargetOperation(
     execution: ExplicitTargetExecutionState,
   ): PositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.explicitTargetExecution === execution &&
-      execution.operation === operation &&
-      execution.request.conversationId === conversationId &&
-      execution.request.generation === generation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+    return this.beginExecutionOperation(
+      execution,
+      () => this.explicitTargetExecution === execution,
+    )
   }
 
   private isExplicitTargetExecutionCurrent(execution: ExplicitTargetExecutionState): boolean {
@@ -3014,38 +2937,10 @@ export class PositioningController {
   private beginUnreadOperation(
     execution: UnreadMarkerExecutionState,
   ): PositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.unreadExecution === execution &&
-      execution.operation === operation &&
-      execution.request.conversationId === conversationId &&
-      execution.request.generation === generation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+    return this.beginExecutionOperation(
+      execution,
+      () => this.unreadExecution === execution,
+    )
   }
 
   private isUnreadExecutionCurrent(execution: UnreadMarkerExecutionState): boolean {
@@ -3463,44 +3358,16 @@ export class PositioningController {
   private beginSavedOperation(
     execution: SavedPositionExecutionState,
   ): SavedPositionExecutionLease {
-    execution.abortController?.abort()
-    const abortController = new AbortController()
-    execution.abortController = abortController
-    const operation = ++execution.operation
-    const { conversationId, generation } = execution.request
-    const isCurrent = () =>
-      !abortController.signal.aborted &&
-      this.savedExecution === execution &&
-      execution.operation === operation &&
-      execution.request.conversationId === conversationId &&
-      execution.request.generation === generation &&
-      isCurrentGeneration(this.model, conversationId, generation)
-    const advance = (phase: PositioningPhase) => {
-      if (!isCurrent()) return false
-      if (
+    return this.beginExecutionOperation(
+      execution,
+      () => this.savedExecution === execution,
+      // A saved-position run that has already settled treats a late "applied" as reached rather
+      // than walking the phase backwards: the entry has finished, and the frame reporting it is
+      // just the loop draining.
+      (phase) =>
         phase.kind === 'position-applied' &&
-        this.model.active?.phase.kind === 'settled'
-      ) {
-        return true
-      }
-      this.model = advancePhaseIfCurrent(
-        this.model,
-        conversationId,
-        generation,
-        phase,
-      )
-      return isCurrent()
-    }
-    return {
-      conversationId,
-      generation,
-      operation,
-      frameBudget: execution.framesLeft,
-      signal: abortController.signal,
-      isCurrent,
-      markApplied: () => advance({ kind: 'position-applied' }),
-      settle: () => advance({ kind: 'settled' }),
-    }
+        this.model.active?.phase.kind === 'settled',
+    )
   }
 
   private isSavedExecutionCurrent(execution: SavedPositionExecutionState): boolean {

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -518,6 +518,29 @@ function positionFrameInShadow<Request extends { conversationId: string }, Resul
   })
 }
 
+/**
+ * Discard a loop whose lease went stale while it was being built.
+ *
+ * `beginLoop` can outlive the ownership that authorised it, and the orphaned loop is nobody else's
+ * to end. Ending it is an adapter call like any other, so it runs inside the shadow — the seven runs
+ * reach this point by different paths and must not differ in whether a failing adapter throws out of
+ * one of them. No public entry point is known to reach this branch; it is depth, kept uniform so a
+ * reader does not have to work out which runs have it.
+ */
+function finishStaleLoopInShadow(
+  run: { request: { conversationId: string } },
+  event: string,
+  loop: PositionFrameLoop | null,
+): void {
+  if (!loop) return
+  runScrollShadowSafely({
+    event,
+    conversationId: run.request.conversationId,
+    fallback: undefined,
+    observe: () => loop.finish(),
+  })
+}
+
 const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
@@ -1699,7 +1722,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'live-edge-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -1927,7 +1950,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'anchor-preservation-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2119,7 +2142,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      loop?.finish()
+      finishStaleLoopInShadow(execution, 'directional-history-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2282,14 +2305,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'resident-top-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'resident-top-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2570,14 +2586,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'explicit-target-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'explicit-target-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -2836,14 +2845,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'unread-marker-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'unread-marker-loop-stale-finish', loop)
       return
     }
     if (!loop) {
@@ -3193,14 +3195,7 @@ export class PositioningController {
       observe: () => execution.executor.beginLoop(lease),
     })
     if (!lease.isCurrent()) {
-      if (loop) {
-        runScrollShadowSafely({
-          event: 'saved-position-loop-stale-finish',
-          conversationId: execution.request.conversationId,
-          fallback: undefined,
-          observe: () => loop.finish(),
-        })
-      }
+      finishStaleLoopInShadow(execution, 'saved-position-loop-stale-finish', loop)
       return
     }
     if (!loop) {


### PR DESCRIPTION
Stacked on #1299.

Seven methods minted the lease that authorises a run — thirty-six lines each, in three shapes. The shapes were not three designs. Three runs asked four questions: has the abort signal fired, does the controller's slot still point at this execution, has a newer operation superseded it, is the conversation generation still current. Three more asked the same four plus whether the execution's request still carried the conversation and generation the lease was minted with. Saved position asked those, and additionally treated a late "applied" on an already-settled entry as reached rather than walking the phase backwards.

**The request comparison is dead.** `execution.request` is assigned in exactly one place in the file — the saved-position around-load path — and that same place aborts the controller and increments the operation counter on the neighbouring lines, so any lease minted before it already fails two other conditions. For the three runs that never reassign the request, the comparison reads a field and checks it against itself. Dropped rather than carried into the shared step, where it would have told the next reader that a request can change under a run.

What remains: one step (252 lines of lease minting become 99), the slot test each run states for itself because the slot is a named field, and saved position's phase rule.

That phase rule was empirical and nothing verified it — neutralising it left the whole suite green. It turns out to be real: saved position is re-driven after an around-load or a recenter, and a first pass may already have settled. A test now pins it, since a phase that goes back from settled reads to the rest of the app as positioning still in progress.