### PR TITLE
docs(readme): fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Fluux Messenger is licensed under the **GNU Affero General Public License v3.0 o
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=processone/fluux-messenger&type=Date&theme=dark&legend=bottom-right)](https://star-history.com/#processone/fluux-messenger&Date&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=processone/fluux-messenger&type=Date&theme=dark&legend=bottom-right)](https://star-history.dera.page/#processone/fluux-messenger&Date&legend=bottom-right)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is broken: the image it points at
no longer renders because the stargazer feed behind it is gone. This is
unfortunate since the project is actively growing and the chart is a
nice way to show that.

Point the chart at star-history.dera.page, which serves both the chart
image and the click-through frontend from the same domain and needs no
API token. The wrapping link keeps the repository and Date parameters.