### PR TITLE
refactor(sdk): one writer for the room message window

### DIFF
--- a/packages/fluux-sdk/src/stores/roomStore.messageWindow.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.messageWindow.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { roomStore } from './roomStore'
+import { createRoom, createRoomMessage } from '../hooks/renderStability.helpers'
+
+/**
+ * The room's resident message window lives in two maps — the `rooms` compat
+ * entry and `roomRuntime` — and one writer keeps them in step.
+ *
+ * These pin the two properties a reader depends on and a hand-written mirror
+ * pair kept losing: the maps agree, and a write that changes nothing hands back
+ * the same reference.
+ */
+describe('room message window', () => {
+  beforeEach(() => {
+    roomStore.setState({
+      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(),
+      activeRoomJid: null, mamQueryStates: new Map(), activeAnimation: null, drafts: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+  })
+
+  it('lands an appended message in BOTH maps, with the same array', () => {
+    roomStore.getState().addRoom(createRoom('a@x', { joined: true }))
+    roomStore.getState().addMessage('a@x', createRoomMessage('a@x', 'nick', 'hello', { id: 'm1' }))
+
+    const state = roomStore.getState()
+    const viaCompat = state.rooms.get('a@x')!.messages
+    const viaRuntime = state.roomRuntime.get('a@x')!.messages
+
+    expect(viaCompat.map((m) => m.id)).toEqual(['m1'])
+    // Same reference, not merely equal contents: a reader that falls back from
+    // one map to the other must not be able to observe two different windows.
+    expect(viaRuntime).toBe(viaCompat)
+  })
+
+  it('keeps the two maps in step across several appends', () => {
+    roomStore.getState().addRoom(createRoom('a@x', { joined: true }))
+    for (const id of ['m1', 'm2', 'm3']) {
+      roomStore.getState().addMessage('a@x', createRoomMessage('a@x', 'nick', id, { id }))
+    }
+
+    const state = roomStore.getState()
+    expect(state.rooms.get('a@x')!.messages).toBe(state.roomRuntime.get('a@x')!.messages)
+    expect(state.rooms.get('a@x')!.messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3'])
+  })
+
+  it('leaves roomRuntime referentially identical when a deactivation evicts an already-empty window', () => {
+    roomStore.getState().addRoom(createRoom('a@x', { joined: true }))
+    roomStore.getState().setActiveRoom('a@x')
+
+    // No messages were ever appended, so deactivating has no window to drop.
+    const before = roomStore.getState().roomRuntime
+    roomStore.getState().setActiveRoom(null)
+
+    // A fresh map here would re-render every runtime subscriber for nothing.
+    expect(roomStore.getState().roomRuntime).toBe(before)
+  })
+
+  it('does not resurrect a room that is gone from the compat map', () => {
+    roomStore.getState().addRoom(createRoom('a@x', { joined: true }))
+    roomStore.getState().removeRoom('a@x')
+
+    roomStore.getState().addMessage('a@x', createRoomMessage('a@x', 'nick', 'hello', { id: 'm1' }))
+
+    expect(roomStore.getState().rooms.has('a@x')).toBe(false)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -726,6 +726,62 @@ function resolveRoomPendingRetractions(
   return { messages, pendingRetractions: nextPending }
 }
 
+/**
+ * The single writer for a room's resident message window.
+ *
+ * The window lives in two maps: the `rooms` compat entry and `roomRuntime`.
+ * Seven call sites used to set both by hand, and the two writes were not even
+ * decided the same way — the compat write was unconditional while the runtime
+ * write sat behind `if (existingRuntime)`. Two independent decisions per write
+ * is exactly what a reader has to trust when it falls back from one map to the
+ * other, and the fallbacks in this file are the trace of that doubt.
+ *
+ * Copy-on-write, and deliberately so on each map separately: a fresh map
+ * reference re-renders every subscriber to it, so a window that is already what
+ * it would become leaves `roomRuntime` untouched.
+ *
+ * @returns the maps to return from `set()`, or `null` when the room is unknown
+ *   — the same miss the call sites already guarded on.
+ */
+function withRoomMessageWindow(
+  state: Pick<RoomState, 'rooms' | 'roomRuntime'>,
+  roomJid: string,
+  messages: RoomMessage[],
+  options: {
+    /** Extra fields for the compat entry only, e.g. a refreshed preview. */
+    roomPatch?: Partial<Room>
+    /**
+     * Move the live-edge flag. Written to the runtime and NOT to the compat
+     * entry: the flag is authoritative on the runtime, which is why
+     * `ROOM_RUNTIME_FIELD_ROUTING` marks it `preserve` — a plain field update
+     * must never silently recenter the window.
+     */
+    atLiveEdge?: boolean
+  } = {}
+): Pick<RoomState, 'rooms' | 'roomRuntime'> | null {
+  const existing = state.rooms.get(roomJid)
+  if (!existing) return null
+
+  const rooms = new Map(state.rooms)
+  rooms.set(roomJid, { ...existing, ...options.roomPatch, messages })
+
+  const runtime = state.roomRuntime.get(roomJid)
+  const windowUnchanged =
+    runtime &&
+    options.atLiveEdge === undefined &&
+    (runtime.messages === messages ||
+      (runtime.messages.length === 0 && messages.length === 0))
+  if (!runtime || windowUnchanged) return { rooms, roomRuntime: state.roomRuntime }
+
+  const roomRuntime = new Map(state.roomRuntime)
+  roomRuntime.set(roomJid, {
+    ...runtime,
+    messages,
+    ...(options.atLiveEdge === undefined ? {} : { windowAtLiveEdge: options.atLiveEdge }),
+  })
+  return { rooms, roomRuntime }
+}
+
 function mergeCachedRoomMessages(
   state: RoomState,
   roomJid: string,
@@ -751,14 +807,8 @@ function mergeCachedRoomMessages(
     findLastNonIgnoredMessage(msgs, roomJid, existing.nickToJidCache)
   )
 
-  newRooms.set(roomJid, { ...existing, messages: merged, lastMessage })
-
-  // Update runtime
-  const newRuntime = new Map(state.roomRuntime)
-  const existingRuntime = newRuntime.get(roomJid)
-  if (existingRuntime) {
-    newRuntime.set(roomJid, { ...existingRuntime, messages: merged })
-  }
+  const written = withRoomMessageWindow(state, roomJid, merged, { roomPatch: { lastMessage } })
+  if (!written) return null
 
   // Update metadata with lastMessage for sidebar
   const newMeta = new Map(state.roomMeta)
@@ -768,8 +818,7 @@ function mergeCachedRoomMessages(
   }
 
   return {
-    rooms: newRooms,
-    roomRuntime: newRuntime,
+    ...written,
     roomMeta: newMeta,
     ...(resolvedRetractions.pendingRetractions ? { pendingRetractions: resolvedRetractions.pendingRetractions } : {}),
   }
@@ -1976,13 +2025,9 @@ export const roomStore = createStore<RoomState>()(
         for (const p of append.patched) {
           void messageCache.updateRoomMessage(roomJid, p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) }, p.from)
         }
-        newRooms.set(roomJid, { ...existing, messages: append.messages })
-        const patchedRuntime = new Map(state.roomRuntime)
-        const runtimeEntry = patchedRuntime.get(roomJid)
-        if (runtimeEntry) {
-          patchedRuntime.set(roomJid, { ...runtimeEntry, messages: append.messages })
-        }
-        return { rooms: newRooms, roomRuntime: patchedRuntime }
+        const backfilled = withRoomMessageWindow(state, roomJid, append.messages)
+        if (!backfilled) return state
+        return backfilled
       }
       acceptedMessage = true
 
@@ -2097,22 +2142,16 @@ export const roomStore = createStore<RoomState>()(
       // never moved on send, unlike chatStore.addMessage — a chat/room parity
       // gap. `onMessageReceived` only ever advances via `advance()`, which is
       // forward-only, so committing it here unconditionally cannot regress it.
-      newRooms.set(roomJid, {
-        ...existing,
-        messages: newMessages,
-        unreadCount,
-        mentionsCount: updated.mentionsCount,
-        readPointer: updated.readPointer,
-        lastMessage,
-        lastInteractedAt: newLastInteractedAt,
+      const written = withRoomMessageWindow(state, roomJid, newMessages, {
+        roomPatch: {
+          unreadCount,
+          mentionsCount: updated.mentionsCount,
+          readPointer: updated.readPointer,
+          lastMessage,
+          lastInteractedAt: newLastInteractedAt,
+        },
       })
-
-      // Update runtime (messages)
-      const newRuntime = new Map(state.roomRuntime)
-      const existingRuntime = newRuntime.get(roomJid)
-      if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
-      }
+      if (!written) return state
 
       // Update metadata
       const newMeta = new Map(state.roomMeta)
@@ -2138,7 +2177,7 @@ export const roomStore = createStore<RoomState>()(
       if (updated.firstNewMessageId) newMarkers.set(roomJid, updated.firstNewMessageId)
       else newMarkers.delete(roomJid)
 
-      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers, ...interiorPlacementPatch }
+      return { ...written, roomMeta: newMeta, firstNewMessageMarkers: newMarkers, ...interiorPlacementPatch }
     })
 
     const transientMessageIdentity = () => transientIdentity({
@@ -2229,16 +2268,9 @@ export const roomStore = createStore<RoomState>()(
         void messageCache.updateRoomMessageReactions(roomJid, messageId, reactorNick, emojis)
       }
 
-      newRooms.set(roomJid, { ...existing, messages: newMessages })
-
-      // Update runtime
-      const newRuntime = new Map(state.roomRuntime)
-      const existingRuntime = newRuntime.get(roomJid)
-      if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
-      }
-
-      return { rooms: newRooms, roomRuntime: newRuntime }
+      const written = withRoomMessageWindow(state, roomJid, newMessages)
+      if (!written) return state
+      return written
     })
   },
 
@@ -2289,18 +2321,12 @@ export const roomStore = createStore<RoomState>()(
         }
       }
 
-      newRooms.set(roomJid, { ...existing, messages: newMessages })
-
-      // Update runtime
-      const newRuntime = new Map(state.roomRuntime)
-      const existingRuntime = newRuntime.get(roomJid)
-      if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
-      }
+      const written = withRoomMessageWindow(state, roomJid, newMessages)
+      if (!written) return state
 
       // Update metadata's lastMessage if the updated message is the last one
       const lastMessage = newMessages[newMessages.length - 1]
-      const result: Partial<RoomState> = { rooms: newRooms, roomRuntime: newRuntime }
+      const result: Partial<RoomState> = { ...written }
       if (updatedMessage && lastMessage === updatedMessage) {
         const newMeta = new Map(state.roomMeta)
         const existingMeta = newMeta.get(roomJid)
@@ -2330,16 +2356,10 @@ export const roomStore = createStore<RoomState>()(
 
       void messageCache.updateRoomMessage(roomJid, existing.messages[targetIdx].id, { stanzaId: undefined }, existing.messages[targetIdx].from)
 
-      const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, messages: newMessages })
+      const written = withRoomMessageWindow(state, roomJid, newMessages)
+      if (!written) return state
 
-      const newRuntime = new Map(state.roomRuntime)
-      const existingRuntime = newRuntime.get(roomJid)
-      if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
-      }
-
-      const result: Partial<RoomState> = { rooms: newRooms, roomRuntime: newRuntime }
+      const result: Partial<RoomState> = { ...written }
       const meta = state.roomMeta.get(roomJid)
       const wasLastMessage =
         !!meta?.lastMessage &&
@@ -2755,24 +2775,14 @@ export const roomStore = createStore<RoomState>()(
       const hadMarker = get().firstNewMessageMarkers.has(prevJid)
 
       set((state) => {
-        // Evict from the runtime mirror (messages live here).
-        const newRuntime = new Map(state.roomRuntime)
-        const prevRuntime = newRuntime.get(prevJid)
-        if (prevRuntime && prevRuntime.messages.length > 0) {
-          newRuntime.set(prevJid, { ...prevRuntime, messages: [] })
-        }
-
-        // Evict from the combined map mirror.
-        const newRooms = new Map(state.rooms)
-        const prevRoom = newRooms.get(prevJid)
-        if (prevRoom) {
-          newRooms.set(prevJid, { ...prevRoom, messages: [] })
-        }
+        // Drop the deactivated room's window; the writer leaves `roomRuntime`
+        // untouched when it is already empty.
+        const evicted = withRoomMessageWindow(state, prevJid, [])
 
         const newMarkers = new Map(state.firstNewMessageMarkers)
         if (hadMarker) newMarkers.delete(prevJid)
 
-        return { roomRuntime: newRuntime, rooms: newRooms, firstNewMessageMarkers: newMarkers }
+        return { ...evicted, firstNewMessageMarkers: newMarkers }
       })
     }
 
@@ -3608,20 +3618,10 @@ export const roomStore = createStore<RoomState>()(
             roomTimelineConfig()
           )
 
-          newRooms.set(roomJid, { ...existing, messages: merged })
-
-          // Update runtime
-          const newRuntime = new Map(state.roomRuntime)
-          const existingRuntime = newRuntime.get(roomJid)
-          if (existingRuntime) {
-            newRuntime.set(roomJid, {
-              ...existingRuntime,
-              messages: merged,
-              ...(newestEvicted ? { windowAtLiveEdge: false } : {}),
-            })
-          }
-
-          return { rooms: newRooms, roomRuntime: newRuntime }
+          const written = withRoomMessageWindow(state, roomJid, merged,
+            newestEvicted ? { atLiveEdge: false } : {})
+          if (!written) return state
+          return written
         })
       }
 
@@ -3673,20 +3673,10 @@ export const roomStore = createStore<RoomState>()(
             roomTimelineConfig()
           )
 
-          newRooms.set(roomJid, { ...existing, messages: merged })
-
-          // Update runtime
-          const newRuntime = new Map(state.roomRuntime)
-          const existingRuntime = newRuntime.get(roomJid)
-          if (existingRuntime) {
-            newRuntime.set(roomJid, {
-              ...existingRuntime,
-              messages: merged,
-              ...(reachedTail ? { windowAtLiveEdge: true } : {}),
-            })
-          }
-
-          return { rooms: newRooms, roomRuntime: newRuntime }
+          const written = withRoomMessageWindow(state, roomJid, merged,
+            reachedTail ? { atLiveEdge: true } : {})
+          if (!written) return state
+          return written
         })
       } else if (reachedTail) {
         // Empty batch: still need to flip the flag if the room isn't already at the edge.
@@ -4062,14 +4052,8 @@ export const roomStore = createStore<RoomState>()(
         if (patched.length === 0 || state.activeRoomJid !== roomJid) {
           return { mamQueryStates: newStates, roomGaps: gapsAfterMerge, roomCoverage: coverageAfterMerge }
         }
-        const backfilledRooms = new Map(state.rooms)
-        backfilledRooms.set(roomJid, { ...room, messages: merged })
-        const backfilledRuntime = new Map(state.roomRuntime)
-        const runtimeEntry = backfilledRuntime.get(roomJid)
-        if (runtimeEntry) {
-          backfilledRuntime.set(roomJid, { ...runtimeEntry, messages: merged })
-        }
-        return { rooms: backfilledRooms, roomRuntime: backfilledRuntime, mamQueryStates: newStates, roomGaps: gapsAfterMerge, roomCoverage: coverageAfterMerge }
+        const backfilled = withRoomMessageWindow(state, roomJid, merged)
+        return { ...backfilled, mamQueryStates: newStates, roomGaps: gapsAfterMerge, roomCoverage: coverageAfterMerge }
       }
 
       // Persist to IndexedDB regardless of active state — this is the durable
@@ -4126,8 +4110,14 @@ export const roomStore = createStore<RoomState>()(
       }
 
       // ACTIVE room: populate the resident array (foreground catch-up / scroll-up).
-      const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...room, messages: merged, lastMessage })
+      const written = withRoomMessageWindow(state, roomJid, merged, {
+        roomPatch: { lastMessage },
+        ...(newestEvicted
+          ? { atLiveEdge: false }
+          : isFetchLatest && newFromMAM.length > 0
+            ? { atLiveEdge: true }
+            : {}),
+      })
 
       // A backward (scroll-up) merge uses keep-oldest and can evict the newest tail
       // (newestEvicted from the timeline machine), sliding the window off the live
@@ -4139,21 +4129,8 @@ export const roomStore = createStore<RoomState>()(
       // keep-newest and jump the window to live — same class as
       // jump-to-latest. The content-anchor scroll restore then degrades to an
       // estimate rather than an exact reposition.
-      const newRuntime = new Map(state.roomRuntime)
-      const existingRuntime = newRuntime.get(roomJid)
-      if (existingRuntime) {
-        newRuntime.set(roomJid, {
-          ...existingRuntime,
-          messages: merged,
-          ...(newestEvicted
-            ? { windowAtLiveEdge: false }
-            : isFetchLatest && newFromMAM.length > 0
-              ? { windowAtLiveEdge: true }
-              : {}),
-        })
-      }
 
-      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
+      return { ...written, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
     if (archiveCommitGate) {


### PR DESCRIPTION
Groundwork for taking the message window out of the room entity model — and it turned up a live drift hazard on the way.

## What was there

A room's resident window lives in two maps: the `rooms` compat entry and `roomRuntime`. **Eleven sites set both by hand**, and the two writes were not even decided the same way:

```ts
newRooms.set(roomJid, { ...existing, messages: newMessages })   // unconditional
const newRuntime = new Map(state.roomRuntime)
const existingRuntime = newRuntime.get(roomJid)
if (existingRuntime) {                                          // guarded
  newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
}
```

Two independent decisions per write, on the hottest path in the store — every append, every MAM merge, every window slide. The code says as much itself: one function calls them *"the runtime mirror (messages live here)"* and *"the combined map mirror"* in consecutive comments, and another site reads

```ts
roomRuntime.get(jid)?.messages ?? rooms.get(jid)?.messages ?? []
```

a fallback that only makes sense if the author could not be sure the two agreed.

## What this does

`withRoomMessageWindow` makes the pairing structural: 11 hand-mirrored pairs become one writer, −23 lines net.

It also carries the live-edge flag, which stays **runtime-only**. `ROOM_RUNTIME_FIELD_ROUTING` marks `windowAtLiveEdge` as `preserve` precisely so a plain field update cannot silently recenter the window; writing it to the compat entry would route around that, so the asymmetry is preserved deliberately and documented.

Copy-on-write per map: a window that is already what it would become leaves `roomRuntime` untouched, so runtime subscribers do not re-render for nothing. That property previously existed as an ad-hoc `messages.length > 0` guard at the deactivation site and nowhere else.

## Why it matters for the model

`chatStore` already keeps the window as two top-level maps (`messages`, `windowAtLiveEdge`); `roomStore` is the only one that buried it inside `RoomRuntime`. Lifting it out is the next step, and it is now a one-function change instead of an eleven-site one.

## Verification

Full suite (SDK 243 files / 6112 tests, app 456 / 6095 + 20 skipped), typecheck, lint, comment provenance, and `npm run test:scroll` **98/98** — these writes are on the pagination path.

Four focused tests pin what the mirror pairs kept losing: the two maps hold the **same array reference** (not merely equal contents, so a reader falling back from one to the other cannot observe two windows), and a no-op eviction hands back the same `roomRuntime` reference. Proven red by making the writer skip the runtime on a one-message window.