### PR TITLE
refactor(sdk): lift the room message window out of the entity runtime

### DIFF
--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -106,15 +106,13 @@ function readUnreadCount(kind: ViewportKind, id: string): number {
 /**
  * Is the loaded window at the tail of the archive.
  *
- * Rooms keep it on `roomRuntime`, conversations in a `windowAtLiveEdge` map — one fact
- * in two shapes. Defaults to `false`, the conservative direction: an unknown window is
- * treated as possibly slid up, which suppresses `fab-at-live-edge` rather than
- * reporting a FAB that may be legitimately offering "jump to latest".
+ * Defaults to `false`, the conservative direction: an unknown window is treated as
+ * possibly slid up, which suppresses `fab-at-live-edge` rather than reporting a FAB
+ * that may be legitimately offering "jump to latest".
  */
 function readWindowAtLiveEdge(kind: ViewportKind, id: string): boolean {
-  return kind === 'room'
-    ? (roomStore.getState().roomRuntime.get(id)?.windowAtLiveEdge ?? false)
-    : (chatStore.getState().windowAtLiveEdge.get(id) ?? false)
+  const store = kind === 'room' ? roomStore : chatStore
+  return store.getState().windowAtLiveEdge.get(id) ?? false
 }
 
 /**

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -135,7 +135,7 @@ export function createDefaultStoreBindings(): StoreBindings {
       getRoomCoverageUnproven: (roomJid: string) => roomStore.getState().getRoomMAMQueryState(roomJid).coverageBottomUnproven,
       getRoomPendingStanzaId: (roomJid: string) => roomStore.getState().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId,
       getAllRoomMessages: () =>
-        Array.from(roomStore.getState().roomRuntime, ([jid, runtime]) => ({ jid, messages: runtime.messages })),
+        Array.from(roomStore.getState().messages, ([jid, messages]) => ({ jid, messages })),
     },
     admin: {
       ...bindStoreMethods(adminStore, adminBindingMethodKeys),

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -161,7 +161,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
     // lastMessage previews can satisfy the resolver before it reaches IndexedDB.
     expect(chatStore.getState().messages.has(EXACT_CHAT)).toBe(false)
     expect(chatStore.getState().messages.has(FALLBACK_CHAT)).toBe(false)
-    expect(roomStore.getState().roomRuntime.get(ROOM)?.messages).toEqual([])
+    expect(roomStore.getState().messages.get(ROOM)).toEqual([])
 
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: OWN_JID } as never)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -507,13 +507,13 @@ describe('setupMdsSideEffects', () => {
     // The reflection lands and backfills the stanza-id; #1142's retry then
     // publishes the TRUE position rather than an approximation of it.
     roomStore.setState((s) => {
-      const runtime = new Map(s.roomRuntime)
-      const entry = runtime.get(room)!
-      runtime.set(room, {
-        ...entry,
-        messages: entry.messages.map((m) => (m.id === 'r2' ? { ...m, stanzaId: 'rs2' } : m)),
-      })
-      return { roomRuntime: runtime }
+      const current = s.messages.get(room) ?? []
+      return {
+        messages: new Map(s.messages).set(
+          room,
+          current.map((m) => (m.id === 'r2' ? { ...m, stanzaId: 'rs2' } : m))
+        ),
+      }
     })
     await vi.advanceTimersByTimeAsync(2_000)
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -174,7 +174,7 @@ export function setupMdsSideEffects(
   function indexOfStanza(jid: string, stanzaId: string | undefined): number {
     if (!stanzaId) return -1
     const messages = isRoom(jid)
-      ? roomStore.getState().roomRuntime.get(jid)?.messages ?? []
+      ? roomStore.getState().messages.get(jid) ?? []
       : chatStore.getState().messages.get(jid) || []
     return messages.findIndex((m) => m.stanzaId === stanzaId)
   }
@@ -358,7 +358,7 @@ export function setupMdsSideEffects(
       const target = exactRoomPointerTarget(pointer)
       if (!target) return undefined
       const { messageId: seenId, from } = target
-      const messages = roomStore.getState().roomRuntime.get(jid)?.messages ?? []
+      const messages = roomStore.getState().messages.get(jid) ?? []
       const fromSlice = messages.find((m) => m.id === seenId && m.from === from)?.stanzaId
       if (fromSlice) return fromSlice
       // Non-active rooms keep no resident array (memory windowing); mark-all-read
@@ -769,8 +769,10 @@ export function setupMdsSideEffects(
     (state) => state.roomMeta,
     considerRooms
   )
-  const unsubscribeRoomRuntime = roomStore.subscribe(
-    (state) => state.roomRuntime,
+  // The window, not the runtime blob: occupancy churn has no bearing on where
+  // the read marker sits, and this now mirrors the chat subscription above.
+  const unsubscribeRoomMessages = roomStore.subscribe(
+    (state) => state.messages,
     considerRooms
   )
   const unsubscribeRoomMam = roomStore.subscribe(
@@ -971,7 +973,7 @@ export function setupMdsSideEffects(
     unsubscribeMessages()
     unsubscribeConversationMam()
     unsubscribeRoomMeta()
-    unsubscribeRoomRuntime()
+    unsubscribeRoomMessages()
     unsubscribeRoomMam()
     unsubscribeRoomsSeedDrain()
     unsubscribeChatEntities()

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -337,6 +337,33 @@ export interface RoomRuntime {
   affiliatedMembers?: RoomMember[]
   /** Our own occupant info (when joined) */
   selfOccupant?: RoomOccupant
+}
+
+/**
+ * A MUC room (group chat).
+ *
+ * Contains all room state including occupants, messages, and bookmark settings.
+ * This is the combined type that includes entity, metadata, and runtime fields.
+ *
+ * @remarks
+ * Internally, the store separates entity, metadata, and runtime into different
+ * maps for performance optimization. This combined type is provided for
+ * convenience and backward compatibility.
+ *
+ * @category MUC
+ */
+/**
+ * A room's resident message window: the slice of history currently held in
+ * memory, and whether it still touches the tail.
+ *
+ * Separate from {@link RoomRuntime} because it is not MUC-specific. `chatStore`
+ * has kept the same two things as top-level maps all along; this is the room
+ * side saying the same thing. Occupancy and the nick/occupant-id caches stay on
+ * the runtime — those exist because MUC hides real JIDs.
+ *
+ * @category MUC
+ */
+export interface RoomMessageWindow {
   /** Messages in this room */
   messages: RoomMessage[]
   /**
@@ -360,20 +387,7 @@ export interface RoomRuntime {
   windowAtLiveEdge?: boolean
 }
 
-/**
- * A MUC room (group chat).
- *
- * Contains all room state including occupants, messages, and bookmark settings.
- * This is the combined type that includes entity, metadata, and runtime fields.
- *
- * @remarks
- * Internally, the store separates entity, metadata, and runtime into different
- * maps for performance optimization. This combined type is provided for
- * convenience and backward compatibility.
- *
- * @category MUC
- */
-export interface Room extends RoomEntity, RoomMetadata, RoomRuntime {}
+export interface Room extends RoomEntity, RoomMetadata, RoomRuntime, RoomMessageWindow {}
 
 /**
  * Room capabilities discovered via disco#info (XEP-0030/XEP-0045 §6.4).

--- a/packages/fluux-sdk/src/hooks/continueCatchUp.cursor.test.tsx
+++ b/packages/fluux-sdk/src/hooks/continueCatchUp.cursor.test.tsx
@@ -76,7 +76,7 @@ beforeEach(() => {
     rooms: new Map(),
     roomEntities: new Map(),
     roomMeta: new Map(),
-    roomRuntime: new Map(),
+    roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
     mamQueryStates: new Map(),
     roomGaps: new Map(),
     activeRoomJid: null,

--- a/packages/fluux-sdk/src/hooks/continueCatchUp.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/continueCatchUp.regression.test.tsx
@@ -59,7 +59,7 @@ describe('continueCatchUp always clears the MAM loading flag', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       mamQueryStates: new Map(),
       roomGaps: new Map(),
       activeRoomJid: null,

--- a/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.renderStability.test.tsx
@@ -20,7 +20,7 @@ describe('useRoomOccupants render stability', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       mamQueryStates: new Map(),
       activeAnimation: null,

--- a/packages/fluux-sdk/src/hooks/useReferencedMessage.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useReferencedMessage.test.tsx
@@ -71,7 +71,8 @@ describe('useReferencedMessage', () => {
 
       act(() => {
         roomStore.setState({
-          roomRuntime: new Map([[roomJid, { occupants: new Map(), messages: [target] }]]),
+          roomRuntime: new Map([[roomJid, { occupants: new Map() }]]),
+          messages: new Map([[roomJid, [target]]]),
         })
       })
       expect(result.current).toBe(target)

--- a/packages/fluux-sdk/src/hooks/useReferencedMessage.ts
+++ b/packages/fluux-sdk/src/hooks/useReferencedMessage.ts
@@ -45,7 +45,7 @@ export function useReferencedMessage(params: ReferencedMessageParams): Message |
   )
   const roomMatch = useRoomStore((s) =>
     roomJid && id
-      ? findMessageById(s.roomRuntime.get(roomJid)?.messages ?? EMPTY_ROOM_MESSAGES, id)
+      ? findMessageById(s.messages.get(roomJid) ?? EMPTY_ROOM_MESSAGES, id)
       : undefined
   )
 

--- a/packages/fluux-sdk/src/hooks/useRoom.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoom.renderStability.test.tsx
@@ -19,7 +19,7 @@ describe('useRoom render stability', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       mamQueryStates: new Map(),
       activeAnimation: null,

--- a/packages/fluux-sdk/src/hooks/useRoomActive.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.renderStability.test.tsx
@@ -18,7 +18,7 @@ describe('useRoomActive render stability', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       mamQueryStates: new Map(),
       activeAnimation: null,

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -108,24 +108,26 @@ export function useRoomActive() {
   // (the load-newer scroll trigger and the jump-to-latest affordance turn on). Absent ⇒ at edge.
   const activeWindowAtLiveEdge = useRoomStore((s) => {
     if (!s.activeRoomJid) return true
-    return s.roomRuntime.get(s.activeRoomJid)?.windowAtLiveEdge ?? true
+    return s.windowAtLiveEdge.get(s.activeRoomJid) ?? true
   })
 
-  // Reconstruct the full Room object from entity + meta + runtime.
-  // Room extends RoomEntity, RoomMetadata, RoomRuntime — so spreading works.
+  // The resident window, from its own map rather than the combined rooms Map.
+  const activeMessages = useRoomStore((s) =>
+    (s.activeRoomJid ? s.messages.get(s.activeRoomJid) : undefined) ?? EMPTY_MESSAGE_ARRAY
+  )
+
+  // Reconstruct the full Room object from entity + meta + runtime + window.
+  // Room extends all four — so spreading works.
   const activeRoom = useMemo((): Room | undefined => {
     if (!activeRoomEntity || !activeRoomMeta || !activeRoomRuntime) return undefined
     return {
       ...activeRoomEntity,
       ...activeRoomMeta,
       ...activeRoomRuntime,
+      messages: activeMessages,
+      windowAtLiveEdge: activeWindowAtLiveEdge,
     }
-  }, [activeRoomEntity, activeRoomMeta, activeRoomRuntime])
-
-  // Messages from runtime (avoids subscribing to the combined rooms Map)
-  const activeMessages = useMemo((): RoomMessage[] => {
-    return activeRoomRuntime?.messages ?? EMPTY_MESSAGE_ARRAY
-  }, [activeRoomRuntime])
+  }, [activeRoomEntity, activeRoomMeta, activeRoomRuntime, activeMessages, activeWindowAtLiveEdge])
 
   // Easter egg animation state
   const activeAnimation = useRoomStore((s) => s.activeAnimation)

--- a/packages/fluux-sdk/src/hooks/useRoomFocusedHooks.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoomFocusedHooks.test.tsx
@@ -91,7 +91,7 @@ describe('focused room hooks render stability', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       mamQueryStates: new Map(),
       drafts: new Map(),

--- a/packages/fluux-sdk/src/hooks/useRoomOccupantCount.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoomOccupantCount.renderStability.test.tsx
@@ -15,7 +15,7 @@ describe('useRoomOccupantCount render stability', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       mamQueryStates: new Map(),
       activeAnimation: null,

--- a/packages/fluux-sdk/src/stores/roomSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.test.ts
@@ -11,7 +11,7 @@ function createMockState(overrides: Partial<RoomState> = {}): RoomState {
     rooms: new Map(),
     roomEntities: new Map(),
     roomMeta: new Map(),
-    roomRuntime: new Map(),
+    roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
     activeRoomJid: null,
     activeAnimation: null,
     drafts: new Map(),
@@ -497,7 +497,6 @@ describe('roomSelectors', () => {
     it('should return runtime for existing room', () => {
       const runtime: RoomRuntime = {
         occupants: new Map([['alice', { nick: 'alice', affiliation: 'member', role: 'participant' }]]),
-        messages: [],
       }
       const roomRuntime = new Map([['room@conference.example.com', runtime]])
       const state = createMockState({ roomRuntime })
@@ -648,12 +647,9 @@ describe('roomSelectors', () => {
   describe('runtimeMessagesFor', () => {
     it('should return messages from runtime', () => {
       const msg = createMockRoomMessage('1', 'room@conference.example.com')
-      const runtime: RoomRuntime = {
-        occupants: new Map(),
-        messages: [msg],
-      }
-      const roomRuntime = new Map([['room@conference.example.com', runtime]])
-      const state = createMockState({ roomRuntime })
+      const state = createMockState({
+        messages: new Map([['room@conference.example.com', [msg]]]),
+      })
 
       const result = roomSelectors.runtimeMessagesFor('room@conference.example.com')(state)
       expect(result).toHaveLength(1)
@@ -672,7 +668,6 @@ describe('roomSelectors', () => {
       const occupant: RoomOccupant = { nick: 'alice', affiliation: 'member', role: 'participant' }
       const runtime: RoomRuntime = {
         occupants: new Map([['alice', occupant]]),
-        messages: [],
       }
       const roomRuntime = new Map([['room@conference.example.com', runtime]])
       const state = createMockState({ roomRuntime })
@@ -690,7 +685,6 @@ describe('roomSelectors', () => {
           ['alice', { nick: 'alice', affiliation: 'member', role: 'participant' }],
           ['bob', { nick: 'bob', affiliation: 'member', role: 'participant' }],
         ]),
-        messages: [],
       }
       const roomRuntime = new Map([['room@conference.example.com', runtime]])
       const state = createMockState({ roomRuntime })

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -586,7 +586,7 @@ export const roomSelectors = {
    * Use this for message list rendering.
    */
   runtimeMessagesFor: (roomJid: string) => (state: RoomState): RoomMessage[] => {
-    return state.roomRuntime.get(roomJid)?.messages ?? EMPTY_MESSAGE_ARRAY
+    return state.messages.get(roomJid) ?? EMPTY_MESSAGE_ARRAY
   },
 
   /**

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -680,9 +680,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     roomStore.setState((state) => {
       const rooms = new Map(state.rooms)
       rooms.set(ROOM, { ...rooms.get(ROOM)!, messages: [p0, p1] })
-      const roomRuntime = new Map(state.roomRuntime)
-      roomRuntime.set(ROOM, { ...roomRuntime.get(ROOM)!, messages: [p0, p1] })
-      return { rooms, roomRuntime }
+      return { rooms, messages: new Map(state.messages).set(ROOM, [p0, p1]) }
     })
     setMeta({
       unreadCount: 5,
@@ -942,9 +940,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     roomStore.setState((state) => {
       const markers = new Map(state.firstNewMessageMarkers)
       markers.set(ROOM, 'stale-marker-id')
-      const runtime = new Map(state.roomRuntime)
-      runtime.set(ROOM, { ...runtime.get(ROOM)!, messages })
-      return { firstNewMessageMarkers: markers, activeRoomJid: ROOM, roomRuntime: runtime }
+      return {
+        firstNewMessageMarkers: markers,
+        activeRoomJid: ROOM,
+        messages: new Map(state.messages).set(ROOM, messages),
+      }
     })
   }
 
@@ -990,12 +990,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     })
     seedCoverage('anchor-stanza')
     roomStore.setState((state) => {
-      const runtime = new Map(state.roomRuntime)
-      runtime.set(ROOM, { ...runtime.get(ROOM)!, messages: [anchor, p0, u1] })
+      const nextMessages = new Map(state.messages).set(ROOM, [anchor, p0, u1])
       const markers = new Map(state.firstNewMessageMarkers)
       // The divider activation parked on the first unread message.
       markers.set(ROOM, 'u1')
-      return { activeRoomJid: ROOM, roomRuntime: runtime, firstNewMessageMarkers: markers }
+      return { activeRoomJid: ROOM, messages: nextMessages, firstNewMessageMarkers: markers }
     })
 
     roomStore.getState().advanceReadPointer(ROOM, 'u1')
@@ -1026,9 +1025,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     roomStore.setState((state) => {
       const markers = new Map(state.firstNewMessageMarkers)
       markers.set(ROOM, 'stale-marker-id')
-      const runtime = new Map(state.roomRuntime)
-      runtime.set(ROOM, { ...runtime.get(ROOM)!, messages: [anchor, p0] })
-      return { firstNewMessageMarkers: markers, activeRoomJid: null, roomRuntime: runtime }
+      return {
+        firstNewMessageMarkers: markers,
+        activeRoomJid: null,
+        messages: new Map(state.messages).set(ROOM, [anchor, p0]),
+      }
     })
 
     await roomStore.getState().recomputeUnreadForRoom(ROOM)
@@ -1232,9 +1233,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     /** Seed the room's resident window (roomRuntime.messages) directly. */
     function seedResident(messages: RoomMessage[]): void {
       roomStore.setState((state) => {
-        const runtime = new Map(state.roomRuntime)
-        runtime.set(ROOM, { ...runtime.get(ROOM)!, messages })
-        return { roomRuntime: runtime }
+        return { messages: new Map(state.messages).set(ROOM, messages) }
       })
     }
 
@@ -1553,9 +1552,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     /** Seed the room's resident window (roomRuntime.messages) directly. */
     function seedResident(messages: RoomMessage[]): void {
       roomStore.setState((state) => {
-        const runtime = new Map(state.roomRuntime)
-        runtime.set(ROOM, { ...runtime.get(ROOM)!, messages })
-        return { roomRuntime: runtime }
+        return { messages: new Map(state.messages).set(ROOM, messages) }
       })
     }
 

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -151,7 +151,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -472,7 +472,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -521,12 +521,10 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     // was outside the loaded window). The gate must skip re-folding the identical marker so it
     // can't reposition the divider on every return (XEP-0490 markers broadcast live over PEP).
     roomStore.setState((s) => {
-      const rt = new Map(s.roomRuntime)
-      const existing = rt.get(REOPEN_ROOM)
-      if (existing) rt.set(REOPEN_ROOM, { ...existing, messages })
+      const nextMessages = new Map(s.messages).set(REOPEN_ROOM, messages)
       const m = new Map(s.roomMeta)
       m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's3' })
-      return { roomRuntime: rt, roomMeta: m }
+      return { messages: nextMessages, roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
     expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m3')
@@ -556,12 +554,10 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     // Re-open: rehydrate the messages (cache reload) and a NEW further-ahead remote read (s4)
     // that the live notify could only stash while the room was unloaded.
     roomStore.setState((s) => {
-      const rt = new Map(s.roomRuntime)
-      const existing = rt.get(REOPEN_ROOM)
-      if (existing) rt.set(REOPEN_ROOM, { ...existing, messages })
+      const nextMessages = new Map(s.messages).set(REOPEN_ROOM, messages)
       const m = new Map(s.roomMeta)
       m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's4' })
-      return { roomRuntime: rt, roomMeta: m }
+      return { messages: nextMessages, roomMeta: m }
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
     expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.readPointer?.identity.messageId).toBe('m4')
@@ -593,10 +589,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     // The archive healed since (e.g. catch-up landed): the marker's message is loadable now.
     const healed = [...early, rmsg('m9', 's9', 9)]
     roomStore.setState((s) => {
-      const rt = new Map(s.roomRuntime)
-      const existing = rt.get(RETRY_ROOM)
-      if (existing) rt.set(RETRY_ROOM, { ...existing, messages: healed })
-      return { roomRuntime: rt }
+      return { messages: new Map(s.messages).set(RETRY_ROOM, healed) }
     })
 
     await roomStore.getState().activateRoom(RETRY_ROOM)
@@ -748,7 +741,7 @@ describe('roomStore — new-message divider is session-only', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -810,7 +803,7 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -846,9 +839,7 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
     roomStore.setState((s) => {
       const m = new Map(s.roomMeta)
       m.set(ROOM, { ...m.get(ROOM)!, unreadCount: 2 })
-      const rt = new Map(s.roomRuntime)
-      rt.set(ROOM, { ...rt.get(ROOM)!, windowAtLiveEdge: false })
-      return { roomMeta: m, roomRuntime: rt }
+      return { roomMeta: m, windowAtLiveEdge: new Map(s.windowAtLiveEdge).set(ROOM, false) }
     })
     roomStore.getState().setActiveRoom(ROOM)
     reportRoomViewport(ROOM, 'at-edge')
@@ -894,7 +885,7 @@ describe('roomStore.advanceReadPointer presence gate', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -950,7 +941,7 @@ describe('roomStore fresh-instance catch-up preserves the remote read position',
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -1033,7 +1024,7 @@ describe('roomStore pending-marker guard edges', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),

--- a/packages/fluux-sdk/src/stores/roomStore.messageWindow.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.messageWindow.test.ts
@@ -13,7 +13,7 @@ import { createRoom, createRoomMessage } from '../hooks/renderStability.helpers'
 describe('room message window', () => {
   beforeEach(() => {
     roomStore.setState({
-      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(),
+      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null, mamQueryStates: new Map(), activeAnimation: null, drafts: new Map(),
       firstNewMessageMarkers: new Map(),
     })
@@ -25,12 +25,12 @@ describe('room message window', () => {
 
     const state = roomStore.getState()
     const viaCompat = state.rooms.get('a@x')!.messages
-    const viaRuntime = state.roomRuntime.get('a@x')!.messages
+    const viaWindow = state.messages.get('a@x')!
 
     expect(viaCompat.map((m) => m.id)).toEqual(['m1'])
     // Same reference, not merely equal contents: a reader that falls back from
     // one map to the other must not be able to observe two different windows.
-    expect(viaRuntime).toBe(viaCompat)
+    expect(viaWindow).toBe(viaCompat)
   })
 
   it('keeps the two maps in step across several appends', () => {
@@ -40,7 +40,7 @@ describe('room message window', () => {
     }
 
     const state = roomStore.getState()
-    expect(state.rooms.get('a@x')!.messages).toBe(state.roomRuntime.get('a@x')!.messages)
+    expect(state.rooms.get('a@x')!.messages).toBe(state.messages.get('a@x'))
     expect(state.rooms.get('a@x')!.messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3'])
   })
 
@@ -49,11 +49,11 @@ describe('room message window', () => {
     roomStore.getState().setActiveRoom('a@x')
 
     // No messages were ever appended, so deactivating has no window to drop.
-    const before = roomStore.getState().roomRuntime
+    const before = roomStore.getState().messages
     roomStore.getState().setActiveRoom(null)
 
-    // A fresh map here would re-render every runtime subscriber for nothing.
-    expect(roomStore.getState().roomRuntime).toBe(before)
+    // A fresh map here would re-render every window subscriber for nothing.
+    expect(roomStore.getState().messages).toBe(before)
   })
 
   it('does not resurrect a room that is gone from the compat map', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.perRoomStability.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.perRoomStability.test.ts
@@ -8,7 +8,7 @@ import { createRoom, createRoomMessage } from '../hooks/renderStability.helpers'
 describe('per-room ref stability after unrelated message', () => {
   beforeEach(() => {
     roomStore.setState({
-      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(),
+      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null, mamQueryStates: new Map(), activeAnimation: null, drafts: new Map(),
     })
   })

--- a/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.resyncDivider.test.ts
@@ -50,7 +50,7 @@ function seed(opts: { lastSeen: string | undefined; marker: string | undefined; 
 
 describe('roomStore.resyncDividerToReadPointer', () => {
   beforeEach(() => {
-    roomStore.setState({ rooms: new Map(), roomMeta: new Map(), roomRuntime: new Map(), firstNewMessageMarkers: new Map() })
+    roomStore.setState({ rooms: new Map(), roomMeta: new Map(), roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(), firstNewMessageMarkers: new Map() })
   })
 
   it('advances an existing divider to the first unread after the pointer', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.selectorPerformance.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.selectorPerformance.test.ts
@@ -24,7 +24,7 @@ describe('roomStore selector performance', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
     })
   })

--- a/packages/fluux-sdk/src/stores/roomStore.sidebarJids.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.sidebarJids.test.ts
@@ -18,7 +18,7 @@ function resetRoomStore() {
     rooms: new Map(),
     roomEntities: new Map(),
     roomMeta: new Map(),
-    roomRuntime: new Map(),
+    roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
     activeRoomJid: null,
     mamQueryStates: new Map(),
     activeAnimation: null,

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -93,7 +93,7 @@ describe('roomStore', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -129,12 +129,12 @@ describe('roomStore', () => {
       roomStore.setState({ activeRoomJid: roomA })
 
       // Sanity: A is resident before switching away.
-      expect(roomStore.getState().roomRuntime.get(roomA)?.messages).toHaveLength(2)
+      expect(roomStore.getState().messages.get(roomA)).toHaveLength(2)
 
       roomStore.getState().setActiveRoom(roomB)
 
       // A's messages are evicted from both mirrors (rooms + roomRuntime)...
-      expect(roomStore.getState().roomRuntime.get(roomA)?.messages).toEqual([])
+      expect(roomStore.getState().messages.get(roomA)).toEqual([])
       expect(roomStore.getState().rooms.get(roomA)?.messages).toEqual([])
       // ...but its sidebar preview / identity are preserved.
       expect(roomStore.getState().rooms.get(roomA)?.lastMessage).toEqual(msgs[1])
@@ -151,7 +151,7 @@ describe('roomStore', () => {
       // Activating A (no previous active room) must not evict A.
       roomStore.getState().setActiveRoom(roomA)
 
-      expect(roomStore.getState().roomRuntime.get(roomA)?.messages).toHaveLength(1)
+      expect(roomStore.getState().messages.get(roomA)).toHaveLength(1)
       expect(roomStore.getState().activeRoomJid).toBe(roomA)
     })
   })
@@ -514,7 +514,6 @@ describe('roomStore', () => {
     it('should NOT set lastInteractedAt when joining room with no messages', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', {
         joined: false,
-        messages: [],
       }))
 
       roomStore.getState().setRoomJoined('test@conference.example.com', true)
@@ -2040,10 +2039,7 @@ describe('roomStore', () => {
       }))
       // Simulate eviction: runtime messages array is empty (non-active room).
       roomStore.setState((state) => {
-        const newRuntime = new Map(state.roomRuntime)
-        const existingRuntime = newRuntime.get(roomJid)
-        if (existingRuntime) newRuntime.set(roomJid, { ...existingRuntime, messages: [] })
-        return { roomRuntime: newRuntime }
+        return { messages: new Map(state.messages).set(roomJid, []) }
       })
 
       roomStore.getState().markReadToNewest(roomJid)
@@ -2345,15 +2341,11 @@ describe('roomStore', () => {
         }
         roomMeta.set(jid, meta)
 
-        const roomRuntime = new Map(s.roomRuntime)
-        const runtime = roomRuntime.get(jid)
-        if (runtime) roomRuntime.set(jid, { ...runtime, messages })
-
         const rooms = new Map(s.rooms)
         const room = rooms.get(jid)
         if (room) rooms.set(jid, { ...room, messages, readPointer: undefined, historyFloor: new Date(2000) })
 
-        return { roomMeta, roomRuntime, rooms }
+        return { roomMeta, messages: new Map(s.messages).set(jid, messages), rooms }
       })
     }
 
@@ -2551,7 +2543,7 @@ describe('roomStore', () => {
         'msg-150',
         expect.any(Object)
       )
-      const resident = roomStore.getState().roomRuntime.get(roomJid)?.messages
+      const resident = roomStore.getState().messages.get(roomJid)
       expect(resident?.some((m) => m.id === 'msg-150')).toBe(true)
       expect(roomStore.getState().firstNewMessageMarkers.get(roomJid)).toBe('msg-151')
     })
@@ -4393,7 +4385,7 @@ describe('roomStore', () => {
       expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.id).toBe('bg-2')
       // ...but the resident array is NOT populated (only the active room is in RAM).
       expect(roomStore.getState().rooms.get(roomJid)?.messages).toEqual([])
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.messages).toEqual([])
+      expect(roomStore.getState().messages.get(roomJid)).toEqual([])
     })
 
     it('should merge older MAM messages at the start with direction backward', () => {
@@ -5425,10 +5417,7 @@ describe('roomStore', () => {
         const newRooms = new Map(state.rooms)
         const existing = newRooms.get(roomJid)!
         newRooms.set(roomJid, { ...existing, messages: resident })
-        const newRuntime = new Map(state.roomRuntime)
-        const existingRuntime = newRuntime.get(roomJid)!
-        newRuntime.set(roomJid, { ...existingRuntime, messages: resident })
-        return { rooms: newRooms, roomRuntime: newRuntime }
+        return { rooms: newRooms, messages: new Map(state.messages).set(roomJid, resident) }
       })
 
       const olderBatch: RoomMessage[] = []
@@ -5439,7 +5428,8 @@ describe('roomStore', () => {
     }
 
     it('a fresh room seeded via addRoom is at the live edge', () => {
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      // Absent means at the live edge — the same convention chatStore's map uses.
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid) ?? true).toBe(true)
     })
 
     it('appends a live message when the window is at the live edge (default)', () => {
@@ -5454,13 +5444,13 @@ describe('roomStore', () => {
     it('sets windowAtLiveEdge false after a load-older that evicts the newest tail', async () => {
       seedSlidWindow()
       await roomStore.getState().loadOlderMessagesFromCache(roomJid, 50)
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
     })
 
     it('does not append a live message when the window has slid off the live edge, but still persists to cache and updates meta', async () => {
       seedSlidWindow()
       await roomStore.getState().loadOlderMessagesFromCache(roomJid, 50)
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
 
       vi.mocked(messageCache.saveRoomMessageWithResult).mockClear()
       const before = roomStore.getState().getRoom(roomJid)!.messages
@@ -5483,33 +5473,30 @@ describe('roomStore', () => {
     it('recenters to the live edge when the latest window is (re)loaded', async () => {
       seedSlidWindow()
       await roomStore.getState().loadOlderMessagesFromCache(roomJid, 50)
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
 
       // A latest-N load (activation path) makes the newest messages resident again.
       vi.mocked(messageCache.getRoomMessages).mockResolvedValue([roomMsgAt('latest-1', 9000)])
       await roomStore.getState().loadMessagesFromCache(roomJid, { limit: 100 })
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(true)
     })
 
     it('mergeRoomMAMMessages flips windowAtLiveEdge true on a fetch-latest merge, but a plain backward merge does not', () => {
       roomStore.setState({ activeRoomJid: roomJid })
       // Seed the flag false, as if a prior scroll-up slid the window off the live edge.
       roomStore.setState((state) => {
-        const newRuntime = new Map(state.roomRuntime)
-        const existing = newRuntime.get(roomJid)!
-        newRuntime.set(roomJid, { ...existing, windowAtLiveEdge: false })
-        return { roomRuntime: newRuntime }
+        return { windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, false) }
       })
 
       // A plain backward merge (isFetchLatest false) must not flip it back.
       const older = roomMsgAt('older-1', 1)
       roomStore.getState().mergeRoomMAMMessages(roomJid, [older], {}, false, 'backward')
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
 
       // A fetch-latest merge lands the window AT the live edge by construction.
       const fresh = roomMsgAt('fresh-1', 20000)
       roomStore.getState().mergeRoomMAMMessages(roomJid, [fresh], {}, false, 'backward', false, true)
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(true)
     })
   })
 
@@ -5559,10 +5546,11 @@ describe('roomStore', () => {
         const newRooms = new Map(state.rooms)
         const existing = newRooms.get(roomJid)!
         newRooms.set(roomJid, { ...existing, messages: resident })
-        const newRuntime = new Map(state.roomRuntime)
-        const existingRuntime = newRuntime.get(roomJid)!
-        newRuntime.set(roomJid, { ...existingRuntime, messages: resident, windowAtLiveEdge: false })
-        return { rooms: newRooms, roomRuntime: newRuntime }
+        return {
+          rooms: newRooms,
+          messages: new Map(state.messages).set(roomJid, resident),
+          windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, false),
+        }
       })
     }
 
@@ -5609,7 +5597,7 @@ describe('roomStore', () => {
 
       await roomStore.getState().loadNewerMessagesFromCache(roomJid, 50)
 
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(true)
     })
 
     it('leaves windowAtLiveEdge slid (false) when a full batch returns (more newer remain)', async () => {
@@ -5622,7 +5610,7 @@ describe('roomStore', () => {
 
       await roomStore.getState().loadNewerMessagesFromCache(roomJid, 50)
 
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
     })
 
     it('returns an empty array and does nothing when the room has no resident messages', async () => {
@@ -5678,10 +5666,11 @@ describe('roomStore', () => {
         const newRooms = new Map(state.rooms)
         const existing = newRooms.get(roomJid)!
         newRooms.set(roomJid, { ...existing, messages: resident })
-        const newRuntime = new Map(state.roomRuntime)
-        const existingRuntime = newRuntime.get(roomJid)!
-        newRuntime.set(roomJid, { ...existingRuntime, messages: resident, windowAtLiveEdge: false })
-        return { rooms: newRooms, roomRuntime: newRuntime }
+        return {
+          rooms: newRooms,
+          messages: new Map(state.messages).set(roomJid, resident),
+          windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, false),
+        }
       })
 
       const latestBatch = [roomMsgAt('latest-1', 90000)]
@@ -5689,7 +5678,7 @@ describe('roomStore', () => {
 
       await roomStore.getState().recenterToLatest(roomJid)
 
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(true)
       const room = roomStore.getState().rooms.get(roomJid)
       expect(room?.messages.some((m) => m.id === 'latest-1')).toBe(true)
     })
@@ -5699,7 +5688,7 @@ describe('roomStore', () => {
 
       await roomStore.getState().recenterToLatest(roomJid)
 
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(true)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(true)
     })
   })
 
@@ -5998,8 +5987,7 @@ describe('roomStore', () => {
 
       roomStore.getState().updateMessage(roomJid, 'server-stanza-id-123', { isRetracted: true })
 
-      const runtime = roomStore.getState().roomRuntime.get(roomJid)
-      expect(runtime?.messages[0]?.isRetracted).toBe(true)
+      expect(roomStore.getState().messages.get(roomJid)?.[0]?.isRetracted).toBe(true)
     })
   })
 
@@ -6308,7 +6296,7 @@ describe('setActiveRoom new-message marker — delayed history unified with chat
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
@@ -6471,7 +6459,7 @@ describe('roomStore pending retractions', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       pendingRetractions: new Map(),
     })
@@ -6578,7 +6566,7 @@ describe('roomStore parity drift regressions', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       firstNewMessageMarkers: new Map(),
       mamQueryStates: new Map(),
@@ -6622,7 +6610,7 @@ describe('roomStore parity drift regressions', () => {
       expect(messages).toHaveLength(1)
       expect(messages[0].stanzaId).toBe('archive-123')
       // The runtime mirror must receive the same patched array.
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('archive-123')
+      expect(roomStore.getState().messages.get(roomJid)?.[0]?.stanzaId).toBe('archive-123')
       // The backfill must also persist so the cursor survives a reload.
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
         roomJid,
@@ -6735,14 +6723,12 @@ describe('roomStore parity drift regressions', () => {
 
     it('updateRoom never recenters the window: windowAtLiveEdge survives a runtime update', () => {
       roomStore.setState((state) => {
-        const roomRuntime = new Map(state.roomRuntime)
-        roomRuntime.set(roomJid, { ...roomRuntime.get(roomJid)!, windowAtLiveEdge: false })
-        return { roomRuntime }
+        return { windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, false) }
       })
 
       roomStore.getState().updateRoom(roomJid, { occupants: new Map() })
 
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.windowAtLiveEdge).toBe(false)
+      expect(roomStore.getState().windowAtLiveEdge.get(roomJid)).toBe(false)
     })
 
     it('MAM merge backfills the archive stanzaId onto resident messages (parity with chatStore)', () => {
@@ -6762,7 +6748,7 @@ describe('roomStore parity drift regressions', () => {
       const messages = roomStore.getState().rooms.get(roomJid)?.messages || []
       expect(messages).toHaveLength(1)
       expect(messages[0].stanzaId).toBe('arch-merge')
-      expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('arch-merge')
+      expect(roomStore.getState().messages.get(roomJid)?.[0]?.stanzaId).toBe('arch-merge')
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
         roomJid,
         'own-1',

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -597,11 +597,7 @@ const ROOM_META_FIELDS = Object.keys({
 const ROOM_RUNTIME_FIELD_ROUTING = {
   occupants: 'sync', nickToJidCache: 'sync', occupantIdToJidCache: 'sync',
   occupantIdToNick: 'sync', nickToAvatarCache: 'sync', occupantIdToAvatarCache: 'sync',
-  affiliatedMembers: 'sync', selfOccupant: 'sync', messages: 'sync',
-  // A plain field update must never silently recenter the window — the
-  // live-edge flag only changes through window operations (see
-  // RoomRuntime.windowAtLiveEdge).
-  windowAtLiveEdge: 'preserve',
+  affiliatedMembers: 'sync', selfOccupant: 'sync',
 } satisfies Record<keyof RoomRuntime, 'sync' | 'preserve'>
 
 const ROOM_RUNTIME_FIELDS = (Object.keys(ROOM_RUNTIME_FIELD_ROUTING) as readonly (keyof RoomRuntime)[])
@@ -744,7 +740,7 @@ function resolveRoomPendingRetractions(
  *   — the same miss the call sites already guarded on.
  */
 function withRoomMessageWindow(
-  state: Pick<RoomState, 'rooms' | 'roomRuntime'>,
+  state: Pick<RoomState, 'rooms' | 'messages' | 'windowAtLiveEdge'>,
   roomJid: string,
   messages: RoomMessage[],
   options: {
@@ -758,35 +754,40 @@ function withRoomMessageWindow(
      */
     atLiveEdge?: boolean
   } = {}
-): Pick<RoomState, 'rooms' | 'roomRuntime'> | null {
+): Pick<RoomState, 'rooms' | 'messages' | 'windowAtLiveEdge'> | null {
   const existing = state.rooms.get(roomJid)
   if (!existing) return null
 
+  // The compat entry keeps mirroring the window, so `Room` stays a truthful
+  // whole for the consumers that still read it as one.
   const rooms = new Map(state.rooms)
-  rooms.set(roomJid, { ...existing, ...options.roomPatch, messages })
-
-  const runtime = state.roomRuntime.get(roomJid)
-  const windowUnchanged =
-    runtime &&
-    options.atLiveEdge === undefined &&
-    (runtime.messages === messages ||
-      (runtime.messages.length === 0 && messages.length === 0))
-  if (!runtime || windowUnchanged) return { rooms, roomRuntime: state.roomRuntime }
-
-  const roomRuntime = new Map(state.roomRuntime)
-  roomRuntime.set(roomJid, {
-    ...runtime,
+  rooms.set(roomJid, {
+    ...existing,
+    ...options.roomPatch,
     messages,
     ...(options.atLiveEdge === undefined ? {} : { windowAtLiveEdge: options.atLiveEdge }),
   })
-  return { rooms, roomRuntime }
+
+  const current = state.messages.get(roomJid)
+  const sameSlice =
+    current === messages || ((current?.length ?? 0) === 0 && messages.length === 0)
+  if (sameSlice && options.atLiveEdge === undefined) {
+    return { rooms, messages: state.messages, windowAtLiveEdge: state.windowAtLiveEdge }
+  }
+
+  const nextMessages = sameSlice ? state.messages : new Map(state.messages).set(roomJid, messages)
+  const nextEdge =
+    options.atLiveEdge === undefined
+      ? state.windowAtLiveEdge
+      : new Map(state.windowAtLiveEdge).set(roomJid, options.atLiveEdge)
+  return { rooms, messages: nextMessages, windowAtLiveEdge: nextEdge }
 }
 
 function mergeCachedRoomMessages(
   state: RoomState,
   roomJid: string,
   cachedMessages: RoomMessage[]
-): Partial<Pick<RoomState, 'rooms' | 'roomRuntime' | 'roomMeta' | 'pendingRetractions'>> | null {
+): Partial<Pick<RoomState, 'rooms' | 'messages' | 'windowAtLiveEdge' | 'roomMeta' | 'pendingRetractions'>> | null {
   const newRooms = new Map(state.rooms)
   const existing = newRooms.get(roomJid)
   if (!existing) return null
@@ -863,6 +864,14 @@ export interface RoomState {
   roomMeta: Map<string, RoomMetadata>
   /** Runtime room data - occupants, messages (rebuilt on join) */
   roomRuntime: Map<string, RoomRuntime>
+  /**
+   * The resident message window per room, and whether it still touches the
+   * tail. Top-level maps, like `chatStore`'s: the window is not MUC-specific,
+   * and a per-room subscriber to occupancy should not re-render when a message
+   * lands. `withRoomMessageWindow` is the only writer.
+   */
+  messages: Map<string, RoomMessage[]>
+  windowAtLiveEdge: Map<string, boolean>
   activeRoomJid: string | null
   // True while activateRoom() is hydrating a room's cache before it becomes active.
   // Lets the UI hold a neutral loading surface during the async gap instead of
@@ -1160,12 +1169,14 @@ function createEmptyRoomState(
   acknowledgedNonAnonymousRooms: Set<string> = new Set(),
   roomCoverage: Map<string, CoverageRecord> = new Map(),
   pendingRetractions: Map<string, PendingRetraction[]> = new Map(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'interiorPlacementVersions'> {
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'messages' | 'windowAtLiveEdge' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'interiorPlacementVersions'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
     roomMeta: new Map(),
     roomRuntime: new Map(),
+    messages: new Map(),
+    windowAtLiveEdge: new Map(),
     activeRoomJid: null,
     activationPending: false,
     activeAnimation: null,
@@ -1246,9 +1257,6 @@ export const roomStore = createStore<RoomState>()(
         occupantIdToNick,
         occupantIdToAvatarCache: room.occupantIdToAvatarCache,
         selfOccupant: room.selfOccupant,
-        messages: room.messages,
-        // A room upsert seeds the newest window → at the live edge by default.
-        windowAtLiveEdge: room.windowAtLiveEdge ?? true,
       }
 
       const newRooms = new Map(state.rooms)
@@ -1271,6 +1279,17 @@ export const roomStore = createStore<RoomState>()(
       const newRuntime = new Map(state.roomRuntime)
       newRuntime.set(room.jid, runtime)
 
+      // Seed the window from the incoming Room. An upsert always lands the
+      // newest slice, so it is at the live edge by construction; the map's
+      // convention is that absent means edge, so only a room arriving with an
+      // explicit `false` records anything.
+      const newMessages = new Map(state.messages)
+      newMessages.set(room.jid, room.messages ?? [])
+      const newEdge =
+        room.windowAtLiveEdge === false
+          ? new Map(state.windowAtLiveEdge).set(room.jid, false)
+          : state.windowAtLiveEdge
+
       // Creation stamps the history floor, so the durable copy is written here
       // too — a room joined and never opened still gets its floor recorded.
       persistRoomReadState(newMeta)
@@ -1280,6 +1299,8 @@ export const roomStore = createStore<RoomState>()(
         roomEntities: newEntities,
         roomMeta: newMeta,
         roomRuntime: newRuntime,
+        messages: newMessages,
+        windowAtLiveEdge: newEdge,
       }
     })
   },
@@ -2009,7 +2030,7 @@ export const roomStore = createStore<RoomState>()(
       // one), and window trim. Gated messages are still persisted to
       // IndexedDB (above) and the preview/unread updates below still run;
       // they reload on jump-to-latest.
-      const atLiveEdge = state.roomRuntime.get(roomJid)?.windowAtLiveEdge !== false
+      const atLiveEdge = state.windowAtLiveEdge.get(roomJid) !== false
       const appendObservation: timeline.AppendLiveObservation = {}
       const append = timeline.appendLive(
         existing.messages,
@@ -2620,7 +2641,7 @@ export const roomStore = createStore<RoomState>()(
         // invariant ever breaks, the failure direction is at worst a lost "new
         // messages" divider for a background room, not a miscounted or corrupted
         // read pointer.
-        const slice = state.roomRuntime.get(roomJid)?.messages ?? []
+        const slice = state.messages.get(roomJid) ?? []
         const divider = notifState.onActivate(
           { unreadCount: 0, mentionsCount: 0, readPointer: meta.readPointer, firstNewMessageId: undefined },
           slice,
@@ -2667,10 +2688,9 @@ export const roomStore = createStore<RoomState>()(
         firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
       }
 
-      const runtime = state.roomRuntime.get(roomJid)
-      const messages = runtime?.messages ?? existing.messages
+      const messages = state.messages.get(roomJid) ?? existing.messages
 
-      const windowAtLiveEdge = runtime?.windowAtLiveEdge !== false
+      const windowAtLiveEdge = state.windowAtLiveEdge.get(roomJid) !== false
       const viewportAtLiveEdge =
         currentViewportEvidence(roomViewportEvidenceKey(roomJid)) === 'at-edge'
       const updated = notifState.onMarkAsRead(notifInput, messages, 'room', {
@@ -2710,8 +2730,8 @@ export const roomStore = createStore<RoomState>()(
       const existing = state.rooms.get(roomJid)
       if (!existing) return state
 
-      const runtime = state.roomRuntime.get(roomJid)
-      const resident = runtime?.messages?.length ? runtime.messages : existing.messages
+      const slice = state.messages.get(roomJid)
+      const resident = slice?.length ? slice : existing.messages
       const newest = resident[resident.length - 1] ?? existing.lastMessage
       if (!newest) return state
 
@@ -2808,8 +2828,7 @@ export const roomStore = createStore<RoomState>()(
           firstNewMessageId: get().firstNewMessageMarkers.get(roomJid),
         }
 
-        const runtime = get().roomRuntime.get(roomJid)
-        const messages = runtime?.messages ?? room.messages
+        const messages = get().messages.get(roomJid) ?? room.messages
         // Position the divider at the first message the canonical count would
         // count — same floor, same predicate (see onActivate).
         const activated = notifState.onActivate(notifInput, messages, 'room')
@@ -2970,7 +2989,7 @@ export const roomStore = createStore<RoomState>()(
       // heals the cache for the next open.
       const pointer = get().roomMeta.get(roomJid)?.readPointer?.identity.messageId
       if (pointer) {
-        const loaded = get().roomRuntime.get(roomJid)?.messages ?? get().rooms.get(roomJid)?.messages ?? []
+        const loaded = get().messages.get(roomJid) ?? []
         if (!loaded.some((m) => m.id === pointer)) {
           await get().loadMessagesAroundFromCache(roomJid, pointer)
           if (token !== activationToken) return
@@ -3001,8 +3020,7 @@ export const roomStore = createStore<RoomState>()(
       const meta = state.roomMeta.get(roomJid)
       const existing = state.rooms.get(roomJid)
       if (!meta && !existing) return state
-      const runtime = state.roomRuntime.get(roomJid)
-      const messages = runtime?.messages ?? existing?.messages ?? []
+      const messages = state.messages.get(roomJid) ?? existing?.messages ?? []
       const readPointer = meta?.readPointer ?? existing?.readPointer
 
       const divider = notifState.onActivate(
@@ -3050,8 +3068,7 @@ export const roomStore = createStore<RoomState>()(
       const meta = state.roomMeta.get(roomJid)
       if (!existing) return state
 
-      const runtime = state.roomRuntime.get(roomJid)
-      const messages = runtime?.messages ?? existing.messages
+      const messages = state.messages.get(roomJid) ?? existing.messages
 
       const notifInput: notifState.EntityNotificationState = {
         unreadCount: meta?.unreadCount ?? existing.unreadCount,
@@ -3059,7 +3076,7 @@ export const roomStore = createStore<RoomState>()(
         readPointer: meta?.readPointer ?? existing.readPointer,
         firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
       }
-      const atLiveEdge = state.roomRuntime.get(roomJid)?.windowAtLiveEdge !== false
+      const atLiveEdge = state.windowAtLiveEdge.get(roomJid) !== false
       const updated = notifState.onMessageSeen(notifInput, messageId, messages, 'room', { atLiveEdge })
       if (updated === notifInput) return state
 
@@ -3112,12 +3129,12 @@ export const roomStore = createStore<RoomState>()(
       const existing = state.rooms.get(roomJid)
       if (!meta) return state
 
-      const runtime = state.roomRuntime.get(roomJid)
       // A non-active room keeps no resident array (memory windowing), so
-      // mergeRoomMAMMessages passes the just-merged array here; else read runtime/rooms.
+      // mergeRoomMAMMessages passes the just-merged array here; else read the
+      // window map, falling back to the compat entry.
       // The resolution state machine (stash / clear-pending / forward-only
       // advance / active-divider recompute) is shared — see shared/readMarkerSync.
-      const messages = messagesOverride ?? runtime?.messages ?? existing?.messages ?? []
+      const messages = messagesOverride ?? state.messages.get(roomJid) ?? existing?.messages ?? []
       const resolution = resolveRemoteDisplayed(
         {
           unreadCount: meta.unreadCount,
@@ -3334,11 +3351,7 @@ export const roomStore = createStore<RoomState>()(
         persistRoomReadState(newMeta)
 
         // Create runtime
-        newRuntime.set(roomJid, {
-          occupants: new Map(),
-          messages: [],
-          windowAtLiveEdge: true,
-        })
+        newRuntime.set(roomJid, { occupants: new Map() })
       }
       return { rooms: newRooms, roomEntities: newEntities, roomMeta: newMeta, roomRuntime: newRuntime }
     })
@@ -3548,12 +3561,9 @@ export const roomStore = createStore<RoomState>()(
           if (!recenter) return update ?? state
           // Recenter: force the flag true (even when the merge was a no-op because the
           // newest window was already resident).
-          const baseRuntime = update?.roomRuntime ?? state.roomRuntime
-          const runtime = baseRuntime.get(roomJid)
-          if (!runtime) return update ?? state
-          const newRuntime = new Map(baseRuntime)
-          newRuntime.set(roomJid, { ...runtime, windowAtLiveEdge: true })
-          return { ...(update ?? {}), roomRuntime: newRuntime }
+          const base = update?.windowAtLiveEdge ?? state.windowAtLiveEdge
+          if (base.get(roomJid) === true) return update ?? state
+          return { ...(update ?? {}), windowAtLiveEdge: new Map(base).set(roomJid, true) }
         })
       }
       return cachedMessages
@@ -3681,11 +3691,8 @@ export const roomStore = createStore<RoomState>()(
       } else if (reachedTail) {
         // Empty batch: still need to flip the flag if the room isn't already at the edge.
         set((state) => {
-          const existingRuntime = state.roomRuntime.get(roomJid)
-          if (!existingRuntime || existingRuntime.windowAtLiveEdge !== false) return state
-          const newRuntime = new Map(state.roomRuntime)
-          newRuntime.set(roomJid, { ...existingRuntime, windowAtLiveEdge: true })
-          return { roomRuntime: newRuntime }
+          if (state.windowAtLiveEdge.get(roomJid) !== false) return state
+          return { windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, true) }
         })
       }
 
@@ -3703,11 +3710,8 @@ export const roomStore = createStore<RoomState>()(
     // unambiguously at the live edge even when the cache had nothing new to merge (the
     // newest window was already fully resident).
     set((state) => {
-      const existingRuntime = state.roomRuntime.get(roomJid)
-      if (!existingRuntime || existingRuntime.windowAtLiveEdge === true) return state
-      const newRuntime = new Map(state.roomRuntime)
-      newRuntime.set(roomJid, { ...existingRuntime, windowAtLiveEdge: true })
-      return { roomRuntime: newRuntime }
+      if (state.windowAtLiveEdge.get(roomJid) === true) return state
+      return { windowAtLiveEdge: new Map(state.windowAtLiveEdge).set(roomJid, true) }
     })
   },
 

--- a/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.viewportGate.test.ts
@@ -141,7 +141,7 @@ describe('roomStore viewport-evidence gate (Task 11)', () => {
       rooms: new Map(),
       roomEntities: new Map(),
       roomMeta: new Map(),
-      roomRuntime: new Map(),
+      roomRuntime: new Map(), messages: new Map(), windowAtLiveEdge: new Map(),
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -979,7 +979,7 @@ test.describe('Virtualization scroll invariants', () => {
     const evicted = await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      return (rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []).length
+      return (rs.messages.get(jid) ?? []).length
     }, STRESS_ROOM_JID)
     expect(evicted, 'resident window should be evicted (or trimmed) after switching away').toBeLessThan(150)
 
@@ -994,7 +994,7 @@ test.describe('Virtualization scroll invariants', () => {
     const reloaded = await page.evaluate(([jid, id]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const msgs = rs.messages.get(jid) ?? []
       return { residentLen: msgs.length, hasAnchor: msgs.some((m: { id: string }) => m.id === id) }
     }, [STRESS_ROOM_JID, anchorId] as const)
     expect(reloaded.residentLen, 'resident window did not grow past the latest slice — anchor slice not reloaded').toBeGreaterThan(150)
@@ -1189,7 +1189,7 @@ test.describe('Virtualization scroll invariants', () => {
     const lastId = await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const msgs = rs.messages.get(jid) ?? []
       const last = msgs[msgs.length - 1]
       if (last) rs.advanceReadPointer(jid, last.id)
       return last?.id ?? null
@@ -1378,7 +1378,7 @@ test.describe('Marker-on-reentry diagnostic', () => {
     const lastId = await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const msgs = rs.messages.get(jid) ?? []
       const last = msgs[msgs.length - 1]
       if (last) rs.advanceReadPointer(jid, last.id)
       return last?.id ?? null
@@ -2544,7 +2544,7 @@ test.describe('Sliding window (load-older past the cap)', () => {
     const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
     return {
       count: room?.messages?.length ?? 0,
-      atLiveEdge: rs.roomRuntime.get(jid)?.windowAtLiveEdge ?? true,
+      atLiveEdge: rs.windowAtLiveEdge.get(jid) ?? true,
       scrollTop: scroller?.scrollTop ?? 0,
     }
   }, STRESS_ROOM_JID)
@@ -2569,7 +2569,7 @@ test.describe('Sliding window (load-older past the cap)', () => {
     await page.waitForFunction((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      return (rs.roomRuntime.get(jid)?.windowAtLiveEdge ?? true) === false
+      return (rs.windowAtLiveEdge.get(jid) ?? true) === false
     }, STRESS_ROOM_JID, { timeout: 6_000 }).catch(() => { /* asserted below with context */ })
     await page.waitForTimeout(800) // anchor-restore re-assert settle
 
@@ -2586,7 +2586,7 @@ test.describe('Sliding window (load-older past the cap)', () => {
     await page.waitForFunction((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      return (rs.roomRuntime.get(jid)?.windowAtLiveEdge ?? true) === true
+      return (rs.windowAtLiveEdge.get(jid) ?? true) === true
     }, STRESS_ROOM_JID, { timeout: 6_000 }).catch(() => { /* asserted below */ })
     const recentered = await readState(page)
     expect(recentered.atLiveEdge, `jump-to-latest did not recenter to the live edge: ${JSON.stringify(recentered)}`).toBe(true)
@@ -2612,7 +2612,7 @@ test.describe('Jump-to-last-read pill', () => {
     await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const msgs = rs.messages.get(jid) ?? []
       const last = msgs[msgs.length - 1]
       if (last) rs.advanceReadPointer(jid, last.id)
     }, STRESS_ROOM_JID)
@@ -2737,7 +2737,7 @@ test.describe('Jump-to-last-read pill', () => {
       const store = (window as any).__roomStore
       const s = store.getState()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const msgs = (s.roomRuntime.get(jid)?.messages ?? s.rooms.get(jid)?.messages ?? []) as { id: string; from?: string; timestamp: Date; isOutgoing?: boolean }[]
+      const msgs = (s.messages.get(jid) ?? []) as { id: string; from?: string; timestamp: Date; isOutgoing?: boolean }[]
       // First unread after the pointer must exist and be incoming — find the last incoming message
       // and put the pointer immediately before it, so resyncDividerToReadPointer lands on it.
       let targetIdx = -1
@@ -2793,7 +2793,7 @@ test.describe('Jump-to-last-read pill', () => {
     const readDividerState = () => page.evaluate(([jid, dividerId]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rs = (window as any).__roomStore.getState()
-      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const msgs = rs.messages.get(jid) ?? []
       const markerId = rs.firstNewMessageMarkers.get(jid) ?? null
       const s = document.querySelector('[data-message-list]') as HTMLElement | null
       return {


### PR DESCRIPTION
Follows #1306. `RoomRuntime` held three unrelated things:

| | |
|---|---|
| `messages`, `windowAtLiveEdge` | the resident **message window** — universal |
| `occupants`, `selfOccupant`, `affiliatedMembers` | **occupancy** — universal, just degenerate for 1:1 |
| `nickToJid*`, `occupantIdTo*` | **identity caches** — genuinely MUC, they exist because MUC hides real JIDs |

Only the last is MUC-specific. And `chatStore` has kept the window as two top-level maps all along — the room side was the only one that buried it, which made it look like a model difference when it was drift.

## What changes

`messages: Map<string, RoomMessage[]>` and `windowAtLiveEdge: Map<string, boolean>` become top-level `RoomState` maps, written only by `withRoomMessageWindow` (the writer introduced in #1306, which is why this is a small change rather than an eleven-site one).

A new `RoomMessageWindow` keeps both fields on `Room`, so **no consumer of the combined entry moves**. `RoomRuntime` is now occupancy plus identity caches — what its name claims.

## Two things this surfaced

**`mdsSideEffects` was watching the wrong map.** It subscribed to `roomRuntime` to notice message changes, while its chat twin two lines above subscribed to `chatStore.messages`. Now it watches the window — so occupant churn no longer wakes the read-marker logic, which it never should have.

**`anomaly/install.ts` documented the drift in a comment**: the flag lives *"on `roomRuntime` for rooms, in a `windowAtLiveEdge` map for conversations — one fact in two shapes"*. Both sides now read the same shape and the branch is gone.

## What the compiler could not see

The scroll harness reads the store through `(window as any).__roomStore` inside `page.evaluate`, so the move was invisible to `tsc`. `npm run test:scroll` caught it: `invariant-13` failed with *"windowAtLiveEdge did not flip false after load-older at the cap"*. Its seven store reads are migrated with it.

That `any` boundary is worth knowing about: an e2e harness that reaches into store internals is outside the type system's reach, and only the e2e run defends it.

## Verification

Typecheck, lint, comment provenance, full suite (SDK 243 files / 6115 tests, app 456 / 6095 + 20 skipped), and **`test:scroll` 98/98**.

Rebased onto `ce8ab217` and re-verified on the final tree.

## Next

`Room` still carries the window for its ~100 external readers. Migrating those, then dropping `RoomMessageWindow` from `Room`, is the step where the typecheck *proves* no reader is left.