### PR TITLE
refactor(sdk): read the room message window from its own map

### DIFF
--- a/apps/fluux/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/fluux/src/hooks/useKeyboardShortcuts.test.tsx
@@ -22,6 +22,9 @@ const mockState = {
   conversations: [] as Array<{ id: string; unreadCount: number }>,
   activeConversationId: null as string | null,
   joinedRooms: [] as Array<{ jid: string; mentionsCount: number; unreadCount: number }>,
+  // The resident window lives in its own store map; these fixtures carry no
+  // messages, so an empty map yields the zero timestamp the sort already expects.
+  roomMessages: new Map<string, Array<{ timestamp?: Date }>>(),
   activeRoomJid: null as string | null,
   archivedConversations: new Set<string>(),
   setActiveConversation: vi.fn(),
@@ -56,6 +59,7 @@ vi.mock('@fluux/sdk', () => ({
       // semantic the fixture represents.
       allRooms: () => mockState.joinedRooms.map(r => ({ ...r, joined: true })),
       activeRoomJid: mockState.activeRoomJid,
+      messages: mockState.roomMessages,
       setActiveRoom: mockState.setActiveRoom,
       loadMessagesFromCache: mockState.roomLoadMessagesFromCache,
       // Mirrors the real store action: hydrate from cache, then set active
@@ -116,6 +120,7 @@ describe('useKeyboardShortcuts', () => {
     mockState.activeConversationId = null
     mockState.setActiveConversation = vi.fn()
     mockState.joinedRooms = []
+    mockState.roomMessages = new Map()
     mockState.activeRoomJid = null
     mockState.setActiveRoom = vi.fn()
     mockState.chatLoadMessagesFromCache = vi.fn(() => Promise.resolve([]))

--- a/apps/fluux/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/fluux/src/hooks/useKeyboardShortcuts.ts
@@ -188,7 +188,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions): Shor
       .filter(r => (r.mentionsCount > 0 || r.unreadCount > 0) && r.jid !== activeRoomJid)
       .map(room => {
         // Get timestamp from last message (safely handle empty/missing messages)
-        const messages = room.messages || []
+        const messages = roomStore.getState().messages.get(room.jid) ?? []
         const lastMessage = messages[messages.length - 1]
         const timestamp = lastMessage?.timestamp instanceof Date
           ? lastMessage.timestamp.getTime()

--- a/apps/fluux/src/hooks/useReactionNotifications.test.tsx
+++ b/apps/fluux/src/hooks/useReactionNotifications.test.tsx
@@ -8,12 +8,21 @@ const chatState = {
   messages: new Map<string, Array<{ id: string; stanzaId?: string; isOutgoing?: boolean; body?: string }>>(),
   activeConversationId: null as string | null,
 }
+type RoomMsg = { id: string; stanzaId?: string; nick?: string; body?: string }
 const roomState = {
-  rooms: new Map<string, { nickname: string; messages: Array<{ id: string; stanzaId?: string; nick?: string; body?: string }> }>(),
+  rooms: new Map<string, { nickname: string; messages: RoomMsg[] }>(),
+  // The resident window, like the chat mock above it.
+  messages: new Map<string, RoomMsg[]>(),
   getMessage: vi.fn(),
   activeRoomJid: null as string | null,
 }
 const connectionState = { jid: 'me@example.com' }
+
+/** Seed a room's identity and its resident window, which live in two maps. */
+function seedRoom(jid: string, messages: RoomMsg[]): void {
+  roomState.rooms.set(jid, { nickname: 'Me', messages })
+  roomState.messages.set(jid, messages)
+}
 const mockGetCachedMessage = vi.fn()
 const mockGetCachedMessageByStanzaId = vi.fn()
 const mockGetCachedRoomMessage = vi.fn()
@@ -249,7 +258,7 @@ describe('useReactionNotifications — room reaction resolution', () => {
     roomState.rooms = new Map()
     roomState.activeRoomJid = null
     roomState.getMessage = vi.fn().mockReturnValue(undefined)
-    roomState.rooms.set(ROOM, { nickname: 'Me', messages: [{ id: 'r-last', nick: 'Alice' }] })
+    seedRoom(ROOM, [{ id: 'r-last', nick: 'Alice' }])
   })
 
   it('raises a toast for a resident own room message reacted to while a different room is active', async () => {
@@ -297,7 +306,7 @@ describe('useReactionNotifications — room reaction resolution', () => {
   it('suppresses the notification when the room reaction references the last message by stanza-id', async () => {
     roomState.activeRoomJid = ROOM
     const last = { id: 'r-last', stanzaId: 'stanza-r-last', nick: 'Me', body: 'my latest' }
-    roomState.rooms.set(ROOM, { nickname: 'Me', messages: [{ id: 'r1', nick: 'Alice' }, last] })
+    seedRoom(ROOM, [{ id: 'r1', nick: 'Alice' }, last])
     roomState.getMessage = vi.fn().mockReturnValue(last)
 
     renderHook(() => useReactionNotifications())

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -136,7 +136,7 @@ export function useReactionNotifications(): void {
       // resident window in RAM, so a reaction to an own message that has scrolled
       // out of the window isn't found there — fall back to the durable cache, same
       // as the 1:1 path.
-      const roomMessages = room.messages
+      const roomMessages = roomStore.getState().messages.get(roomJid) ?? []
       let message = state.getMessage(roomJid, messageId)
       if (!message) {
         message = (await getCachedRoomMessage(roomJid, messageId)) ?? (await getCachedRoomMessageByStanzaId(roomJid, messageId)) ?? undefined

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -712,8 +712,9 @@ export function createStoreBindings(
 
       // Recalculate lastMessage from in-memory messages
       const room = stores.room.getRoom(roomJid)
-      if (room && room.messages.length > 0) {
-        const newLast = findLastNonIgnoredMessage(room.messages, roomJid, room.nickToJidCache)
+      const roomMessages = stores.room.messages.get(roomJid) ?? []
+      if (room && roomMessages.length > 0) {
+        const newLast = findLastNonIgnoredMessage(roomMessages, roomJid, room.nickToJidCache)
         if (newLast) {
           stores.room.updateLastMessagePreview(roomJid, newLast)
         }

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
@@ -161,7 +161,12 @@ function deserializeRoomMessage(m: SerializedRoomMessage): RoomMessage {
   }
 }
 
-function serializeRoom(r: Room): SerializedRoom {
+/**
+ * @param window - the room's resident messages. Passed in rather than read off
+ *   `r`: the window lives in its own store map, and the combined entry's copy is
+ *   a mirror this must not come to depend on.
+ */
+function serializeRoom(r: Room, window: RoomMessage[]): SerializedRoom {
   return {
     jid: r.jid,
     name: r.name,
@@ -185,7 +190,7 @@ function serializeRoom(r: Room): SerializedRoom {
     supportsHats: r.supportsHats,
     isIrcGateway: r.isIrcGateway,
     readPointer: r.readPointer ? serializeReadPointer(r.readPointer) : undefined,
-    messages: r.messages.slice(-MAX_MESSAGES_PER_ROOM).map(serializeRoomMessage),
+    messages: window.slice(-MAX_MESSAGES_PER_ROOM).map(serializeRoomMessage),
   }
 }
 
@@ -353,9 +358,10 @@ export class StateSnapshot {
           (rooms) => this.schedule('rooms', () => {
             const jid = this.deps.getJid()
             if (!jid || !adapter.setRooms) return
+            const windows = roomStore.getState().messages
             const serialized = Array.from(rooms.values())
               .filter((r) => !r.isQuickChat)
-              .map(serializeRoom)
+              .map((r) => serializeRoom(r, windows.get(r.jid) ?? []))
             return adapter.setRooms(jid, serialized)
           })
         )
@@ -429,9 +435,10 @@ export class StateSnapshot {
       jobs.push(adapter.setRoster(jid, serialized))
     }
     if (adapter.setRooms) {
+      const windows = roomStore.getState().messages
       const serialized = Array.from(roomStore.getState().rooms.values())
         .filter((r) => !r.isQuickChat)
-        .map(serializeRoom)
+        .map((r) => serializeRoom(r, windows.get(r.jid) ?? []))
       jobs.push(adapter.setRooms(jid, serialized))
     }
     if (adapter.setServerInfo) {

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -212,7 +212,7 @@ export function setupRoomSideEffects(
       }
 
       // Latest-first orchestrator — room twin, Phase A only (active entity).
-      const roomMessages = roomStore.getState().rooms.get(roomJid)?.messages || []
+      const roomMessages = roomStore.getState().messages.get(roomJid) ?? []
       await client.internal.mam.catchUpRoomHistory(roomJid, roomMessages, { sessionStartTime })
       if (!isRoomFetchOwnerCurrent(roomJid, fetchOwner)) {
         return
@@ -277,7 +277,7 @@ export function setupRoomSideEffects(
         // message array AFTER the list mounted and scrolled, knocking the restored
         // scroll position off (lands mid-list). Live delivery keeps the resident set
         // current, so there is genuinely nothing to fetch.
-        const residentCount = roomStore.getState().rooms.get(activeRoomJid)?.messages.length ?? 0
+        const residentCount = roomStore.getState().messages.get(activeRoomJid)?.length ?? 0
         if (
           fetchInitiated.has(activeRoomJid) &&
           (residentCount > 0 || resumeArchiveHeldRooms.has(activeRoomJid))
@@ -374,7 +374,7 @@ export function setupRoomSideEffects(
     const archiveHeld = (jid: string): boolean => {
       const room = state.rooms.get(jid)
       if (!room) return false
-      return room.messages.length > 0 || state.getRoomMAMQueryState(jid).hasQueried
+      return (state.messages.get(jid)?.length ?? 0) > 0 || state.getRoomMAMQueryState(jid).hasQueried
     }
     for (const [jid, room] of state.rooms) {
       if ((room.joined || room.isJoining) && archiveHeld(jid)) {

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -51,6 +51,9 @@ const triggerChatStoreUpdate = () => {
 const triggerRoomStoreUpdate = () => {
   const state = {
     rooms: mockRooms,
+    // The resident window lives in its own map; these fixtures keep it on the
+    // room object, so project it rather than duplicating every seed.
+    messages: new Map(Array.from(mockRooms, ([jid, r]) => [jid, r.messages ?? []])),
     activeRoomJid: mockActiveRoomJid,
     allRooms: () => Array.from(mockRooms.values()),
   }

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -237,7 +237,11 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
         new Map(
           allRooms.map(r => [
             r.jid,
-            { mentionsCount: r.mentionsCount, messagesLength: r.messages.length, unreadCount: r.unreadCount ?? 0 },
+            {
+              mentionsCount: r.mentionsCount,
+              messagesLength: state.messages.get(r.jid)?.length ?? 0,
+              unreadCount: r.unreadCount ?? 0,
+            },
           ])
         )
 
@@ -263,9 +267,10 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
 
         if (!onRoomMessage) continue
 
+        const roomMessages = state.messages.get(room.jid) ?? []
         const prevMessagesLength = prev?.messagesLength ?? 0
-        const hasNewMessages = room.messages.length > prevMessagesLength
-        const newMessageCount = room.messages.length - prevMessagesLength
+        const hasNewMessages = roomMessages.length > prevMessagesLength
+        const newMessageCount = roomMessages.length - prevMessagesLength
 
         if (!hasNewMessages) continue
 
@@ -276,11 +281,11 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
         const isActive = room.jid === activeRoomJid
 
         // Find the most recent message that warrants notification
-        const searchStartIndex = room.messages.length - 1
-        const searchEndIndex = Math.max(0, room.messages.length - newMessageCount)
+        const searchStartIndex = roomMessages.length - 1
+        const searchEndIndex = Math.max(0, roomMessages.length - newMessageCount)
 
         for (let i = searchStartIndex; i >= searchEndIndex; i--) {
-          const msg = room.messages[i]
+          const msg = roomMessages[i]
 
           const result = shouldNotifyRoom(
             {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -669,6 +669,20 @@ function commitRoomUpdate(
     }
   }
 
+  // The window still reaches `Room`, so a `Partial<Room>` can carry it. Route it
+  // through the one writer rather than letting this become a second one — and
+  // rather than accepting a field only to drop it, which is how `lastMessage`
+  // went missing from the old hand-maintained lists.
+  if ('messages' in update || 'windowAtLiveEdge' in update) {
+    const written = withRoomMessageWindow(
+      { rooms: result.rooms ?? state.rooms, messages: state.messages, windowAtLiveEdge: state.windowAtLiveEdge },
+      roomJid,
+      update.messages ?? state.messages.get(roomJid) ?? [],
+      update.windowAtLiveEdge === undefined ? {} : { atLiveEdge: update.windowAtLiveEdge }
+    )
+    if (written) Object.assign(result, written)
+  }
+
   return result
 }
 


### PR DESCRIPTION
Follows #1307. Every consumer outside `roomStore` now reads the resident window from `roomStore.messages` rather than off the combined `Room` entry.

## Smaller than expected

The campaign estimate was ~100 external readers. Measured against the compiler after #1307, it was **12**, in six files — the app-side readers had already moved with the selectors and `useRoomActive`.

| | |
|---|---|
| `useNotificationEvents` (SDK) | 6 — the new-message diffing |
| `roomSideEffects` | 3 — catch-up cursor, resident count, archive-held probe |
| `stateSnapshot` | 1 |
| `storeBindings` | 1 — ignore-list preview recompute |
| `useKeyboardShortcuts`, `useReactionNotifications` (app) | 1 each |

## Three judgement calls

**`serializeRoom` takes the window as a parameter** rather than reading `r.messages`. The snapshot has to keep working across the step where `Room` stops carrying it, and a parameter says where the data comes from.

**`commitRoomUpdate` routes a window carried on a `Partial<Room>`** through `withRoomMessageWindow` instead of ignoring it. No production caller passes one — but `Room` still declares the fields, so a caller could, and a routing table that accepts a field and silently drops it is exactly how `lastMessage` went missing from the hand-maintained lists that table replaced. The file documents that scar; I would rather not re-cut it.

**Two reads went through `room.jid`** where the enclosing `roomJid` was already in scope. That indirection is also what made a mocked room (which carries no `jid`) miss the lookup — the direct route is both simpler and what the test caught.

## Test fixtures

Three mocks modelled the window on the room object. They now expose the map: `useNotificationEvents` projects it from its existing fixtures rather than duplicating every seed, and the two app mocks gained the map their chat halves already had.

## Verification

Typecheck, lint, comment provenance, full suite (SDK 243 files / 6115 tests, app 456 / 6095 + 20 skipped), `test:scroll` 98/98.

## Next

The only remaining readers of `Room.messages` are `roomStore` itself — which writes the mirror — and the tests. Dropping `RoomMessageWindow` from `Room` is the step where the typecheck **proves** nothing is left behind.