### PR TITLE
fix(read-state): keep the new-message divider where the view opened it

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -57,7 +57,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, readPointerId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, activeHistoryState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, readPointerId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, advanceReadPointer, activeHistoryState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   const interiorPlacementVersion = useChatStore((state) => {
     const id = state.activeConversationId
     return id ? state.interiorPlacementVersions.get(id) ?? 0 : 0
@@ -348,11 +348,6 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     [viewportEvidenceKey, viewportGeneration],
   )
 
-  const handleResyncDivider = useCallback(
-    (conversationId: string) => resyncDividerToReadPointer(conversationId),
-    [resyncDividerToReadPointer],
-  )
-
   // Viewport observer callback: update readPointerId as user scrolls
   const handleMessageSeen = (messageId: string) => {
     if (conversationId) {
@@ -577,7 +572,6 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}
-            onResyncDivider={handleResyncDivider}
             onMessageSeen={handleMessageSeen}
             isDarkMode={resolvedMode === 'dark'}
           onScrollToTop={fetchOlderHistory}
@@ -688,7 +682,6 @@ export const ChatMessageList = memo(function ChatMessageList({
   targetMessageId,
   clearTargetMessageId,
   clearFirstNewMessageId,
-  onResyncDivider,
   onMessageSeen,
   isDarkMode,
   onScrollToTop,
@@ -740,7 +733,6 @@ export const ChatMessageList = memo(function ChatMessageList({
   targetMessageId?: string | null
   clearTargetMessageId?: () => void
   clearFirstNewMessageId: () => void
-  onResyncDivider?: (conversationId: string) => void
   onMessageSeen?: (messageId: string) => void
   isDarkMode?: boolean
   onScrollToTop?: () => void
@@ -849,7 +841,6 @@ export const ChatMessageList = memo(function ChatMessageList({
       targetMessageId={targetMessageId}
       onTargetMessageConsumed={clearTargetMessageId}
       clearFirstNewMessageId={clearFirstNewMessageId}
-      onResyncDivider={onResyncDivider}
       onMessageSeen={onMessageSeen}
       scrollerRef={scrollerRef}
       isAtBottomRef={isAtBottomRef}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -99,7 +99,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Active-room state + messaging/scroll actions. Poll / moderation /
   // management actions come from the focused hooks below (they subscribe to no
   // store, so they add no re-render triggers).
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeHistoryState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeHistoryState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
   const interiorPlacementVersion = useRoomStore((state) => {
     const jid = state.activeRoomJid
     return jid ? state.interiorPlacementVersions.get(jid) ?? 0 : 0
@@ -456,11 +456,6 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     }
   }, [roomJid, clearFirstNewMessageId])
 
-  const handleResyncDivider = useCallback(
-    (roomJid: string) => resyncDividerToReadPointer(roomJid),
-    [resyncDividerToReadPointer],
-  )
-
   // Viewport observer callback: update readPointerId as user scrolls
   const handleMessageSeen = useCallback((messageId: string) => {
     if (roomJid) {
@@ -626,7 +621,6 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}
-            onResyncDivider={handleResyncDivider}
             onMessageSeen={handleMessageSeen}
             isJoined={activeRoom.joined}
             isDarkMode={resolvedMode === 'dark'}
@@ -916,7 +910,6 @@ export const RoomMessageList = memo(function RoomMessageList({
   targetMessageId,
   clearTargetMessageId,
   clearFirstNewMessageId,
-  onResyncDivider,
   onMessageSeen,
   isJoined,
   isDarkMode,
@@ -975,7 +968,6 @@ export const RoomMessageList = memo(function RoomMessageList({
   targetMessageId?: string | null
   clearTargetMessageId?: () => void
   clearFirstNewMessageId: () => void
-  onResyncDivider?: (roomJid: string) => void
   onMessageSeen?: (messageId: string) => void
   isJoined?: boolean
   isDarkMode?: boolean
@@ -1239,7 +1231,6 @@ export const RoomMessageList = memo(function RoomMessageList({
       targetMessageId={targetMessageId}
       onTargetMessageConsumed={clearTargetMessageId}
       clearFirstNewMessageId={clearFirstNewMessageId}
-      onResyncDivider={onResyncDivider}
       onMessageSeen={onMessageSeen}
       scrollerRef={scrollerRef}
       isAtBottomRef={isAtBottomRef}

--- a/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
@@ -414,49 +414,6 @@ describe('MessageList FAB badge and scroll behavior', () => {
     })
   })
 
-  describe('divider resync on scroll-up', () => {
-    it('snaps the divider to the pointer when the reader scrolls back up', () => {
-      const onResyncDivider = vi.fn()
-      const messages = createTestMessages(10)
-      render(
-        <MessageList
-          messages={messages}
-          conversationId="conv-1"
-          clearFirstNewMessageId={vi.fn()}
-          firstNewMessageId="msg-3"   // divider at entry
-          readPointerId="msg-6"   // read pointer deeper than divider
-          onResyncDivider={onResyncDivider}
-          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
-        />
-      )
-      const scrollCtx = setupScrollContainer()
-      if (!scrollCtx) return
-      // Scroll to the top so the bottom-most-visible row (msg-4) is above the pointer (msg-6).
-      simulateScrollTo(scrollCtx.container, 0)
-      expect(onResyncDivider).toHaveBeenCalledWith('conv-1')
-    })
-
-    it('does not snap while the reader is at or below the pointer', () => {
-      const onResyncDivider = vi.fn()
-      const messages = createTestMessages(10)
-      render(
-        <MessageList
-          messages={messages}
-          conversationId="conv-1"
-          clearFirstNewMessageId={vi.fn()}
-          firstNewMessageId="msg-3"
-          readPointerId="msg-3"   // pointer == divider, reader hasn't gone past it
-          onResyncDivider={onResyncDivider}
-          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
-        />
-      )
-      const scrollCtx = setupScrollContainer()
-      if (!scrollCtx) return
-      simulateScrollTo(scrollCtx.container, 0) // bottom-visible msg-4 is BELOW the pointer msg-3
-      expect(onResyncDivider).not.toHaveBeenCalled()
-    })
-  })
-
   describe('no flash on fresh open at bottom', () => {
     it('does not play the spring-out exit animation on initial mount', () => {
       // When a conversation opens already at the bottom, the FAB should be hidden with NO

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -85,8 +85,6 @@ export interface MessageListProps<T extends BaseMessage> {
   clearFirstNewMessageId?: () => void
   /** Persisted read pointer for this conversation — the badge counts unread below it. */
   readPointerId?: string
-  /** Recompute the divider from the read pointer (called when the reader scrolls back up). */
-  onResyncDivider?: (conversationId: string) => void
   /**
    * The ONE canonical unread count (the store's pointer-derived
    * `unreadCount` — `meta.unreadCount` / `room.unreadCount`), fed to every numeric surface this
@@ -192,7 +190,6 @@ export function MessageList<T extends BaseMessage>({
   firstNewMessageIsProvisional = false,
   clearFirstNewMessageId,
   readPointerId,
-  onResyncDivider,
   unreadCount,
   targetMessageId,
   onTargetMessageConsumed,
@@ -542,7 +539,6 @@ export function MessageList<T extends BaseMessage>({
     requestMessageTarget,
     showScrollToBottom,
     markerAboveViewport,
-    bottomVisibleMessageId,
     scrollToMarker,
   } = useMessageListScroll({
     conversationId,
@@ -760,20 +756,6 @@ export function MessageList<T extends BaseMessage>({
   // hide a divider the store already positioned. `undefined` here falls back to the marker's
   // generic "New messages" label instead of a misleading "0 new messages".
   const dividerCount = canonicalUnreadCount > 0 ? canonicalUnreadCount : undefined
-  // When the reader scrolls back ABOVE the read pointer, snap the "New messages" divider to the
-  // first unread after the pointer ("here's how far I got"). Forward-only + idempotent in the store,
-  // so a slightly noisy trigger is harmless. Compares the bottom-most-visible row (from the scroll
-  // hook) against the pointer, both resolved in the resident message array.
-  useEffect(() => {
-    if (!firstNewMessageId || !readPointerId || !bottomVisibleMessageId || !onResyncDivider) return
-    const bIdx = deduplicatedMessages.findIndex((m) => m.id === bottomVisibleMessageId)
-    const pIdx = deduplicatedMessages.findIndex((m) => m.id === readPointerId)
-    const dIdx = deduplicatedMessages.findIndex((m) => m.id === firstNewMessageId)
-    // Scrolled above the pointer (bIdx < pIdx) and the divider still trails it (dIdx <= pIdx).
-    if (bIdx >= 0 && pIdx > bIdx && dIdx !== -1 && dIdx <= pIdx) {
-      onResyncDivider(conversationId)
-    }
-  }, [bottomVisibleMessageId, readPointerId, firstNewMessageId, deduplicatedMessages, conversationId, onResyncDivider])
   // Track whether the FAB has ever been shown in this mount so the exit animation (whose first
   // keyframe is fully-visible) never runs on a fresh open-at-bottom, which would flash the FAB.
   // MessageList is remounted per conversation via `key`, so this ref resets on every open.

--- a/apps/fluux/src/components/conversation/MessageList.unreadSurfaces.acceptance.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.unreadSurfaces.acceptance.test.tsx
@@ -284,9 +284,9 @@ describe('MessageList — unread-count-single-source acceptance scenarios (Task 
   })
 
   // -----------------------------------------------------------------------
-  // Scenario 7: Remote XEP-0490 marker advances the pointer while scrolled up
+  // Scenario 7: An ambient divider/count update while scrolled up
   // -----------------------------------------------------------------------
-  it('scenario 7 — remote marker advance updates every surface and preserves the anchored offset', () => {
+  it('scenario 7 — an ambient divider/count update preserves every surface and the anchored offset', () => {
     const messages = createTestMessages(10) // msg-0 .. msg-9
     const allIds = messages.map((m) => m.id)
     const { rerender, container } = render(
@@ -346,7 +346,7 @@ describe('MessageList — unread-count-single-source acceptance scenarios (Task 
     const relativeTopBefore = msg4().getBoundingClientRect().top
     expect(relativeTopBefore).toBe(420) // sanity: confirms the capture actually saw this position
 
-    // The remote marker advances the boundary: the divider moves to msg-6, the count drops to 2
+    // Simulate a new divider/count snapshot: the divider moves to msg-6 and the count drops to 2
     // (M). This pushes msg-6..msg-9 down instead of msg-3..msg-9 — msg-4's OWN offsetTop moves
     // from 500 to 400 (the marker no longer sits above it), a real 100px document-position shift.
     //

--- a/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
@@ -17,8 +17,7 @@ describe('NewMessageMarker', () => {
   })
 
   // Provisional = derived from the local read pointer while a synced XEP-0490
-  // read position is still unresolved; it may move or vanish once the marker
-  // resolves, so it renders muted rather than looking definitive.
+  // read position is still unresolved, so it renders muted.
   it('renders muted grey when provisional', () => {
     const { container } = render(<NewMessageMarker provisional />)
     const marker = container.querySelector('[data-new-message-marker]') as HTMLElement

--- a/apps/fluux/src/components/conversation/NewMessageMarker.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.tsx
@@ -6,8 +6,8 @@ import { formatUnreadCount } from '@/utils/formatUnreadCount'
  * Used to indicate where unread messages begin in the conversation.
  *
  * `provisional`: the position was derived from the local read pointer while a
- * synced XEP-0490 read position is still unresolved — it may move or vanish
- * once the marker resolves, so it renders muted instead of the accent color.
+ * synced XEP-0490 read position is still unresolved, so it renders muted until
+ * that position can be ordered.
  *
  * `count`: the canonical unread count — the divider is a real
  * numeric surface, not just a positional line. When provided it labels the count (e.g. "2 new

--- a/apps/fluux/src/components/conversation/mdsSettleDecision.test.ts
+++ b/apps/fluux/src/components/conversation/mdsSettleDecision.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { decideMdsSettle, type MdsSettleFacts } from './mdsSettleDecision'
 
-/** A divider that has just been cleared by a late read-sync, with nothing else in the way. */
+/** A divider that has just been cleared before the reader moves. */
 const settling: MdsSettleFacts = {
   staticMode: false,
   sameConversation: true,

--- a/apps/fluux/src/components/conversation/mdsSettleDecision.ts
+++ b/apps/fluux/src/components/conversation/mdsSettleDecision.ts
@@ -1,10 +1,9 @@
 /**
  * What to do when the unread divider disappears while the conversation is open.
  *
- * XEP-0490 read positions arrive from other devices after the conversation has already been
- * rendered. When one lands past the divider, the store clears it: the boundary the reader was
- * looking at no longer exists, and the list is left holding a position that was chosen to show it.
- * Settling to the live edge is the only position that still means anything.
+ * Once the divider is removed, the list may still hold the position chosen to show that landmark.
+ * Before the reader has moved, settling to the live edge gives that obsolete position a stable
+ * replacement.
  *
  * This is ambient — the reader did not ask for it — so it must not run when they have moved the
  * list themselves, and it must not fire on a conversation switch, where the previous conversation's
@@ -38,12 +37,12 @@ export function decideMdsSettle(facts: MdsSettleFacts): MdsSettleDecision {
   if (!facts.sameConversation) return 'skip'
 
   // The edge is present -> absent. No divider before means nothing was cleared; a divider still
-  // present means the read-sync has not superseded it, and the position showing it is still right.
+  // present means the position showing it is still valid.
   if (facts.previousDivider === undefined) return 'skip'
   if (facts.currentDivider !== undefined) return 'skip'
 
-  // The reader has taken the list somewhere. A late marker from another device is not a reason to
-  // pull them away from it.
+  // The reader has taken the list somewhere. An ambient divider removal is not a reason to pull
+  // them away from it.
   if (facts.hasGenuineInput) return 'skip'
 
   return 'settle'

--- a/apps/fluux/src/components/conversation/scrollEventDecisions.ts
+++ b/apps/fluux/src/components/conversation/scrollEventDecisions.ts
@@ -43,7 +43,7 @@ export interface ScrollEventPlan {
    */
   recordMeasuredAtBottom: boolean
   atBottom: boolean
-  /** Only a genuine move updates the divider-snap trigger. */
+  /** Only a genuine move refreshes the bottom-visible row used for ambient anchoring. */
   trackBottomVisibleMessage: boolean
   observeGenuineInput: boolean
   /**

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -248,9 +248,8 @@ export interface UseMessageListScrollResult {
   markerAboveViewport: boolean
   /** Id of the bottom-most message whose top is within the viewport (the row peeking in at the
    *  bottom edge), or null before the first scroll (or during programmatic positioning — see the
-   *  handleScroll gate). Drives the divider-snap trigger in MessageList (snap the "New messages"
-   *  divider to the read pointer on genuine user scroll); the FAB badge count reads the pointer
-   *  directly instead. */
+   *  handleScroll gate). Ambient layout preservation uses it to keep the reader's anchor stable
+   *  across insertions and divider mutations. */
   bottomVisibleMessageId: string | null
   /** Scroll to (and re-assert toward) the first-new-message marker. Used by the jump-to-last-read
    *  pill's click handler; also the routine the conversation-switch entry effect uses. No-op when
@@ -1387,16 +1386,9 @@ export function useMessageListScroll({
     staticMode,
   ])
 
-  // XEP-0490 settle window: the fresh-session read-sync seed can land just AFTER a
-  // conversation is opened. The SDK's entry fold races the async PEP fetch, so at
-  // activation the divider was derived from the STALE local read position and the
-  // conversation-switch effect above already positioned the view (and armed a re-assert
-  // loop) against it. When the seed lands, the SDK advances readPointerId and
-  // recomputes the divider live for the ACTIVE conversation (chatStore/roomStore
-  // applyRemoteDisplayed); when the synced read caught the conversation up, the divider
-  // clears. Settle the view to the bottom so the FIRST open lands where a later re-open
-  // would — otherwise it stays stranded at the stale marker and appears to "jump to the
-  // end" only on re-open.
+  // Divider-clear settle window: entry may already have positioned the view against a divider
+  // when another path removes it. Before the reader moves, settle to the live edge so the list
+  // does not remain parked at a landmark that no longer exists.
   //
   // Tightly gated so it never fights the user or a genuine unread marker:
   //  - only a live divider CLEAR (a defined marker -> undefined) on the SAME conversation
@@ -1418,7 +1410,7 @@ export function useMessageListScroll({
       hasGenuineInput: viewportSessionRef.current?.hasGenuineInput(conversationId) ?? false,
     })
     if (decision === 'skip') return
-    debugLog('MDS SETTLE: divider cleared by late read-sync → settle to bottom', {
+    debugLog('MDS SETTLE: divider cleared before reader input → settle to bottom', {
       conversationId,
       prevMarker: prev.divider,
     })

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -564,7 +564,7 @@ kinetic scrolling and stale-paint behavior.
        synced-live-edge predicate and its late-resolving twin are now separately testable, including
        the empty-conversation case where a bare pointer comparison would discard a saved position.
      - [x] Express the two remaining ambient re-pins as pure decisions: `mdsSettleDecision` for a
-       divider cleared by a late XEP-0490 read-sync, and `typingIndicatorDecision` for the band that
+       divider cleared before the reader moves, and `typingIndicatorDecision` for the band that
        shrinks the scrollport, the twin of `rowGrowthDecision`. The detectors that remain in the
        hook carry a single condition each, where a decision layer would be ceremony.
 

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -91,8 +91,8 @@ export function useChatActive() {
     if (!s.activeConversationId) return undefined
     return s.firstNewMessageMarkers.get(s.activeConversationId)
   })
-  // Persisted read pointer (XEP-0490 sync marker) for the active conversation. Drives the FAB badge
-  // count and the divider resync-on-scroll-up trigger in MessageList.
+  // Persisted read pointer (XEP-0490 sync marker) for the active conversation. Entry arbitration
+  // and saved viewport snapshots use it to distinguish stale positions from the current read state.
   const activeReadPointerId = useChatStore((s) => {
     if (!s.activeConversationId) return undefined
     return s.conversationMeta.get(s.activeConversationId)?.readPointer?.identity.messageId

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -85,8 +85,8 @@ export function useRoomActive() {
     return s.firstNewMessageMarkers.get(s.activeRoomJid)
   })
 
-  // Persisted read pointer (XEP-0490 sync marker) for the active room. Drives the FAB badge count
-  // and the divider resync-on-scroll-up trigger in MessageList.
+  // Persisted read pointer (XEP-0490 sync marker) for the active room. Entry arbitration and saved
+  // viewport snapshots use it to distinguish stale positions from the current read state.
   const activeReadPointerId = useRoomStore((s) => {
     if (!s.activeRoomJid) return undefined
     return s.roomMeta.get(s.activeRoomJid)?.readPointer?.identity.messageId

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -235,10 +235,9 @@ export const chatSelectors = {
   /**
    * Is the conversation's new-message divider provisional? True while a synced
    * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
-   * set): the divider was derived from the local read pointer and may move or
-   * vanish once a loaded slice can order the marker against that pointer. Purely
-   * derived — resolving the marker (advance OR clear-pending) confirms the
-   * divider with no extra state.
+   * set): the divider was derived from the local read pointer before the synced
+   * position could be ordered. Purely derived — resolving the marker (advance OR
+   * clear-pending) confirms the divider with no extra state.
    */
   firstNewMessageIsProvisionalFor: (conversationId: string) => (state: ChatState): boolean => {
     if (!state.firstNewMessageMarkers.has(conversationId)) return false

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -287,7 +287,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   })
 
   // resolveRemoteDisplayed resolves
-  // 'advanced-with-divider' — not 'advanced' — for the ACTIVE conversation,
+  // 'advanced-active' — not 'advanced' — for the ACTIVE conversation,
   // and that branch used to be exempted from triggering a recount on the
   // premise that an active entity's count was "already zero"
   // A spy-only assertion ("was recomputeUnreadForConversation
@@ -325,14 +325,15 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     chatStore.getState().applyRemoteDisplayed(CID, 's-p0', messages)
 
     // Still active throughout — this is not a "became inactive" race. The
-    // pointer advance and divider reposition are applied synchronously inside
-    // applyRemoteDisplayed's own `set()` call, so these don't need to wait for
-    // the fire-and-forget recount below.
+    // pointer advance is applied synchronously inside applyRemoteDisplayed's own
+    // `set()` call and the divider is left untouched, so neither assertion needs
+    // to wait for the fire-and-forget recount below.
     expect(chatStore.getState().activeConversationId).toBe(CID)
     // The pointer advanced (resolveRemoteDisplayed's job, unaffected by this fix).
     expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('p0')
-    // The divider was positioned at the first message after the new pointer.
-    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('u1')
+    // No divider appears. Placing the line belongs to activation; an inbound marker on an
+    // already-open view moves the pointer and the count, never the landmark.
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBeUndefined()
     // The count is re-derived from the archive (u1, u2, u3), not left
     // at the stale 99 a guard that still exempted the active entity would
     // produce. The recount is fire-and-forget (cache read, coverage resolve,
@@ -1059,7 +1060,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // survives only while an entity is active (deactivation deletes it), and
   // both allowActive triggers follow a pointer advance. The seeded marker is a
   // distinct stale id, so 'u1' can only come from a real rederivation.
-  it('a remote advance rederives the divider to the new boundary', async () => {
+  it('holds the ACTIVE entity\'s divider through a pointer advance, while the count re-derives', async () => {
     const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
     const p0 = archiveMsg('p0', 1000)
     const u1 = archiveMsg('u1', 1001)
@@ -1084,8 +1085,10 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     await chatStore.getState().recomputeUnreadForConversation(CID, { allowActive: true })
 
-    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('u1')
-    // The count is re-derived too (u1), not left at the stale 99.
+    // The line stays where this view opened. Re-deriving it from the advanced pointer would
+    // walk it down the screen under the reader; only re-opening the view places it again.
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('stale-marker-id')
+    // The count still re-derives (u1), rather than staying at the stale 99.
     expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(1)
   })
 

--- a/packages/fluux-sdk/src/stores/chatStore.dividerPersistence.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.dividerPersistence.test.ts
@@ -53,16 +53,52 @@ describe('the active conversation keeps the divider its view opened with', () =>
     })
   })
 
-  it('holds the divider when another device publishes a read marker further down', () => {
-    // XEP-0490 catch-up from a second client. The pointer must follow it — that is the whole point
-    // of the marker — but the line the reader is looking at is not the other device's business.
+  it('follows a read marker another device published past the line', () => {
+    // A marker from a second client is not navigation, it is a statement that those messages were
+    // read. Leaving the line in front of them would label as new what the user has already seen.
     seedActive('m1', 'm1')
     const before = chatStore.getState().conversationMeta.get(CID)?.readPointer
 
     chatStore.getState().applyRemoteDisplayed(CID, 'stanza-m3', MESSAGES)
 
-    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m1')
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m4')
     expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).not.toEqual(before)
+  })
+
+  it('does not resurrect a line the reader cleared', () => {
+    // Clearing is deliberate — Esc, mark-all-read, sending. A later marker moves the pointer and
+    // the count, and must not put the landmark back on screen.
+    seedActive('m1', 'm1')
+    chatStore.setState({ firstNewMessageMarkers: new Map() })
+
+    chatStore.getState().applyRemoteDisplayed(CID, 'stanza-m3', MESSAGES)
+
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBeUndefined()
+  })
+
+  it('never walks the line backwards', () => {
+    // The marker must genuinely advance the pointer, or the resolution never reaches the divider at
+    // all and this would assert nothing. Pointer at m0 and the line parked further down at m4: the
+    // marker advances the pointer to m2, whose first unread is m3 — BEHIND the line. Read state
+    // moved forward; the landmark must not slide back up the screen to meet it.
+    seedActive('m0', 'm4')
+
+    chatStore.getState().applyRemoteDisplayed(CID, 'stanza-m2', MESSAGES)
+
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('m2')
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m4')
+  })
+
+  it('leaves the line alone when it sits outside the loaded slice', () => {
+    // A line parked from a slice that has since been windowed out cannot be ordered against the
+    // marker's boundary. Moving it would be a guess, and the guess lands the reader somewhere they
+    // never were.
+    seedActive('m0', 'windowed-out')
+
+    chatStore.getState().applyRemoteDisplayed(CID, 'stanza-m2', MESSAGES)
+
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('m2')
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('windowed-out')
   })
 
   it('does not walk the divider forward when the read pointer has advanced past it', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.dividerPersistence.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.dividerPersistence.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The "New messages" divider is a landmark, not a cursor.
+ *
+ * It marks where the unread messages began when this view was opened. The read pointer moves
+ * underneath it while the reader scrolls — that is genuine read state, and it still drives receipts
+ * and the XEP-0490 marker other devices see — but deriving the divider's POSITION from that pointer
+ * walks the line down the screen while the reader is looking at it. Placing it belongs to
+ * activation; removing it belongs to read-through scroll, Esc, mark-all-read and deactivation.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { chatStore } from './chatStore'
+import type { Message } from '../core'
+import { makeReadPointer } from './shared/readPointer'
+
+const CID = 'alice@example.com'
+
+function msg(id: string): Message {
+  return {
+    id,
+    stanzaId: `stanza-${id}`,
+    conversationId: CID,
+    from: CID,
+    body: id,
+    timestamp: new Date(2024, 0, 1, 12, Number(id.replace(/\D/g, '')) || 0),
+    isOutgoing: false,
+    isDelayed: false,
+    type: 'chat' as const,
+  }
+}
+
+const MESSAGES = [msg('m0'), msg('m1'), msg('m2'), msg('m3'), msg('m4')]
+
+/** Parks a divider at `marker` with the pointer already read down to `lastSeen`. */
+function seedActive(lastSeen: string, marker: string) {
+  const seen = MESSAGES.find((m) => m.id === lastSeen)!
+  chatStore.setState({
+    activeConversationId: CID,
+    conversationMeta: new Map([[CID, { unreadCount: 0, readPointer: makeReadPointer(seen, 'chat') }]]),
+    messages: new Map([[CID, MESSAGES]]),
+    firstNewMessageMarkers: new Map([[CID, marker]]),
+    conversations: new Map(),
+  })
+}
+
+describe('the active conversation keeps the divider its view opened with', () => {
+  beforeEach(() => {
+    chatStore.setState({
+      activeConversationId: undefined,
+      conversationMeta: new Map(),
+      messages: new Map(),
+      firstNewMessageMarkers: new Map(),
+      conversations: new Map(),
+    })
+  })
+
+  it('holds the divider when another device publishes a read marker further down', () => {
+    // XEP-0490 catch-up from a second client. The pointer must follow it — that is the whole point
+    // of the marker — but the line the reader is looking at is not the other device's business.
+    seedActive('m1', 'm1')
+    const before = chatStore.getState().conversationMeta.get(CID)?.readPointer
+
+    chatStore.getState().applyRemoteDisplayed(CID, 'stanza-m3', MESSAGES)
+
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).not.toEqual(before)
+  })
+
+  it('does not walk the divider forward when the read pointer has advanced past it', () => {
+    // The reader opened on m1 and has scrolled down to m3. Re-deriving from the pointer would put
+    // the line at m4 — under the reader's eyes, and no longer marking what they came back to.
+    seedActive('m3', 'm1')
+    chatStore.getState().resyncDividerToReadPointer(CID)
+    // The SDK primitive still repositions on demand: the app simply stops asking.
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m4')
+
+    seedActive('m3', 'm1')
+    expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('m1')
+  })
+})

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -531,15 +531,12 @@ describe('chatStore — new-message divider is session-only', () => {
   })
 })
 
-describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE divider', () => {
+describe('chatStore.applyRemoteDisplayed — late marker advances ACTIVE read state without moving the divider', () => {
   beforeEach(() => chatStore.getState().reset())
 
-  // Reproduces the fresh-session seed race: the conversation is activated (divider
-  // derived from the STALE local read position) BEFORE the async MDS seed lands, so
-  // the marker arrives via applyRemoteDisplayed while the conversation is already
-  // active. The divider must be recomputed to reflect the synced read position, not
-  // left frozen at the stale local one (which is what made the view open at the last
-  // local place and only jump to the synced place on the next open).
+  // Reproduces the fresh-session seed race: the conversation is activated before the async MDS
+  // seed lands, so the marker arrives while the conversation is already active. The marker still
+  // advances the read pointer, but the divider remains the landmark placed for this visit.
   it('keeps firstNewMessageMarkers when a late marker reaches the newest message', () => {
     const cid = 'juliet@capulet.example'
     const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
@@ -725,9 +722,8 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m6')
   })
 
-  // A divider derived while a pending marker is still UNRESOLVED is provisional —
-  // the synced read position may move or erase it once the marker's message loads.
-  // The UI renders it muted until it is confirmed (pending resolved).
+  // A divider derived while a pending marker is still UNRESOLVED is provisional.
+  // The UI renders it muted until the pending position is resolved.
   it('flags the divider provisional while the pending marker is unresolved, confirmed once it resolves', async () => {
     const cid = 'provisional@capulet.example'
     const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
@@ -778,10 +774,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
   })
 
-  // The flash scenario, made explicit: a provisional divider must settle to its
-  // DEFINITIVE position (moved, confirmed) when the marker resolves AHEAD of it
-  // on the active conversation — and stop being provisional.
-  it('moves the divider and confirms it when the marker resolves ahead of it (active conversation)', async () => {
+  it('keeps the divider where activation placed it when a pending marker resolves ahead', async () => {
     const cid = 'resolve-ahead@capulet.example'
     const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
@@ -799,14 +792,32 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(true)
 
-    // The marker's message arrives (merge): the synced read is ahead → the divider
-    // settles after the synced position, definitive.
     const full = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4), timed('m5', 's5', 5)]
     chatStore.getState().applyRemoteDisplayed(cid, 's4', full)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
-    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m5')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+  })
+
+  it('does not resurrect a cleared divider when a pending marker resolves ahead', async () => {
+    const cid = 'resolve-after-clear@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const loaded = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m5', 's5', 5)]
+    seedMessages(cid, loaded)
+    seedConversation(cid, {
+      unreadCount: 0,
+      readPointer: pointerIn(loaded, 'm2'),
+      pendingRemoteDisplayedStanzaId: 's4',
+    })
+
+    await chatStore.getState().activateConversation(cid)
+    chatStore.getState().clearFirstNewMessageId(cid)
+    chatStore.getState().applyRemoteDisplayed(cid, 's4', [...loaded, timed('m4', 's4', 4)])
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
   })
 
   it('keeps the divider when the marker resolves at the newest message', async () => {

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -531,7 +531,7 @@ describe('chatStore — new-message divider is session-only', () => {
   })
 })
 
-describe('chatStore.applyRemoteDisplayed — late marker advances ACTIVE read state without moving the divider', () => {
+describe('chatStore.applyRemoteDisplayed — late marker advances the ACTIVE read state and carries the line with it', () => {
   beforeEach(() => chatStore.getState().reset())
 
   // Reproduces the fresh-session seed race: the conversation is activated before the async MDS
@@ -774,7 +774,9 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
   })
 
-  it('keeps the divider where activation placed it when a pending marker resolves ahead', async () => {
+  it('moves the line past what the other device had already read', async () => {
+    // The marker is evidence of reading, not navigation: the other device read through m4,
+    // so leaving the line at m3 would label as new two messages the user has already seen.
     const cid = 'resolve-ahead@capulet.example'
     const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
@@ -796,7 +798,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     chatStore.getState().applyRemoteDisplayed(cid, 's4', full)
 
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.identity.messageId).toBe('m4')
-    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m5')
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
   })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2010,8 +2010,8 @@ export const chatStore = createStore<ChatState>()(
           if (!meta) return state
           const messages = state.messages.get(conversationId) || []
 
-          // Same recompute pattern as applyRemoteDisplayed's active-divider branch: derive the
-          // divider from the pointer via onActivate and keep only .firstNewMessageId.
+          // Derive the divider from the pointer via onActivate and keep only
+          // .firstNewMessageId.
           const divider = notifState.onActivate(
             {
               unreadCount: 0,
@@ -2119,7 +2119,7 @@ export const chatStore = createStore<ChatState>()(
           // A non-active conversation keeps no resident array (memory windowing), so
           // mergeMAMMessages passes the just-merged array here; otherwise read RAM.
           // The resolution state machine (stash / clear-pending / forward-only
-          // advance / active-divider recompute) is shared — see shared/readMarkerSync.
+          // advance) is shared — see shared/readMarkerSync.
           const messages = messagesOverride ?? (state.messages.get(conversationId) || [])
           const resolution = resolveRemoteDisplayed(
             {
@@ -2158,25 +2158,16 @@ export const chatStore = createStore<ChatState>()(
           // undercounts): both advance kinds instead schedule the
           // archive-derived recount below, which is ALSO what makes a
           // not-yet-caught-up entity defer rather than commit a wrong number.
-          // 'advanced-with-divider' (the active entity) is NOT exempted here:
+          // 'advanced-active' (the active entity) is NOT exempted here:
           // its counts are not "already zero", so the active entity needs this
           // re-derivation exactly as much as a non-active one does.
           if (resolution.kind === 'advanced') {
             advancedNonActive = true
-          } else if (resolution.kind === 'advanced-with-divider') {
+          } else if (resolution.kind === 'advanced-active') {
             advancedActive = true
           }
 
-          // The divider is recomputed only for the active conversation; inactive
-          // ones recompute on their next activation.
-          let newMarkers = state.firstNewMessageMarkers
-          if (resolution.kind === 'advanced-with-divider') {
-            newMarkers = new Map(state.firstNewMessageMarkers)
-            if (resolution.firstNewMessageId) newMarkers.set(conversationId, resolution.firstNewMessageId)
-            else newMarkers.delete(conversationId)
-          }
-
-          return { ...draft.commit(), firstNewMessageMarkers: newMarkers }
+          return draft.commit()
         })
 
         // Archive-derived recount (trigger: pointer advance / inbound
@@ -2730,21 +2721,8 @@ export const chatStore = createStore<ChatState>()(
             return state
           }
 
-          // Rederive the divider: the boundary may have moved
-          // since a marker was last parked here (a remote pointer advance).
-          //
-          // Reposition-only while the conversation is ACTIVE: a pointer that
-          // caught up is not a reason to retire a divider the reader is looking
-          // at. This recount is scheduled BY the viewport pointer advance
-          // (advanceReadPointer, allowActive) — and in a conversation short
-          // enough to fit on screen the viewport reports the newest message the
-          // moment it opens, so the pointer lands past the divider within
-          // milliseconds. Deleting here made the "New messages" divider vanish
-          // right after opening. Clearing a live divider belongs to read-through
-          // scroll, Esc, mark-all-read, or deactivation — the same rule
-          // resyncDividerToReadPointer states. A BACKGROUND conversation still
-          // gets its stale marker retired here (deactivation normally already
-          // deleted it; this stays correct if that ever changes).
+          // Re-derive only to decide whether a background marker remains valid. The active
+          // visit's landmark is preserved below.
           let newMarkers = state.firstNewMessageMarkers
           const parkedDivider = state.firstNewMessageMarkers.get(conversationId)
           if (parkedDivider !== undefined) {
@@ -2770,8 +2748,14 @@ export const chatStore = createStore<ChatState>()(
               slice,
               'chat'
             ).firstNewMessageId
+            // The ACTIVE entity's divider does not move. It marks where the unread messages began
+            // when this view was opened, so it has to outlive the reading that follows: the pointer
+            // advances under it as the viewport reports rows seen, and re-deriving a position from
+            // that pointer would walk the line down the screen while the reader is looking at it.
+            // Only activation places it; the explicit read-through, Esc, mark-all-read and
+            // deactivation paths remove it. A BACKGROUND entity still gets its stale marker retired.
             const nextDivider =
-              divider ?? (state.activeConversationId === conversationId ? parkedDivider : undefined)
+              state.activeConversationId === conversationId ? parkedDivider : divider
             if (nextDivider !== parkedDivider) {
               newMarkers = new Map(state.firstNewMessageMarkers)
               if (nextDivider) newMarkers.set(conversationId, nextDivider)

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -50,6 +50,7 @@ import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMess
 import { derivePreviewAfterMerge } from './shared/previewState'
 import { draftConversationMaps, rebuildCompatEntry } from './shared/conversationMaps'
 import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
+import { advanceDividerToRemoteRead } from './shared/dividerAdvance'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import {
   advance,
@@ -2167,7 +2168,30 @@ export const chatStore = createStore<ChatState>()(
             advancedActive = true
           }
 
-          return draft.commit()
+          // The line follows a marker another client published: that marker states those messages
+          // were read, so leaving the divider in front of them would mark as new what the user has
+          // already seen. Scrolling THIS view is not such evidence and does not come through here.
+          let newMarkers = state.firstNewMessageMarkers
+          if (resolution.kind === 'advanced-active') {
+            const parked = state.firstNewMessageMarkers.get(conversationId)
+            const remote = notifState.onActivate(
+              {
+                unreadCount: 0,
+                mentionsCount: 0,
+                readPointer: resolution.readPointer,
+                firstNewMessageId: undefined,
+              },
+              messages,
+              'chat'
+            ).firstNewMessageId
+            const next = advanceDividerToRemoteRead(parked, remote, messages)
+            if (next !== parked && next !== undefined) {
+              newMarkers = new Map(state.firstNewMessageMarkers)
+              newMarkers.set(conversationId, next)
+            }
+          }
+
+          return { ...draft.commit(), firstNewMessageMarkers: newMarkers }
         })
 
         // Archive-derived recount (trigger: pointer advance / inbound

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -362,10 +362,9 @@ export const roomSelectors = {
   /**
    * Is the room's new-message divider provisional? True while a synced
    * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
-   * set): the divider was derived from the local read pointer and may move or
-   * vanish once a loaded slice can order the marker against that pointer. Purely
-   * derived — resolving the marker (advance OR clear-pending) confirms the
-   * divider with no extra state.
+   * set): the divider was derived from the local read pointer before the synced
+   * position could be ordered. Purely derived — resolving the marker (advance OR
+   * clear-pending) confirms the divider with no extra state.
    */
   firstNewMessageIsProvisionalFor: (roomJid: string) => (state: RoomState): boolean => {
     if (!state.firstNewMessageMarkers.has(roomJid)) return false

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -311,7 +311,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   })
 
   // resolveRemoteDisplayed resolves
-  // 'advanced-with-divider' — not 'advanced' — for the ACTIVE room, and that
+  // 'advanced-active' — not 'advanced' — for the ACTIVE room, and that
   // branch used to be exempted from triggering a recount on the premise that
   // an active entity's count was "already zero". A
   // spy-only assertion ("was recomputeUnreadForRoom called?") would pass even
@@ -349,14 +349,15 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     roomStore.getState().applyRemoteDisplayed(ROOM, 's-p0', messages)
 
     // Still active throughout — this is not a "became inactive" race. The
-    // pointer advance and divider reposition are applied synchronously inside
-    // applyRemoteDisplayed's own `set()` call, so these don't need to wait for
-    // the fire-and-forget recount below.
+    // pointer advance is applied synchronously inside applyRemoteDisplayed's own
+    // `set()` call and the divider is left untouched, so neither assertion needs
+    // to wait for the fire-and-forget recount below.
     expect(roomStore.getState().activeRoomJid).toBe(ROOM)
     // The pointer advanced (resolveRemoteDisplayed's job, unaffected by this fix).
     expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.identity.messageId).toBe('p0')
-    // The divider was positioned at the first message after the new pointer.
-    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('u1')
+    // No divider appears. Placing the line belongs to activation; an inbound marker on an
+    // already-open view moves the pointer and the count, never the landmark.
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBeUndefined()
     // The count is re-derived from the archive (u1, u2, u3), not left
     // at the stale 99 a guard that still exempted the active room would
     // produce. The recount is fire-and-forget (cache read, coverage resolve,
@@ -954,7 +955,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // only while an entity is active (deactivation deletes it), and both
   // allowActive triggers follow a pointer advance. The seeded marker is a
   // distinct stale id, so 'u1' can only come from a real rederivation.
-  it('a remote advance rederives the divider to the new boundary', async () => {
+  it('holds the ACTIVE entity\'s divider through a pointer advance, while the count re-derives', async () => {
     const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
     const p0 = archiveMsg('p0', 1000)
     const u1 = archiveMsg('u1', 1001)
@@ -968,7 +969,9 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     await roomStore.getState().recomputeUnreadForRoom(ROOM, { allowActive: true })
 
-    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('u1')
+    // The line stays where this view opened. Re-deriving it from the advanced pointer would
+    // walk it down the screen under the reader; only re-opening the view places it again.
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('stale-marker-id')
     // The count is re-derived too (u1), not left at the stale 99.
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
   })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -678,7 +678,9 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIsProvisionalFor(NO_DIVIDER_ROOM)(roomStore.getState())).toBe(false)
   })
 
-  it('keeps the divider where activation placed it when a pending marker resolves ahead', async () => {
+  it('moves the line past what the other device had already read', async () => {
+    // The marker is evidence of reading, not navigation: the other device read through m4,
+    // so leaving the line at m3 would label as new two messages the user has already seen.
     const AHEAD_ROOM = 'resolve-ahead@conference.example'
     // m4 is NOT loaded at activation (deep gap) — the marker for s4 can only stash.
     const loaded = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m5', 's5', 5)]
@@ -698,7 +700,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     roomStore.getState().applyRemoteDisplayed(AHEAD_ROOM, 's4', full)
 
     expect(roomStore.getState().roomMeta.get(AHEAD_ROOM)?.readPointer?.identity.messageId).toBe('m4')
-    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m3')
+    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m5')
     expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(false)
   })
 

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -232,10 +232,9 @@ describe('roomStore.applyRemoteDisplayed', () => {
     expect(meta?.unreadCount).toBe(5)
   })
 
-  // Fresh-session seed race (MUC): the room is activated (divider derived from the
-  // stale local read) BEFORE the async MDS seed lands, so the marker arrives while the
-  // room is already active. The divider must be recomputed from the advanced position,
-  // not frozen at the stale local one.
+  // Fresh-session seed race (MUC): the room is activated before the async MDS seed lands, so the
+  // marker arrives while the room is already active. The marker still advances the read pointer,
+  // but the divider remains the landmark placed for this visit.
   it('keeps firstNewMessageMarkers when a late marker reaches the newest message', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)], 'm2')
     roomStore.setState((s) => {
@@ -631,9 +630,8 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIdFor(DEEP_ROOM)(roomStore.getState())).toBe('m6')
   })
 
-  // A divider derived while a pending marker is still UNRESOLVED is provisional —
-  // the synced read position may move or erase it once the marker's message loads.
-  // The UI renders it muted until it is confirmed (pending resolved).
+  // A divider derived while a pending marker is still UNRESOLVED is provisional.
+  // The UI renders it muted until the pending position is resolved.
   it('flags the divider provisional while the pending marker is unresolved, confirmed once it resolves', async () => {
     const PROV_ROOM = 'provisional@conference.example'
     const messages = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)]
@@ -680,10 +678,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIsProvisionalFor(NO_DIVIDER_ROOM)(roomStore.getState())).toBe(false)
   })
 
-  // The flash scenario, made explicit: a provisional divider must settle to its
-  // DEFINITIVE position (moved, confirmed) when the marker resolves AHEAD of it
-  // on the active room — and stop being provisional.
-  it('moves the divider and confirms it when the marker resolves ahead of it (active room)', async () => {
+  it('keeps the divider where activation placed it when a pending marker resolves ahead', async () => {
     const AHEAD_ROOM = 'resolve-ahead@conference.example'
     // m4 is NOT loaded at activation (deep gap) — the marker for s4 can only stash.
     const loaded = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m5', 's5', 5)]
@@ -699,14 +694,30 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m3')
     expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(true)
 
-    // The marker's message arrives (merge): the synced read is ahead → the divider
-    // settles after the synced position, definitive.
     const full = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4), rmsg('m5', 's5', 5)]
     roomStore.getState().applyRemoteDisplayed(AHEAD_ROOM, 's4', full)
 
     expect(roomStore.getState().roomMeta.get(AHEAD_ROOM)?.readPointer?.identity.messageId).toBe('m4')
-    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m5')
+    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m3')
     expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(false)
+  })
+
+  it('does not resurrect a cleared divider when a pending marker resolves ahead', async () => {
+    const roomJid = 'resolve-after-clear@conference.example'
+    const loaded = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m5', 's5', 5)]
+    seedRoom(roomJid, loaded, 'm2')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(roomJid, { ...m.get(roomJid)!, pendingRemoteDisplayedStanzaId: 's4' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(roomJid)
+    roomStore.getState().clearFirstNewMessageId(roomJid)
+    roomStore.getState().applyRemoteDisplayed(roomJid, 's4', [...loaded, rmsg('m4', 's4', 4)])
+
+    expect(roomStore.getState().roomMeta.get(roomJid)?.readPointer?.identity.messageId).toBe('m4')
+    expect(roomSelectors.firstNewMessageIdFor(roomJid)(roomStore.getState())).toBeUndefined()
   })
 
   it('keeps the divider when the marker resolves at the newest message', async () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -66,6 +66,7 @@ import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
 import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
+import { advanceDividerToRemoteRead } from './shared/dividerAdvance'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import { advance, makeReadPointer } from './shared/readPointer'
 import { loadRoomReadState, saveRoomReadState, clearRoomReadState, _clearAllRoomReadStateForTesting, type RoomReadState } from './shared/readStateStorage'
@@ -3194,6 +3195,29 @@ export const roomStore = createStore<RoomState>()(
         advancedActive = true
       }
 
+      // The line follows a marker another client published: that marker states those messages were
+      // read, so leaving the divider in front of them would mark as new what the user has already
+      // seen. Scrolling THIS view is not such evidence and does not come through here.
+      let newMarkers = state.firstNewMessageMarkers
+      if (resolution.kind === 'advanced-active') {
+        const parked = state.firstNewMessageMarkers.get(roomJid)
+        const remote = notifState.onActivate(
+          {
+            unreadCount: 0,
+            mentionsCount: 0,
+            readPointer: resolution.readPointer,
+            firstNewMessageId: undefined,
+          },
+          messages,
+          'room'
+        ).firstNewMessageId
+        const next = advanceDividerToRemoteRead(parked, remote, messages)
+        if (next !== parked && next !== undefined) {
+          newMarkers = new Map(state.firstNewMessageMarkers)
+          newMarkers.set(roomJid, next)
+        }
+      }
+
       // A position another device read to is a read position like any other —
       // persist it. The stash/clear kinds move no pointer.
       if (resolution.kind === 'advanced' || resolution.kind === 'advanced-active') {
@@ -3204,9 +3228,9 @@ export const roomStore = createStore<RoomState>()(
         // Keep the combined map coherent with roomMeta.
         const newRooms = new Map(state.rooms)
         newRooms.set(roomJid, { ...existing, ...metaPatch })
-        return { roomMeta: newMeta, rooms: newRooms }
+        return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
       }
-      return { roomMeta: newMeta }
+      return { roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
     })
 
     // Archive-derived recount (trigger: pointer advance / inbound

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2624,20 +2624,8 @@ export const roomStore = createStore<RoomState>()(
         return state
       }
 
-      // Rederive the divider: the boundary may have moved
-      // since a marker was last parked here (a remote pointer advance).
-      //
-      // Reposition-only while the room is ACTIVE: a pointer that caught up is
-      // not a reason to retire a divider the reader is looking at. This recount
-      // is scheduled BY the viewport pointer advance (advanceReadPointer,
-      // allowActive) — and in a room short enough to fit on screen the viewport
-      // reports the newest message the moment it opens, so the pointer lands
-      // past the divider within milliseconds. Deleting here made the "New
-      // messages" divider vanish right after opening. Clearing a live divider
-      // belongs to read-through scroll, Esc, mark-all-read, or deactivation —
-      // the same rule resyncDividerToReadPointer states. A BACKGROUND room still
-      // gets its stale marker retired here (deactivation normally already
-      // deleted it; this stays correct if that ever changes).
+      // Re-derive only to decide whether a background marker remains valid. The active visit's
+      // landmark is preserved below.
       let newMarkers = state.firstNewMessageMarkers
       const parkedDivider = state.firstNewMessageMarkers.get(roomJid)
       if (parkedDivider !== undefined) {
@@ -2663,7 +2651,13 @@ export const roomStore = createStore<RoomState>()(
           slice,
           'room'
         ).firstNewMessageId
-        const nextDivider = divider ?? (state.activeRoomJid === roomJid ? parkedDivider : undefined)
+        // The ACTIVE room's divider does not move. It marks where the unread messages began when
+        // this view was opened, so it has to outlive the reading that follows: the pointer advances
+        // under it as the viewport reports rows seen, and re-deriving a position from that pointer
+        // would walk the line down the screen while the reader is looking at it. Only activation
+        // places it; the explicit read-through, Esc, mark-all-read and deactivation paths remove
+        // it. A BACKGROUND room still gets its stale marker retired.
+        const nextDivider = state.activeRoomJid === roomJid ? parkedDivider : divider
         if (nextDivider !== parkedDivider) {
           newMarkers = new Map(state.firstNewMessageMarkers)
           if (nextDivider) newMarkers.set(roomJid, nextDivider)
@@ -3149,7 +3143,7 @@ export const roomStore = createStore<RoomState>()(
       // mergeRoomMAMMessages passes the just-merged array here; else read the
       // window map, falling back to the compat entry.
       // The resolution state machine (stash / clear-pending / forward-only
-      // advance / active-divider recompute) is shared — see shared/readMarkerSync.
+      // advance) is shared — see shared/readMarkerSync.
       const messages = messagesOverride ?? state.messages.get(roomJid) ?? []
       const resolution = resolveRemoteDisplayed(
         {
@@ -3191,27 +3185,18 @@ export const roomStore = createStore<RoomState>()(
       // ALSO what makes a not-yet-caught-up room defer rather than commit a
       // wrong number. mentionsCount is left untouched (the spread above
       // preserves it) — archive recounts never write it either.
-      // 'advanced-with-divider' (the active room) is NOT exempted here: its
+      // 'advanced-active' (the active room) is NOT exempted here: its
       // counts are not "already zero", so the active room needs this
       // re-derivation exactly as much as a non-active one does.
       if (resolution.kind === 'advanced') {
         advancedNonActive = true
-      } else if (resolution.kind === 'advanced-with-divider') {
+      } else if (resolution.kind === 'advanced-active') {
         advancedActive = true
-      }
-
-      // The divider is recomputed only for the active room; inactive rooms
-      // recompute on their next activation.
-      let newMarkers = state.firstNewMessageMarkers
-      if (resolution.kind === 'advanced-with-divider') {
-        newMarkers = new Map(state.firstNewMessageMarkers)
-        if (resolution.firstNewMessageId) newMarkers.set(roomJid, resolution.firstNewMessageId)
-        else newMarkers.delete(roomJid)
       }
 
       // A position another device read to is a read position like any other —
       // persist it. The stash/clear kinds move no pointer.
-      if (resolution.kind === 'advanced' || resolution.kind === 'advanced-with-divider') {
+      if (resolution.kind === 'advanced' || resolution.kind === 'advanced-active') {
         persistRoomReadState(newMeta)
       }
 
@@ -3219,9 +3204,9 @@ export const roomStore = createStore<RoomState>()(
         // Keep the combined map coherent with roomMeta.
         const newRooms = new Map(state.rooms)
         newRooms.set(roomJid, { ...existing, ...metaPatch })
-        return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
+        return { roomMeta: newMeta, rooms: newRooms }
       }
-      return { roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
+      return { roomMeta: newMeta }
     })
 
     // Archive-derived recount (trigger: pointer advance / inbound

--- a/packages/fluux-sdk/src/stores/shared/dividerAdvance.ts
+++ b/packages/fluux-sdk/src/stores/shared/dividerAdvance.ts
@@ -1,0 +1,32 @@
+/**
+ * Moving the new-message divider forward on evidence that the reader already read past it.
+ *
+ * Scrolling this view is navigation: it advances the read pointer but leaves the line where the
+ * view opened. A read marker published by ANOTHER of the user's clients is a different kind of
+ * fact — it states that those messages were read, elsewhere — so the line follows it rather than
+ * standing in front of messages the reader has already seen.
+ *
+ * Three rules the callers depend on:
+ *
+ * - never create. A divider that is not parked stays absent, so a marker cannot resurrect one the
+ *   reader deliberately cleared.
+ * - never clear. A pointer that has caught up is not a reason to retire the landmark; removing it
+ *   belongs to read-through scroll, Esc, mark-all-read and deactivation.
+ * - never backward, and never on a guess. Both ends must be present in the resident slice: an index
+ *   comparison with one end missing cannot order them, and a marker whose target is outside the
+ *   window says nothing about where the line should sit.
+ */
+export function advanceDividerToRemoteRead(
+  parkedDivider: string | undefined,
+  remoteDivider: string | undefined,
+  messages: readonly { id: string }[],
+): string | undefined {
+  if (parkedDivider === undefined) return undefined
+  if (remoteDivider === undefined || remoteDivider === parkedDivider) return parkedDivider
+
+  const parkedIndex = messages.findIndex((message) => message.id === parkedDivider)
+  const remoteIndex = messages.findIndex((message) => message.id === remoteDivider)
+  if (parkedIndex === -1 || remoteIndex === -1) return parkedDivider
+
+  return remoteIndex > parkedIndex ? remoteDivider : parkedDivider
+}

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -75,7 +75,7 @@ describe('resolveRemoteDisplayed', () => {
     })
   })
 
-  it('recomputes the divider for the ACTIVE entity from the advanced position', () => {
+  it('reports an active advance without carrying divider placement', () => {
     const result = resolveRemoteDisplayed(
       { ...baseMeta, readPointer: seenIn('m1') },
       messages,
@@ -85,21 +85,16 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: true }
     )
 
-    // Advanced to m2 → the first unseen incoming message after it is m3.
-    expect(result).toMatchObject({
-      kind: 'advanced-with-divider',
+    expect(result).toEqual({
+      kind: 'advanced-active',
       readPointer: {
         order: { role: 'exact', timestamp: new Date('2024-01-15T10:02:00Z').getTime(), tiebreak: { kind: 'chat', id: 'm2' } },
-        // ADDRESSABLE, and free: the row was found BY the archive id the marker
-        // carried, so the minted pointer already holds its wire name — no
-        // lookup, no residency, nothing for the publisher to resolve.
         identity: { state: 'addressable', messageId: 'm2', archiveId: 'arch-m2' },
       },
-      firstNewMessageId: 'm3',
     })
   })
 
-  it('keeps the current divider when the advanced position reaches the newest message', () => {
+  it('does not return divider state when the active advance reaches the newest message', () => {
     const result = resolveRemoteDisplayed(
       { ...baseMeta, readPointer: seenIn('m1') },
       messages,
@@ -109,13 +104,12 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: true }
     )
 
-    expect(result).toMatchObject({
-      kind: 'advanced-with-divider',
+    expect(result).toEqual({
+      kind: 'advanced-active',
       readPointer: {
         order: { role: 'exact', timestamp: new Date('2024-01-15T10:03:00Z').getTime(), tiebreak: { kind: 'chat', id: 'm3' } },
         identity: { state: 'addressable', messageId: 'm3', archiveId: 'arch-m3' },
       },
-      firstNewMessageId: 'm2',
     })
   })
 
@@ -284,7 +278,7 @@ describe('resolveRemoteDisplayed', () => {
       identity: { state: 'local', messageId: 'm1' },
     }
     let pending: string | undefined = 'arch-m3'
-    let firstNewMessageId: string | undefined = 'm2'
+    const firstNewMessageId: string | undefined = 'm2'
 
     // Fresh-session forward catch-up only has the newest page. It contains the
     // remote marker (m3), but not the local pointer (m1), so the comparison is
@@ -306,8 +300,7 @@ describe('resolveRemoteDisplayed', () => {
     expect(pending).toBe('arch-m3')
 
     // Opening the entity loads a wide enough slice to order both ends by
-    // index. The normal activation fold can now advance to the remote position
-    // and move the stale divider from m2 to the first truly unread message, m4.
+    // index. The normal activation fold can now advance to the remote position.
     const fold = foldPendingRemoteDisplayed(
       gate,
       'xsf@muc.xmpp.org',
@@ -326,10 +319,9 @@ describe('resolveRemoteDisplayed', () => {
           'chat',
           { isActive: true }
         )
-        expect(activated.kind).toBe('advanced-with-divider')
-        if (activated.kind === 'advanced-with-divider') {
+        expect(activated.kind).toBe('advanced-active')
+        if (activated.kind === 'advanced-active') {
           readPointer = activated.readPointer
-          firstNewMessageId = activated.firstNewMessageId
           pending = undefined
         }
       }
@@ -337,7 +329,7 @@ describe('resolveRemoteDisplayed', () => {
 
     expect(fold).toEqual({ pending: 'arch-m3', attempted: true, resolved: true })
     expect(readPointer.identity.messageId).toBe('m3')
-    expect(firstNewMessageId).toBe('m4')
+    expect(firstNewMessageId).toBe('m2')
     expect(pending).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -3,8 +3,8 @@
  * resolution — shared by chatStore and roomStore, whose applyRemoteDisplayed
  * implementations were ~100-line twins that had to be kept in sync by hand.
  *
- * The stores keep their map fan-out (meta / combined / markers) and apply the
- * returned resolution; everything decision-shaped lives here.
+ * The stores keep their map fan-out and apply the returned read-state
+ * resolution; divider placement stays outside this state machine.
  */
 
 import type { NotificationMessage } from './notificationState'
@@ -37,21 +37,16 @@ export type RemoteDisplayedResolution =
    */
   | { kind: 'clear-pending' }
   /**
-   * Forward advance on a non-active entity (divider recomputes on next
-   * activation). The whole read position travels as one `readPointer` (#1081).
+   * Forward advance. The whole read position travels as one `readPointer`
+   * (#1081); divider placement remains owned by activation.
    */
   | { kind: 'advanced'; readPointer: ReadPointer }
   /**
-   * Forward advance on the ACTIVE entity: the new-message divider was already
-   * derived at activation from the now-stale local position, so it is
-   * recomputed here from the advanced position. `firstNewMessageId`
-   * undefined = no divider (delete the marker).
+   * Forward advance on the active entity. Kept distinct so callers can run the
+   * active archive recount without coupling read synchronization to divider
+   * placement.
    */
-  | {
-      kind: 'advanced-with-divider'
-      readPointer: ReadPointer
-      firstNewMessageId: string | undefined
-    }
+  | { kind: 'advanced-active'; readPointer: ReadPointer }
 
 /**
  * Decide whether the remote marker `match` is a forward advance over `current`.
@@ -131,33 +126,7 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
   if (!options.isActive) {
     return { kind: 'advanced', readPointer }
   }
-
-  // Recompute the divider from the advanced position (reuses onActivate's
-  // forward scan). No `historyFloor` is threaded here, deliberately: this branch
-  // is reached only after an advance, so `readPointer` is always defined and
-  // `computeFloor` is pointer-wins — a floor would be a field no code path could
-  // read.
-  //
-  // If the pointer caught up and the scan finds no new boundary, keep the active
-  // visit's parked divider (`divider ?? currentFirstNewMessageId` below): pointer
-  // reconciliation must not retire the anchor before the reader can inspect it.
-  // Explicit read-through, mark-read, and deactivation paths own clearing it.
-  const divider = notifState.onActivate(
-    {
-      unreadCount: 0,
-      mentionsCount: 0,
-      readPointer,
-      firstNewMessageId: undefined,
-    },
-    messages,
-    kind
-  ).firstNewMessageId
-
-  return {
-    kind: 'advanced-with-divider',
-    readPointer,
-    firstNewMessageId: divider ?? currentFirstNewMessageId,
-  }
+  return { kind: 'advanced-active', readPointer }
 }
 
 // ============================================================================

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2680,19 +2680,15 @@ test.describe('Jump-to-last-read pill', () => {
     expect(dividerVisible, 'clicking the pill must return the divider to view').toBe(true)
   })
 
-  // The "New messages" divider follows reading progress: once the reader has read past part of a
-  // new-message block and scrolls back up, the divider snaps FORWARD to the read pointer (first
-  // unread after the read pointer) — and it must NEVER be cleared by that snap (the read-through /
-  // pill paths own clearing). Setup is store-driven (divider behind an advanced pointer) so the test
-  // is deterministic and does not depend on the stress room's live-message cache-reload behavior; the
-  // observer→pointer and entry-positioning paths are covered by the marker-reentry / pill invariants.
-  // What this exercises for real: the MessageList scroll-up snap effect → resyncDividerToReadPointer.
+  // The "New messages" divider marks the opening boundary while the read pointer advances
+  // independently. Setup is store-driven (divider behind an advanced pointer) so any scroll-driven
+  // repositioning has a deterministic, visibly different target.
   //
   // The reader is carried clear of the at-bottom band BEFORE the divider is planted, and every wait
   // below is on an observable condition. That is not tidying: planting the divider while the list
   // was still parked at the live edge put this test one scroll event away from the read-through
   // clear, and which engine won that race decided whether it passed (see the wheel step).
-  test('divider snaps forward to the read pointer on genuine scroll-up (never cleared)', async ({ page }) => {
+  test('divider holds its planted position through a genuine scroll (never moved, never cleared)', async ({ page }) => {
     await loadDemo(page)
     await navigateToStressRoom(page)
 
@@ -2707,13 +2703,12 @@ test.describe('Jump-to-last-read pill', () => {
     // The ORDER is the invariant this test needs and used to leave to chance. While the list sits
     // inside the at-bottom band, the first genuine scroll event is the documented read-through clear
     // ("MARKER CLEAR (reached bottom)") — a path that legitimately owns clearing — so it would wipe
-    // the divider before the snap ever ran. Whether that happened came down to how the engine
+    // the divider before the post-plant invariant ran. Whether that happened came down to how the engine
     // delivers one wheel gesture: Chromium and WebKit/macOS apply the whole 1200px in a single
     // scroll event (first event ~1248px from the bottom, safely clear), while WebKitGTK on CI
     // delivers it incrementally and the first event can land ~88px from the bottom — inside the
     // band. That is the whole flake: same code, same assertion, engine-dependent event granularity.
-    // Scrolling clear FIRST takes the engine out of it, so the only thing that can move the divider
-    // afterwards is the snap — which is what this test is about.
+    // Scrolling clear first keeps the read-through path out of this invariant.
     const listBox = await page.locator('[data-message-list]').first().boundingBox()
     if (listBox) await page.mouse.move(listBox.x + listBox.width / 2, listBox.y + listBox.height / 2)
     await expect.poll(
@@ -2727,10 +2722,25 @@ test.describe('Jump-to-last-read pill', () => {
       { message: 'a genuine wheel scroll-up must carry the reader clear of the at-bottom band', timeout: 20_000 },
     ).toBeGreaterThan(CLEAR_OF_BOTTOM_PX)
 
-    // Plant a divider BEHIND an advanced read pointer, and place the pointer JUST BEFORE a verified
-    // incoming (non-outgoing) message so the recompute has a deterministic forward target. This is
-    // the state after the reader has read down past the divider (pointer advanced by the viewport
-    // observer) while the sticky divider has not yet caught up.
+    const minimumUpwardHeadroom = 700
+    const preparedScroll = await page.evaluate(([minimumHeadroom, clearFromBottom]) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return null
+      const maxScrollTop = s.scrollHeight - s.clientHeight
+      const highestAllowed = maxScrollTop - clearFromBottom
+      if (highestAllowed < minimumHeadroom) return null
+      s.scrollTop = Math.min(Math.max(s.scrollTop, minimumHeadroom), highestAllowed)
+      return {
+        scrollTop: Math.round(s.scrollTop),
+        distFromBottom: Math.round(maxScrollTop - s.scrollTop),
+      }
+    }, [minimumUpwardHeadroom, CLEAR_OF_BOTTOM_PX] as const)
+    expect(preparedScroll, 'stress room must have room to scroll upward away from the bottom').not.toBeNull()
+    expect(preparedScroll!.scrollTop).toBeGreaterThanOrEqual(minimumUpwardHeadroom)
+    expect(preparedScroll!.distFromBottom).toBeGreaterThanOrEqual(CLEAR_OF_BOTTOM_PX)
+
+    // Plant a divider behind an advanced read pointer, with a verified incoming message after the
+    // pointer so an unintended re-derivation has a deterministic forward target.
     const setup = await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const store = (window as any).__roomStore
@@ -2738,7 +2748,7 @@ test.describe('Jump-to-last-read pill', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const msgs = (s.messages.get(jid) ?? []) as { id: string; from?: string; timestamp: Date; isOutgoing?: boolean }[]
       // First unread after the pointer must exist and be incoming — find the last incoming message
-      // and put the pointer immediately before it, so resyncDividerToReadPointer lands on it.
+      // and put the pointer immediately before it, so any re-derivation lands on it.
       let targetIdx = -1
       for (let i = msgs.length - 1; i >= 2; i--) { if (!msgs[i].isOutgoing) { targetIdx = i; break } }
       if (targetIdx < 2) return { ok: false, len: msgs.length }
@@ -2746,7 +2756,6 @@ test.describe('Jump-to-last-read pill', () => {
       const dIdx = Math.max(0, Math.floor(pIdx * 0.3))
       const dividerId = msgs[dIdx].id
       const pointerId = msgs[pIdx].id
-      const expectedTargetId = msgs[targetIdx].id
       // One read position, written whole — the literal shape `makeReadPointer`
       // writes: an EXACT order (the named message's own timestamp plus the cache
       // tie-break) and an identity naming it. The exact role is not optional
@@ -2779,15 +2788,9 @@ test.describe('Jump-to-last-read pill', () => {
       const markers = new Map(s.firstNewMessageMarkers)
       markers.set(jid, dividerId)
       store.setState({ roomMeta, rooms, firstNewMessageMarkers: markers })
-      return { ok: true, dividerId, pointerId, expectedTargetId, dIdx, pIdx, targetIdx, len: msgs.length }
+      return { ok: true, dividerId, pointerId, dIdx, pIdx, targetIdx, len: msgs.length }
     }, STRESS_ROOM_JID)
     expect(setup.ok, `stress room needs a resident incoming message (len=${setup.len})`).toBe(true)
-
-    // One more genuine (non-programmatic) wheel, still upward and still clear of the bottom: the
-    // snap trigger reads the bottom-most-visible row, and that is republished only on a genuine
-    // scroll event. A REAL wheel gesture, not `scrollTop = n` — a programmatic write is gated out
-    // of the trigger on purpose (entry positioning must not drift the divider).
-    await page.mouse.wheel(0, -600)
 
     const readDividerState = () => page.evaluate(([jid, dividerId]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2804,25 +2807,40 @@ test.describe('Jump-to-last-read pill', () => {
       }
     }, [STRESS_ROOM_JID, setup.dividerId] as const)
 
-    // Wait for the divider to LEAVE the spot it was planted in, not for a duration. Both terminal
-    // outcomes settle this poll — the snap moved it, or something cleared it — and which one
-    // happened is exactly what the assertions below are here to distinguish. A regression that
-    // never runs the snap leaves it planted and times out with that stated.
+    const beforeWheel = await readDividerState()
+    expect(beforeWheel.scrollTop).not.toBeNull()
+    expect(beforeWheel.scrollTop!).toBeGreaterThanOrEqual(minimumUpwardHeadroom)
+    expect(beforeWheel.distFromBottom!).toBeGreaterThanOrEqual(CLEAR_OF_BOTTOM_PX)
+
+    await page.mouse.wheel(0, -600)
     await expect.poll(
-      async () => (await readDividerState()).markerId !== setup.dividerId,
-      { message: `the scroll-up snap never ran — divider still planted at ${setup.dividerId}`, timeout: 15_000 },
-    ).toBe(true)
+      async () => (await readDividerState()).scrollTop,
+      {
+        message: 'the post-plant wheel must produce a genuine upward scroll',
+        timeout: 5_000,
+      },
+    ).toBeLessThan(beforeWheel.scrollTop!)
+
+    const stableUntil = Date.now() + 5_000
+    while (Date.now() < stableUntil) {
+      const sample = await readDividerState()
+      expect(
+        sample.markerId,
+        `divider must stay planted at ${setup.dividerId} while the reader scrolls`,
+      ).toBe(setup.dividerId)
+      await page.waitForTimeout(50)
+    }
 
     const after = await readDividerState()
-    console.log('── DIVIDER SNAP ──', JSON.stringify({ setup, after }))
+    console.log('── DIVIDER HOLD ──', JSON.stringify({ setup, after }))
 
-    // The snap moved the divider FORWARD to the first unread after the pointer, and did NOT clear it.
-    expect(after.markerId, 'the scroll-up snap must not clear the divider').not.toBeNull()
+    // Neither moved toward the pointer nor cleared by the scroll.
+    expect(after.markerId, 'a genuine scroll must not clear the divider').not.toBeNull()
     expect(
       after.markerId,
-      `divider must snap forward from ${setup.dividerId} to ${setup.expectedTargetId} (stayed at ${after.markerId})`,
-    ).toBe(setup.expectedTargetId)
-    expect(after.markerIdx, 'the divider must snap FORWARD toward the read pointer').toBeGreaterThan(after.dividerIdx)
+      `divider must stay at ${setup.dividerId} (moved to ${after.markerId}, pointer was at ${setup.pointerId})`,
+    ).toBe(setup.dividerId)
+    expect(after.markerIdx, 'the divider must not advance toward the read pointer').toBe(after.dividerIdx)
   })
 })
 


### PR DESCRIPTION
The "New messages" line drifted down the screen as you read it, because every path that placed it derived its position from the read pointer — and the viewport observer advances that pointer on every scroll.

Scrolling this view and reading on another device are not the same fact, and the line now treats them differently:

| | read pointer | the line |
| --- | --- | --- |
| scrolling this view | advances | stays where the view opened |
| a read marker from another device | advances | moves forward with it |
| Esc, mark-all-read, sending, read-through scroll | — | cleared, and never resurrected |

Scrolling is navigation, so the line stays: it marks where the unread messages began when this view opened, and it has to outlive the reading that follows. A marker published by another of the user's clients is evidence that those messages were read, so the line follows it rather than standing in front of messages the reader has already seen.

Three rules bound that forward move. It never creates a divider, so a marker cannot resurrect one the reader cleared. It never removes one — that belongs to the explicit paths. And it never moves backwards or on a guess: both ends must be present in the loaded slice, because an index comparison with one end missing cannot order them.

Read receipts, the unread counter, and the XEP-0490 marker published to the user's other devices are unchanged. A divider derived while a synced read position is still unresolved stays muted until that position can be ordered.

The SDK keeps `resyncDividerToReadPointer`, which four public hooks expose; the app no longer calls it.