### PR TITLE
refactor(sdk): resolve a conversation id to its own store

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -42,6 +42,14 @@ import type { SideEffectsOptions } from './chatSideEffects'
 import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { roomStore } from '../stores/roomStore'
+import {
+  conversationKind,
+  conversationMessages,
+  conversationMetadata,
+  conversationLastMessage,
+  conversationHistoryState,
+  conversationIds,
+} from '../stores/conversationLens'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
 import {
   compareExact,
@@ -138,9 +146,9 @@ export function setupMdsSideEffects(
     currentSessionConfirmedNodeJids.add(jid)
   }
 
-  /** Is this JID a known room (bookmarked or joined)? Routes accessors per-store. */
+  /** Is this JID a known room (bookmarked or joined)? */
   function isRoom(jid: string): boolean {
-    return roomStore.getState().rooms.has(jid)
+    return conversationKind(jid) === 'room'
   }
 
   /** Our own bare JID, or '' before the connection JID is known. */
@@ -173,10 +181,7 @@ export function setupMdsSideEffects(
   /** Index of a stanza-id in a conversation's/room's loaded messages, or -1. */
   function indexOfStanza(jid: string, stanzaId: string | undefined): number {
     if (!stanzaId) return -1
-    const messages = isRoom(jid)
-      ? roomStore.getState().messages.get(jid) ?? []
-      : chatStore.getState().messages.get(jid) || []
-    return messages.findIndex((m) => m.stanzaId === stanzaId)
+    return conversationMessages(jid).findIndex((m) => m.stanzaId === stanzaId)
   }
 
   /**
@@ -188,9 +193,7 @@ export function setupMdsSideEffects(
    * cannot tell".
    */
   function pendingRemoteDisplayed(jid: string): string | undefined {
-    return isRoom(jid)
-      ? roomStore.getState().roomMeta.get(jid)?.pendingRemoteDisplayedStanzaId
-      : chatStore.getState().conversationMeta.get(jid)?.pendingRemoteDisplayedStanzaId
+    return conversationMetadata(jid)?.pendingRemoteDisplayedStanzaId
   }
 
   /**
@@ -290,9 +293,7 @@ export function setupMdsSideEffects(
   }
 
   function readPointer(jid: string): ReadPointer | undefined {
-    return isRoom(jid)
-      ? roomStore.getState().roomMeta.get(jid)?.readPointer
-      : chatStore.getState().conversationMeta.get(jid)?.readPointer
+    return conversationMetadata(jid)?.readPointer
   }
 
   /**
@@ -364,8 +365,7 @@ export function setupMdsSideEffects(
       // Non-active rooms keep no resident array (memory windowing); mark-all-read
       // points at the newest known message, whose stanza-id survives on the
       // lastMessage preview.
-      const last = roomStore.getState().roomMeta.get(jid)?.lastMessage
-        ?? roomStore.getState().rooms.get(jid)?.lastMessage
+      const last = conversationLastMessage(jid)
       return last?.id === seenId && last.from === from ? last.stanzaId : undefined
     }
     const seenId = pointer.identity.messageId
@@ -373,8 +373,7 @@ export function setupMdsSideEffects(
     const fromSlice = messages.find((m) => m.id === seenId)?.stanzaId
     if (fromSlice) return fromSlice
     // Same eviction fallback for backgrounded 1:1 conversations.
-    const last = chatStore.getState().conversationMeta.get(jid)?.lastMessage
-      ?? chatStore.getState().conversations.get(jid)?.lastMessage
+    const last = conversationLastMessage(jid)
     if (last?.id === seenId && last.stanzaId) return last.stanzaId
     // The pointer names a message with no stanza-id — in 1:1 the normal resting
     // state once the user has replied. Publish the newest position we CAN
@@ -569,9 +568,7 @@ export function setupMdsSideEffects(
    * entirely.
    */
   function archiveIsTrustworthy(jid: string): boolean {
-    const mam = isRoom(jid)
-      ? roomStore.getState().getRoomMAMQueryState(jid)
-      : chatStore.getState().getMAMQueryState(jid)
+    const mam = conversationHistoryState(jid)
     if (mam.error !== null) return false
     if (!mam.hasQueried && !mam.isLoading) return true // never queried — nothing partial
     return !mam.isLoading && mam.isCaughtUpToLive
@@ -684,14 +681,6 @@ export function setupMdsSideEffects(
     })()
   }
 
-  /** Current live set: 1:1 conversation entities ∪ known rooms. */
-  function liveJids(): Set<string> {
-    const s = new Set<string>()
-    for (const jid of chatStore.getState().conversationEntities.keys()) s.add(jid)
-    for (const jid of roomStore.getState().rooms.keys()) s.add(jid)
-    return s
-  }
-
   /**
    * Forget a JID's in-memory publisher state so a retract/recreate is clean.
    * `dirty.delete` drops a still-buffered (debounced) publish; a publish that
@@ -715,7 +704,7 @@ export function setupMdsSideEffects(
    * retracts nothing.
    */
   function reconcileDeletions(): void {
-    const current = liveJids()
+    const current = conversationIds()
 
     if (!syncEnabled || connectionStore.getState().status !== 'online') {
       trackedJids = current // keep baseline synced while disarmed; never retract
@@ -843,7 +832,7 @@ export function setupMdsSideEffects(
 
       if (result.status === 'unknown') {
         syncEnabled = true
-        trackedJids = liveJids()
+        trackedJids = conversationIds()
         logInfo('MDS: node state unavailable; publishing remains guarded')
         return
       }
@@ -906,7 +895,7 @@ export function setupMdsSideEffects(
       syncEnabled = true
       // Rebuild the delete-detection baseline to the current live set so the
       // fresh-session population is never seen as deletions.
-      trackedJids = liveJids()
+      trackedJids = conversationIds()
       // Sweep once now that publishing is armed. Every entity is re-considered
       // against the freshly seeded node state, so a position the previous session
       // never managed to publish goes out now instead of waiting for incidental
@@ -939,7 +928,7 @@ export function setupMdsSideEffects(
     syncEnabled = true
     // Rebuild the delete-detection baseline to the current live set (mirrors the
     // fresh-session handler) so a resume's known entities aren't seen as deletes.
-    trackedJids = liveJids()
+    trackedJids = conversationIds()
     considerConversations()
     considerRooms()
   })

--- a/packages/fluux-sdk/src/stores/conversationLens.test.ts
+++ b/packages/fluux-sdk/src/stores/conversationLens.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+import {
+  conversationKind,
+  conversationMessages,
+  conversationMetadata,
+  conversationLastMessage,
+  conversationIds,
+} from './conversationLens'
+import type { Conversation, Message } from '../core/types'
+import { createRoom, createMessage } from './roomStore.testHelpers'
+
+const CHAT = 'alice@example.com'
+const ROOM = 'team@conference.example.com'
+
+function chatMessage(id: string, at: number): Message {
+  return {
+    type: 'chat',
+    id,
+    conversationId: CHAT,
+    from: CHAT,
+    body: id,
+    timestamp: new Date(at),
+    isOutgoing: false,
+  }
+}
+
+function conversation(id: string, extra: Partial<Conversation> = {}): Conversation {
+  return { id, name: id, type: 'chat', unreadCount: 0, ...extra }
+}
+
+describe('conversationLens', () => {
+  beforeEach(() => {
+    chatStore.setState({
+      conversationEntities: new Map(),
+      conversationMeta: new Map(),
+      conversations: new Map(),
+      messages: new Map(),
+      activeConversationId: null,
+    })
+    roomStore.setState({
+      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(),
+      messages: new Map(), windowAtLiveEdge: new Map(), activeRoomJid: null,
+      firstNewMessageMarkers: new Map(),
+    })
+  })
+
+  describe('conversationKind', () => {
+    it('names the store that owns the id', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      chatStore.getState().addConversation(conversation(CHAT))
+
+      expect(conversationKind(ROOM)).toBe('room')
+      expect(conversationKind(CHAT)).toBe('chat')
+    })
+
+    it('is undefined for an id neither store knows', () => {
+      // Bookmarks load late, so an unclassifiable id is "not yet known" — a
+      // caller must not read it as 1:1.
+      expect(conversationKind('nobody@example.com')).toBeUndefined()
+    })
+  })
+
+  describe('conversationMessages', () => {
+    it('reads the window of whichever store owns the id', () => {
+      const resident = [createMessage('r1', ROOM, 'alice', 'hello')]
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }), resident)
+      chatStore.getState().addConversation(conversation(CHAT))
+      chatStore.getState().addMessage(chatMessage('c1', 1000))
+
+      expect(conversationMessages(ROOM).map((m) => m.id)).toEqual(['r1'])
+      expect(conversationMessages(CHAT).map((m) => m.id)).toEqual(['c1'])
+    })
+
+    it('hands back the same empty array for a conversation with no window', () => {
+      // A fresh array per call would re-render every subscriber for nothing.
+      expect(conversationMessages('unknown@example.com')).toBe(conversationMessages(CHAT))
+    })
+  })
+
+  describe('conversationMetadata', () => {
+    it('reads the split map for both kinds', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      roomStore.setState((s) => ({
+        roomMeta: new Map(s.roomMeta).set(ROOM, { ...s.roomMeta.get(ROOM)!, unreadCount: 4 }),
+      }))
+      chatStore.getState().addConversation(conversation(CHAT))
+      chatStore.setState((s) => ({
+        conversationMeta: new Map(s.conversationMeta).set(CHAT, {
+          ...s.conversationMeta.get(CHAT)!,
+          unreadCount: 7,
+        }),
+      }))
+
+      expect(conversationMetadata(ROOM)?.unreadCount).toBe(4)
+      expect(conversationMetadata(CHAT)?.unreadCount).toBe(7)
+    })
+
+    it('falls back to the combined entry when the split map has no row', () => {
+      // The persist middleware rehydrates the combined map; a room from a
+      // bookmark has an entry there before `roomMeta` is written.
+      roomStore.setState((s) => ({
+        rooms: new Map(s.rooms).set(ROOM, createRoom(ROOM, { joined: true, unreadCount: 3 })),
+      }))
+
+      expect(roomStore.getState().roomMeta.has(ROOM)).toBe(false)
+      expect(conversationMetadata(ROOM)?.unreadCount).toBe(3)
+    })
+
+    it('is undefined for an id neither store knows', () => {
+      expect(conversationMetadata('nobody@example.com')).toBeUndefined()
+    })
+  })
+
+  describe('conversationLastMessage', () => {
+    it('prefers the split map', () => {
+      const newest = createMessage('m2', ROOM, 'alice', 'newest')
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      roomStore.setState((s) => ({
+        roomMeta: new Map(s.roomMeta).set(ROOM, { ...s.roomMeta.get(ROOM)!, lastMessage: newest }),
+      }))
+
+      expect(conversationLastMessage(ROOM)?.id).toBe('m2')
+    })
+
+    it('falls back FIELD-wise, not record-wise', () => {
+      // A metadata record can exist carrying no preview while the combined
+      // entry still has one — a record-wise `??` would return undefined here.
+      const preview = createMessage('m1', ROOM, 'alice', 'preview')
+      roomStore.setState((s) => ({
+        rooms: new Map(s.rooms).set(ROOM, createRoom(ROOM, { joined: true, lastMessage: preview })),
+        roomMeta: new Map(s.roomMeta).set(ROOM, {
+          unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>(),
+        }),
+      }))
+
+      expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage).toBeUndefined()
+      expect(conversationLastMessage(ROOM)?.id).toBe('m1')
+    })
+  })
+
+  describe('conversationIds', () => {
+    it('unions 1:1 entities and known rooms', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      chatStore.getState().addConversation(conversation(CHAT))
+
+      expect([...conversationIds()].sort()).toEqual([CHAT, ROOM].sort())
+    })
+  })
+})

--- a/packages/fluux-sdk/src/stores/conversationLens.ts
+++ b/packages/fluux-sdk/src/stores/conversationLens.ts
@@ -1,0 +1,138 @@
+/**
+ * A read lens over both conversation stores.
+ *
+ * A conversation is either a 1:1 chat or a MUC room, and the two live in
+ * different stores because their entity models genuinely differ — occupancy,
+ * affiliations and nicknames mean nothing to a 1:1 conversation. What they hold
+ * identically, keyed by conversation id, is the message window and the churny
+ * metadata: read pointer, unread count, preview.
+ *
+ * This resolves an id to whichever store owns it and reads those, so a caller
+ * that only wants "the unread count for this conversation" does not have to
+ * know which kind it is.
+ *
+ * Reads only. The two write paths differ in ways a lens would have to paper
+ * over, so a caller that writes picks its store.
+ *
+ * SDK-internal, deliberately not exported from the package barrel: these bind
+ * to the store modules directly, so a consumer that swaps the stores out — as
+ * the app's tests do at the `@fluux/sdk` boundary — would keep the real stores
+ * here and read an empty world. A caller that already knows the kind should
+ * branch on it rather than pay a second resolution.
+ *
+ * @example
+ * ```ts
+ * import { conversationKind, conversationMetadata } from './conversationLens'
+ *
+ * const unread = conversationMetadata('team@conference.example.com')?.unreadCount ?? 0
+ * const kind = conversationKind('alice@example.com') // 'chat'
+ * ```
+ *
+ * @packageDocumentation
+ * @module Stores/ConversationLens
+ */
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+import type { BaseMessage } from '../core/types/message-base'
+import type { ReadPointer } from '../core/types/readState'
+import type { HistoryQueryState } from '../core/types/pagination'
+
+/** Which store owns a conversation id. */
+export type ConversationKind = 'chat' | 'room'
+
+/**
+ * The metadata both stores keep, under the same names.
+ *
+ * Not `ConversationMetadata` itself: the two records diverge on `lastMessage`,
+ * a `Message` for a 1:1 conversation and a `RoomMessage` for a room. Widened
+ * here to the base every message shares, which is what a caller reading through
+ * the lens can rely on.
+ */
+export interface ConversationMetadataView {
+  /** Number of unread messages. */
+  unreadCount: number
+  /** Most recent message, as the sidebar preview shows it. */
+  lastMessage?: BaseMessage
+  /** Where the user has read to. Only ever advances forward. */
+  readPointer?: ReadPointer
+  /** When this conversation entered our world — the floor for unread counting. */
+  historyFloor?: Date
+  /**
+   * XEP-0490: a remote device reported reading up to this stanza-id, but the
+   * message is not yet in the local cache.
+   */
+  pendingRemoteDisplayedStanzaId?: string
+}
+
+/** Shared so a caller that finds nothing does not allocate a fresh array. */
+const EMPTY_MESSAGES: readonly BaseMessage[] = Object.freeze([])
+
+/**
+ * Which kind of conversation `id` names, or `undefined` when neither store
+ * knows it.
+ *
+ * A room is known once it is bookmarked or joined, which can be long after the
+ * session starts — bookmarks load late. Treat `undefined` as "not yet
+ * classifiable", not as "1:1".
+ */
+export function conversationKind(id: string): ConversationKind | undefined {
+  if (roomStore.getState().rooms.has(id)) return 'room'
+  if (chatStore.getState().conversationEntities.has(id)) return 'chat'
+  return undefined
+}
+
+/**
+ * The conversation's resident message window — the slice of history currently
+ * held in memory, empty for a conversation that has none loaded.
+ */
+export function conversationMessages(id: string): readonly BaseMessage[] {
+  if (roomStore.getState().rooms.has(id)) {
+    return roomStore.getState().messages.get(id) ?? EMPTY_MESSAGES
+  }
+  return chatStore.getState().messages.get(id) ?? EMPTY_MESSAGES
+}
+
+/**
+ * The conversation's metadata, falling back to the combined entry.
+ *
+ * The split map is the authority, but it can be empty while the combined entry
+ * is populated: the persist middleware rehydrates the combined map, and a room
+ * arriving from a bookmark has an entry before `roomMeta` is written.
+ */
+export function conversationMetadata(id: string): ConversationMetadataView | undefined {
+  const rooms = roomStore.getState()
+  if (rooms.rooms.has(id)) return rooms.roomMeta.get(id) ?? rooms.rooms.get(id)
+  const chats = chatStore.getState()
+  return chats.conversationMeta.get(id) ?? chats.conversations.get(id)
+}
+
+/**
+ * The newest message this conversation knows of, preview included.
+ *
+ * Field-wise fallback rather than {@link conversationMetadata}'s record-wise
+ * one: a metadata record can exist with no preview on it while the combined
+ * entry still carries the last message.
+ */
+export function conversationLastMessage(id: string): BaseMessage | undefined {
+  const rooms = roomStore.getState()
+  if (rooms.rooms.has(id)) {
+    return rooms.roomMeta.get(id)?.lastMessage ?? rooms.rooms.get(id)?.lastMessage
+  }
+  const chats = chatStore.getState()
+  return chats.conversationMeta.get(id)?.lastMessage ?? chats.conversations.get(id)?.lastMessage
+}
+
+/** The conversation's MAM query state. */
+export function conversationHistoryState(id: string): HistoryQueryState {
+  return roomStore.getState().rooms.has(id)
+    ? roomStore.getState().getRoomMAMQueryState(id)
+    : chatStore.getState().getMAMQueryState(id)
+}
+
+/** Every conversation either store currently knows: 1:1 entities and rooms. */
+export function conversationIds(): Set<string> {
+  const ids = new Set<string>()
+  for (const id of chatStore.getState().conversationEntities.keys()) ids.add(id)
+  for (const id of roomStore.getState().rooms.keys()) ids.add(id)
+  return ids
+}


### PR DESCRIPTION
A conversation is a 1:1 chat or a MUC room, and the two live in separate stores. `mdsSideEffects` works from a bare JID, so every read it made began by branching on which store owned it — eight of them, each repeating the resolution, and two also repeating the rule that a metadata read falls back to the combined entry.

`stores/conversationLens.ts` does the resolution once and reads what the two stores hold under the same shape: the message window, the metadata, the preview, the MAM state, the set of known ids.

The fallback rule now has one home and a test that pins it as field-wise rather than record-wise: a metadata record can exist carrying no preview while the combined entry still has one, so a record-wise `??` would answer `undefined` where the entry knows the message. `roomStore` already applies the same rule internally.

Not exported from the package barrel. The lens binds to the store modules, so a consumer that swaps the stores out — as the app's tests do at the `@fluux/sdk` boundary — would keep the real stores here and read an empty world. A caller that already knows the kind branches on it rather than pay a second resolution, which is why the two arms of `resolveFromStores` keep theirs.