### PR TITLE
fix(scroll): re-pin the live edge when a row is measured taller late on reaction reception

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -23,6 +23,7 @@ import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 
 const scrollToEndCalls = { count: 0 }
+let reportMeasuredRow: ((key: string, size: number) => void) | undefined
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
@@ -35,23 +36,30 @@ vi.mock('@/hooks', () => ({
   })),
 }))
 vi.mock('./tanstackMessageVirtualizer', () => ({
-  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
-    getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
-    getTotalSize: () => args.items.length * 40,
-    itemCount: args.items.length,
-    getOffsetForMessageId: () => 0,
-    getIndexForMessageId: (id: string) => { const i = args.items.findIndex((it) => it.key === id); return i >= 0 ? i : null },
-    ensureMessageMounted: vi.fn(() => Promise.resolve()),
-    measureElement: () => {},
-    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
-    // jsdom has no smooth-scroll animation, so an animated scroll lands immediately.
-    beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
-    scrollToIndex: (_index: number, opts?: { align?: string }) => {
-      const el = args.scrollRef.current; if (!el) return
-      if (opts?.align === 'end') { scrollToEndCalls.count += 1; el.scrollTop = el.scrollHeight }
-      else el.scrollTop = _index * 40
-    },
-  }),
+  useTanstackMessageVirtualizer: (args: {
+    items: { key: string }[]
+    scrollRef: React.RefObject<HTMLElement | null>
+    onMeasured?: (key: string, size: number) => void
+  }) => {
+    reportMeasuredRow = args.onMeasured
+    return {
+      getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
+      getTotalSize: () => args.items.length * 40,
+      itemCount: args.items.length,
+      getOffsetForMessageId: () => 0,
+      getIndexForMessageId: (id: string) => { const i = args.items.findIndex((it) => it.key === id); return i >= 0 ? i : null },
+      ensureMessageMounted: vi.fn(() => Promise.resolve()),
+      measureElement: () => {},
+      scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+      // jsdom has no smooth-scroll animation, so an animated scroll lands immediately.
+      beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+      scrollToIndex: (_index: number, opts?: { align?: string }) => {
+        const el = args.scrollRef.current; if (!el) return
+        if (opts?.align === 'end') { scrollToEndCalls.count += 1; el.scrollTop = el.scrollHeight }
+        else el.scrollTop = _index * 40
+      },
+    }
+  },
 }))
 
 function makeMessages(count: number, prefix = 'msg'): BaseMessage[] {
@@ -171,6 +179,123 @@ describe('MessageList — live-edge executor cost control', () => {
 
     expect(scrollToEndCalls.count).toBeGreaterThan(0)
     expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight)
+  })
+
+  it('re-pins when a virtual row reports growth after the original reaction pin has settled', () => {
+    const isAtBottomRef = { current: true }
+    const messages = makeMessages(50)
+    const view = render(
+      <MessageList messages={messages} conversationId="conv-late-reaction-measure" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70)
+    scroller.scrollTop = geo.scrollHeight
+    act(() => { scroller.dispatchEvent(new Event('scroll')) })
+    act(() => { reportMeasuredRow?.('msg-49', 40) })
+
+    view.rerender(
+      <MessageList
+        messages={messages.map((message, index) =>
+          index === messages.length - 1
+            ? { ...message, reactions: { '👍': ['someone@example.com'] } }
+            : message,
+        )}
+        conversationId="conv-late-reaction-measure"
+        isAtBottomRef={isAtBottomRef}
+        {...props}
+      />,
+    )
+    flush(20)
+    expect(rafQueue.length).toBe(0)
+
+    scrollToEndCalls.count = 0
+    geo.scrollHeight += 28
+    act(() => {
+      reportMeasuredRow?.('msg-49', 68)
+      flush(10)
+    })
+
+    expect(scrollToEndCalls.count).toBeGreaterThan(0)
+    expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight)
+  })
+
+  it('does not re-pin late measured reaction growth for a reader in history', () => {
+    const isAtBottomRef = { current: true }
+    const messages = makeMessages(50)
+    const view = render(
+      <MessageList messages={messages} conversationId="conv-late-reaction-history" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70)
+    scroller.scrollTop = 400
+    act(() => {
+      scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+      reportMeasuredRow?.('msg-49', 40)
+    })
+
+    view.rerender(
+      <MessageList
+        messages={messages.map((message, index) =>
+          index === messages.length - 1
+            ? { ...message, reactions: { '👍': ['someone@example.com'] } }
+            : message,
+        )}
+        conversationId="conv-late-reaction-history"
+        isAtBottomRef={isAtBottomRef}
+        {...props}
+      />,
+    )
+    flush(20)
+
+    scrollToEndCalls.count = 0
+    geo.scrollHeight += 28
+    act(() => { reportMeasuredRow?.('msg-49', 68) })
+    flush(10)
+
+    expect(scrollToEndCalls.count).toBe(0)
+    expect(scroller.scrollTop).toBe(400)
+  })
+
+  it('waits for post-measurement geometry before deciding whether to re-pin', () => {
+    const isAtBottomRef = { current: true }
+    const messages = makeMessages(50)
+    const view = render(
+      <MessageList messages={messages} conversationId="conv-reaction-threshold" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70)
+    scroller.scrollTop = geo.scrollHeight - geo.clientHeight - 160
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+      reportMeasuredRow?.('msg-49', 40)
+    })
+
+    view.rerender(
+      <MessageList
+        messages={messages.map((message, index) =>
+          index === messages.length - 1
+            ? { ...message, reactions: { '👍': ['someone@example.com'] } }
+            : message,
+        )}
+        conversationId="conv-reaction-threshold"
+        isAtBottomRef={isAtBottomRef}
+        {...props}
+      />,
+    )
+    flush(20)
+    scrollToEndCalls.count = 0
+
+    act(() => { reportMeasuredRow?.('msg-49', 68) })
+    expect(scrollToEndCalls.count).toBe(0)
+
+    geo.scrollHeight += 28
+    act(() => { flush(10) })
+    expect(scrollToEndCalls.count).toBe(0)
+    expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight - 188)
   })
 
   it('does not yank a scrolled-up reader down when a link-preview fastening lands', () => {

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -390,9 +390,14 @@ export function MessageList<T extends BaseMessage>({
   }
   const initialMeasurements = initialMeasurementsRef.current
 
-  // Write-back: record each row's measured height to the persistent cache.
-  // scalePct/conversationId are captured via a ref so the stable callback identity
-  // is preserved (no virtualizer re-creation on every render).
+  // Write-back: record each row's measured height to the persistent cache. A repeated measurement
+  // for the same row also carries the authoritative delta from @tanstack's ResizeObserver. Positive
+  // deltas are forwarded to the positioning controller so a late reaction/media measurement can
+  // re-pin after an earlier signature-triggered loop has already settled. The first measurement is
+  // only a baseline; conversation and scale are part of the key so unrelated layouts never compare.
+  // All live parameters are captured via refs so the callback stays stable.
+  const measuredRowSizesRef = useRef(new Map<string, number>())
+  const handleVirtualRowMeasuredGrowthRef = useRef<(heightDelta: number) => void>(() => {})
   const onMeasuredParamsRef = useRef({ conversationId, scalePct, rowMetricsRef, indexById, virtualItems })
   onMeasuredParamsRef.current = { conversationId, scalePct, rowMetricsRef, indexById, virtualItems }
   const onMeasured = useMemo(
@@ -402,6 +407,12 @@ export function MessageList<T extends BaseMessage>({
             const { conversationId: cid, scalePct: scale, rowMetricsRef: metricsRef, indexById: idMap, virtualItems: items } = onMeasuredParamsRef.current
             const idx = idMap.get(key)
             const item = idx != null ? items[idx] : undefined
+            const measurementKey = `${cid}\u0000${scale}\u0000${key}`
+            const previousSize = measuredRowSizesRef.current.get(measurementKey)
+            measuredRowSizesRef.current.set(measurementKey, size)
+            if (previousSize !== undefined && size > previousSize) {
+              handleVirtualRowMeasuredGrowthRef.current(size - previousSize)
+            }
             // isFirstNew rows include the "new messages" divider, which comes and goes with
             // read-state between opens — caching their height re-blinks the next open.
             if (!(item?.kind === 'message' && item.isFirstNew)) {
@@ -535,6 +546,7 @@ export function MessageList<T extends BaseMessage>({
     handleWheel,
     handleLoadEarlier,
     handleMediaLoad,
+    handleVirtualRowMeasuredGrowth,
     scrollToBottom,
     requestMessageTarget,
     showScrollToBottom,
@@ -567,6 +579,7 @@ export function MessageList<T extends BaseMessage>({
     staticMode,
     virtualizer: activeVirtualizer,
   })
+  handleVirtualRowMeasuredGrowthRef.current = handleVirtualRowMeasuredGrowth
 
   // Combined ref setter for scroll container
   const setScrollContainerRef = (element: HTMLDivElement | null) => {

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -124,6 +124,7 @@ const allowedHookFunctions = [
   'handleLoadEarlier',
   'handleMediaLoad',
   'handleScroll',
+  'handleVirtualRowMeasuredGrowth',
   'handleWheel',
   'markerAboveViewport',
   'requestMessageTarget',

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -238,6 +238,8 @@ export interface UseMessageListScrollResult {
   handleWheel: (e: React.WheelEvent<HTMLDivElement>) => void
   handleLoadEarlier: () => void
   handleMediaLoad: () => void
+  /** Reconcile a positive, virtualizer-reported row-height delta against live scroll geometry. */
+  handleVirtualRowMeasuredGrowth: (heightDelta: number) => void
   scrollToBottom: () => void
   scrollToTop: () => void
   /** Submit a reply/poll/find target to the generation-aware positioning controller. */
@@ -311,6 +313,8 @@ export function useMessageListScroll({
   // Lazy-ref idiom shared with the extracted browser-adapter hook: a ref is stable, so reading it
   // at the use sites keeps the exhaustive-deps rule satisfied without a dependency.
   const pinBottomClaim = () => (pinBottomClaimRef.current ??= createPinLoopClaim())
+  const measuredRowGrowthFrameRef = useRef<number | null>(null)
+  const pendingMeasuredRowGrowthRef = useRef(0)
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -607,6 +611,50 @@ export function useMessageListScroll({
     }
     rememberBottomIntent()
   }, [rememberBottomIntent])
+
+  const handleVirtualRowMeasuredGrowth = useCallback((heightDelta: number) => {
+    const scroller = scrollerRef.current
+    if (!scroller || staticMode || !virtualizerRef.current || heightDelta <= 0) return
+    pendingMeasuredRowGrowthRef.current += heightDelta
+    if (measuredRowGrowthFrameRef.current !== null) return
+
+    const measuredConversationId = activeConversationIdRef.current
+    measuredRowGrowthFrameRef.current = requestAnimationFrame(() => {
+      measuredRowGrowthFrameRef.current = null
+      const measuredGrowth = pendingMeasuredRowGrowthRef.current
+      pendingMeasuredRowGrowthRef.current = 0
+      const liveScroller = scrollerRef.current
+      if (
+        !liveScroller ||
+        latestRef.current.staticMode ||
+        !virtualizerRef.current ||
+        activeConversationIdRef.current !== measuredConversationId
+      ) return
+
+      const active = positioningControllerRef.current?.snapshot().active
+      const decision = decideRowGrowth({
+        distanceFromBottom: getDistanceFromBottom(liveScroller),
+        heightDelta: measuredGrowth,
+        atBottomThreshold: AT_BOTTOM_THRESHOLD,
+        pinClaimHeld: pinBottomClaim().isHeld(),
+        navigationInFlight: Boolean(
+          active &&
+          active.request.conversationId === activeConversationIdRef.current &&
+          active.request.desired.kind !== 'live-edge' &&
+          active.phase.kind !== 'settled',
+        ),
+      })
+      if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+    })
+  }, [staticMode])
+
+  useEffect(() => () => {
+    if (measuredRowGrowthFrameRef.current !== null) {
+      cancelAnimationFrame(measuredRowGrowthFrameRef.current)
+      measuredRowGrowthFrameRef.current = null
+    }
+    pendingMeasuredRowGrowthRef.current = 0
+  }, [])
 
   // Ambient layout preservation for divider movement and mid-array insertion. It owns the
   // pre-mutation anchors and their tracking; every branch decision is a pure function in
@@ -2112,6 +2160,7 @@ export function useMessageListScroll({
     handleWheel,
     handleLoadEarlier,
     handleMediaLoad,
+    handleVirtualRowMeasuredGrowth,
     scrollToBottom,
     scrollToTop,
     requestMessageTarget,


### PR DESCRIPTION
`decideRowGrowth` (#1186) was fed by a single signal: a row-growth signature change, consumed exactly once per signature. That leaves a gap for growth whose real height only arrives with the browser's own measurement — a reaction, an attachment, a late media load. The measurement lands after the signature pass has settled, nothing re-runs for that signature, and a reader who was following the bottom is left a row-height short of it with no further chance to recover.

The virtualizer already observes those measurements. This feeds the second one, and every later one, into the same decision.

- Only a repeated measurement carries a delta; the first is a baseline. The key includes the conversation and the scale, so unrelated layouts never compare.
- Only positive deltas forward. A shrink pulls the bottom toward the reader and the browser clamps `scrollTop` itself — the same reason `decideRowGrowth` already skips a measured shrink.
- Deltas coalesce into one frame and geometry is re-read after it. Deciding on the pre-measurement layout would compare a distance the growth has not landed in yet.
- The frame re-checks that the scroller, the virtualizer and the conversation are still the ones measured, so a room switch mid-frame cannot re-pin the list the reader just left.

`decideRowGrowth` still owns every branch, so a reader in history, a running pin loop and an in-flight navigation are refused exactly as before.