### PR TITLE
fix(reactions): name what was reacted to when the message has no body

### DIFF
--- a/apps/fluux/src/components/conversation/ReactionMentions.test.tsx
+++ b/apps/fluux/src/components/conversation/ReactionMentions.test.tsx
@@ -21,4 +21,11 @@ describe('ReactionMentions', () => {
     fireEvent.click(screen.getByLabelText('common.dismiss'))
     expect(reactionMentionStore.getState().mentions.get('c1')?.length ?? 0).toBe(0)
   })
+  it('uses the quote-free label when the reacted message had nothing to preview', () => {
+    // Shares the toast's derivation, so the chip can no longer read "reacted to ''".
+    reactionMentionStore.getState().addMention({ id: 'c1:m1', conversationId: 'c1', messageId: 'm1', reactorName: 'Marie', emoji: '❤️', preview: '' })
+    render(<ReactionMentions conversationId="c1" onSee={vi.fn()} />)
+    expect(screen.getByText(/reactions\.mentionNoPreview/)).toBeTruthy()
+    expect(screen.queryByText(/reactions\.mention:/)).toBeNull()
+  })
 })

--- a/apps/fluux/src/components/conversation/ReactionMentions.tsx
+++ b/apps/fluux/src/components/conversation/ReactionMentions.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useReactionMentionStore } from '@/stores/reactionMentionStore'
+import { formatReactionNotification } from '@/utils/reactionNotificationText'
 import { MentionChip } from './MentionChip'
 
 interface ReactionMentionsProps {
@@ -25,7 +26,7 @@ export function ReactionMentions({ conversationId, onSee }: ReactionMentionsProp
       {mentions.map((m) => (
         <MentionChip
           key={m.id}
-          label={t('reactions.mention', { name: m.reactorName, emoji: m.emoji, preview: m.preview })}
+          label={formatReactionNotification(t, { name: m.reactorName, emoji: m.emoji, preview: m.preview })}
           actionLabel={t('reactions.see')}
           onAction={() => onSee(m.messageId)}
           onDismiss={() => dismissMention(conversationId, m.id)}

--- a/apps/fluux/src/hooks/useReactionNotifications.test.tsx
+++ b/apps/fluux/src/hooks/useReactionNotifications.test.tsx
@@ -49,7 +49,9 @@ vi.mock('@fluux/sdk/cache', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, params?: Record<string, unknown>) => `${key}:${params?.name ?? ''}:${params?.emoji ?? ''}`,
+    // Include `preview` so tests can assert the derived preview text, not just the key.
+    t: (key: string, params?: Record<string, unknown>) =>
+      `${key}:${params?.name ?? ''}:${params?.emoji ?? ''}:${params?.preview ?? ''}`,
   }),
 }))
 
@@ -334,5 +336,157 @@ describe('useReactionNotifications — room reaction resolution', () => {
 
     expect(mockGetCachedRoomMessage).not.toHaveBeenCalled()
     expect(mockAddToast).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Preview derivation
+//
+// The notification quotes what was reacted to. Deriving that from `body` alone
+// left every bodiless message kind quoting nothing — a reaction to a poll read
+// `1️⃣ danielstein reacted to ''`. Both paths now go through the same shared
+// derivation the sidebar uses (formatLocalizedPreview), so a poll names its
+// title, an attachment names its file, and a message with nothing to quote
+// falls back to a quote-free string instead of empty quotes.
+// ---------------------------------------------------------------------------
+describe('useReactionNotifications — notification preview', () => {
+  const ROOM = 'team@conference.example.com'
+  const POLL = {
+    title: 'Which emoji do you use more often?',
+    options: [
+      { emoji: '1️⃣', label: 'thumbs up' },
+      { emoji: '2️⃣', label: 'heart' },
+    ],
+    settings: { allowMultiple: false, hideResultsBeforeVote: false },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSubscribe.mockReturnValue(vi.fn())
+    chatState.messages = new Map()
+    chatState.activeConversationId = 'other@example.com'
+    connectionState.jid = 'me@example.com'
+    roomState.rooms = new Map()
+    roomState.activeRoomJid = 'other@conference.example.com'
+    roomState.getMessage = vi.fn().mockReturnValue(undefined)
+    mockGetCachedMessage.mockResolvedValue(null)
+    mockGetCachedMessageByStanzaId.mockResolvedValue(null)
+    mockGetCachedRoomMessage.mockResolvedValue(null)
+    mockGetCachedRoomMessageByStanzaId.mockResolvedValue(null)
+    seedRoom(ROOM, [{ id: 'r-last', nick: 'Alice' }])
+  })
+
+  /** The toast label the hook handed to the toast store. */
+  function toastLabel(): string {
+    expect(mockAddToast).toHaveBeenCalledTimes(1)
+    return mockAddToast.mock.calls[0][1] as string
+  }
+
+  /** Drive the 1:1 path with `message` resolved from the durable cache. */
+  async function reactInChat(message: Record<string, unknown>): Promise<void> {
+    mockGetCachedMessage.mockResolvedValue({ id: 'm1', isOutgoing: true, body: '', ...message })
+    renderHook(() => useReactionNotifications())
+    await chatHandler()({
+      conversationId: 'peer@example.com',
+      messageId: 'm1',
+      reactorJid: 'peer@example.com/res',
+      emojis: ['1️⃣'],
+      isLive: true,
+    })
+  }
+
+  /** Drive the room path with `message` resident in the room window. */
+  async function reactInRoom(message: Record<string, unknown>): Promise<void> {
+    roomState.getMessage = vi.fn().mockReturnValue({ id: 'r1', nick: 'Me', body: '', ...message })
+    renderHook(() => useReactionNotifications())
+    await roomHandler()({ roomJid: ROOM, messageId: 'r1', reactorNick: 'danielstein', emojis: ['1️⃣'], isLive: true })
+  }
+
+  it('names the poll when a poll is reacted to in a 1:1 chat', async () => {
+    await reactInChat({ poll: POLL })
+
+    expect(toastLabel()).toContain('Which emoji do you use more often?')
+  })
+
+  it('names the poll when a poll is reacted to in a room', async () => {
+    await reactInRoom({ poll: POLL })
+
+    expect(toastLabel()).toContain('Which emoji do you use more often?')
+  })
+
+  it('names the poll in the in-flow mention chip too', async () => {
+    const conv = 'peer@example.com'
+    chatState.activeConversationId = conv
+    chatState.messages.set(conv, [
+      { id: 'm1', isOutgoing: true, body: '', poll: POLL } as never,
+      { id: 'last', isOutgoing: false },
+    ])
+
+    renderHook(() => useReactionNotifications())
+    await chatHandler()({ conversationId: conv, messageId: 'm1', reactorJid: 'peer@example.com', emojis: ['1️⃣'], isLive: true })
+
+    expect(mockAddMention).toHaveBeenCalledWith(
+      expect.objectContaining({ preview: expect.stringContaining('Which emoji do you use more often?') }),
+    )
+  })
+
+  it('names the poll for a frozen poll-results announcement', async () => {
+    await reactInChat({
+      pollClosed: { title: 'Which emoji do you use more often?', pollMessageId: 'p1', results: [] },
+    })
+
+    expect(toastLabel()).toContain('Which emoji do you use more often?')
+  })
+
+  it('names the file for an attachment-only message', async () => {
+    await reactInRoom({
+      attachment: { url: 'https://example.com/report.pdf', name: 'report.pdf', mediaType: 'application/pdf' },
+    })
+
+    expect(toastLabel()).toContain('report.pdf')
+  })
+
+  it('shows the localized deleted-message notice for a retracted message', async () => {
+    await reactInChat({ isRetracted: true, body: '' })
+
+    expect(toastLabel()).toContain('chat.messageDeleted')
+  })
+
+  it('shows the localized notice — not the sender-chosen fallback body — for unsupported encryption', async () => {
+    await reactInChat({
+      body: 'You received a message encrypted with OMEMO but your client does not support it.',
+      unsupportedEncryption: { name: 'OMEMO' },
+    })
+
+    const label = toastLabel()
+    expect(label).toContain('chat.encryption.unsupportedMessage')
+    expect(label).not.toContain('but your client does not support it')
+  })
+
+  it('keeps the 80-character truncation for long text bodies', async () => {
+    const body = 'x'.repeat(200)
+    await reactInChat({ body })
+
+    // The mocked t() renders `key:name:emoji:preview`, so the preview is the last segment.
+    const preview = toastLabel().split(':').pop() as string
+    expect(preview).toBe('x'.repeat(80))
+  })
+
+  it('falls back to a quote-free label when nothing can be previewed', async () => {
+    // A bodiless signal placeholder (e.g. an encrypted reaction stored as an
+    // empty-body message) has nothing to quote. It must never render `''`.
+    await reactInChat({ body: '   ' })
+
+    const label = toastLabel()
+    expect(label).toContain('reactions.mentionNoPreview')
+    expect(label).not.toContain("''")
+  })
+
+  it('falls back to a quote-free label when formatting leaves only whitespace', async () => {
+    await reactInChat({ body: '`````` ``````' })
+
+    const label = toastLabel()
+    expect(label).toContain('reactions.mentionNoPreview')
+    expect(label).not.toContain("''")
   })
 })

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -7,6 +7,7 @@ import { getMessage as getCachedMessage, getMessageByStanzaId as getCachedMessag
 import { getRoomMessage as getCachedRoomMessage, getRoomMessageByStanzaId as getCachedRoomMessageByStanzaId } from '@fluux/sdk/cache'
 import { useToastStore } from '@/stores/toastStore'
 import { useReactionMentionStore } from '@/stores/reactionMentionStore'
+import { formatReactionNotification, reactionPreviewText } from '@/utils/reactionNotificationText'
 import { useNavigateToTarget } from './useNavigateToTarget'
 import { decideReactionNotification, type ReactionDecision } from './reactionNotificationDecision'
 
@@ -39,7 +40,7 @@ export function useReactionNotifications(): void {
     ) => {
       if (decision.kind === 'none') return
 
-      const label = t('reactions.mention', { name: m.reactorName, emoji: m.emoji, preview: m.preview })
+      const label = formatReactionNotification(t, { name: m.reactorName, emoji: m.emoji, preview: m.preview })
 
       if (decision.kind === 'toast') {
         useToastStore.getState().addToast('info', label, 6000, () => {
@@ -115,7 +116,7 @@ export function useReactionNotifications(): void {
         messageId: canonicalMessageId,
         reactorName,
         emoji: emojis[0] ?? '',
-        preview: message.body?.slice(0, 80) ?? '',
+        preview: reactionPreviewText(message, t),
         isRoom: false,
       })
     })
@@ -164,7 +165,7 @@ export function useReactionNotifications(): void {
         messageId: canonicalMessageId,
         reactorName: reactorNick,
         emoji: emojis[0] ?? '',
-        preview: message.body?.slice(0, 80) ?? '',
+        preview: reactionPreviewText(message, t),
         isRoom: true,
       })
     })

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -1355,6 +1355,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} تفاعل مع '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "عرض"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} адрэагаваў на '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Паказаць"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} реагира на '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Виж"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} ha reaccionat a '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Mostra"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -1353,6 +1353,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} zareagoval na '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Zobrazit"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagerede på '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Vis"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -1349,6 +1349,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} hat auf '{{preview}}' reagiert",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Anzeigen"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -1348,6 +1348,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} αντέδρασε στο '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Προβολή"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reacted to '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "See"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reaccionó a '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Ver"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -1349,6 +1349,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reageeris sõnumile '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Vaata"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagoi viestiin '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Näytä"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -1350,6 +1350,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} a réagi à « {{preview}} »",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Voir"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -1353,6 +1353,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} d'imoibrigh {{name}} le '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Amharc"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -1349,6 +1349,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} הגיב על '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "הצג"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -1349,6 +1349,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagirao je na '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Prikaži"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagált erre: '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Megtekintés"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} brást við '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Skoða"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} ha reagito a '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Vedi"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/ko.json
+++ b/apps/fluux/src/i18n/locales/ko.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}}이(가) '{{preview}}'에 반응했습니다",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "보기"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} sureagavo į '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Peržiūrėti"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -1350,6 +1350,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reaģēja uz '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Skatīt"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -1355,6 +1355,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} irreaġixxa għal '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Ara"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagerte på '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Vis"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reageerde op '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Bekijken"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -1353,6 +1353,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} zareagował(a) na '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Pokaż"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagiu a '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Ver"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} a reacționat la '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Vezi"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} отреагировал(а) на '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Показать"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -1352,6 +1352,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} zareagoval na '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Zobraziť"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -1353,6 +1353,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} se je odzval(a) na '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Prikaži"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} reagerade på '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Visa"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -1351,6 +1351,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} відреагував(ла) на '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "Показати"
     },
     "commands": {

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -1347,6 +1347,7 @@
     },
     "reactions": {
         "mention": "{{emoji}} {{name}} 回应了 '{{preview}}'",
+        "mentionNoPreview": "{{emoji}} {{name}} reacted to your message",
         "see": "查看"
     },
     "commands": {

--- a/apps/fluux/src/utils/reactionNotificationText.ts
+++ b/apps/fluux/src/utils/reactionNotificationText.ts
@@ -1,0 +1,49 @@
+import { isPreviewableMessage, type BaseMessage } from '@fluux/sdk'
+import { formatLocalizedPreview } from './messagePreviewText'
+
+/** Minimal shape of the i18next `t` we rely on — matches messagePreviewText.ts. */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+/** Longest quoted preview a reaction notification shows. */
+const PREVIEW_MAX_LENGTH = 80
+
+type ReactedMessage = Parameters<typeof formatLocalizedPreview>[0] &
+  Pick<BaseMessage, 'isRetracted'>
+
+/**
+ * Quoted text for "X reacted to '…'".
+ *
+ * Reuses the sidebar's preview derivation ({@link formatLocalizedPreview}) so a
+ * bodiless message names itself: a poll quotes its title, a file quotes its
+ * name, an unsupported-encryption message quotes a localized notice rather than
+ * the sender-chosen plaintext fallback. Reading `body` alone made every one of
+ * those collapse to empty quotes.
+ *
+ * Returns `''` when the message has nothing displayable at all — a bodiless
+ * signal placeholder, e.g. an encrypted reaction stored as an empty-body
+ * message. Callers must then use {@link formatReactionNotification}, which
+ * swaps in a quote-free label.
+ */
+export function reactionPreviewText(message: ReactedMessage, t: TranslateFn): string {
+  // Retracted messages render their own notice everywhere else in the app
+  // (the sidebar pairs it with italic styling); mirror that wording here.
+  if (message.isRetracted) return t('chat.messageDeleted').slice(0, PREVIEW_MAX_LENGTH)
+  if (!isPreviewableMessage(message)) return ''
+  return formatLocalizedPreview(message, t).slice(0, PREVIEW_MAX_LENGTH)
+}
+
+/**
+ * Label for a reaction notification — the toast and the in-flow mention chip
+ * share it so the two surfaces cannot drift apart.
+ *
+ * An empty or whitespace-only `preview` selects a quote-free key: a visually
+ * blank quote is never a sensible thing to show.
+ */
+export function formatReactionNotification(
+  t: TranslateFn,
+  { name, emoji, preview }: { name: string; emoji: string; preview: string },
+): string {
+  return preview.trim()
+    ? t('reactions.mention', { name, emoji, preview })
+    : t('reactions.mentionNoPreview', { name, emoji })
+}


### PR DESCRIPTION
Reacting to a poll produced a notification that quoted nothing — `1️⃣ danielstein reacted to ''`. The reactor name, the emoji and the "See" jump link were all correct; only the quoted preview was empty.

The preview was built from `message.body`, duplicated across the `chat:reactions` and `room:reactions` handlers. A poll carries its text in `poll.title`, not in `body`, so the preview collapsed to an empty string and the `reactions.mention` template rendered bare quotes. The same applied to every bodyless kind: frozen poll results, file-only messages, and retracted messages.

Both handlers now derive the quoted text through `formatLocalizedPreview` — the formatter the sidebar already uses — so a poll names its title and a file names its name. The toast and the in-flow mention chip, which built the same label independently and carried the same bug, now share one derivation instead of three copies that can drift apart. The 80-character truncation is unchanged.

Two things fall out of reusing that formatter:

- An unsupported-encryption message now shows the localized notice rather than quoting the sender-chosen plaintext fallback body verbatim, matching how it already renders elsewhere.
- When a message has nothing displayable at all — including a body that formatting reduces to whitespace — the notification uses a new quote-free string instead of rendering a blank quote.

That last case needs a key with no `'{{preview}}'` fragment, so `reactions.mentionNoPreview` is new. The locale parity suite requires every English key in all 34 files, so it is mirrored as the English string in the other 33 for translators to pick up.

The bug was reproduced at the handler level rather than end to end, since the test harness cannot drive a real XMPP room; that reproduction is the regression test. Behaviour was also checked interactively in demo mode across both paths.
