### PR TITLE
fix(scroll): isolate late row growth by conversation

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -59,6 +59,7 @@ import {
   hydrateHeightCache,
 } from './messageHeightCache'
 import { collectSettledRowHeights } from './settledRowSnapshot'
+import { VirtualRowSizeHistory } from './virtualRowGrowth'
 import { Loader2, ChevronUp, ChevronDown, MessageCircle } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import { MessageSelectionBar } from './MessageSelectionBar'
@@ -393,11 +394,15 @@ export function MessageList<T extends BaseMessage>({
   // Write-back: record each row's measured height to the persistent cache. A repeated measurement
   // for the same row also carries the authoritative delta from @tanstack's ResizeObserver. Positive
   // deltas are forwarded to the positioning controller so a late reaction/media measurement can
-  // re-pin after an earlier signature-triggered loop has already settled. The first measurement is
-  // only a baseline; conversation and scale are part of the key so unrelated layouts never compare.
-  // All live parameters are captured via refs so the callback stays stable.
-  const measuredRowSizesRef = useRef(new Map<string, number>())
-  const handleVirtualRowMeasuredGrowthRef = useRef<(heightDelta: number) => void>(() => {})
+  // re-pin after an earlier signature-triggered loop has already settled. The bounded history is
+  // reset when conversation or scale changes, so the first measurement in a new layout is always a
+  // baseline and measurements retained by a long session cannot grow without limit. All live
+  // parameters are captured via refs so the callback stays stable.
+  const measuredRowSizesRef = useRef(new VirtualRowSizeHistory())
+  const handleVirtualRowMeasuredGrowthRef = useRef<(
+    conversationId: string,
+    heightDelta: number,
+  ) => void>(() => {})
   const onMeasuredParamsRef = useRef({ conversationId, scalePct, rowMetricsRef, indexById, virtualItems })
   onMeasuredParamsRef.current = { conversationId, scalePct, rowMetricsRef, indexById, virtualItems }
   const onMeasured = useMemo(
@@ -407,11 +412,9 @@ export function MessageList<T extends BaseMessage>({
             const { conversationId: cid, scalePct: scale, rowMetricsRef: metricsRef, indexById: idMap, virtualItems: items } = onMeasuredParamsRef.current
             const idx = idMap.get(key)
             const item = idx != null ? items[idx] : undefined
-            const measurementKey = `${cid}\u0000${scale}\u0000${key}`
-            const previousSize = measuredRowSizesRef.current.get(measurementKey)
-            measuredRowSizesRef.current.set(measurementKey, size)
-            if (previousSize !== undefined && size > previousSize) {
-              handleVirtualRowMeasuredGrowthRef.current(size - previousSize)
+            const measuredGrowth = measuredRowSizesRef.current.observe(cid, scale, key, size)
+            if (measuredGrowth !== null) {
+              handleVirtualRowMeasuredGrowthRef.current(cid, measuredGrowth)
             }
             // isFirstNew rows include the "new messages" divider, which comes and goes with
             // read-state between opens — caching their height re-blinks the next open.

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -67,6 +67,7 @@ import {
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
 import { findMessageTargetElement } from './messageTargetElement'
+import { VirtualRowGrowthBatcher } from './virtualRowGrowth'
 
 // ============================================================================
 // DEBUG
@@ -239,7 +240,7 @@ export interface UseMessageListScrollResult {
   handleLoadEarlier: () => void
   handleMediaLoad: () => void
   /** Reconcile a positive, virtualizer-reported row-height delta against live scroll geometry. */
-  handleVirtualRowMeasuredGrowth: (heightDelta: number) => void
+  handleVirtualRowMeasuredGrowth: (conversationId: string, heightDelta: number) => void
   scrollToBottom: () => void
   scrollToTop: () => void
   /** Submit a reply/poll/find target to the generation-aware positioning controller. */
@@ -313,8 +314,17 @@ export function useMessageListScroll({
   // Lazy-ref idiom shared with the extracted browser-adapter hook: a ref is stable, so reading it
   // at the use sites keeps the exhaustive-deps rule satisfied without a dependency.
   const pinBottomClaim = () => (pinBottomClaimRef.current ??= createPinLoopClaim())
-  const measuredRowGrowthFrameRef = useRef<number | null>(null)
-  const pendingMeasuredRowGrowthRef = useRef(0)
+  const measuredRowGrowthFlushRef = useRef<(conversationId: string, heightDelta: number) => void>(
+    () => {},
+  )
+  const measuredRowGrowthBatcherRef = useRef<VirtualRowGrowthBatcher | null>(null)
+  if (measuredRowGrowthBatcherRef.current === null) {
+    measuredRowGrowthBatcherRef.current = new VirtualRowGrowthBatcher(
+      (measuredConversationId, measuredGrowth) => {
+        measuredRowGrowthFlushRef.current(measuredConversationId, measuredGrowth)
+      },
+    )
+  }
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -612,48 +622,48 @@ export function useMessageListScroll({
     rememberBottomIntent()
   }, [rememberBottomIntent])
 
-  const handleVirtualRowMeasuredGrowth = useCallback((heightDelta: number) => {
-    const scroller = scrollerRef.current
-    if (!scroller || staticMode || !virtualizerRef.current || heightDelta <= 0) return
-    pendingMeasuredRowGrowthRef.current += heightDelta
-    if (measuredRowGrowthFrameRef.current !== null) return
+  measuredRowGrowthFlushRef.current = (measuredConversationId, measuredGrowth) => {
+    const liveScroller = scrollerRef.current
+    if (
+      !liveScroller ||
+      latestRef.current.staticMode ||
+      !virtualizerRef.current ||
+      activeConversationIdRef.current !== measuredConversationId
+    ) return
 
-    const measuredConversationId = activeConversationIdRef.current
-    measuredRowGrowthFrameRef.current = requestAnimationFrame(() => {
-      measuredRowGrowthFrameRef.current = null
-      const measuredGrowth = pendingMeasuredRowGrowthRef.current
-      pendingMeasuredRowGrowthRef.current = 0
-      const liveScroller = scrollerRef.current
-      if (
-        !liveScroller ||
-        latestRef.current.staticMode ||
-        !virtualizerRef.current ||
-        activeConversationIdRef.current !== measuredConversationId
-      ) return
-
-      const active = positioningControllerRef.current?.snapshot().active
-      const decision = decideRowGrowth({
-        distanceFromBottom: getDistanceFromBottom(liveScroller),
-        heightDelta: measuredGrowth,
-        atBottomThreshold: AT_BOTTOM_THRESHOLD,
-        pinClaimHeld: pinBottomClaim().isHeld(),
-        navigationInFlight: Boolean(
-          active &&
-          active.request.conversationId === activeConversationIdRef.current &&
-          active.request.desired.kind !== 'live-edge' &&
-          active.phase.kind !== 'settled',
-        ),
-      })
-      if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+    const active = positioningControllerRef.current?.snapshot().active
+    const decision = decideRowGrowth({
+      distanceFromBottom: getDistanceFromBottom(liveScroller),
+      heightDelta: measuredGrowth,
+      atBottomThreshold: AT_BOTTOM_THRESHOLD,
+      pinClaimHeld: pinBottomClaim().isHeld(),
+      navigationInFlight: Boolean(
+        active &&
+        active.request.conversationId === activeConversationIdRef.current &&
+        active.request.desired.kind !== 'live-edge' &&
+        active.phase.kind !== 'settled',
+      ),
     })
+    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+  }
+
+  const handleVirtualRowMeasuredGrowth = useCallback((
+    measuredConversationId: string,
+    heightDelta: number,
+  ) => {
+    const scroller = scrollerRef.current
+    if (
+      !scroller ||
+      staticMode ||
+      !virtualizerRef.current ||
+      activeConversationIdRef.current !== measuredConversationId ||
+      heightDelta <= 0
+    ) return
+    measuredRowGrowthBatcherRef.current?.enqueue(measuredConversationId, heightDelta)
   }, [staticMode])
 
   useEffect(() => () => {
-    if (measuredRowGrowthFrameRef.current !== null) {
-      cancelAnimationFrame(measuredRowGrowthFrameRef.current)
-      measuredRowGrowthFrameRef.current = null
-    }
-    pendingMeasuredRowGrowthRef.current = 0
+    measuredRowGrowthBatcherRef.current?.dispose()
   }, [])
 
   // Ambient layout preservation for divider movement and mid-array insertion. It owns the

--- a/apps/fluux/src/components/conversation/virtualRowGrowth.test.ts
+++ b/apps/fluux/src/components/conversation/virtualRowGrowth.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MAX_TRACKED_VIRTUAL_ROW_SIZES,
+  VirtualRowGrowthBatcher,
+  VirtualRowSizeHistory,
+} from './virtualRowGrowth'
+
+describe('VirtualRowSizeHistory', () => {
+  it('starts a fresh measurement baseline when the conversation changes', () => {
+    const history = new VirtualRowSizeHistory()
+
+    expect(history.observe('room-a', 100, 'same-row-key', 40)).toBeNull()
+    expect(history.observe('room-b', 100, 'same-row-key', 60)).toBeNull()
+    expect(history.observe('room-b', 100, 'same-row-key', 72)).toBe(12)
+    expect(history.observe('room-a', 100, 'same-row-key', 80)).toBeNull()
+  })
+
+  it('starts a fresh measurement baseline when the message scale changes', () => {
+    const history = new VirtualRowSizeHistory()
+
+    expect(history.observe('room', 100, 'row', 40)).toBeNull()
+    expect(history.observe('room', 110, 'row', 60)).toBeNull()
+    expect(history.observe('room', 110, 'row', 66)).toBe(6)
+  })
+
+  it('evicts the least-recently measured row when the history reaches its bound', () => {
+    const history = new VirtualRowSizeHistory()
+    history.observe('room', 100, 'oldest', 40)
+    for (let index = 0; index < MAX_TRACKED_VIRTUAL_ROW_SIZES; index += 1) {
+      history.observe('room', 100, `row-${index}`, 40)
+    }
+
+    expect(history.observe('room', 100, 'oldest', 60)).toBeNull()
+  })
+})
+
+describe('VirtualRowGrowthBatcher', () => {
+  it('coalesces growth measured for the same conversation into one frame', () => {
+    const callbacks: FrameRequestCallback[] = []
+    const flush = vi.fn()
+    const batcher = new VirtualRowGrowthBatcher(
+      flush,
+      (callback) => callbacks.push(callback),
+      vi.fn(),
+    )
+
+    batcher.enqueue('room', 12)
+    batcher.enqueue('room', 16)
+    for (const callback of callbacks) callback(0)
+
+    expect(callbacks).toHaveLength(1)
+    expect(flush).toHaveBeenCalledWith('room', 28)
+  })
+
+  it('drops the obsolete batch and preserves growth measured after a conversation switch', () => {
+    const callbacks = new Map<number, FrameRequestCallback>()
+    const canceled: number[] = []
+    let nextFrameId = 1
+    const flush = vi.fn()
+    const batcher = new VirtualRowGrowthBatcher(
+      flush,
+      (callback) => {
+        const frameId = nextFrameId
+        nextFrameId += 1
+        callbacks.set(frameId, callback)
+        return frameId
+      },
+      (frameId) => {
+        canceled.push(frameId)
+        callbacks.delete(frameId)
+      },
+    )
+
+    batcher.enqueue('room-a', 20)
+    batcher.enqueue('room-b', 28)
+    for (const callback of callbacks.values()) callback(0)
+
+    expect(canceled).toEqual([1])
+    expect(flush).toHaveBeenCalledOnce()
+    expect(flush).toHaveBeenCalledWith('room-b', 28)
+  })
+})

--- a/apps/fluux/src/components/conversation/virtualRowGrowth.ts
+++ b/apps/fluux/src/components/conversation/virtualRowGrowth.ts
@@ -1,0 +1,71 @@
+/**
+ * Value-only bookkeeping for virtual-row measurements. Pixel decisions and writes remain owned by
+ * the positioning controller; these helpers only retain a bounded size baseline and coalesce the
+ * positive deltas reported during one animation frame.
+ */
+export const MAX_TRACKED_VIRTUAL_ROW_SIZES = 512
+
+export class VirtualRowSizeHistory {
+  private context: string | null = null
+  private readonly sizes = new Map<string, number>()
+
+  observe(conversationId: string, scalePct: number, rowKey: string, size: number): number | null {
+    const context = `${conversationId}\u0000${scalePct}`
+    if (context !== this.context) {
+      this.context = context
+      this.sizes.clear()
+    }
+
+    const previousSize = this.sizes.get(rowKey)
+    // Map insertion order is our LRU order. Refresh existing rows as well as adding new ones.
+    this.sizes.delete(rowKey)
+    this.sizes.set(rowKey, size)
+    while (this.sizes.size > MAX_TRACKED_VIRTUAL_ROW_SIZES) {
+      const oldest = this.sizes.keys().next().value
+      if (oldest === undefined) break
+      this.sizes.delete(oldest)
+    }
+    return previousSize !== undefined && size > previousSize ? size - previousSize : null
+  }
+}
+
+type RequestFrame = (callback: FrameRequestCallback) => number
+type CancelFrame = (frameId: number) => void
+
+export class VirtualRowGrowthBatcher {
+  private pending: { conversationId: string; heightDelta: number; frameId: number } | null = null
+
+  constructor(
+    private readonly flush: (conversationId: string, heightDelta: number) => void,
+    private readonly requestFrame: RequestFrame = requestAnimationFrame,
+    private readonly cancelFrame: CancelFrame = cancelAnimationFrame,
+  ) {}
+
+  enqueue(conversationId: string, heightDelta: number): void {
+    if (!(heightDelta > 0)) return
+    if (this.pending) {
+      if (this.pending.conversationId === conversationId) {
+        this.pending.heightDelta += heightDelta
+        return
+      }
+      // A frame captured for the room we just left must not consume growth already measured in the
+      // room we entered. Supersede the obsolete batch and give the active room its own frame.
+      this.cancelFrame(this.pending.frameId)
+      this.pending = null
+    }
+
+    const pending = { conversationId, heightDelta, frameId: 0 }
+    this.pending = pending
+    pending.frameId = this.requestFrame(() => {
+      if (this.pending !== pending) return
+      this.pending = null
+      this.flush(pending.conversationId, pending.heightDelta)
+    })
+  }
+
+  dispose(): void {
+    if (!this.pending) return
+    this.cancelFrame(this.pending.frameId)
+    this.pending = null
+  }
+}


### PR DESCRIPTION
## Summary

- Scope virtual-row size baselines to the active conversation and message scale, with bounded LRU retention.
- Supersede a pending measurement batch when a new conversation reports growth, so a stale frame cannot consume the active room's correction.
- Keep all geometry decisions and pixel writes in the existing positioning controller.
