### PR TITLE
refactor(scroll): isolate viewport resize reconciliation

### DIFF
--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -18,6 +18,13 @@ const hookSource = readFileSync(
   ),
   'utf8',
 )
+const viewportResizeHookPath = resolve(
+  process.cwd(),
+  'src/components/conversation/useViewportResizeReconciliation.ts',
+)
+const viewportResizeHookSource = existsSync(viewportResizeHookPath)
+  ? readFileSync(viewportResizeHookPath, 'utf8')
+  : ''
 const activeControllerSource = readFileSync(
   resolve(
     process.cwd(),
@@ -157,6 +164,23 @@ describe('live message-list scroll ownership', () => {
     expect(viewportSessionSource).not.toMatch(/\b(?:HTMLElement|Element|MessageVirtualizer)\b/)
     expect(viewportSessionSource).not.toMatch(/\b(?:scrollTop|scrollTo|scrollIntoView)\b/)
     expect(viewportSessionSource).not.toMatch(/\brequestAnimationFrame\b/)
+  })
+
+  it('keeps viewport and container resize scheduling behind one dedicated hook', () => {
+    expect(existsSync(viewportResizeHookPath)).toBe(true)
+    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('viewport-resize')")
+    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('container-shrink')")
+    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('width-change')")
+    expect(hookSource).not.toMatch(/\bnew ResizeObserver\b/)
+    expect(hookSource).not.toMatch(/\brequestAnimationFrame\b/)
+    expect(hookSource).not.toMatch(/addEventListener\(['"]resize['"]/)
+  })
+
+  it('keeps resize reconciliation semantic and unable to write pixels', () => {
+    expect(existsSync(viewportResizeHookPath)).toBe(true)
+    expect(viewportResizeHookSource).not.toMatch(
+      /\.scrollTop\s*=|\.scrollTo\s*\(|\.scrollIntoView\s*\(/,
+    )
   })
 
   it('keeps scroll persistence behind its adapter boundary', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -19,11 +19,9 @@
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
-// Still used by the composer/container resize observer below, a separate owner from the content
-// observer that moved into useScrollContainerBinding.
-import { createResizeLoopMonitor } from './resizeLoopMonitor'
 import type { ControllerFrameLoopRegistration } from './controllerFrameLoop'
 import { useScrollContainerBinding } from './useScrollContainerBinding'
+import { useViewportResizeReconciliation } from './useViewportResizeReconciliation'
 import { useAmbientAnchorPreservation } from './useAmbientAnchorPreservation'
 import { useMediaGrowthPreservation } from './useMediaGrowthPreservation'
 import { useDirectionalHistoryLoads } from './useDirectionalHistoryLoads'
@@ -42,7 +40,6 @@ import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
 import { decideMdsSettle } from './mdsSettleDecision'
 import { decideTypingIndicator } from './typingIndicatorDecision'
-import { signalAnomaly } from '@/utils/anomalySignal'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
@@ -50,7 +47,6 @@ import { ViewportSession } from './viewportSession'
 import { ScrollPersistenceAdapter } from './scrollPersistenceAdapter'
 import { DirectionalHistoryWindowCoordinator } from './directionalHistoryWindowCoordinator'
 import { TARGET_HIGHLIGHT_MS } from './explicitTargetBrowserAdapter'
-import { BOTTOM_PIN_TOLERANCE } from './liveEdgeBrowserAdapter'
 import { useScrollExecutors } from './useScrollExecutors'
 import { PositioningController } from './positioningController'
 import {
@@ -120,7 +116,6 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 // AT_BOTTOM_THRESHOLD is imported from scrollStateManager (shared with wasAtBottom persistence).
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
-// BOTTOM_PIN_TOLERANCE is imported from liveEdgeBrowserAdapter, which owns bottom-pin geometry.
 
 /**
  * Freeze a callback's identity while always invoking its latest version.
@@ -833,33 +828,6 @@ export function useMessageListScroll({
   // tracks row/window facts so normal appends do not churn global keydown subscriptions.
   const scrollToTop = useStableCallback(scrollToTopImpl)
 
-  // Re-pin to the bottom when the VIEWPORT itself shrinks (or grows) under a list
-  // that is following along — most importantly when the mobile on-screen keyboard
-  // deploys. The keyboard shrinks the scroller's clientHeight WITHOUT changing the
-  // content height, so the content ResizeObserver binding never fires and the latest
-  // message slides out of view behind the composer/keyboard. window 'resize' fires
-  // when the layout viewport resizes (Android, resizing webviews); visualViewport
-  // 'resize' covers the overlay-keyboard case (iOS). Reasserts directly (no rAF
-  // coalescing) to match the new-message / typing re-pin sites — a window 'resize'
-  // handler is not a ResizeObserver callback, so a synchronous scroll write here is
-  // safe. Gated on isAtBottomRef so a reader who scrolled up to history is not
-  // yanked back down.
-  useEffect(() => {
-    if (staticMode) return
-    const onViewportResize = () => {
-      if (isAtBottomRef.current) {
-        reconcileLiveEdgeRef.current('viewport-resize')
-      }
-    }
-    window.addEventListener('resize', onViewportResize)
-    const vv = window.visualViewport
-    vv?.addEventListener('resize', onViewportResize)
-    return () => {
-      window.removeEventListener('resize', onViewportResize)
-      vv?.removeEventListener('resize', onViewportResize)
-    }
-  }, [staticMode, isAtBottomRef])
-
   // ==========================================================================
   // LOAD OLDER MESSAGES
   // ==========================================================================
@@ -948,6 +916,19 @@ export function useMessageListScroll({
       positioningControllerRef.current?.observeUserInput(id),
     log: debugLog,
   })
+
+  useViewportResizeReconciliation({
+    ports: {
+      getScroller: () => scrollerRef.current,
+      isAtBottom: () => isAtBottomRef.current,
+      reconcileLiveEdge: (trigger) => {
+        reconcileLiveEdgeRef.current(trigger)
+      },
+    },
+    conversationId,
+    staticMode,
+  })
+
   // The implementation must close over the current conversation and executors, so its identity
   // legitimately changes on appends/window updates. Message rows must not observe that churn: a
   // changed onMediaLoad prop bypasses their memo bailout and re-renders the whole mounted window.
@@ -2016,107 +1997,6 @@ export function useMessageListScroll({
 
     reconcileLiveEdge('typing')
   }, [hasTypingIndicator, conversationId, reconcileLiveEdge, staticMode])
-
-  // ==========================================================================
-  // EFFECT: Container resize (composer grows/shrinks)
-  // ==========================================================================
-
-  useEffect(() => {
-    const scroller = scrollerRef.current
-    if (!scroller) return
-
-    let lastHeight: number | null = null
-    let pendingHeight: number | null = null
-    let lastWidth: number | null = null
-    let pendingWidth: number | null = null
-    let scheduled = false
-    let rafId: number | null = null
-    let monitor: ReturnType<typeof createResizeLoopMonitor> | null = null
-
-    // The measure + scroll-correction. Runs inside a rAF so the scrollTop write
-    // never happens synchronously inside the ResizeObserver delivery cycle —
-    // that synchronous write is the literal trigger for WebKitGTK's
-    // "ResizeObserver loop completed with undelivered notifications". Parity with
-    // the content observer's rAF coalescing in useScrollContainerBinding.
-    const runCorrection = () => {
-      scheduled = false
-      rafId = null
-      const newHeight = pendingHeight
-      const newWidth = pendingWidth
-      pendingHeight = null
-      pendingWidth = null
-      if (newHeight === null) return
-
-      if (lastHeight === null) { lastHeight = newHeight; lastWidth = newWidth; return }
-
-      const shrunk = lastHeight - newHeight
-      if (shrunk > 0 && scrollerRef.current) {
-        const distanceFromBottom = getDistanceFromBottom(scrollerRef.current)
-        const wasNear = distanceFromBottom <= shrunk + AT_BOTTOM_THRESHOLD
-        // Route through live-edge reconciliation so the virtualized path re-windows rather
-        // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
-        if (wasNear && distanceFromBottom > BOTTOM_PIN_TOLERANCE) {
-          reconcileLiveEdgeRef.current('container-shrink')
-        }
-      } else if (
-        newWidth !== null && lastWidth !== null && newWidth !== lastWidth &&
-        scrollerRef.current && isAtBottomRef.current
-      ) {
-        // A WIDTH change with no height shrink — most notably the occupant sidebar toggling
-        // in/out at lg+, where the message column narrows/widens as the panel becomes an
-        // in-flow flex sibling. That re-wraps message text and grows/shrinks row heights, but
-        // fires no window 'resize' event (so the viewport-resize handler never runs) and does
-        // not shrink the scroller's height (so the branch above never runs) — leaving the list
-        // drifted off the bottom. Re-assert while the user is following along, mirroring the
-        // window-resize handler. The scroller's own width only changes on real layout changes,
-        // not on row measurement, so this cannot feed back into the @tanstack spacer churn.
-        reconcileLiveEdgeRef.current('width-change')
-      }
-
-      lastHeight = newHeight
-      lastWidth = newWidth
-    }
-
-    const observer = new ResizeObserver((entries) => {
-      // Diagnostic only: surface a runaway fire rate (the composer-resize
-      // observer is a second candidate for the WebKitGTK feedback loop).
-      // Log-rate-limited; never disconnects.
-      if (!monitor) monitor = createResizeLoopMonitor()
-      const warning = monitor.record(performance.now())
-      if (warning) {
-        console.warn(warning.message)
-        if (__FLUUX_ANOMALY__) {
-          signalAnomaly({
-            name: 'scroll/resize-loop',
-            fires: warning.fires,
-            threshold: warning.threshold,
-            elapsedMs: warning.elapsedMs,
-          })
-        }
-      }
-
-      // Track the latest height and coalesce the correction into one rAF per
-      // frame, no matter how many times the observer fires this frame. The
-      // `scheduled` flag (rather than `rafId === null`) is what guards against
-      // double-scheduling: it stays correct even when rAF runs the callback
-      // synchronously and reentrantly.
-      pendingHeight = entries[0].contentRect.height
-      pendingWidth = entries[0].contentRect.width
-      if (!scheduled) {
-        scheduled = true
-        rafId = requestAnimationFrame(runCorrection)
-      }
-    })
-
-    observer.observe(scroller)
-    return () => {
-      observer.disconnect()
-      if (rafId !== null) cancelAnimationFrame(rafId)
-    }
-    // Re-create with the current conversation's live-edge executor.
-    // isAtBottomRef is stable unless the caller passes a new externalIsAtBottomRef (same
-    // rationale as the viewport-resize effect above).
-  }, [conversationId, isAtBottomRef])
 
   // ==========================================================================
   // EFFECT: Keyboard shortcuts

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
@@ -1,0 +1,197 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useViewportResizeReconciliation,
+  type ViewportResizeReconciliationPorts,
+} from './useViewportResizeReconciliation'
+
+interface FakeObserver {
+  target: Element | null
+  fire: (height: number, width: number) => void
+  disconnected: boolean
+}
+
+interface PendingFrame {
+  id: number
+  callback: FrameRequestCallback
+  cancelled: boolean
+}
+
+let observers: FakeObserver[] = []
+let frames: PendingFrame[] = []
+let nextFrameId = 1
+let originalVisualViewport: PropertyDescriptor | undefined
+let visualViewport: EventTarget
+
+function flushFrames() {
+  const due = frames
+  frames = []
+  for (const frame of due) {
+    if (!frame.cancelled) frame.callback(performance.now())
+  }
+}
+
+beforeEach(() => {
+  observers = []
+  frames = []
+  nextFrameId = 1
+  visualViewport = new EventTarget()
+  originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport')
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: visualViewport,
+  })
+
+  vi.stubGlobal('ResizeObserver', class {
+    private readonly record: FakeObserver
+
+    constructor(callback: ResizeObserverCallback) {
+      this.record = {
+        target: null,
+        disconnected: false,
+        fire: (height, width) => {
+          const entry = {
+            contentRect: { height, width },
+          } as ResizeObserverEntry
+          callback([entry], this as unknown as ResizeObserver)
+        },
+      }
+    }
+
+    observe(target: Element) {
+      this.record.target = target
+      observers.push(this.record)
+    }
+
+    disconnect() {
+      this.record.disconnected = true
+    }
+
+    unobserve() {}
+  })
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextFrameId++
+    frames.push({ id, callback, cancelled: false })
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    const frame = frames.find((candidate) => candidate.id === id)
+    if (frame) frame.cancelled = true
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  if (originalVisualViewport) {
+    Object.defineProperty(window, 'visualViewport', originalVisualViewport)
+  } else {
+    Reflect.deleteProperty(window, 'visualViewport')
+  }
+})
+
+function scrollerHarness() {
+  const element = document.createElement('div')
+  const geometry = {
+    scrollHeight: 1_000,
+    scrollTop: 400,
+    clientHeight: 600,
+  }
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, get: () => geometry.scrollHeight },
+    scrollTop: { configurable: true, get: () => geometry.scrollTop },
+    clientHeight: { configurable: true, get: () => geometry.clientHeight },
+  })
+  return { element, geometry }
+}
+
+function mount(staticMode = false) {
+  const scroller = scrollerHarness()
+  const state = { atBottom: true }
+  const reconcileLiveEdge = vi.fn()
+  const ports: ViewportResizeReconciliationPorts = {
+    getScroller: () => scroller.element,
+    isAtBottom: () => state.atBottom,
+    reconcileLiveEdge,
+  }
+  const rendered = renderHook(
+    (props: { conversationId: string; staticMode: boolean }) =>
+      useViewportResizeReconciliation({ ports, ...props }),
+    { initialProps: { conversationId: 'room-a', staticMode } },
+  )
+  return { ...rendered, scroller, state, reconcileLiveEdge }
+}
+
+describe('useViewportResizeReconciliation', () => {
+  it('reconciles viewport changes only while following the live edge', () => {
+    const scope = mount()
+
+    scope.state.atBottom = false
+    window.dispatchEvent(new Event('resize'))
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+
+    scope.state.atBottom = true
+    window.dispatchEvent(new Event('resize'))
+    visualViewport.dispatchEvent(new Event('resize'))
+    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(1, 'viewport-resize')
+    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(2, 'viewport-resize')
+
+    scope.unmount()
+    window.dispatchEvent(new Event('resize'))
+    visualViewport.dispatchEvent(new Event('resize'))
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps viewport listeners disabled for static lists', () => {
+    const scope = mount(true)
+    window.dispatchEvent(new Event('resize'))
+    visualViewport.dispatchEvent(new Event('resize'))
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('coalesces height observations and requests container-shrink after the frame', () => {
+    const scope = mount()
+    expect(observers).toHaveLength(1)
+    expect(observers[0].target).toBe(scope.scroller.element)
+
+    observers[0].fire(600, 800)
+    flushFrames()
+    scope.scroller.geometry.clientHeight = 480
+    scope.scroller.geometry.scrollTop = 390
+    observers[0].fire(500, 800)
+    observers[0].fire(480, 800)
+
+    expect(frames).toHaveLength(1)
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+    flushFrames()
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledOnce()
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink')
+  })
+
+  it('requests width-change only when the reader remains at the live edge', () => {
+    const scope = mount()
+    observers[0].fire(600, 800)
+    flushFrames()
+
+    observers[0].fire(600, 700)
+    flushFrames()
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('width-change')
+
+    scope.reconcileLiveEdge.mockClear()
+    scope.state.atBottom = false
+    observers[0].fire(600, 650)
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('disconnects its observer and cancels a pending frame on cleanup', () => {
+    const scope = mount()
+    observers[0].fire(600, 800)
+    const pending = frames[0]
+
+    scope.unmount()
+    expect(observers[0].disconnected).toBe(true)
+    expect(pending.cancelled).toBe(true)
+    flushFrames()
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
@@ -1,0 +1,134 @@
+/**
+ * Owns viewport/scroller resize observation and frame coalescing for the live message list.
+ *
+ * This hook only emits semantic live-edge reconciliation requests. It never writes pixels and
+ * owns no positioning generation; the positioning controller and its browser adapters remain the
+ * sole live-list position authority.
+ */
+
+import { useEffect, useRef } from 'react'
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+import { signalAnomaly } from '@/utils/anomalySignal'
+import { BOTTOM_PIN_TOLERANCE } from './liveEdgeBrowserAdapter'
+import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
+
+export type ViewportResizeReconciliationTrigger =
+  | 'viewport-resize'
+  | 'container-shrink'
+  | 'width-change'
+
+export interface ViewportResizeReconciliationPorts {
+  getScroller: () => HTMLDivElement | null
+  isAtBottom: () => boolean
+  reconcileLiveEdge: (trigger: ViewportResizeReconciliationTrigger) => void
+}
+
+export interface UseViewportResizeReconciliationInput {
+  ports: ViewportResizeReconciliationPorts
+  conversationId: string
+  staticMode: boolean
+}
+
+const distanceFromBottom = (scroller: HTMLElement) =>
+  scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+
+export function useViewportResizeReconciliation({
+  ports,
+  conversationId,
+  staticMode,
+}: UseViewportResizeReconciliationInput): void {
+  const portsRef = useRef(ports)
+  portsRef.current = ports
+
+  // The on-screen keyboard can resize the layout or visual viewport without changing content
+  // height. Re-open live-edge reconciliation only while the reader is following the bottom.
+  useEffect(() => {
+    if (staticMode) return
+    const onViewportResize = () => {
+      const active = portsRef.current
+      if (active.isAtBottom()) active.reconcileLiveEdge('viewport-resize')
+    }
+    window.addEventListener('resize', onViewportResize)
+    const visualViewport = window.visualViewport
+    visualViewport?.addEventListener('resize', onViewportResize)
+    return () => {
+      window.removeEventListener('resize', onViewportResize)
+      visualViewport?.removeEventListener('resize', onViewportResize)
+    }
+  }, [staticMode])
+
+  // Composer height and conversation-column width changes arrive through ResizeObserver. Coalesce
+  // every burst into one frame so reconciliation never runs inside the observer delivery cycle.
+  useEffect(() => {
+    const scroller = portsRef.current.getScroller()
+    if (!scroller) return
+
+    let lastHeight: number | null = null
+    let pendingHeight: number | null = null
+    let lastWidth: number | null = null
+    let pendingWidth: number | null = null
+    let scheduled = false
+    let rafId: number | null = null
+    let monitor: ReturnType<typeof createResizeLoopMonitor> | null = null
+
+    const runCorrection = () => {
+      scheduled = false
+      rafId = null
+      const newHeight = pendingHeight
+      const newWidth = pendingWidth
+      pendingHeight = null
+      pendingWidth = null
+      if (newHeight === null) return
+
+      if (lastHeight === null) {
+        lastHeight = newHeight
+        lastWidth = newWidth
+        return
+      }
+
+      const active = portsRef.current
+      const liveScroller = active.getScroller()
+      const shrunk = lastHeight - newHeight
+      if (shrunk > 0 && liveScroller) {
+        const distance = distanceFromBottom(liveScroller)
+        const wasNear = distance <= shrunk + AT_BOTTOM_THRESHOLD
+        if (wasNear && distance > BOTTOM_PIN_TOLERANCE) {
+          active.reconcileLiveEdge('container-shrink')
+        }
+      } else if (
+        newWidth !== null &&
+        lastWidth !== null &&
+        newWidth !== lastWidth &&
+        liveScroller &&
+        active.isAtBottom()
+      ) {
+        active.reconcileLiveEdge('width-change')
+      }
+
+      lastHeight = newHeight
+      lastWidth = newWidth
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      if (!monitor) monitor = createResizeLoopMonitor()
+      const warning = monitor.record(performance.now())
+      if (warning) {
+        console.warn(warning.message)
+        if (__FLUUX_ANOMALY__) signalAnomaly(resizeLoopSignal(warning))
+      }
+
+      pendingHeight = entries[0].contentRect.height
+      pendingWidth = entries[0].contentRect.width
+      if (!scheduled) {
+        scheduled = true
+        rafId = requestAnimationFrame(runCorrection)
+      }
+    })
+
+    observer.observe(scroller)
+    return () => {
+      observer.disconnect()
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
+  }, [conversationId])
+}


### PR DESCRIPTION
Extract viewport and scroller resize observation from `useMessageListScroll` into a dedicated hook.

The hook owns resize listeners, `ResizeObserver`, and frame coalescing while emitting only semantic live-edge reconciliation requests. The positioning controller and browser adapters remain the sole pixel authority, with mobile keyboard, composer shrink, and width-change behavior preserved.
