### PR TITLE
fix(messages): preserve delayed carbon ordering

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { XMPPClient, getInternalSurfaceForTesting, bindStoresForTesting } from '../XMPPClient'
 import { E2EEEncryptionRequiredError } from '../e2ee'
+import { createStoreBindings, type StoreRefs } from '../../bindings/storeBindings'
+import { chatStore } from '../../stores/chatStore'
 import {
   createMockXmppClient,
   createMockStores,
@@ -382,6 +384,193 @@ describe('XMPPClient Message', () => {
           body: 'I sent this from my phone',
           isOutgoing: true,
         })
+      })
+    })
+
+    it('should preserve a replay delay from the sent carbon envelope', async () => {
+      await connectClient()
+
+      const replayedAt = '2026-08-24T08:44:21.173Z'
+      const carbonStanza = createMockElement('message', {
+        from: 'user@example.com',
+        to: 'user@example.com/desktop',
+      }, [
+        {
+          name: 'sent',
+          attrs: { xmlns: 'urn:xmpp:carbons:2' },
+          children: [
+            {
+              name: 'forwarded',
+              attrs: { xmlns: 'urn:xmpp:forward:0' },
+              children: [
+                {
+                  name: 'message',
+                  attrs: {
+                    from: 'user@example.com/phone',
+                    to: 'contact@example.com',
+                    type: 'chat',
+                    id: 'replayed-sent-carbon',
+                  },
+                  children: [{ name: 'body', text: 'Sent while desktop was suspended' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'delay',
+          attrs: {
+            xmlns: 'urn:xmpp:delay',
+            stamp: replayedAt,
+          },
+          text: 'Resent',
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', carbonStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
+        message: expect.objectContaining({
+          id: 'replayed-sent-carbon',
+          timestamp: new Date(replayedAt),
+          isDelayed: true,
+        }),
+      })
+    })
+
+    it('should keep a replayed sent carbon before a newer post-resume message', async () => {
+      vi.setSystemTime(new Date('2026-08-24T08:45:00.000Z'))
+      await connectClient()
+
+      const originalChatState = chatStore.getState()
+      chatStore.setState({
+        conversations: new Map(),
+        conversationEntities: new Map(),
+        conversationMeta: new Map(),
+        messages: new Map(),
+        activeConversationId: null,
+      })
+      const stores = createMockStores()
+      stores.chat.addConversation.mockImplementation(chatStore.getState().addConversation)
+      stores.chat.addMessage.mockImplementation(chatStore.getState().addMessage)
+      const unsubscribe = createStoreBindings(xmppClient, () => stores as unknown as StoreRefs)
+
+      try {
+        mockXmppClientInstance._emit('stanza', createMockElement('message', {
+          from: 'contact@example.com/phone',
+          to: 'user@example.com/desktop',
+          type: 'chat',
+          id: 'a-post-resume',
+        }, [
+          { name: 'body', text: 'Arrived after desktop resumed' },
+        ]))
+
+        mockXmppClientInstance._emit('stanza', createMockElement('message', {
+          from: 'user@example.com',
+          to: 'user@example.com/desktop',
+        }, [
+          {
+            name: 'sent',
+            attrs: { xmlns: 'urn:xmpp:carbons:2' },
+            children: [
+              {
+                name: 'forwarded',
+                attrs: { xmlns: 'urn:xmpp:forward:0' },
+                children: [
+                  {
+                    name: 'message',
+                    attrs: {
+                      from: 'user@example.com/phone',
+                      to: 'contact@example.com',
+                      type: 'chat',
+                      id: 'z-sent-while-suspended',
+                    },
+                    children: [{ name: 'body', text: 'Sent while desktop was suspended' }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'delay',
+            attrs: {
+              xmlns: 'urn:xmpp:delay',
+              stamp: '2026-08-24T08:44:21.173Z',
+            },
+            text: 'Resent',
+          },
+        ]))
+
+        const messages = chatStore.getState().messages.get('contact@example.com')
+        const observedOrder = messages?.map(({ id, body, timestamp }) => ({
+          id,
+          body,
+          timestamp: timestamp.toISOString(),
+        }))
+        expect(observedOrder?.map(({ id, timestamp }) => [id, timestamp])).toEqual([
+          ['z-sent-while-suspended', '2026-08-24T08:44:21.173Z'],
+          ['a-post-resume', '2026-08-24T08:45:00.000Z'],
+        ])
+      } finally {
+        unsubscribe()
+        chatStore.setState(originalChatState, true)
+      }
+    })
+
+    it('should keep a received-carbon whisper on live room semantics', async () => {
+      vi.setSystemTime(new Date('2026-08-24T08:45:00.000Z'))
+      await connectClient()
+      mockStores.room.getRoom = vi.fn().mockReturnValue({
+        jid: 'room@conference.example.com',
+        nickname: 'me',
+        joined: true,
+      })
+
+      mockXmppClientInstance._emit('stanza', createMockElement('message', {
+        from: 'user@example.com',
+        to: 'user@example.com/desktop',
+      }, [
+        {
+          name: 'received',
+          attrs: { xmlns: 'urn:xmpp:carbons:2' },
+          children: [
+            {
+              name: 'forwarded',
+              attrs: { xmlns: 'urn:xmpp:forward:0' },
+              children: [
+                {
+                  name: 'message',
+                  attrs: {
+                    from: 'room@conference.example.com/alice',
+                    to: 'user@example.com/phone',
+                    type: 'chat',
+                    id: 'replayed-whisper',
+                  },
+                  children: [{ name: 'body', text: 'Private hello' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'delay',
+          attrs: {
+            xmlns: 'urn:xmpp:delay',
+            stamp: '2026-08-24T08:44:21.173Z',
+          },
+          text: 'Resent',
+        },
+      ]))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:whisper', {
+        roomJid: 'room@conference.example.com',
+        message: expect.objectContaining({
+          id: 'replayed-whisper',
+          timestamp: new Date('2026-08-24T08:45:00.000Z'),
+          isPrivate: true,
+        }),
+        incrementUnread: true,
+        incrementMentions: true,
       })
     })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -161,6 +161,12 @@ interface E2EEOutboundOptions {
  * checks the real claims rather than a copy of them. */
 export const CHAT_CLAIMS: readonly StanzaClaim[] = [{ kind: 'message' }]
 
+interface MessageEnvelopeContext {
+  isCarbonCopy?: boolean
+  isSentCarbon?: boolean
+  delayEl?: Element
+}
+
 export class Chat extends BaseModule {
   private mamModule: MAM
 
@@ -192,9 +198,9 @@ export class Chat extends BaseModule {
    */
   private handleMessageInternal(
     stanza: Element,
-    isCarbonCopy = false,
-    isSentCarbon = false
+    context: MessageEnvelopeContext = {},
   ): { handled: boolean; message?: Message | RoomMessage | null } {
+    const { isCarbonCopy = false, isSentCarbon = false, delayEl } = context
     const carbonSent = stanza.getChild('sent', NS_CARBONS)
     const carbonReceived = stanza.getChild('received', NS_CARBONS)
 
@@ -202,7 +208,17 @@ export class Chat extends BaseModule {
       const forwarded = (carbonSent || carbonReceived)!.getChild('forwarded', NS_FORWARD)
       const forwardedMessage = forwarded?.getChild('message')
       if (forwardedMessage) {
-        return this.handleMessageInternal(forwardedMessage, true, !!carbonSent)
+        // A forwarding service places its delay beside the forwarded message,
+        // while a server replaying an unacknowledged carbon can place it on the
+        // outer stanza. Both describe when the nested message entered storage.
+        const forwardedDelay = forwarded?.getChild('delay', NS_DELAY)
+          ?? stanza.getChild('delay', NS_DELAY)
+          ?? delayEl
+        return this.handleMessageInternal(forwardedMessage, {
+          isCarbonCopy: true,
+          isSentCarbon: !!carbonSent,
+          ...(forwardedDelay && { delayEl: forwardedDelay }),
+        })
       }
       return { handled: true }
     }
@@ -212,7 +228,7 @@ export class Chat extends BaseModule {
     // plaintext body in place of the encrypted element. Returning
     // `{ handled: true }` here prevents other modules from also processing
     // the encrypted stanza.
-    if (this.tryHandleEncrypted(stanza, isCarbonCopy, isSentCarbon)) {
+    if (this.tryHandleEncrypted(stanza, context)) {
       return { handled: true }
     }
 
@@ -428,7 +444,7 @@ export class Chat extends BaseModule {
       if (type === 'groupchat') {
         message = this.processRoomMessage(stanza, from, bareFrom, body || '', isCarbonCopy, isSentCarbon)
       } else {
-        message = this.processChatMessage(stanza, from, bareFrom, bareTo, body || '', isCarbonCopy, isSentCarbon)
+        message = this.processChatMessage(stanza, from, bareFrom, bareTo, body || '', isCarbonCopy, isSentCarbon, delayEl)
       }
 
       if (message) {
@@ -454,21 +470,19 @@ export class Chat extends BaseModule {
    */
   private tryHandleEncrypted(
     stanza: Element,
-    isCarbonCopy: boolean,
-    isSentCarbon: boolean,
+    context: MessageEnvelopeContext,
   ): boolean {
     const manager = this.deps.getE2EEManager?.()
     if (!manager) return false
     if (!stanzaHasE2EEClaim(stanza, manager)) return false
-    void this.decryptAndReprocess(manager, stanza, isCarbonCopy, isSentCarbon)
+    void this.decryptAndReprocess(manager, stanza, context)
     return true
   }
 
   private async decryptAndReprocess(
     manager: E2EEManager,
     stanza: Element,
-    isCarbonCopy: boolean,
-    isSentCarbon: boolean,
+    context: MessageEnvelopeContext,
   ): Promise<void> {
     // Single helper covers every live shape (regular received, received
     // carbon, sent carbon): if `from` is our bare JID, the peer is the
@@ -481,7 +495,7 @@ export class Chat extends BaseModule {
     await decryptStanzaInPlace(stanza, manager, peer, 'live', {
       isSelfOutgoing,
     })
-    this.handleMessageInternal(stanza, isCarbonCopy, isSentCarbon)
+    this.handleMessageInternal(stanza, context)
   }
 
   /**
@@ -2109,7 +2123,7 @@ export class Chat extends BaseModule {
     return false
   }
 
-  private processChatMessage(stanza: Element, _from: string, bareFrom: string, bareTo: string | undefined, body: string, isCarbonCopy: boolean, isSentCarbon: boolean): Message | null {
+  private processChatMessage(stanza: Element, _from: string, bareFrom: string, bareTo: string | undefined, body: string, isCarbonCopy: boolean, isSentCarbon: boolean, delayEl?: Element): Message | null {
     const myBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const isOutgoing = isSentCarbon || bareFrom === myBareJid
     const conversationId = isOutgoing ? bareTo : bareFrom
@@ -2127,6 +2141,7 @@ export class Chat extends BaseModule {
       // XEP-0359: the valid stanza-id for a 1:1 message is the one stamped by
       // the user's own archive (bare JID), so it works as a MAM cursor.
       expectedStanzaIdBy: myBareJid,
+      ...(delayEl && { delayEl }),
       ...(authoredAt && { authoredAt }),
     })
     const isCorrection = !!stanza.getChild('replace', NS_CORRECTION)


### PR DESCRIPTION
Preserve XEP-0203 delay metadata carried by replayed carbon envelopes for one-to-one messages. This keeps messages sent while a suspended desktop was offline ordered before newer replies received after resume.

Room messages and whispers retain their live, server-ordered semantics. Regression coverage exercises delayed sent carbons, final chat-store ordering, and whisper behavior.
