### PR TITLE
refactor(scroll): centralize emergency positioning writes

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render, screen, act, fireEvent } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
+import { PositioningController } from './positioningController'
 
 // Mock useTranslation with full i18n object
 vi.mock('react-i18next', () => ({
@@ -145,6 +146,33 @@ describe('MessageList scroll behavior', () => {
   })
 
   describe('resident-top navigation', () => {
+    it('falls back to an immediate resident-top write when the controller rejects Home', () => {
+      const reject = vi.spyOn(
+        PositioningController.prototype,
+        'beginResidentTopNavigation',
+      ).mockReturnValue(null)
+      try {
+        render(
+          <MessageList
+            messages={createTestMessages(10)}
+            conversationId="conv-1"
+            clearFirstNewMessageId={vi.fn()}
+            renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+          />,
+        )
+        const container = document.querySelector(
+          '[data-message-list]',
+        ) as HTMLDivElement
+        container.scrollTop = 500
+
+        fireEvent.keyDown(window, { key: 'Home' })
+
+        expect(container.scrollTop).toBe(0)
+      } finally {
+        reject.mockRestore()
+      }
+    })
+
     it.each([
       {
         label: 'Home',

--- a/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
+++ b/apps/fluux/src/components/conversation/layoutBrowserAdapters.test.ts
@@ -45,6 +45,7 @@ function scrollerHarness(input: {
 
 function virtualizerHarness(input: { itemCount?: number } = {}) {
   const beginAnimatedScrollToOffset = vi.fn()
+  const scrollToOffset = vi.fn()
   const virtualizer: MessageVirtualizer = {
     getVirtualItems: () => [],
     getTotalSize: () => 2_000,
@@ -53,11 +54,11 @@ function virtualizerHarness(input: { itemCount?: number } = {}) {
     getIndexForMessageId: vi.fn(() => 5),
     ensureMessageMounted: vi.fn(async () => {}),
     measureElement: vi.fn(),
-    scrollToOffset: vi.fn(),
+    scrollToOffset,
     scrollToIndex: vi.fn(),
     beginAnimatedScrollToOffset,
   }
-  return { virtualizer, beginAnimatedScrollToOffset }
+  return { virtualizer, beginAnimatedScrollToOffset, scrollToOffset }
 }
 
 function lease(isCurrent: () => boolean = () => true): PositionExecutionLease {
@@ -247,7 +248,8 @@ describe('ResidentTopBrowserAdapter', () => {
     const viewport = scrollerHarness()
     const scroller = input.scroller === undefined ? viewport.scroller : input.scroller
     const { loop, beginLoop } = loopHarness()
-    const executor = new ResidentTopBrowserAdapter({
+    const recordProgrammaticWrite = vi.fn()
+    const adapter = new ResidentTopBrowserAdapter({
       getScroller: () => scroller,
       getVirtualizer: () => input.virtualizer,
       getWindowFacts: () => ({
@@ -255,8 +257,10 @@ describe('ResidentTopBrowserAdapter', () => {
         windowAtLiveEdge: true,
       }),
       beginLoop,
-    }).createExecutor()
-    return { executor, viewport, loop, beginLoop }
+      recordProgrammaticWrite,
+    })
+    const executor = adapter.createExecutor()
+    return { adapter, executor, viewport, loop, beginLoop, recordProgrammaticWrite }
   }
 
   function residentTopRequest() {
@@ -290,6 +294,25 @@ describe('ResidentTopBrowserAdapter', () => {
       top: 0,
       behavior: 'smooth',
     })
+  })
+
+  it('degrades a rejected virtualized Home to one instant adapter write', () => {
+    const { virtualizer, scrollToOffset, beginAnimatedScrollToOffset } = virtualizerHarness()
+    const scope = harness({ virtualizer })
+
+    expect(scope.adapter.emergencyWrite()).toBe(true)
+    expect(scrollToOffset).toHaveBeenCalledWith(0)
+    expect(beginAnimatedScrollToOffset).not.toHaveBeenCalled()
+    expect(scope.recordProgrammaticWrite).toHaveBeenCalledOnce()
+  })
+
+  it('degrades a rejected native Home to one instant adapter write', () => {
+    const scope = harness()
+
+    expect(scope.adapter.emergencyWrite()).toBe(true)
+    expect(scope.viewport.scrollTop).toBe(0)
+    expect(scope.viewport.scroller.scrollTo).not.toHaveBeenCalled()
+    expect(scope.recordProgrammaticWrite).toHaveBeenCalledOnce()
   })
 
   it('starts nothing under a stale lease or without a scroller', () => {

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
@@ -167,6 +167,33 @@ function harness(input: {
 }
 
 describe('LiveEdgeBrowserAdapter', () => {
+  it('keeps the emergency virtualized write and bottom intent behind the adapter', () => {
+    const viewport = scrollerHarness()
+    const { virtualizer, scrollToIndex } = virtualizerHarness(viewport.setScrollTop)
+    const scope = harness({ scroller: viewport.scroller, virtualizer })
+
+    expect(scope.adapter.emergencyWrite({
+      rememberBottomIntent: scope.rememberBottomIntent,
+    })).toBe(true)
+    expect(scrollToIndex).toHaveBeenCalledWith(19, { align: 'end' })
+    expect(scope.rememberBottomIntent).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the emergency native smooth write used by the FAB', () => {
+    const viewport = scrollerHarness({ scrollHeight: 2_000 })
+    const scope = harness({ scroller: viewport.scroller })
+
+    expect(scope.adapter.emergencyWrite({
+      smoothNonVirtualized: true,
+      rememberBottomIntent: scope.rememberBottomIntent,
+    })).toBe(true)
+    expect(viewport.scroller.scrollTo).toHaveBeenCalledWith({
+      top: 2_000,
+      behavior: 'smooth',
+    })
+    expect(scope.rememberBottomIntent).toHaveBeenCalledOnce()
+  })
+
   it('re-reads window facts per call while keeping recenter provenance per execution', () => {
     const viewport = scrollerHarness()
     const { virtualizer } = virtualizerHarness(viewport.setScrollTop)

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
@@ -92,6 +92,11 @@ export interface LiveEdgeBrowserPorts {
   recenter?: LiveEdgeExecutor['recenter']
 }
 
+export interface EmergencyLiveEdgeWrite {
+  smoothNonVirtualized?: boolean
+  rememberBottomIntent: () => void
+}
+
 /**
  * Owns every bottom-specific browser mechanic: tail-layout flushes for late WebKit measurement, the
  * missed-frame distance correction, repaint-burst coalescing, background-MAM repaint suppression,
@@ -110,6 +115,26 @@ export class LiveEdgeBrowserAdapter {
   /** Drop repaint debt from a conversation being left so it cannot flush into the next one. */
   resetRepaintDebt(): void {
     this.burst?.reset()
+  }
+
+  /**
+   * Last-resort one-shot when controller construction or arbitration fails. Keep this write behind
+   * the same browser boundary as normal live-edge execution, but deliberately outside its repaint
+   * and convergence machinery: without a current lease there is no safe loop to continue.
+   */
+  emergencyWrite(input: EmergencyLiveEdgeWrite): boolean {
+    const scroller = this.options.getScroller()
+    if (!scroller) return false
+    const virtualizer = this.options.getVirtualizer()
+    if (virtualizer && virtualizer.itemCount > 0) {
+      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
+    } else if (input.smoothNonVirtualized) {
+      scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
+    } else {
+      scroller.scrollTop = scroller.scrollHeight
+    }
+    input.rememberBottomIntent()
+    return true
   }
 
   createExecutor(ports: LiveEdgeBrowserPorts): LiveEdgeExecutor {

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -88,6 +88,14 @@ const explicitTargetBrowserAdapterPath = resolve(
 const explicitTargetBrowserAdapterSource = existsSync(explicitTargetBrowserAdapterPath)
   ? readFileSync(explicitTargetBrowserAdapterPath, 'utf8')
   : ''
+const liveEdgeBrowserAdapterSource = readFileSync(
+  resolve(process.cwd(), 'src/components/conversation/liveEdgeBrowserAdapter.ts'),
+  'utf8',
+)
+const residentTopBrowserAdapterSource = readFileSync(
+  resolve(process.cwd(), 'src/components/conversation/residentTopBrowserAdapter.ts'),
+  'utf8',
+)
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -101,6 +109,10 @@ const directScrollPersistenceCall =
   /\bscrollStateManager\.(?:clearSavedScrollState|saveScrollPosition|leaveConversation|markAsLeft|isInitialized|enterConversation|getSavedScrollTop|getSavedAnchor|getSavedReadPositionId)\s*\(/
 const browserOrPixelAuthority =
   /\b(?:HTMLElement|Element|MessageVirtualizer|requestAnimationFrame|cancelAnimationFrame|scrollIntoView|scrollTo)\b|\.scrollTop\s*=/
+const inlineEmergencyLiveEdgeWrite =
+  /\bscroller\.scrollTop\s*=\s*scroller\.scrollHeight|\bscroller\.scrollTo\(\{\s*top:\s*scroller\.scrollHeight|\bvirtualizer\.scrollToIndex\(virtualizer\.itemCount\s*-\s*1/
+const inlineEmergencyResidentTopWrite =
+  /\bvirtualizer\.scrollToOffset\(0\)|\bscroller\.scrollTop\s*=\s*0/
 
 function interfaceMemberNames(
   sourceText: string,
@@ -180,6 +192,23 @@ describe('live message-list scroll ownership', () => {
     expect(existsSync(viewportResizeHookPath)).toBe(true)
     expect(viewportResizeHookSource).not.toMatch(
       /\.scrollTop\s*=|\.scrollTo\s*\(|\.scrollIntoView\s*\(/,
+    )
+  })
+
+  it('keeps emergency live-list writes behind the matching browser adapters', () => {
+    expect(hookSource).not.toMatch(/const emergencyLiveEdgeWrite\b/)
+    expect(hookSource).not.toMatch(/const emergencyResidentTopWrite\b/)
+    expect(hookSource).not.toMatch(inlineEmergencyLiveEdgeWrite)
+    expect(hookSource).not.toMatch(inlineEmergencyResidentTopWrite)
+    expect(liveEdgeBrowserAdapterSource).toMatch(/emergencyWrite\s*\(/)
+    expect(residentTopBrowserAdapterSource).toMatch(/emergencyWrite\s*\(/)
+
+    // Control implementations: the guard must fail if either one-shot write is inlined again.
+    expect('scroller.scrollTop = scroller.scrollHeight').toMatch(
+      inlineEmergencyLiveEdgeWrite,
+    )
+    expect('virtualizer.scrollToOffset(0)').toMatch(
+      inlineEmergencyResidentTopWrite,
     )
   })
 

--- a/apps/fluux/src/components/conversation/residentTopBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/residentTopBrowserAdapter.ts
@@ -16,6 +16,7 @@ export interface ResidentTopBrowserAdapterOptions {
   getVirtualizer: () => MessageVirtualizer | undefined
   getWindowFacts: () => ResidentTopWindowFacts
   beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  recordProgrammaticWrite: () => void
   log?: (action: string, data?: Record<string, unknown>) => void
 }
 
@@ -25,6 +26,22 @@ export interface ResidentTopBrowserAdapterOptions {
  */
 export class ResidentTopBrowserAdapter {
   constructor(private readonly options: ResidentTopBrowserAdapterOptions) {}
+
+  /**
+   * Controller rejection must degrade to progress, not a dead Home key. This write is instant on
+   * purpose: an unleased smooth animation has no loop to mark its intermediate scroll events as
+   * programmatic and can otherwise re-arm resident-top pagination while travelling.
+   */
+  emergencyWrite(): boolean {
+    const scroller = this.options.getScroller()
+    if (!scroller) return false
+    this.options.recordProgrammaticWrite()
+    const virtualizer = this.options.getVirtualizer()
+    if (virtualizer) virtualizer.scrollToOffset(0)
+    else scroller.scrollTop = 0
+    this.options.log?.('RESIDENT TOP: emergency write')
+    return true
+  }
 
   createExecutor(): ResidentTopExecutor {
     return {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -540,12 +540,14 @@ export function useMessageListScroll({
   // churn with the live window so dependent effects below re-run when the window moves.
   const {
     createLiveEdgeExecutor,
+    emergencyLiveEdgeWrite,
     createAnchorPreservationExecutor,
     buildDirectionalHistoryExecutor,
     buildSavedPositionExecutor,
     buildUnreadMarkerExecutor,
     buildExplicitTargetExecutor,
     createResidentTopExecutor,
+    emergencyResidentTopWrite,
     // Not construction: an availability probe and the one-frame settlement scheduler, both of which
     // the directional load flow drives directly.
     getDirectionalHistoryBrowser,
@@ -597,25 +599,6 @@ export function useMessageListScroll({
     })
   }, [conversationId, createLiveEdgeExecutor])
   reconcileLiveEdgeRef.current = reconcileLiveEdge
-
-  // Controller/instrumentation failure boundary only. Normal bottom positioning always goes through
-  // a generation-bearing live-edge execution; this one-shot keeps the UI usable if that machinery
-  // cannot be constructed.
-  const emergencyLiveEdgeWrite = useCallback((
-    smoothNonVirtualized = false,
-  ) => {
-    const scroller = scrollerRef.current
-    const virtualizer = virtualizerRef.current
-    if (!scroller) return
-    if (virtualizer && virtualizer.itemCount > 0) {
-      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
-    } else if (smoothNonVirtualized) {
-      scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
-    } else {
-      scroller.scrollTop = scroller.scrollHeight
-    }
-    rememberBottomIntent()
-  }, [rememberBottomIntent])
 
   measuredRowGrowthFlushRef.current = (measuredConversationId, measuredGrowth) => {
     const liveScroller = scrollerRef.current
@@ -819,11 +802,17 @@ export function useMessageListScroll({
     // prepend history and supersede the resident-top request. A later genuine move away from the
     // top re-arms the latch in handleScroll.
     viewportSessionRef.current?.clearTravel(conversationId, 'top')
-    positioningControllerRef.current?.beginResidentTopNavigation({
+    const request = positioningControllerRef.current?.beginResidentTopNavigation({
       conversationId,
       executor: createResidentTopExecutor(),
     })
-  }, [conversationId, createResidentTopExecutor, staticMode])
+    if (!request) emergencyResidentTopWrite()
+  }, [
+    conversationId,
+    createResidentTopExecutor,
+    emergencyResidentTopWrite,
+    staticMode,
+  ])
   // Published to MessageList's keyboard listeners. Keep the shell stable while the executor factory
   // tracks row/window facts so normal appends do not churn global keydown subscriptions.
   const scrollToTop = useStableCallback(scrollToTopImpl)

--- a/apps/fluux/src/components/conversation/useScrollExecutors.ts
+++ b/apps/fluux/src/components/conversation/useScrollExecutors.ts
@@ -131,6 +131,7 @@ export interface ScrollExecutors {
     trigger: string,
     smoothNonVirtualized?: boolean,
   ) => LiveEdgeExecutor
+  emergencyLiveEdgeWrite: (smoothNonVirtualized?: boolean) => boolean
   createAnchorPreservationExecutor: (
     loopLabel: AnchorPreservationLoopLabel,
   ) => AnchorPreservationExecutor
@@ -144,6 +145,7 @@ export interface ScrollExecutors {
     consumeStoreTarget: boolean,
   ) => ExplicitTargetExecutor
   createResidentTopExecutor: () => ResidentTopExecutor
+  emergencyResidentTopWrite: () => boolean
   getDirectionalHistoryBrowser: () => DirectionalHistoryBrowserAdapter
   /** Conversation entry: drop repaint debt owed by the room being left. */
   resetLiveEdgeRepaintDebt: () => void
@@ -306,6 +308,13 @@ export function useScrollExecutors({
     rememberBottomIntent,
     windowAtLiveEdge,
   ])
+
+  const emergencyLiveEdgeWrite = useCallback((
+    smoothNonVirtualized = false,
+  ): boolean => getLiveEdgeBrowser().emergencyWrite({
+    smoothNonVirtualized,
+    rememberBottomIntent,
+  }), [getLiveEdgeBrowser, rememberBottomIntent])
 
   const createAnchorPreservationExecutor = useCallback(
     (loopLabel: AnchorPreservationLoopLabel): AnchorPreservationExecutor =>
@@ -517,7 +526,7 @@ export function useScrollExecutors({
     setMeasuredAtBottom,
   ])
 
-  const createResidentTopExecutor = useCallback((): ResidentTopExecutor =>
+  const createResidentTopBrowser = useCallback(() =>
     new ResidentTopBrowserAdapter({
       getScroller: () => portsRef.current.getScroller(),
       getVirtualizer: () => portsRef.current.getVirtualizer(),
@@ -526,13 +535,22 @@ export function useScrollExecutors({
         windowAtLiveEdge: windowAtLiveEdge !== false,
       }),
       beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
+      recordProgrammaticWrite: () =>
+        portsRef.current.recordProgrammaticWrite(conversationId, Date.now()),
       log: (action, data) => portsRef.current.log(action, data),
-    }).createExecutor(), [
+    }), [
     beginControllerFrameLoop,
+    conversationId,
     firstMessageId,
     messageCount,
     windowAtLiveEdge,
   ])
+
+  const createResidentTopExecutor = useCallback((): ResidentTopExecutor =>
+    createResidentTopBrowser().createExecutor(), [createResidentTopBrowser])
+
+  const emergencyResidentTopWrite = useCallback((): boolean =>
+    createResidentTopBrowser().emergencyWrite(), [createResidentTopBrowser])
 
   const resetLiveEdgeRepaintDebt = useCallback(() => {
     // Read through the ref, not the lazy getter: a list that never pinned owes nothing, and building
@@ -550,12 +568,14 @@ export function useScrollExecutors({
 
   return {
     createLiveEdgeExecutor,
+    emergencyLiveEdgeWrite,
     createAnchorPreservationExecutor,
     buildDirectionalHistoryExecutor,
     buildSavedPositionExecutor,
     buildUnreadMarkerExecutor,
     buildExplicitTargetExecutor,
     createResidentTopExecutor,
+    emergencyResidentTopWrite,
     getDirectionalHistoryBrowser,
     resetLiveEdgeRepaintDebt,
     disposeDirectionalHistoryBrowser,


### PR DESCRIPTION
Move live-edge and resident-top emergency writes behind their browser adapters so `useMessageListScroll` no longer owns live pixel fallbacks.

Preserve the existing End/FAB fallback behavior, and make rejected Home navigation degrade to one instant resident-top write instead of silently doing nothing. The accepted Home path remains controller-owned and smooth.
