### PR TITLE
fix(copy): include polls and file-only messages when copying a selection

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
+import { deriveCopyBody } from '@/utils/copyMessageBody'
 import { useChatActive, useContactIdentities, useReferencedMessage, getBareJid, getLocalPart, getMyReactions, useXMPPContext, chatStore, getStorageScopeJid, currentViewportGeneration, reportViewport, type Message, type ContactIdentity, type ViewportEvidenceKey } from '@fluux/sdk'
 import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -772,7 +773,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       ? (ownNickname || getLocalPart(msg.from))
       : (contactsByJid.get(getBareJid(msg.from))?.name || getLocalPart(msg.from)),
     time: formatTime(msg.timestamp),
-    body: msg.body || '',
+    body: deriveCopyBody(msg, t),
     date: format(msg.timestamp, 'yyyy-MM-dd'),
   })
 

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -12,6 +12,7 @@ import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvata
 import { selectRoomInitialLoading } from './conversation/roomLoadingState'
 import { format } from 'date-fns'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
+import { deriveCopyBody } from '@/utils/copyMessageBody'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, MessageCircle, EyeOff, User, Settings, Ear, X, Hash } from 'lucide-react'
 import { EasterEggAnimation } from './easter-eggs/EasterEggAnimation'
 import { TextInput, TextArea } from './ui/TextInput'
@@ -1107,7 +1108,7 @@ export const RoomMessageList = memo(function RoomMessageList({
     id: msg.id,
     from: resolveRoomSender(msg, room, contactsByJid, selfOccupant).resolvedSenderName,
     time: formatTime(msg.timestamp),
-    body: msg.body || '',
+    body: deriveCopyBody(msg, t),
     date: format(msg.timestamp, 'yyyy-MM-dd'),
   })
 

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -566,6 +566,58 @@ describe('MessageBubble', () => {
       expect(messageDiv.getAttribute('data-message-from')).toBe('TestUser')
       expect(messageDiv.getAttribute('data-message-body')).toBe('Test message content')
     })
+
+    it('refreshes poll content and copy metadata when the poll changes', () => {
+      const poll = {
+        title: 'Lunch where?',
+        options: [
+          { emoji: '1️⃣', label: 'Sushi' },
+          { emoji: '2️⃣', label: 'Pizza' },
+        ],
+        settings: { allowMultiple: false, hideResultsBeforeVote: false },
+      }
+      const props = createDefaultProps({
+        message: createTestMessage({ body: '', poll }),
+      })
+      const { container, rerender } = render(<MessageBubble {...props} />)
+
+      const messageDiv = container.firstChild as HTMLElement
+      expect(messageDiv.getAttribute('data-message-body')).toBe('📊 Lunch where?')
+
+      rerender(
+        <MessageBubble
+          {...props}
+          message={createTestMessage({ body: '', poll: { ...poll, title: 'Dinner where?' } })}
+        />,
+      )
+
+      expect(messageDiv.getAttribute('data-message-body')).toBe('📊 Dinner where?')
+      expect(screen.getByText('Dinner where?')).toBeInTheDocument()
+      expect(screen.queryByText('Lunch where?')).not.toBeInTheDocument()
+    })
+
+    it('removes rejected poll-close content and copy metadata', () => {
+      const props = createDefaultProps({
+        message: createTestMessage({
+          body: '',
+          pollClosed: { title: 'Lunch where?', pollMessageId: 'poll-1', results: [] },
+        }),
+      })
+      const { container, rerender } = render(<MessageBubble {...props} />)
+
+      const messageDiv = container.firstChild as HTMLElement
+      expect(messageDiv.getAttribute('data-message-body')).toBe('📊 Poll closed: Lunch where?')
+
+      rerender(
+        <MessageBubble
+          {...props}
+          message={createTestMessage({ body: '', pollClosed: undefined })}
+        />,
+      )
+
+      expect(messageDiv.getAttribute('data-message-body')).toBe('')
+      expect(screen.queryByText('Lunch where?')).not.toBeInTheDocument()
+    })
   })
 
   describe('Whisper threads (MUC private messages)', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -16,6 +16,7 @@ import { AvatarLightbox } from '../AvatarLightbox'
 import { MessageToolbar } from './MessageToolbar'
 import { MessageBody } from './MessageBody'
 import { renderQuotePreview } from '@/utils/messageStyles'
+import { deriveCopyBody } from '@/utils/copyMessageBody'
 import { EncryptedPlaceholder } from './EncryptedPlaceholder'
 import { UnsupportedEncryptionNotice } from './UnsupportedEncryptionNotice'
 import { MessageReactions } from './MessageReactions'
@@ -227,6 +228,8 @@ function arePropsEqual(prev: MessageBubbleProps, next: MessageBubbleProps): bool
   // Attachment and link preview (compare by reference - they shouldn't change)
   if (prev.message.attachment !== next.message.attachment) return false
   if (prev.message.linkPreview !== next.message.linkPreview) return false
+  if (prev.message.poll !== next.message.poll) return false
+  if (prev.message.pollClosed !== next.message.pollClosed) return false
 
   // Display state
   if (prev.showAvatar !== next.showAvatar) return false
@@ -534,7 +537,7 @@ export const MessageBubble = memo(function MessageBubble({
       data-message-id={message.id}
       data-message-from={senderName}
       data-message-time={formatTime(message.timestamp)}
-      data-message-body={message.body || ''}
+      data-message-body={deriveCopyBody(message, t)}
       className={`${outerRowClass}${ownRowClass}`}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/apps/fluux/src/hooks/useMessageCopy.ts
+++ b/apps/fluux/src/hooks/useMessageCopy.ts
@@ -46,7 +46,7 @@ export function useMessageCopy(containerRef: RefObject<HTMLElement | null>) {
           const body = element.getAttribute('data-message-body') || ''
           const timestamp = element.getAttribute('data-message-time') || ''
 
-          // Only include if we have body content
+          // Only include non-empty derived clipboard text from a named sender.
           if (body && from) {
             selectedMessages.push({ id, from, body, timestamp })
           }

--- a/apps/fluux/src/utils/buildCopyText.test.ts
+++ b/apps/fluux/src/utils/buildCopyText.test.ts
@@ -26,6 +26,24 @@ describe('buildCopyText', () => {
     ).toBeNull()
   })
 
+  it('treats a whitespace-only body as absent, never as a blank transcript line', () => {
+    const out = buildCopyText([
+      { id: '1', from: 'Alice', time: '14:30', body: 'Hello', date: '2024-01-15' },
+      { id: '2', from: 'Bob', time: '14:31', body: '  \n\t ', date: '2024-01-15' },
+      { id: '3', from: 'Carol', time: '14:32', body: 'Bye', date: '2024-01-15' },
+    ])
+    expect(out).toBe(['— Monday, January 15, 2024 —', 'Alice 14:30', 'Hello', 'Carol 14:32', 'Bye'].join('\n'))
+  })
+
+  it('returns null when only one message carries non-whitespace text', () => {
+    expect(
+      buildCopyText([
+        { id: '1', from: 'Alice', time: '14:30', body: 'Hello', date: '2024-01-15' },
+        { id: '2', from: 'Bob', time: '14:31', body: '   ', date: '2024-01-15' },
+      ]),
+    ).toBeNull()
+  })
+
   it('groups across two dates, sorted ascending, with a blank line between groups', () => {
     const out = buildCopyText([
       { id: '2', from: 'Bob', time: '09:00', body: 'Second day', date: '2024-01-16' },

--- a/apps/fluux/src/utils/buildCopyText.ts
+++ b/apps/fluux/src/utils/buildCopyText.ts
@@ -11,8 +11,12 @@
  * Output mirrors the long-standing inline formatter: messages grouped by date,
  * each date preceded by a "— Weekday, Month D, YYYY —" header (blank line between
  * groups), each message as "From HH:MM\nbody". Returns null when fewer than two
- * messages carry a body — single-message selections fall back to the browser's
+ * messages carry text — single-message selections fall back to the browser's
  * native copy.
+ *
+ * `body` is the caller-derived clipboard text. `deriveCopyBody` in
+ * `copyMessageBody.ts` owns that derivation contract; this formatter only decides
+ * what is empty and how lines are laid out.
  */
 import { format, parseISO } from 'date-fns'
 
@@ -29,9 +33,12 @@ export function buildCopyText(
   messages: CopyMessageMeta[],
   opts: { fallbackDate?: string } = {},
 ): string | null {
-  // Only messages with a body participate (matches the legacy DOM path); a single
-  // message is left to the native browser copy.
-  const withBody = messages.filter((m) => m.body)
+  // Only messages that carry text participate; a single message is left to the
+  // native browser copy. Whitespace-only counts as absent — a message that would
+  // contribute nothing but a blank line must not appear in the transcript at all.
+  // Callers derive `body` through `deriveCopyBody`; this function deliberately
+  // remains unaware of the source message kind.
+  const withBody = messages.filter((m) => m.body.trim().length > 0)
   if (withBody.length <= 1) return null
 
   // Fallback date for messages that carry none: caller-provided, else the earliest

--- a/apps/fluux/src/utils/copyMessageBody.test.ts
+++ b/apps/fluux/src/utils/copyMessageBody.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest'
+import { deriveCopyBody, type CopyableMessage } from './copyMessageBody'
+
+/** Translator stub: returns the key so localized notices are identifiable. */
+const t = (key: string, options?: Record<string, unknown>) =>
+  options?.method ? `${key}:${String(options.method)}` : key
+
+const message = (over: Partial<CopyableMessage>): CopyableMessage =>
+  ({ body: '', ...over }) as CopyableMessage
+
+describe('deriveCopyBody', () => {
+  describe('messages that have a body copy it verbatim', () => {
+    it('returns a plain body unchanged', () => {
+      expect(deriveCopyBody(message({ body: 'Hello there' }), t)).toBe('Hello there')
+    })
+
+    // Regression guard for the byte-identity requirement: the preview formatter
+    // strips XEP-0393 styling, and a transcript must quote, not normalize.
+    it('keeps styling markup intact instead of stripping it like a preview would', () => {
+      const body = 'a **bold** and _italic_ and ~~struck~~ and `code`'
+      expect(deriveCopyBody(message({ body }), t)).toBe(body)
+    })
+
+    it('keeps a reply-quote prefix intact', () => {
+      const body = '> Bob: original\nMy reply'
+      expect(deriveCopyBody(message({ body, replyTo: { id: '123' } } as Partial<CopyableMessage>), t)).toBe(body)
+    })
+
+    it('keeps the body of a message that also carries an attachment', () => {
+      expect(
+        deriveCopyBody(
+          message({
+            body: 'look at this',
+            attachment: { url: 'https://e.x/p.png', mediaType: 'image/png', name: 'p.png' },
+          } as Partial<CopyableMessage>),
+          t,
+        ),
+      ).toBe('look at this')
+    })
+  })
+
+  describe('messages whose text lives outside body', () => {
+    it('renders a poll as its emoji and title', () => {
+      const poll = message({
+        poll: { title: 'Lunch where?', options: [], settings: { allowMultiple: false, hideResultsBeforeVote: false } },
+      } as Partial<CopyableMessage>)
+      expect(deriveCopyBody(poll, t)).toBe('📊 Lunch where?')
+    })
+
+    it('renders a closed-poll announcement', () => {
+      const closed = message({
+        pollClosed: { title: 'Lunch where?', pollMessageId: 'p1', results: [] },
+      } as Partial<CopyableMessage>)
+      expect(deriveCopyBody(closed, t)).toBe('📊 Poll closed: Lunch where?')
+    })
+
+    it('renders a file-only message as its emoji and filename', () => {
+      const file = message({
+        attachment: { url: 'https://e.x/report.pdf', mediaType: 'application/pdf', name: 'report.pdf' },
+      } as Partial<CopyableMessage>)
+      expect(deriveCopyBody(file, t)).toBe('📕 report.pdf')
+    })
+  })
+
+  describe('whitespace-only is absent, never content', () => {
+    it('returns empty for an empty body with nothing else', () => {
+      expect(deriveCopyBody(message({}), t)).toBe('')
+    })
+
+    it('returns empty for a whitespace-only body', () => {
+      expect(deriveCopyBody(message({ body: '   \n  ' }), t)).toBe('')
+    })
+
+    // A body of empty code fences previews as whitespace, but it IS a body, so
+    // rule 1 quotes it verbatim rather than routing it through the preview path.
+    it('quotes a body of empty code fences verbatim rather than previewing it away', () => {
+      expect(deriveCopyBody(message({ body: '```\n```' }), t)).toBe('```\n```')
+    })
+
+    it('returns empty when the preview would reduce to whitespace', () => {
+      expect(deriveCopyBody(message({ body: '\t' }), t)).toBe('')
+    })
+  })
+
+  it('uses the localized notice for a message encrypted with an unreadable method', () => {
+    const encrypted = message({
+      body: 'This message is encrypted with OMEMO and cannot be displayed.',
+      unsupportedEncryption: { namespace: 'eu.siacs.conversations.axolotl', name: 'OMEMO' },
+    } as Partial<CopyableMessage>)
+    expect(deriveCopyBody(encrypted, t)).toBe('chat.encryption.unsupportedMessage:OMEMO')
+  })
+})

--- a/apps/fluux/src/utils/copyMessageBody.ts
+++ b/apps/fluux/src/utils/copyMessageBody.ts
@@ -1,0 +1,55 @@
+/**
+ * copyMessageBody — the single derivation of the text a message contributes to a
+ * multi-message clipboard transcript.
+ *
+ * Shared by every copy path (the 1:1 `ChatView` and MUC `RoomView` store-backed
+ * formatters, and the `data-message-body` attribute the mounted-DOM path reads),
+ * so a message copies the same way wherever the selection is collected from.
+ *
+ * Three rules, in order:
+ *
+ *  1. An unsupported-encryption message copies the localized notice from
+ *     {@link formatLocalizedPreview}, even when it has a body. That raw body is a
+ *     sender-chosen XEP-0380 fallback which the bubble deliberately refuses to
+ *     display and the single-message copy action already excludes.
+ *  2. Every other message that HAS a body copies that body **verbatim**. A transcript is a
+ *     quotation: styling markup and reply-quote prefixes must survive intact, and
+ *     {@link formatLocalizedPreview} strips both. Copy output for ordinary text
+ *     messages is therefore byte-identical to what it has always been.
+ *  3. A message whose text lives OUTSIDE `body` — a poll (`poll.title`), a closed-poll
+ *     announcement (`pollClosed.title`), a file-only message (`attachment`) — falls
+ *     back to the shared preview formatter, the same one that renders the sidebar,
+ *     the command palette and notifications. It yields an emoji plus the title or
+ *     filename, so a pasted poll cannot be mistaken for someone having typed that
+ *     sentence. Before this, such messages were dropped from the transcript entirely.
+ *
+ * Whitespace-only bodies and previews are treated as absent. Any other raw body
+ * remains verbatim, including markup-only forms such as empty code fences.
+ * `buildCopyText` applies the same trim test, so nothing can contribute a blank line.
+ *
+ * Retracted messages keep the behaviour they have always had: the store preserves
+ * `body` through a retraction, so a retracted message still copies its original text
+ * even though the bubble renders "message deleted". That divergence predates this
+ * module and is left deliberately unchanged here rather than silently altered.
+ */
+import { formatLocalizedPreview } from './messagePreviewText'
+
+/** Minimal shape of the i18next `t` we rely on — mirrors messagePreviewText. */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+/** Any message the preview formatter accepts (chat or room). */
+export type CopyableMessage = Parameters<typeof formatLocalizedPreview>[0]
+
+/** Text a message contributes to a copied transcript; '' when it has none. */
+export function deriveCopyBody(message: CopyableMessage, t: TranslateFn): string {
+  if (message.unsupportedEncryption) {
+    const preview = formatLocalizedPreview(message, t)
+    return preview.trim() ? preview : ''
+  }
+
+  const body = message.body
+  if (body && body.trim()) return body
+
+  const preview = formatLocalizedPreview(message, t)
+  return preview.trim() ? preview : ''
+}

--- a/apps/fluux/src/utils/copyTranscript.test.ts
+++ b/apps/fluux/src/utils/copyTranscript.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression suite for copying a multi-message selection that contains messages
+ * whose text does not live in `<body>` (polls, closed polls, file-only messages).
+ *
+ * Reproduction level: this drives the two units the copy paths compose —
+ * `deriveCopyBody` (what a message contributes) and `buildCopyText` (how the
+ * transcript is laid out) — rather than performing a real DOM selection-and-copy.
+ * `ChatView.formatMessageForCopy`, `RoomView.formatMessageForCopy` and the
+ * `data-message-body` attribute all now route through `deriveCopyBody`, so this is
+ * the whole derivation both copy paths use.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildCopyText, type CopyMessageMeta } from './buildCopyText'
+import { deriveCopyBody, type CopyableMessage } from './copyMessageBody'
+
+const t = (key: string, options?: Record<string, unknown>) =>
+  options?.method ? `${key}:${String(options.method)}` : key
+
+/** The derivation both `formatMessageForCopy` implementations perform. */
+const meta = (
+  id: string,
+  from: string,
+  time: string,
+  message: Partial<CopyableMessage>,
+): CopyMessageMeta => ({
+  id,
+  from,
+  time,
+  body: deriveCopyBody({ body: '', ...message } as CopyableMessage, t),
+  date: '2024-01-15',
+})
+
+const POLL = {
+  poll: {
+    title: 'Lunch where?',
+    options: [
+      { emoji: '1️⃣', label: 'Sushi' },
+      { emoji: '2️⃣', label: 'Pizza' },
+    ],
+    settings: { allowMultiple: false, hideResultsBeforeVote: false },
+  },
+} as Partial<CopyableMessage>
+
+const POLL_CLOSED = {
+  pollClosed: { title: 'Lunch where?', pollMessageId: 'm3', results: [] },
+} as Partial<CopyableMessage>
+
+const FILE_ONLY = {
+  attachment: { url: 'https://e.x/report.pdf', mediaType: 'application/pdf', name: 'report.pdf' },
+} as Partial<CopyableMessage>
+
+const HEADER = '— Monday, January 15, 2024 —'
+
+describe('copying a selection with bodyless messages', () => {
+  it('includes a poll in a five-message selection instead of silently dropping it', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Anyone hungry?' }),
+      meta('2', 'Bob', '14:31', { body: 'Starving' }),
+      meta('3', 'Alice', '14:32', POLL),
+      meta('4', 'Bob', '14:33', { body: 'Sushi obviously' }),
+      meta('5', 'Carol', '14:34', { body: 'Pizza!' }),
+    ])
+    expect(out).toBe(
+      [
+        HEADER,
+        'Alice 14:30', 'Anyone hungry?',
+        'Bob 14:31', 'Starving',
+        'Alice 14:32', '📊 Lunch where?',
+        'Bob 14:33', 'Sushi obviously',
+        'Carol 14:34', 'Pizza!',
+      ].join('\n'),
+    )
+    expect(out!.split('\n')).toHaveLength(11)
+  })
+
+  it('includes a closed-poll announcement', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Results?' }),
+      meta('2', 'Alice', '14:31', POLL_CLOSED),
+    ])
+    expect(out).toBe([HEADER, 'Alice 14:30', 'Results?', 'Alice 14:31', '📊 Poll closed: Lunch where?'].join('\n'))
+  })
+
+  it('includes a file-only message as its emoji and filename', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Here you go' }),
+      meta('2', 'Alice', '14:31', FILE_ONLY),
+    ])
+    expect(out).toBe([HEADER, 'Alice 14:30', 'Here you go', 'Alice 14:31', '📕 report.pdf'].join('\n'))
+  })
+
+  // The sharp case from the report: two messages, one a poll. The poll used to
+  // contribute nothing, so fewer than two messages had a body and buildCopyText
+  // returned null — the whole formatted transcript was lost to native copy.
+  it('produces a transcript for a two-message selection where one is a poll', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Deciding lunch' }),
+      meta('2', 'Alice', '14:31', POLL),
+    ])
+    expect(out).not.toBeNull()
+    expect(out).toBe([HEADER, 'Alice 14:30', 'Deciding lunch', 'Alice 14:31', '📊 Lunch where?'].join('\n'))
+  })
+
+  // Guards the byte-identity requirement: the preview formatter strips styling and
+  // reply-quote prefixes; the copy path must not. This test fails if plain-text copy
+  // output changes at all.
+  it('copies ordinary text messages exactly as before, markup and quotes intact', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'a **bold** claim and `code`' }),
+      meta('2', 'Bob', '14:31', { body: '> Alice: a **bold** claim\nI disagree', replyTo: { id: '1' } } as Partial<CopyableMessage>),
+      meta('3', 'Carol', '14:32', { body: '# heading _italic_ ~~struck~~' }),
+    ])
+    expect(out).toBe(
+      [
+        HEADER,
+        'Alice 14:30', 'a **bold** claim and `code`',
+        'Bob 14:31', '> Alice: a **bold** claim\nI disagree',
+        'Carol 14:32', '# heading _italic_ ~~struck~~',
+      ].join('\n'),
+    )
+  })
+
+  it('never lets a message contribute a blank or whitespace-only line', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Real text' }),
+      meta('2', 'Bob', '14:31', { body: '   \n\t ' }),
+      meta('3', 'Carol', '14:32', { body: 'More text' }),
+    ])
+    expect(out).toBe([HEADER, 'Alice 14:30', 'Real text', 'Carol 14:32', 'More text'].join('\n'))
+    expect(out!.split('\n').every((line) => line.trim().length > 0)).toBe(true)
+  })
+
+  // Pinned, not endorsed: the store preserves `body` through a retraction, so a
+  // retracted message has always copied its original text even though the bubble
+  // renders "message deleted". This change leaves that untouched; see the PR note.
+  it('still copies a retracted message body, as it did before this change', () => {
+    const out = buildCopyText([
+      meta('1', 'Alice', '14:30', { body: 'Kept' }),
+      meta('2', 'Bob', '14:31', { body: 'Oops wrong channel', isRetracted: true } as Partial<CopyableMessage>),
+    ])
+    expect(out).toBe([HEADER, 'Alice 14:30', 'Kept', 'Bob 14:31', 'Oops wrong channel'].join('\n'))
+  })
+})


### PR DESCRIPTION
Copying a multi-message selection silently dropped any message whose text does not live in `<body>` — a poll, a closed-poll announcement, or a file-only message. Select five messages of which one is a poll, paste, and you get four. With only two messages selected, one of them bodyless, the whole formatted transcript was lost to the browser's native copy.

All three copy sites — the 1:1 and MUC store-backed formatters and the `data-message-body` attribute the mounted-DOM path reads — now derive their text through one shared helper. A message that has a body copies it verbatim, so ordinary text keeps its styling markup and reply-quote prefix byte-for-byte as before; a message without one falls back to the shared preview formatter that already renders the sidebar and notifications, giving an emoji plus the poll title or filename so a pasted poll cannot be mistaken for someone having typed that sentence.

**Behaviour change worth flagging:** copy output for messages encrypted with a method this client cannot read (e.g. OMEMO) changes. They previously copied the sender-chosen XEP-0380 fallback body; they now copy the localized notice. This divergence was pre-existing rather than introduced here, and the fix aligns multi-message copy with both the bubble and `canCopyBody`, which already excluded those messages from single-message copy.

Not addressed here: retracted messages still copy their original body even though the bubble renders "message deleted" — the same class of divergence, but resolving it needs a product decision on what a retracted message should contribute plus a new localized string in every locale file.
