### PR TITLE
fix(scroll): make ambient position requests yield to in-flight navigation

### DIFF
--- a/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
@@ -16,6 +16,7 @@ import {
   type BottomFractionAnchorPosition,
   type PixelOffset,
   type PositionRequest,
+  type PositioningPhase,
 } from './scrollPositionModel'
 
 const conversationId = 'room@example.test'
@@ -99,6 +100,30 @@ function dividerPreservation(generation: number): PositionRequest {
     source: { kind: 'layout-preservation', reason: 'divider-mutation' },
     desired: savedAnchor,
     onUnavailable: { kind: 'warn-and-stop' },
+  }
+}
+
+function mediaPreservation(generation: number): PositionRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'media-preservation', reason: 'remeasure' },
+    desired: savedAnchor,
+    onUnavailable: { kind: 'warn-and-stop' },
+  }
+}
+
+function windowShift(generation: number): PositionRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'history-preservation', reason: 'window-shift' },
+    desired: {
+      kind: 'anchor',
+      messageId: 'top-visible',
+      placement: { kind: 'top-offset', offsetPx: pixelOffset(-24) },
+    },
+    onUnavailable: { kind: 'distance-from-bottom', distancePx: pixelOffset(600) },
   }
 }
 
@@ -206,6 +231,88 @@ describe('scroll position model', () => {
       kind: 'layout-preservation',
       reason: 'divider-mutation',
     })
+  })
+
+  it('refuses every ambient correction while an explicit navigation is in flight', () => {
+    // The whole point of the guard is that it covers the CLASS, so both ambient sources are driven
+    // through every phase in which the reader is still waiting to reach the target.
+    const unsettledPhases: PositioningPhase[] = [
+      { kind: 'resolving' },
+      { kind: 'pending', reason: 'around-load' },
+      { kind: 'loading-around', messageId: 'explicit-target' },
+      { kind: 'recentering-live-edge' },
+      { kind: 'mounting', index: 12, messageId: 'explicit-target' },
+      { kind: 'unavailable', policy: { kind: 'wait' } },
+      { kind: 'reconciling' },
+      { kind: 'position-applied' },
+    ]
+    const ambientRequests = [mediaPreservation(3), windowShift(3)]
+
+    unsettledPhases.forEach((phase) => {
+      const navigating = advancePhaseIfCurrent(
+        acceptPositionRequest(
+          acceptPositionRequest(initialPositioningModel(), liveEntry(1)),
+          explicitMessage(2),
+        ),
+        conversationId,
+        2,
+        phase,
+      )
+      expect(navigating.active?.phase).toEqual(phase)
+
+      ambientRequests.forEach((ambient) => {
+        expect(acceptPositionRequest(navigating, ambient)).toBe(navigating)
+      })
+
+      // Counterfactual: nothing else about these requests makes them unacceptable. The same model
+      // and the same generation take a request whose source is exempt from the guard...
+      expect(
+        acceptPositionRequest(navigating, outgoingMessage(3)).active?.request,
+      ).toEqual(outgoingMessage(3))
+      // ...and the same ambient requests are accepted once the target is reached, so the guard is
+      // the only thing refusing them above. Remove it and both assertions above would fail.
+      const settled = advancePhaseIfCurrent(navigating, conversationId, 2, {
+        kind: 'settled',
+      })
+      ambientRequests.forEach((ambient) => {
+        const accepted = acceptPositionRequest(settled, ambient)
+        expect(accepted.watermark).toBe(3)
+        expect(accepted.active?.request).toEqual(ambient)
+      })
+    })
+  })
+
+  it('lets an outgoing send supersede an in-flight navigation, by design', () => {
+    // Deliberate exemption, asserted so it reads as a choice: sending a message is an explicit
+    // reader action that implies wanting to see it land, unlike media growth or a window shift.
+    const navigating = advancePhaseIfCurrent(
+      acceptPositionRequest(
+        acceptPositionRequest(initialPositioningModel(), liveEntry(1)),
+        explicitMessage(2),
+      ),
+      conversationId,
+      2,
+      { kind: 'loading-around', messageId: 'explicit-target' },
+    )
+
+    const sent = acceptPositionRequest(navigating, outgoingMessage(3))
+
+    expect(sent.watermark).toBe(3)
+    expect(sent.active).toEqual({
+      request: outgoingMessage(3),
+      phase: { kind: 'resolving' },
+    })
+  })
+
+  it('still lets ambient corrections re-anchor a live-edge follow', () => {
+    // Following the bottom is a policy, not a destination the reader is waiting on, so media and
+    // window-shift preservation may still correct it while entry positioning is unsettled.
+    const entering = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+
+    expect(acceptPositionRequest(entering, mediaPreservation(2)).watermark).toBe(2)
+    expect(acceptPositionRequest(entering, windowShift(2)).watermark).toBe(2)
+    // Layout preservation is the strictest class and keeps yielding to it.
+    expect(acceptPositionRequest(entering, dividerPreservation(2))).toBe(entering)
   })
 
   it('distinguishes empty, loadable, unavailable, unmounted, and mounted targets', () => {

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -417,6 +417,77 @@ export function isCurrentGeneration(
 }
 
 /**
+ * How a request behaves when it arrives while an earlier one is still converging.
+ *
+ * This is a property of the request CLASS, not of any single `source.kind`: the same rule has to
+ * cover every ambient correction, present and future, or the hole simply moves to the next source
+ * somebody adds. `requestPrecedence` therefore resolves an UNKNOWN kind to the strictest value, so
+ * a new source is refused while positioning until its author deliberately classifies it.
+ *
+ * - `yields-to-any-unsettled-position` — ambient correction that must never displace a position the
+ *   reader is still waiting to reach, including a live-edge one. The safe default.
+ * - `yields-to-navigation` — ambient correction that stands aside for an explicit navigation
+ *   (Home, jump-to-message, saved-position restore) but may still correct a live-edge follow, which
+ *   is a policy rather than a destination. Matches `RowGrowthFacts.navigationInFlight` in
+ *   `rowGrowthDecision.ts`, the repo's existing answer to "is a navigation in flight".
+ * - `supersedes` — reader intent, or a deliberate exemption from the rule.
+ */
+type RequestPrecedence =
+  | 'yields-to-any-unsettled-position'
+  | 'yields-to-navigation'
+  | 'supersedes'
+
+const REQUEST_PRECEDENCE: Record<PositionRequestSource['kind'], RequestPrecedence> = {
+  entry: 'supersedes',
+  'user-navigation': 'supersedes',
+  fallback: 'supersedes',
+  'late-mds-supersession': 'supersedes',
+  /**
+   * DELIBERATE EXEMPTION, not an oversight. Sending a message is an explicit reader action that
+   * reasonably implies wanting to see it land, so an outgoing send is allowed to take the live edge
+   * from an in-flight navigation. It is still refused behind an unfinished restore or window shift
+   * by the `preservationPending` rule below.
+   */
+  'live-update': 'supersedes',
+  /**
+   * Divider movement and mid-array insertion: layout changes ABOVE the reader that nobody asked
+   * for. Strictest class — see `LayoutPreservationReason`.
+   */
+  'layout-preservation': 'yields-to-any-unsettled-position',
+  /** Media finishing its load and remeasuring: an ambient correction on a debounce. */
+  'media-preservation': 'yields-to-navigation',
+  /** A directional window shift re-anchoring the resident range: also ambient. */
+  'history-preservation': 'yields-to-navigation',
+}
+
+function requestPrecedence(kind: PositionRequestSource['kind']): RequestPrecedence {
+  return REQUEST_PRECEDENCE[kind] ?? 'yields-to-any-unsettled-position'
+}
+
+/**
+ * The active request has not reached its position yet. `paused-user-input` is excluded: the reader
+ * took over, so nothing is converging for them any more.
+ */
+function isConverging(phase: PositioningPhase): boolean {
+  return phase.kind !== 'settled' && phase.kind !== 'paused-user-input'
+}
+
+/**
+ * The controller is converging on a position the reader explicitly asked for — the model-level
+ * counterpart of `RowGrowthFacts.navigationInFlight`. A live-edge desire is excluded for the same
+ * reason it is there: following the bottom is a policy an ambient correction may re-assert, not a
+ * destination the reader is waiting on.
+ */
+function isNavigationInFlight(active: PositioningModel['active']): boolean {
+  return (
+    active !== null &&
+    isConverging(active.phase) &&
+    active.request.desired.kind !== 'live-edge' &&
+    requestPrecedence(active.request.source.kind) === 'supersedes'
+  )
+}
+
+/**
  * Accept a newer request and supersede the previous one.
  *
  * Entry chooses the displayed conversation. Automatic late MDS may only correct that same
@@ -445,16 +516,18 @@ export function acceptPositionRequest(
   }
 
   const active = model.active
-  const layoutPreservationWhilePositioning =
-    request.source.kind === 'layout-preservation' &&
-    active !== null &&
-    active.phase.kind !== 'settled' &&
-    active.phase.kind !== 'paused-user-input'
-  if (layoutPreservationWhilePositioning) {
-    // Divider movement is ambient layout preservation, not navigation. It may preserve a settled
-    // reading point, but it must never supersede Home, a message target, entry restore, or another
-    // position the reader is still waiting to reach.
-    return model
+  switch (requestPrecedence(request.source.kind)) {
+    case 'yields-to-any-unsettled-position':
+      // Ambient preservation is not navigation. It may preserve a settled reading point, but it must
+      // never supersede Home, a message target, entry restore, or another position the reader is
+      // still waiting to reach.
+      if (active !== null && isConverging(active.phase)) return model
+      break
+    case 'yields-to-navigation':
+      if (isNavigationInFlight(active)) return model
+      break
+    case 'supersedes':
+      break
   }
 
   const preservationPending =

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -39,13 +39,13 @@ same-generation content stimuli, global-tail recentering, the 60-frame/8-stable-
 budget, and user cancellation. Media growth, unread-divider movement, and delayed live-path
 insertions while reading history share one fixed-anchor execution machine with the former
 90-frame/8-stable-frame/8px contract. Divider movement and delayed insertion have distinct
-`layout-preservation` reasons and are ambient: they are rejected rather than superseding an
-unsettled entry restore, explicit target, or user navigation. Leased imperative executors
-translate accepted requests into browser/virtualizer writes, and every frame must hold the current
-controller lease before it can write. Directional history is accepted before a load begins, remains
-pending until the first resident ID changes or the load settles without a window shift, then either
-performs its pre-paint anchor/fallback write or releases the request. A landed shift retains the
-former full 60-frame late-measurement budget under one lease. Its executor retains WebKit
+`layout-preservation` reasons. Their request arbitration, along with media and directional-history
+preservation, is defined under "Entry arbitration and later supersession" below. Leased imperative
+executors translate accepted requests into browser/virtualizer writes, and every frame must hold the
+current controller lease before it can write. Directional history is accepted before a load begins,
+remains pending until the first resident ID changes or the load settles without a window shift, then
+either performs its pre-paint anchor/fallback write or releases the request. A landed shift retains
+the former full 60-frame late-measurement budget under one lease. Its executor retains WebKit
 kinetic-scroll cancellation, 2px target-shift correction, 5px clamp recovery, and bounded
 distance-from-bottom fallback. Boundary input while the load is still pending retains the captured
 anchor because no pixel owner exists yet; takeover becomes cancellable after the initial
@@ -261,6 +261,15 @@ Source priority chooses the one provisional entry request. After entry, generati
 permitted supersession; a newer generation alone does not bypass current-conversation or MDS
 eligibility guards. Async work tagged with a stale generation is ignored.
 
+Request precedence is classified exhaustively by source. Layout preservation is the strictest
+ambient class: it yields to every unsettled position, including live-edge follow. Media and
+directional-history preservation yield while a non-live-edge reader-intent position is still
+converging, but may re-anchor an unsettled live-edge follow because following the bottom is a policy,
+not a destination the reader is waiting to reach. Unknown future sources default to the strictest
+class until deliberately classified. An outgoing-message live-edge request is the deliberate
+exception: sending is reader intent and may supersede an in-flight navigation, subject to the
+unfinished restore or history-preservation ownership rule above.
+
 User input and follow-live are separate facts. Genuine input cancels the current reconciliation
 run immediately. A live-edge request retains its generation in a paused-user-input phase until
 settled geometry shows whether the reader left the edge; stale callbacks cannot resume that pause.
@@ -362,12 +371,12 @@ abort valid deep growth and media-settle runs.
 | FAB or live-edge keyboard command | Unread marker, then live edge | If the marker is still below the viewport, first activation visits it (virtualized start alignment; current non-virtualized path uses top-third); a later activation goes live |
 | Outgoing message | Live edge | Deliberately supersedes a fixed historical position after its first landing releases preservation ownership; it need not wait for full convergence |
 | Incoming message at the resident live edge | Existing live edge only | Must not make a fixed anchor follow |
-| Delayed live-path message inserted inside the resident window while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; reject the ambient request while requested navigation is unsettled |
+| Delayed live-path message inserted inside the resident window while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; subject to ambient request precedence above |
 | Late MDS live-edge state | Live edge | Newer automatic request only before user takeover |
 | Media at live edge | Existing live edge | Debounced measurement stimulus |
-| Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement |
-| Unread divider moves while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; reject the ambient request while requested navigation is unsettled |
-| Load older/newer | Fixed top-relative offset anchor | Wait for the directional window change; release if the load settles without one; if the anchor disappears after a shift, preserve captured distance from bottom and clamp |
+| Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement; subject to ambient request precedence above |
+| Unread divider moves while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; subject to ambient request precedence above |
+| Load older/newer | Fixed top-relative offset anchor | Subject to ambient request precedence above; wait for the directional window change and release if the load settles without one; if the anchor disappears after a shift, preserve captured distance from bottom and clamp |
 | Home / resident-top command | Resident top | Does not itself trigger load-older; later genuine user travel can re-arm ordinary boundary loading |
 | Reaction, typing, resize, MAM completion | Current live edge, when active | Geometry stimulus, not a new position request |
 


### PR DESCRIPTION
Positioning refused only `layout-preservation` while an earlier request was still converging, even though that guard's own comment describes the rule as covering every ambient correction. Media remeasure and directional window shifts could still supersede a position the reader was still waiting to reach — a jump-to-message parked in `loading-around` easily outlasts the 150ms media debounce.

Requests are now classified by precedence class instead of a hard-coded `source.kind`. The map is exhaustive over source kinds and an unknown kind resolves to the strictest class, so a future ambient source cannot silently reintroduce the hole. `layout-preservation` keeps its existing behaviour; media and history preservation now yield to an in-flight explicit navigation while still being allowed to re-anchor a live-edge follow, which is a policy rather than a destination the reader is waiting to reach.

Outgoing sends keep their current ability to take the live edge, now recorded as a deliberate exemption rather than an unlisted gap: sending a message is an explicit reader action that implies wanting to see it land.

The in-flight predicate mirrors the `navigationInFlight` fact the row-growth path already uses, rather than introducing a second way to ask the same question. Verified at the positioning-model level by driving `acceptPositionRequest` directly; no browser-level end-to-end check of this path was run.