### PR TITLE
feat(anomaly): judge drift on rates, and close the review loop

### DIFF
--- a/apps/fluux/src/anomaly/denominators.test.ts
+++ b/apps/fluux/src/anomaly/denominators.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createDenominatorTracker, type DenominatorName } from './denominators'
+
+interface Msg {
+  id: string
+}
+type Arrivals = Map<string, Msg>
+
+function tracker() {
+  const seen: DenominatorName[] = []
+  return { seen, t: createDenominatorTracker((name) => seen.push(name)) }
+}
+
+const state = (arrivals: Arrivals, active?: string | null) => ({
+  lastArrivedMessage: arrivals,
+  activeId: active ?? null,
+})
+
+describe('arrival denominator', () => {
+  it('counts one arrival per conversation that received a new message', () => {
+    const { seen, t } = tracker()
+    const a: Msg = { id: 'm1' }
+    const b: Msg = { id: 'm2' }
+    t.observe(state(new Map([['conv-a', a]])), state(new Map()))
+    t.observe(state(new Map([['conv-a', a], ['conv-b', b]])), state(new Map([['conv-a', a]])))
+    expect(seen).toEqual(['message.arrivals', 'message.arrivals'])
+  })
+
+  it('ignores a state change that did not bring a message', () => {
+    // The store publishes on typing, presence and read-state writes many times a
+    // second. Counting those as arrivals would inflate the denominator until the
+    // rate it divides became meaningless.
+    const { seen, t } = tracker()
+    const arrivals: Arrivals = new Map([['conv-a', { id: 'm1' }]])
+    t.observe(state(arrivals, 'conv-a'), state(arrivals, null))
+    t.observe(state(arrivals, 'conv-b'), state(arrivals, 'conv-a'))
+    expect(seen.filter((n) => n === 'message.arrivals')).toEqual([])
+  })
+
+  it('does not recount a conversation whose message is unchanged', () => {
+    const { seen, t } = tracker()
+    const a: Msg = { id: 'm1' }
+    const before = new Map([['conv-a', a]])
+    // A NEW Map holding the SAME message: the store rebuilt the map for an unrelated
+    // reason. Comparing map identity alone would count an arrival that never happened.
+    t.observe(state(new Map(before)), state(before))
+    expect(seen.filter((n) => n === 'message.arrivals')).toEqual([])
+  })
+})
+
+describe('room-switch denominator', () => {
+  it('counts a switch when the active entity changes', () => {
+    const { seen, t } = tracker()
+    const arrivals: Arrivals = new Map()
+    t.observe(state(arrivals, 'room-a'), state(arrivals, null))
+    t.observe(state(arrivals, 'room-b'), state(arrivals, 'room-a'))
+    expect(seen.filter((n) => n === 'room.switches')).toHaveLength(2)
+  })
+
+  it('does not count closing the last conversation as a switch', () => {
+    // Leaving for the empty state is not navigation between conversations, and
+    // counting it would credit a render burst to a switch that never happened.
+    const { seen, t } = tracker()
+    const arrivals: Arrivals = new Map()
+    t.observe(state(arrivals, null), state(arrivals, 'room-a'))
+    expect(seen.filter((n) => n === 'room.switches')).toEqual([])
+  })
+})

--- a/apps/fluux/src/anomaly/denominators.ts
+++ b/apps/fluux/src/anomaly/denominators.ts
@@ -1,0 +1,54 @@
+/**
+ * The denominators, read from the stores rather than signalled by the app.
+ *
+ * A rate needs something that scales with USE to divide by, and both of these are
+ * already visible in exported store state. Deriving them here rather than adding
+ * call sites keeps two more seams out of production code for no loss of fidelity.
+ *
+ * @module Anomaly/Denominators
+ */
+
+export type DenominatorName = 'message.arrivals' | 'room.switches'
+
+/** The slice of a store's state these denominators are derived from. */
+export interface DenominatorSample {
+  /** Newest arrival per conversation. NOT the message list — MAM backfill is absent. */
+  lastArrivedMessage: ReadonlyMap<string, unknown>
+  /** The conversation or room on screen, or null. */
+  activeId: string | null
+}
+
+export interface DenominatorTracker {
+  observe(next: DenominatorSample, prev: DenominatorSample): void
+}
+
+export function createDenominatorTracker(
+  count: (name: DenominatorName) => void,
+): DenominatorTracker {
+  return {
+    observe(next: DenominatorSample, prev: DenominatorSample): void {
+      // `lastArrivedMessage` rather than the message map: the latter also grows by
+      // MAM backfill, and a catch-up of two thousand rows would swamp the
+      // denominator with messages nobody watched arrive — turning the rate it
+      // divides into a measure of how much history was fetched.
+      //
+      // The reference check is the cheap gate. This subscription sees every store
+      // publication — typing, presence, read-state — so walking the map each time
+      // would cost far more than the arrivals it is looking for.
+      if (next.lastArrivedMessage !== prev.lastArrivedMessage) {
+        for (const [id, message] of next.lastArrivedMessage) {
+          // Per ENTRY, not per map: the store rebuilds this map for unrelated
+          // reasons, and identity alone would count arrivals that never happened.
+          // A batch delivered to one conversation still counts once — the map holds
+          // only the newest — so this measures arrival EVENTS, not messages.
+          if (prev.lastArrivedMessage.get(id) !== message) count('message.arrivals')
+        }
+      }
+
+      // Only an arrival AT a conversation. Closing the last one leaves for the empty
+      // state, which is not navigation between conversations, and counting it would
+      // credit the teardown render burst to a switch that never happened.
+      if (next.activeId !== null && next.activeId !== prev.activeId) count('room.switches')
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/metricCounts.test.ts
+++ b/apps/fluux/src/anomaly/detectors/metricCounts.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearAnomalyMetricHandler,
+  countAnomalyMetric,
+  setAnomalyMetricHandler,
+  type AnomalyMetricName,
+} from '../../utils/anomalyMetric'
+import { metricConstant } from './metricCounts'
+import { initTokenizer, isKind, resetValuesForTesting } from '../values'
+
+/**
+ * Every member of the seam's union, written out.
+ *
+ * A loop over `Object.keys` of the map under test would pass by construction — it
+ * would only prove the map agrees with itself. This list is the independent copy
+ * that makes the assertion mean something, and adding a name to the union without
+ * adding it here leaves it uncovered rather than silently green.
+ */
+const EVERY_NAME: AnomalyMetricName[] = [
+  'render.MessageList',
+  'scroll.writes',
+  'scroll.positioningOps',
+]
+
+beforeEach(async () => {
+  localStorage.clear()
+  resetValuesForTesting()
+  clearAnomalyMetricHandler()
+  await initTokenizer()
+})
+
+describe('metric names become registry constants', () => {
+  it('maps every name the seam can carry', () => {
+    for (const name of EVERY_NAME) {
+      const constant = metricConstant(name)
+      expect(constant, `${name} has no constant`).not.toBeNull()
+      // A counter, specifically. A constant of any other category would be refused
+      // by `count()` at the far end and the metric would vanish.
+      expect(isKind(constant, 'counter'), `${name} is not a counter`).toBe(true)
+    }
+  })
+
+  it('refuses a name it does not mint rather than counting a free string', () => {
+    expect(metricConstant('made.up' as AnomalyMetricName)).toBeNull()
+    // An inherited member must not resolve to a function off Object.prototype.
+    expect(metricConstant('toString' as AnomalyMetricName)).toBeNull()
+    expect(metricConstant('constructor' as AnomalyMetricName)).toBeNull()
+  })
+})
+
+describe('the counting seam', () => {
+  it('is inert with no handler, which is every release build', () => {
+    expect(() => countAnomalyMetric('render.MessageList')).not.toThrow()
+  })
+
+  it('routes the name and the increment to the handler', () => {
+    const seen: Array<[string, number]> = []
+    setAnomalyMetricHandler((name, by) => seen.push([name, by]))
+    countAnomalyMetric('scroll.writes')
+    countAnomalyMetric('scroll.writes', 4)
+    expect(seen).toEqual([
+      ['scroll.writes', 1],
+      ['scroll.writes', 4],
+    ])
+  })
+
+  it('swallows a handler fault, because these call sites are a render and a frame loop', () => {
+    setAnomalyMetricHandler(() => {
+      throw new Error('recorder exploded')
+    })
+    expect(() => countAnomalyMetric('render.MessageList')).not.toThrow()
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/metricCounts.ts
+++ b/apps/fluux/src/anomaly/detectors/metricCounts.ts
@@ -1,0 +1,25 @@
+/**
+ * The single translation point from a metric name to a registry constant.
+ *
+ * Mirrors `signalRecords.ts`: the seam carries a closed string union because it may
+ * not import `values.ts`, and this is where that union becomes provenance-carrying
+ * constants. Typed as a total `Record`, so a name added to the union without a
+ * constant here is a COMPILE error rather than a counter that silently vanishes.
+ *
+ * @module Anomaly/Detectors/MetricCounts
+ */
+import type { AnomalyMetricName } from '../../utils/anomalyMetric'
+import { METRIC, type Opaque } from '../values'
+
+const METRICS: Readonly<Record<AnomalyMetricName, Opaque>> = Object.freeze({
+  'render.MessageList': METRIC.renderMessageList,
+  'scroll.writes': METRIC.scrollWrites,
+  'scroll.positioningOps': METRIC.scrollPositioningOps,
+})
+
+/** The constant for a metric name, or null if the name is not one we mint. */
+export function metricConstant(name: AnomalyMetricName): Opaque | null {
+  // `Object.hasOwn`, not a truthiness check: a name matching an Object.prototype
+  // member would otherwise resolve to an inherited function and be counted.
+  return Object.hasOwn(METRICS, name) ? METRICS[name] : null
+}

--- a/apps/fluux/src/anomaly/environment.test.ts
+++ b/apps/fluux/src/anomaly/environment.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createEnvironmentReader, createForegroundShare } from './environment'
+import { initTokenizer, resetValuesForTesting } from './values'
+
+beforeEach(async () => {
+  localStorage.clear()
+  resetValuesForTesting()
+  await initTokenizer()
+})
+
+const asObject = (pairs: Array<[{ s: string }, unknown]>): Record<string, unknown> =>
+  Object.fromEntries(pairs.map(([k, v]) => [k.s, typeof v === 'object' && v !== null ? (v as { s: string }).s : v]))
+
+function reader(over: Partial<Parameters<typeof createEnvironmentReader>[0]> = {}) {
+  return createEnvironmentReader({
+    os: 'macos',
+    userAgent: 'Mozilla/5.0 (Macintosh) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    width: () => 1400,
+    accounts: () => 1,
+    foreground: () => 1,
+    ...over,
+  })
+}
+
+describe('environment', () => {
+  it('reports the engine as a closed constant and a major version, never the user-agent', () => {
+    // The UA is free text of exactly the kind the registries exist to keep out of a
+    // record, and its precision buys nothing a cross-session comparison needs.
+    const env = asObject(reader()())
+    expect(env.engine).toBe('webkit')
+    expect(env.engineVersion).toBe(605)
+    expect(JSON.stringify(env)).not.toContain('Mozilla')
+  })
+
+  it('tells Blink from WebKit, which is the comparison that matters here', () => {
+    // A WebKitGTK session and a Chromium one produce different scroll and render
+    // rates for reasons that are not regressions.
+    const env = asObject(
+      reader({
+        userAgent:
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        os: 'linux',
+      })(),
+    )
+    expect(env.engine).toBe('blink')
+    expect(env.engineVersion).toBe(120)
+    expect(env.platform).toBe('linux')
+  })
+
+  it('buckets the window width instead of emitting geometry', () => {
+    expect(asObject(reader({ width: () => 500 })()).sizeClass).toBe('sm')
+    expect(asObject(reader({ width: () => 800 })()).sizeClass).toBe('md')
+    expect(asObject(reader({ width: () => 1400 })()).sizeClass).toBe('lg')
+    expect(asObject(reader({ width: () => 2000 })()).sizeClass).toBe('xl')
+  })
+
+  it('falls back to a constant rather than echoing an engine it cannot place', () => {
+    const env = asObject(reader({ userAgent: 'something else entirely' })())
+    expect(env.engine).toBe('engine-unknown')
+    expect(env.engineVersion).toBe(0)
+  })
+})
+
+describe('foreground share', () => {
+  it('measures the fraction of the window the document was visible', () => {
+    // A backgrounded session renders almost nothing, so its rates are not comparable
+    // with a session someone was actually using. Without this the baseline mixes them.
+    const share = createForegroundShare(true, 0)
+    share.note(false, 1000) // visible for the first second
+    share.note(true, 3000) // hidden for two
+    expect(share.take(4000)).toBeCloseTo(0.5, 5)
+  })
+
+  it('starts the next window fresh, so one long absence does not stain every digest', () => {
+    const share = createForegroundShare(true, 0)
+    share.note(false, 0)
+    share.note(true, 1000)
+    expect(share.take(1000)).toBeCloseTo(0, 5)
+    expect(share.take(2000)).toBeCloseTo(1, 5)
+  })
+
+  it('reports a fully visible window as 1, not as a division by a zero elapsed time', () => {
+    const share = createForegroundShare(true, 0)
+    expect(share.take(0)).toBe(1)
+  })
+})

--- a/apps/fluux/src/anomaly/environment.ts
+++ b/apps/fluux/src/anomaly/environment.ts
@@ -1,0 +1,126 @@
+/**
+ * The session's environment, as closed constants.
+ *
+ * A rate is only comparable against a baseline gathered under a compatible platform
+ * and engine while the app was meaningfully foregrounded. WebKitGTK and Chromium
+ * render and scroll at different costs for reasons that are not regressions, and a
+ * backgrounded session barely renders at all. Window size remains useful context,
+ * so the review reports its mix without fragmenting each machine into sparse series.
+ *
+ * Everything here is bucketed or mapped to a registry constant. The user-agent
+ * string in particular never reaches a record: it is free text of exactly the kind
+ * the registries exist to keep out, and no comparison needs its precision.
+ *
+ * @module Anomaly/Environment
+ */
+import type { PlatformOS } from '@/platform'
+import type { Scalar } from './serializer'
+import { ENV, TAG, type Opaque } from './values'
+
+export interface EnvironmentInputs {
+  os: PlatformOS
+  userAgent: string
+  /** Viewport width in px, bucketed before it is recorded. */
+  width: () => number
+  accounts: () => number
+  /** Fraction of the digest window the document was visible, 0..1. */
+  foreground: () => number
+}
+
+const PLATFORM: Readonly<Record<PlatformOS, Opaque>> = Object.freeze({
+  macos: TAG.platformMacos,
+  linux: TAG.platformLinux,
+  windows: TAG.platformWindows,
+  other: TAG.platformWeb,
+})
+
+/**
+ * Engine and major version from the user-agent.
+ *
+ * Order matters: every Chromium UA also contains `AppleWebKit`, so testing WebKit
+ * first would file every Blink session as WebKit and merge the two series this
+ * exists to keep apart. Chrome is therefore checked first, and its own version is
+ * read rather than the `AppleWebKit/537.36` compatibility token every Blink build
+ * freezes at.
+ */
+function engineOf(userAgent: string): { engine: Opaque; version: number } {
+  const chrome = /Chrome\/(\d+)/.exec(userAgent)
+  if (chrome) return { engine: TAG.engineBlink, version: Number(chrome[1]) }
+  const webkit = /AppleWebKit\/(\d+)/.exec(userAgent)
+  if (webkit) return { engine: TAG.engineWebkit, version: Number(webkit[1]) }
+  const gecko = /Firefox\/(\d+)/.exec(userAgent)
+  if (gecko) return { engine: TAG.engineGecko, version: Number(gecko[1]) }
+  // A constant, not the string. An engine we cannot place is still a bucket; the
+  // raw UA would be free text, and echoing it is the one thing this must not do.
+  return { engine: TAG.engineUnknown, version: 0 }
+}
+
+/**
+ * Tailwind's breakpoints, so a size class means the same thing here as in the UI.
+ * The class is a snapshot taken when the digest flushes, not a window boundary; the
+ * review reports its distribution across retained windows instead of treating one
+ * endpoint sample as representative of the whole window.
+ */
+function sizeClassOf(width: number): Opaque {
+  if (width < 640) return TAG.sizeSm
+  if (width < 1024) return TAG.sizeMd
+  if (width < 1536) return TAG.sizeLg
+  return TAG.sizeXl
+}
+
+export function createEnvironmentReader(inputs: EnvironmentInputs): () => Array<[Opaque, Scalar]> {
+  const { engine, version } = engineOf(inputs.userAgent)
+  // Platform and engine are fixed for the process; only the mutable readings are
+  // taken fresh, so a digest costs one UA parse per session rather than per window.
+  return () => [
+    [ENV.platform, PLATFORM[inputs.os] ?? TAG.platformWeb],
+    [ENV.engine, engine],
+    [ENV.engineVersion, version],
+    [ENV.sizeClass, sizeClassOf(inputs.width())],
+    [ENV.accounts, inputs.accounts()],
+    [ENV.foreground, inputs.foreground()],
+  ]
+}
+
+export interface ForegroundShare {
+  /** Record a visibility transition. `visible` is the state being ENTERED. */
+  note(visible: boolean, at: number): void
+  /** Visible fraction since the last take, and start a fresh window. */
+  take(at: number): number
+}
+
+/**
+ * Accumulates visible time across a digest window.
+ *
+ * Sampling visibility at digest time would answer a different question — whether the
+ * window happened to be visible at one instant — and a session left in the
+ * background all afternoon would report as foreground if someone glanced at it on
+ * the tick. Only accumulation distinguishes those.
+ */
+export function createForegroundShare(visible: boolean, at: number): ForegroundShare {
+  let current = visible
+  let since = at
+  let windowStart = at
+  let visibleMs = 0
+
+  return {
+    note(next: boolean, when: number): void {
+      if (next === current) return
+      if (current) visibleMs += when - since
+      current = next
+      since = when
+    },
+    take(when: number): number {
+      if (current) visibleMs += when - since
+      const elapsed = when - windowStart
+      // A window with no elapsed time is fully whatever it currently is. Dividing
+      // would yield NaN, which the serializer rejects — costing the whole digest its
+      // environment over an arithmetic edge case at session start.
+      const share = elapsed > 0 ? visibleMs / elapsed : current ? 1 : 0
+      visibleMs = 0
+      since = when
+      windowStart = when
+      return share
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -16,18 +16,24 @@
  * @module Anomaly/Install
  */
 import { chatStore, getStorageScopeJid, readRecountDeferrals, roomStore } from '@fluux/sdk'
+import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
+import { createDenominatorTracker, type DenominatorName } from './denominators'
+import { createEnvironmentReader, createForegroundShare } from './environment'
+import { metricConstant } from './detectors/metricCounts'
 import { clearAnomalySignalHandler, setAnomalySignalHandler } from '../utils/anomalySignal'
 import type { ViewportKind } from '../utils/viewportAtBottom'
-import { platform } from '@/platform'
+import { detectOS, platform } from '@/platform'
 import { recordForSignal } from './detectors/signalRecords'
 import { browserWorld, startDetectorTick, type DetectorTick } from './detectors/tick'
 import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
 import { createPluginFsWriter, createTauriSink } from './sinks/tauri'
-import { ID, RECOUNT_METRIC, initTokenizer } from './values'
+import { ID, METRIC, RECOUNT_METRIC, initTokenizer, type Opaque } from './values'
 
 const DIGEST_INTERVAL_MS = 5 * 60 * 1000
+/** Shared empty map for a store with no arrival signal — allocating one per publish would cost more than the reading is worth. */
+const NO_ARRIVALS: ReadonlyMap<string, unknown> = new Map()
 /**
  * The session announcement retries itself, because nothing else will.
  *
@@ -75,6 +81,7 @@ let attachRefs = 0
 let digestTimer: ReturnType<typeof setInterval> | null = null
 let detachListener: (() => void) | null = null
 let detectorTick: DetectorTick | null = null
+let storeUnsubscribes: (() => void) | null = null
 
 /**
  * Read the active conversation from the vanilla stores.
@@ -146,6 +153,18 @@ function foldRecountDeferrals(rec: Recorder): void {
   }
 }
 
+/**
+ * Visible-time accumulator for the environment block.
+ *
+ * Module scope, alongside the recorder, because it must span attachments: a
+ * StrictMode remount would otherwise restart the window and report the session as
+ * fully foreground however long it had been buried.
+ */
+const foregroundShare = createForegroundShare(
+  typeof document !== 'undefined' && document.visibilityState === 'visible',
+  Date.now(),
+)
+
 function runtime(): Recorder {
   if (!recorder) {
     recorder = createRecorder({
@@ -154,6 +173,17 @@ function runtime(): Recorder {
       now: () => Date.now(),
       build: `${__APP_VERSION__}+${__GIT_COMMIT__}`,
       sid: sessionId,
+      env: createEnvironmentReader({
+        os: detectOS(),
+        userAgent: typeof navigator === 'undefined' ? '' : navigator.userAgent,
+        width: () => (typeof window === 'undefined' ? 0 : window.innerWidth),
+        // One today. A seam rather than a literal so multi-account does not ship a
+        // baseline silently mixing one-account and many-account sessions.
+        accounts: () => 1,
+        // Taken, not peeked: the share resets so each digest describes its own
+        // window, which is what `windowMs` already promises about every other field.
+        foreground: () => foregroundShare.take(Date.now()),
+      }),
     })
   }
   return recorder
@@ -251,6 +281,41 @@ export function install(): () => void {
       if (input) rec.record(input)
     })
 
+    // Metrics arrive by NAME from the neutral seam, and become constants here. An
+    // unmapped name is dropped rather than counted under a string: a counter name is
+    // a closed registry, and inventing one from a free string is the hole it closes.
+    setAnomalyMetricHandler((name, by) => {
+      const metric = metricConstant(name)
+      if (metric) rec.count(metric, by)
+    })
+
+    // Denominators are DERIVED from store state rather than signalled, so counting
+    // them costs production no call sites at all.
+    const DENOMINATORS: Readonly<Record<DenominatorName, Opaque>> = {
+      'message.arrivals': METRIC.messageArrivals,
+      'room.switches': METRIC.roomSwitches,
+    }
+    const denominators = createDenominatorTracker((name) => rec.count(DENOMINATORS[name], 1))
+    const unsubChat = chatStore.subscribe((next, prev) =>
+      denominators.observe(
+        { lastArrivedMessage: next.lastArrivedMessage, activeId: next.activeConversationId ?? null },
+        { lastArrivedMessage: prev.lastArrivedMessage, activeId: prev.activeConversationId ?? null },
+      ),
+    )
+    // Rooms contribute SWITCHES only. They have no arrival signal: `lastArrivedMessage`
+    // is the chat store's alone, and `roomMeta.lastMessage` moves on a MAM merge too,
+    // so a room arrival cannot be told apart from a history fetch.
+    const unsubRooms = roomStore.subscribe((next, prev) =>
+      denominators.observe(
+        { lastArrivedMessage: NO_ARRIVALS, activeId: next.activeRoomJid ?? null },
+        { lastArrivedMessage: NO_ARRIVALS, activeId: prev.activeRoomJid ?? null },
+      ),
+    )
+    storeUnsubscribes = () => {
+      unsubChat()
+      unsubRooms()
+    }
+
     // The timed detectors. Started here rather than at module scope so it shares the
     // refcount: a StrictMode remount must not leave two intervals sampling, which
     // would double every verdict and turn the duplicate into a phantom suppression.
@@ -269,6 +334,7 @@ export function install(): () => void {
     }, DIGEST_INTERVAL_MS)
 
     const onVisibility = () => {
+      foregroundShare.note(document.visibilityState === 'visible', Date.now())
       // Best effort: the WebView gives no guarantee that asynchronous I/O completes
       // during teardown, so a missing trailing digest is normal and never a signal.
       if (document.visibilityState === 'hidden') {
@@ -291,6 +357,9 @@ export function install(): () => void {
     if (attachRefs > 0) return
 
     clearAnomalySignalHandler()
+    clearAnomalyMetricHandler()
+    storeUnsubscribes?.()
+    storeUnsubscribes = null
     detectorTick?.stop()
     detectorTick = null
     detachListener?.()
@@ -308,6 +377,9 @@ export function setSessionRetryDelayForTesting(ms: number): void {
 /** Test-only: tears down the runtime as well as the subscriptions. */
 export function resetInstallForTesting(): void {
   clearAnomalySignalHandler()
+  clearAnomalyMetricHandler()
+  storeUnsubscribes?.()
+  storeUnsubscribes = null
   detectorTick?.stop()
   detectorTick = null
   detachListener?.()

--- a/apps/fluux/src/anomaly/recorder.test.ts
+++ b/apps/fluux/src/anomaly/recorder.test.ts
@@ -6,6 +6,7 @@ import type { Sink } from './sinks/sink'
 import {
   COUNTER,
   CTX,
+  ENV,
   ID,
   initTokenizer,
   localRef,
@@ -485,5 +486,75 @@ describe('the ring pins local refs', () => {
     releaseRef('q', 'query-1')
     for (let i = 0; i < 2100; i++) localRef('m', `more-${i}`)
     expect(localRef('q', 'query-1')!.s).not.toBe(ref.s)
+  })
+})
+
+describe('rates', () => {
+  it('reports a rate as its numerator and its sample count, not as a quotient', () => {
+    // The DENOMINATOR travels with every rate because the review tool suppresses a
+    // drift verdict below a minimum sample size: three room switches producing a high
+    // render rate is noise, and a bare quotient cannot be told apart from a real one.
+    // The recorder does no division — a quotient it computed would lose exactly the
+    // number needed to judge whether the quotient means anything.
+    const sink = fakeSink()
+    const rec = make(sink)
+    rec.count(METRIC.renderMessageList, 40)
+    rec.count(METRIC.messageArrivals, 10)
+    rec.count(METRIC.roomSwitches, 4)
+    rec.count(METRIC.scrollWrites, 12)
+    rec.count(METRIC.scrollPositioningOps, 6)
+    rec.flushDigest(1000)
+
+    expect(digests(sink)[0].rates).toEqual({
+      'render.MessageList/roomSwitch': { n: 40, d: 4, informational: true },
+      'scroll.writes/positioning': { n: 12, d: 6, informational: true },
+    })
+  })
+
+  it('omits a rate that saw no activity, so an idle window stays small', () => {
+    const sink = fakeSink()
+    const rec = make(sink)
+    rec.count(METRIC.roomJoins, 1)
+    rec.flushDigest(1000)
+
+    expect(digests(sink)[0].rates).toEqual({})
+  })
+
+  it('still reports a numerator that ran against no denominator at all', () => {
+    // Renders with zero arrivals is the most interesting shape this can take — work
+    // done for no reason. Dropping it as a divide-by-zero would hide the one window
+    // worth looking at.
+    const sink = fakeSink()
+    const rec = make(sink)
+    rec.count(METRIC.renderMessageList, 40)
+    rec.flushDigest(1000)
+
+    expect(digests(sink)[0].rates).toEqual({
+      'render.MessageList/roomSwitch': { n: 40, d: 0, informational: true },
+    })
+  })
+
+  it('carries the environment, so two platforms are never compared as one series', () => {
+    // A WebKitGTK session and a macOS session produce different rates for reasons
+    // that are not regressions. A baseline that silently mixes them drifts forever.
+    const sink = fakeSink()
+    const rec = createRecorder({
+      sink,
+      now,
+      build: '0.17.2+abc',
+      sid: 'sid-1',
+      env: () => [
+        [ENV.platform, TAG.platformMacos],
+        [ENV.engine, TAG.engineWebkit],
+        [ENV.sizeClass, TAG.sizeLg],
+      ],
+    })
+    rec.flushDigest(1000)
+
+    expect(digests(sink)[0].env).toEqual({
+      platform: 'macos',
+      engine: 'webkit',
+      sizeClass: 'lg',
+    })
   })
 })

--- a/apps/fluux/src/anomaly/recorder.ts
+++ b/apps/fluux/src/anomaly/recorder.ts
@@ -19,6 +19,7 @@ import {
   isReservedCounter,
   isTokenizerReady,
   localRefOverflowCount,
+  RATE,
   releaseOpaque,
   retainOpaque,
   tokenKeyId,
@@ -73,10 +74,20 @@ export interface RecorderOptions {
    * would not revive the recorder anyway.
    */
   maxBytes?: () => number
+  /**
+   * The session's environment, read fresh at each digest.
+   *
+   * Injected rather than sniffed so the recorder stays free of the DOM, the platform
+   * module and the clock-dependent foreground share — all three of which would
+   * otherwise have to be mocked to assert anything about a digest. Defaults to
+   * empty, which is also what a non-browser embedder gets.
+   */
+  env?: () => Array<[Opaque, Scalar]>
 }
 
 export function createRecorder(opts: RecorderOptions): Recorder {
   const { sink, now, build, sid } = opts
+  const env = opts.env ?? ((): Array<[Opaque, Scalar]> => [])
 
   // Clamp on every read: the seam exists so a test can TIGHTEN the budget, and one
   // that could relax it is a way to disable the bound in production by mistake.
@@ -322,11 +333,25 @@ export function createRecorder(opts: RecorderOptions): Recorder {
         all.push([constant, total - (lastHealth.get(constant.s) ?? 0)])
       }
 
+      // Derived from the SAME window the counters describe, before they are cleared.
+      // A rate whose numerator and denominator are both zero is dropped: every rate
+      // would otherwise appear in every digest, and an idle window would be as large
+      // as a busy one. A zero DENOMINATOR is kept — work done against nothing is the
+      // most interesting shape a rate takes, not a divide-by-zero to discard.
+      const rates: Array<[Opaque, number, number, boolean?]> = []
+      for (const spec of Object.values(RATE)) {
+        const n = counters.get(spec.numerator.s)?.[1] ?? 0
+        const d = counters.get(spec.denominator.s)?.[1] ?? 0
+        if (n === 0 && d === 0) continue
+        rates.push([spec.id, n, d, spec.informational])
+      }
+
       const base = {
         ...envelope(),
         kind: 'digest' as const,
         windowMs,
         suppressed: [...suppressed.values()],
+        env: env(),
       }
 
       // Shed WHOLE counter entries — smallest first, so the largest signals survive
@@ -335,11 +360,19 @@ export function createRecorder(opts: RecorderOptions): Recorder {
       let entries = [...all].sort((a, b) => b[1] - a[1])
       let line: string | null = null
       while (entries.length > 0) {
-        line = serialize({ ...base, counters: entries })
+        line = serialize({ ...base, counters: entries, rates })
         if (line) break
         entries = entries.slice(0, entries.length - 1)
       }
-      if (!line) line = serialize({ ...base, counters: [] })
+      // Counters go first because a rate is what drift is judged on, and its
+      // numerator survives inside it. Shedding a rate to keep the raw counter it was
+      // computed from would discard the interpretation and keep the ambiguity.
+      let shedRates = [...rates]
+      while (!line && shedRates.length > 0) {
+        shedRates = shedRates.slice(0, shedRates.length - 1)
+        line = serialize({ ...base, counters: [], rates: shedRates })
+      }
+      if (!line) line = serialize({ ...base, counters: [], rates: [] })
 
       // A digest that could not be SERIALIZED is a malformed digest, not a budget
       // event — announcing the ceiling here would claim the recorder had stopped

--- a/apps/fluux/src/anomaly/serializer.test.ts
+++ b/apps/fluux/src/anomaly/serializer.test.ts
@@ -6,6 +6,7 @@ import {
   ID,
   initTokenizer,
   METRIC,
+  RATE,
   resetValuesForTesting,
   TAG,
   tokenSync,
@@ -92,6 +93,15 @@ describe('happy path', () => {
     const parsed = JSON.parse(serialize(anomaly())!)
     expect('expected' in parsed).toBe(false)
     expect('observed' in parsed).toBe(false)
+  })
+
+  it('rejects non-finite rate scalars before JSON serialization', () => {
+    for (const value of [Infinity, -Infinity, NaN]) {
+      expect(
+        serialize(digest({ rates: [[RATE.renderPerRoomSwitch.id, value, 1, true]] })),
+      ).toBeNull()
+    }
+    expect(rejectedValueCount()).toBe(3)
   })
 })
 

--- a/apps/fluux/src/anomaly/serializer.ts
+++ b/apps/fluux/src/anomaly/serializer.ts
@@ -38,6 +38,7 @@ const ANOMALY_KEYS: ReadonlySet<string> = new Set([
 ])
 const DIGEST_KEYS: ReadonlySet<string> = new Set([
   'v', 't', 'sid', 'build', 'tokenKeyId', 'kind', 'windowMs', 'counters', 'suppressed',
+  'rates', 'env',
 ])
 
 /** A value admissible in a record VALUE position. */
@@ -71,6 +72,16 @@ export interface DigestRecord extends Envelope {
   counters: Array<[Opaque, number]>
   /** Keyed by INVARIANT ID — these count suppressed anomalies, not metrics. */
   suppressed: Array<[Opaque, number]>
+  /**
+   * `[RATE constant, numerator, denominator, informational?]` tuples.
+   *
+   * Optional because a digest with no rates is a real state — an embedder that
+   * wires no metrics produces one every window — and treating it as malformed
+   * would drop the counters it does carry.
+   */
+  rates?: Array<[Opaque, number, number, boolean?]>
+  /** `[ENV constant, value]` pairs describing the session, not one observation. */
+  env?: Array<[Opaque, Scalar]>
 }
 
 export interface SerializeOptions {
@@ -128,7 +139,9 @@ function assertNoUnknownKeys(record: object, allowed: ReadonlySet<string>): void
  */
 function unwrap(value: unknown, position: Position): string | number | boolean | null {
   if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
-    if (position !== 'value') throw new Error('scalar in a key position')
+    if (position !== 'value' || (typeof value === 'number' && !Number.isFinite(value))) {
+      throw new Error('invalid scalar value')
+    }
     return value
   }
 
@@ -140,6 +153,36 @@ function unwrap(value: unknown, position: Position): string | number | boolean |
   // one, so this is belt-and-braces rather than the primary defence.
   if (s.includes('\n') || s.includes('\r')) throw new Error('newline in an opaque value')
   return s
+}
+
+/**
+ * Rate tuples to `{ rate: { n, d, informational? } }`.
+ *
+ * The denominator is kept ALONGSIDE the numerator rather than divided into it: it is
+ * the sample count, and the review tool refuses a drift verdict without it. A
+ * quotient emitted here would discard the one number that says whether the quotient
+ * is worth believing.
+ */
+function ratesToObject(
+  rates: Array<[Opaque, number, number, boolean?]>,
+): Record<string, { n: number; d: number; informational?: true }> {
+  if (rates.length > MAX_ARRAY) throw new Error('too many rates for one record')
+
+  const out: Record<string, { n: number; d: number; informational?: true }> = {}
+  for (const [key, numerator, denominator, informational] of rates) {
+    if (informational !== undefined && typeof informational !== 'boolean') {
+      throw new Error('invalid informational rate flag')
+    }
+    // Both positions are plain numbers, but they still go through `unwrap` so a
+    // non-finite value is rejected here rather than becoming `null` in the file.
+    const value: { n: number; d: number; informational?: true } = {
+      n: unwrap(numerator, 'value') as number,
+      d: unwrap(denominator, 'value') as number,
+    }
+    if (informational) value.informational = true
+    out[String(unwrap(key, 'rate'))] = value
+  }
+  return out
 }
 
 function pairsToObject(
@@ -198,6 +241,9 @@ export function serialize(
         counters: pairsToObject(record.counters, 'counter', 'value'),
         // `suppressed` is keyed by invariant id, not by counter name.
         suppressed: pairsToObject(record.suppressed, 'id', 'value'),
+        rates: ratesToObject(record.rates ?? []),
+        // Environment keys are minted as `ctx`, so they reuse the pair walk.
+        env: pairsToObject(record.env ?? [], 'ctx', 'value'),
       })
       return byteLength(line) <= maxLineBytes ? line : null
     }

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -25,7 +25,7 @@
  * That leaks nothing, but it dissolves the registries' meaning — so the serializer
  * must be able to ask "is this an id?", not merely "did we make this?".
  */
-export type Kind = 'tag' | 'id' | 'ctx' | 'counter' | 'token' | 'ref'
+export type Kind = 'tag' | 'id' | 'ctx' | 'counter' | 'token' | 'ref' | 'rate'
 
 const KIND = new WeakMap<object, Kind>()
 
@@ -104,6 +104,22 @@ export const TAG = Object.freeze({
   loopMarker: mint('loop:marker', 'tag'),
   loopTarget: mint('loop:target', 'tag'),
   loopResidentTop: mint('loop:resident-top', 'tag'),
+  // Environment values. Closed constants rather than the strings the platform and
+  // the user-agent hand over: a UA string is free text of exactly the kind the
+  // registries exist to keep out of a record, and its precision buys nothing a
+  // comparison needs.
+  platformMacos: mint('macos', 'tag'),
+  platformLinux: mint('linux', 'tag'),
+  platformWindows: mint('windows', 'tag'),
+  platformWeb: mint('web', 'tag'),
+  engineWebkit: mint('webkit', 'tag'),
+  engineBlink: mint('blink', 'tag'),
+  engineGecko: mint('gecko', 'tag'),
+  engineUnknown: mint('engine-unknown', 'tag'),
+  sizeSm: mint('sm', 'tag'),
+  sizeMd: mint('md', 'tag'),
+  sizeLg: mint('lg', 'tag'),
+  sizeXl: mint('xl', 'tag'),
 })
 
 /** Invariant ids. One entry per row in docs/ANOMALY_INVARIANTS.md. */
@@ -147,6 +163,29 @@ export const CTX = Object.freeze({
 })
 
 /**
+ * Keys for the digest's environment block.
+ *
+ * Separate from `CTX` because these describe the SESSION rather than one
+ * observation, and mixing them would let an environment key be used as an anomaly's
+ * context. They are minted as `ctx` so the digest can reuse the existing pair
+ * serialization rather than growing a second key category the serializer must learn.
+ */
+export const ENV = Object.freeze({
+  /** A platform TAG. */
+  platform: mint('platform', 'ctx'),
+  /** A WebView engine TAG. */
+  engine: mint('engine', 'ctx'),
+  /** Engine major version, as a number — enough to separate two series. */
+  engineVersion: mint('engineVersion', 'ctx'),
+  /** A window size-class TAG, never raw geometry. */
+  sizeClass: mint('sizeClass', 'ctx'),
+  /** How many accounts the session holds. */
+  accounts: mint('accounts', 'ctx'),
+  /** Fraction of the window the document was visible, 0..1. */
+  foreground: mint('foreground', 'ctx'),
+})
+
+/**
  * Counter names reserved for the recorder's own health. `count()` refuses these:
  * the digest appends them itself, and an application counter sharing a key would
  * be silently overwritten by the health delta when the pairs are folded into an
@@ -168,6 +207,74 @@ export const METRIC = Object.freeze({
   roomJoins: mint('room.joins', 'counter'),
   scrollWrites: mint('scroll.writes', 'counter'),
   probe: mint('probe.metric', 'counter'),
+  // Numerators and denominators for the rates below. A denominator is an ordinary
+  // counter: it is a real quantity in its own right, and keeping it one means the
+  // raw number survives even when its rate is shed.
+  renderMessageList: mint('render.MessageList', 'counter'),
+  messageArrivals: mint('message.arrivals.conversation', 'counter'),
+  roomSwitches: mint('room.switches', 'counter'),
+  scrollPositioningOps: mint('scroll.positioningOps', 'counter'),
+})
+
+/** A numerator and the denominator that makes it comparable across sessions. */
+export interface RateSpec {
+  readonly id: Opaque
+  readonly numerator: Opaque
+  readonly denominator: Opaque
+  readonly informational?: boolean
+}
+
+/**
+ * Drift is judged on RATES, never on raw counters.
+ *
+ * `render.MessageList: 1840` compared against a committed number mostly measures how
+ * much the app was used that day: a quiet day and a fixed regression look the same,
+ * and so do a busy day and a new one. Dividing by something that scales with use is
+ * what makes the two distinguishable.
+ *
+ * The pairing lives HERE rather than in the review tool so that the log carries its
+ * own meaning. A skill holding the pairings would have to be kept in step with this
+ * file by hand, and a mismatch would silently compare the wrong two numbers.
+ *
+ * `mam.rowsRetained`, `idb.writes` and `mam.queries` are deliberately absent. Rows
+ * retained is not observable from either end of the MAM path — retention is decided
+ * downstream of the typed event — and nothing MAM-related is exported at all, so
+ * both the numerator and the denominator would have to be invented. They arrive in
+ * stage 5 with the seams they need.
+ *
+ * MessageList renders have several causes: arrivals, typing, presence, read-state,
+ * scroll and resize. The only denominator publicly observable today is a room
+ * switch, so renders per switch tracks traffic volume rather than switch cost and is
+ * informational. It becomes judgeable when a room-arrival signal exists, alongside
+ * the deferred render-per-arrival rate. `lastArrivedMessage` already distinguishes a
+ * real conversation arrival from a preview update, but `RoomState` has no equivalent
+ * and `roomMeta.lastMessage` is bumped by MAM merges too.
+ *
+ * The reassert-loop monitor's `wrote` flag mixes "a scroll call was issued" with
+ * "geometry moved". A redundant write landing at the same offset therefore reads as
+ * no write, so scroll writes per positioning is informational too. It becomes
+ * judgeable once the frame loop carries write-issued and movement as separate
+ * signals. The counters remain useful raw evidence and inputs for that later rate.
+ *
+ * Build stamps contain the app version and short HEAD, so dirty rebuilds from the
+ * same HEAD share a review series. Before stage 5 makes any rate judgeable, choose
+ * either a content-derived fingerprint or a clean-tree requirement. Current
+ * informational rates issue no per-build verdicts, so the shared series cannot
+ * dilute a verdict today.
+ */
+export const RATE: Readonly<Record<string, RateSpec>> = Object.freeze({
+  renderPerRoomSwitch: Object.freeze({
+    id: mint('render.MessageList/roomSwitch', 'rate'),
+    numerator: METRIC.renderMessageList,
+    denominator: METRIC.roomSwitches,
+    informational: true,
+  }),
+  scrollWritesPerPositioning: Object.freeze({
+    id: mint('scroll.writes/positioning', 'rate'),
+    numerator: METRIC.scrollWrites,
+    denominator: METRIC.scrollPositioningOps,
+    informational: true,
+  }),
 })
 
 /**

--- a/apps/fluux/src/components/conversation/MessageList.floatingDate.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.floatingDate.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import { createTestMessages } from './MessageList.test-utils'
 import { scrollStateManager } from '@/utils/scrollStateManager'
+import { countAnomalyMetric } from '@/utils/anomalyMetric'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
@@ -20,6 +21,10 @@ vi.mock('@/hooks', () => ({
     clearSelection: vi.fn(),
     copySelected: vi.fn(),
   })),
+}))
+
+vi.mock('@/utils/anomalyMetric', () => ({
+  countAnomalyMetric: vi.fn(),
 }))
 
 describe('MessageList floating date header wiring', () => {
@@ -41,5 +46,16 @@ describe('MessageList floating date header wiring', () => {
       <MessageList messages={messages} conversationId="c2" renderMessage={renderMessage} staticMode />,
     )
     expect(container.querySelector('[data-floating-date]')).toBeNull()
+  })
+
+  it('counts live renders but excludes static previews from the rate', () => {
+    render(<MessageList messages={messages} conversationId="live" renderMessage={renderMessage} />)
+    expect(countAnomalyMetric).toHaveBeenCalledWith('render.MessageList')
+
+    vi.mocked(countAnomalyMetric).mockClear()
+    render(
+      <MessageList messages={messages} conversationId="preview" renderMessage={renderMessage} staticMode />,
+    )
+    expect(countAnomalyMetric).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -17,6 +17,7 @@ import type { BaseMessage } from '@fluux/sdk'
 import { useMessageCopyFormatter, useMessageRangeSelection } from '@/hooks'
 import { useViewportObserver } from '@/hooks/useViewportObserver'
 import { useRenderCostProbe } from '@/hooks/useRenderCostProbe'
+import { countAnomalyMetric } from '@/utils/anomalyMetric'
 import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { DateSeparator } from './DateSeparator'
 import { NewMessageMarker } from './NewMessageMarker'
@@ -223,6 +224,17 @@ export function MessageList<T extends BaseMessage>({
 }: MessageListProps<T>) {
   // Detect render loops before they freeze the UI
   detectRenderLoop('MessageList')
+
+  // The numerator of the render rates, counted in the render body rather than an
+  // effect. An effect with no dependency array would survive dead-code elimination
+  // as an empty callback invoked after every render of the hottest component in the
+  // app; this statement disappears entirely when the gate is false.
+  //
+  // React double-invokes render under StrictMode, so `npm run dev` counts twice. The
+  // packaged Dev build does not: StrictMode only double-invokes when React itself is
+  // in development mode, and `tauri build` runs the production build. The bundle
+  // these rates are compared across is therefore counted once per render.
+  if (__FLUUX_ANOMALY__ && !staticMode) countAnomalyMetric('render.MessageList')
 
   // A density change re-measures every visible row once; arm the interaction
   // grace window so the virtualizer's re-window burst is not flagged as a loop.

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -31,6 +31,7 @@
  * frame, timestamps passed in so it is deterministic and unit-testable.
  */
 import type { AnomalySignal } from '@/utils/anomalySignal'
+import { countAnomalyMetric } from '@/utils/anomalyMetric'
 
 /**
  * Every loop kind the message list can start.
@@ -156,12 +157,21 @@ export function createReassertLoopMonitor(
           : Math.max(1, Math.ceil(frameBudget / WRITES_PER_FRAME_BUDGET))
       const id = nextId++
       active.set(id, label)
+      // One loop IS one positioning operation — a live-edge stick, an anchor
+      // restore, a jump. It is the denominator that makes the write count mean
+      // something: twenty writes across twenty operations is healthy, and across one
+      // is the non-converging loop this monitor already warns about.
+      if (__FLUUX_ANOMALY__) countAnomalyMetric('scroll.positioningOps')
       let writeCount = 0
       let lastHotWarnAt = Number.NEGATIVE_INFINITY
 
       return {
         frame(now: number, wrote: boolean): ReassertLoopWarning | null {
           if (wrote) writeCount++
+          // Counted here rather than at the scroll call sites: every re-assert write
+          // passes through this frame hook, and the call sites are spread across a
+          // dozen adapters that would each need their own seam.
+          if (__FLUUX_ANOMALY__ && wrote) countAnomalyMetric('scroll.writes')
 
           // OVERLAP (checked first — a fight between loops is the worse signal).
           if (active.size >= overlapThreshold && now - lastOverlapWarnAt >= cooldownMs) {

--- a/apps/fluux/src/utils/anomalyMetric.ts
+++ b/apps/fluux/src/utils/anomalyMetric.ts
@@ -1,0 +1,50 @@
+/**
+ * The neutral counting seam into the dev-only anomaly runtime.
+ *
+ * Separate from `anomalySignal` on purpose. A signal is a VERDICT — the anomaly side
+ * maps each case to an invariant id with its own severity, expected and observed —
+ * while these are quantities with no opinion attached. Folding them into one union
+ * would put entries in it that no record can be built from, and every new signal
+ * case would have to explain why it is not one.
+ *
+ * Same inversion as that seam, for the same reason: the call sites ship in every
+ * build, so they must never import anything under `src/anomaly/`. A release build
+ * registers nothing and `countAnomalyMetric` is a null check — and the hot call
+ * sites additionally guard on `__FLUUX_ANOMALY__`, so the call itself is eliminated
+ * rather than merely cheap.
+ *
+ * @module Utils/AnomalyMetric
+ */
+
+/**
+ * A metric the app can count.
+ *
+ * A closed union rather than a string: these become counter names in the log, and
+ * the registries exist so a free string can never become one. Held in parity with
+ * the `METRIC` constants by a test, since this module may not import `values.ts`.
+ */
+export type AnomalyMetricName = 'render.MessageList' | 'scroll.writes' | 'scroll.positioningOps'
+
+type Handler = (metric: AnomalyMetricName, by: number) => void
+
+let handler: Handler | null = null
+
+export function setAnomalyMetricHandler(next: Handler): void {
+  handler = next
+}
+
+export function clearAnomalyMetricHandler(): void {
+  handler = null
+}
+
+/** Count one occurrence. Never throws — a counting fault must not break a render. */
+export function countAnomalyMetric(metric: AnomalyMetricName, by = 1): void {
+  if (!handler) return
+  try {
+    handler(metric, by)
+  } catch {
+    // Swallowed for the same reason as `signalAnomaly`: these call sites sit in the
+    // render path and the scroll frame loop, and a diagnostic that can break either
+    // is worse than no diagnostic. The recorder surfaces its own faults by counter.
+  }
+}

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -25,6 +25,40 @@ so their parity is asserted by a test in `values.test.ts` rather than assumed.
 - `c:unresolved`. **not an identity.** Never correlate two of them with each other.
 - `s:` refs are session-local. Never correlate them across `sid` values.
 
+Digest records summarize one recorder window. `counters` are raw quantities,
+`suppressed` restores anomalies hidden by the per-id cooldown, and each `rates` entry
+keeps its numerator `n` and denominator/sample count `d` together. `env` supplies the
+platform context needed to compare those rates.
+
+## Running the review
+
+From the repository root:
+
+```bash
+npm run anomaly:review
+```
+
+The command reads the last seven UTC days from the platform's Fluux log directory.
+Pass options after npm's `--`: `--dir <path>` for another directory, `--days <n>` for
+another window, and `--json` for machine-readable output. It reports malformed or
+unsupported records instead of silently omitting them; legacy v1 digests without
+`rates` or `env` still contribute their counters and suppressed anomalies.
+
+Rate evidence is grouped by build and by platform and engine together. Windows with less than
+20% foreground time are excluded from rate aggregation, but their anomalies and raw
+counters remain in the report. A rate gets a verdict only when it is not marked
+informational, has at least the baseline's `minSamples`, and has an accepted entry in
+`docs/anomaly-baseline.json`. The default tolerance is 30% of that accepted rate.
+
+Pruning is explicit, never a side effect of inspection:
+
+```bash
+npm run anomaly:review -- --prune
+```
+
+That removes complete UTC-day files older than 30 days by default; override the
+boundary with `--retention <days>`.
+
 ## Recorder health
 
 These describe the recorder itself, not the app.
@@ -182,4 +216,16 @@ the message list.
 
 ### `resource/`
 
-_(stage 4: rates with denominators; no pass/fail)_
+Stage 4 records these rates as **informational** measurements. They appear in the
+weekly sweep with their numerator, denominator, size-class mix, and foreground share,
+but they never produce `ok` or `drift` and must not be added to the baseline yet.
+
+| rate | Numerator / denominator | Why it is informational |
+|---|---|---|
+| `render.MessageList/roomSwitch` | Message-list renders / conversation or room switches | Renders also scale with arrivals, typing, presence, read-state, scroll, and resize. Room arrivals are not yet observable without confusing them with MAM merges |
+| `scroll.writes/positioning` | Re-assert-loop scroll writes / positioning operations | The frame-loop signal does not yet distinguish a scroll call being issued from geometry actually moving |
+
+`apps/fluux/src/anomaly/values.ts` owns these pairings and their judgeability. Before
+stage 5 makes either rate judgeable, also resolve the build-stamp limitation documented
+in `docs/anomaly-baseline.json`: dirty rebuilds from one short HEAD currently share a
+series.

--- a/docs/anomaly-baseline.json
+++ b/docs/anomaly-baseline.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "minSamples": 30,
+  "rates": {},
+  "_readme": [
+    "Accepted judgeable rates, keyed by environment then by metric.",
+    "",
+    "This stays EMPTY on purpose while Stage 4 has no judgeable rates. Every rate",
+    "currently emitted is informational, which is expected rather than a broken sweep.",
+    "Informational rates report their numerator, denominator and value but never 'drift'",
+    "or 'ok'. An all-informational window is not a clean judged week.",
+    "render.MessageList/roomSwitch stays informational until room arrivals are observable.",
+    "scroll.writes/positioning stays informational until write-issued and movement signals",
+    "are carried separately by the frame loop.",
+    "Build stamps contain the app version and short HEAD, so dirty rebuilds from one",
+    "HEAD share a series. Before Stage 5 makes any rate judgeable, choose either a",
+    "content-derived fingerprint or a clean-tree requirement.",
+    "",
+    "When a judgeable rate exists, seed it from a week you are willing to call normal",
+    "after it reaches minSamples. Record the environment key exactly as the report",
+    "prints it (platform/engine). Until then, do not add informational rates here.",
+    "",
+    "tolerance is a FRACTION of the baseline rate and defaults to 0.3 when omitted.",
+    "",
+    "MAINTENANCE: when a drift is investigated and accepted, update the rate here in",
+    "the SAME commit as the change that caused it. A baseline left stale reports the",
+    "same drift every run until people learn to ignore the review."
+  ]
+}

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -44,7 +44,7 @@ right tool for human troubleshooting and is not modified or reduced anywhere (se
 
 | Constraint | Source | Consequence |
 |---|---|---|
-| Local only, no transport | Decided | No consent flow, no collector, no remote retention obligation. Local files are pruned at 30 days by the review skill (§3.5) |
+| Local only, no transport | Decided | No consent flow, no collector, no remote retention obligation. The review command can explicitly prune local files after 30 days (§3.5) |
 | Dev builds only | Decided | Corpus comes from `Fluux Messenger Dev`, demo mode, and Playwright |
 | Zero production JS, no new native command, no new permission | Decided | Build-time constant + guarded call sites + build-audit plugin + paired CI assertions (§7.2). One named exception: the stage-5 SDK seams (§5.5) |
 | SDK `dist` is built without defines | `packages/fluux-sdk/tsup.config.ts` | Detectors must not live in SDK source — see §3.1 |
@@ -197,11 +197,12 @@ Cost of this choice: append ordering must be enforced in JS. All sink writes go 
 **Web / demo / Playwright:** memory sink on `window.__fluuxAnomalies`. This is what later allows the
 same detectors to run as CI oracles.
 
-**Retention happens in `/fluux-anomaly-review`, not in the app.** A startup sweep would need
+**Retention happens in `npm run anomaly:review -- --prune`, not in the app.** A startup sweep would need
 `fs:allow-read-dir` and `fs:allow-remove`, neither of which is currently granted, and both of which
-would widen the **production** native capability surface for a Dev-only feature. The review skill
-already reads the directory and runs outside the app, so it prunes files older than 30 days as part
-of each sweep. The app only ever appends.
+would widen the **production** native capability surface for a Dev-only feature. The review command
+already reads the directory and runs outside the app, so an explicit `--prune` removes files older
+than 30 days without widening the app. Inspection alone never deletes them. The app only ever
+appends.
 
 ### 3.6 Data flow
 
@@ -239,14 +240,18 @@ The envelope — `v`, `t`, `sid`, `build`, `tokenKeyId` — is identical on both
 { "v":1, "t":"2026-07-29T11:50:00Z", "sid":"9f2c1a04-...", "build":"0.17.2+5abd37a",
   "tokenKeyId":"3b91cc07",
   "kind":"digest", "windowMs":300000,
-  "counters":{ "mam.queries":108, "mam.rowsRetained":340, "mam.pagesEmpty":4,
-               "room.joins":10, "render.MessageList":1840, "scroll.writes":96 },
-  "suppressed":{ "scroll/reassert-nonconverging":47 } }
+  "counters":{ "render.MessageList":1840, "room.switches":10,
+               "scroll.writes":96, "scroll.positioningOps":12 },
+  "suppressed":{ "scroll/reassert-nonconverging":47 },
+  "rates":{ "render.MessageList/roomSwitch":{ "n":1840, "d":10, "informational":true },
+            "scroll.writes/positioning":{ "n":96, "d":12, "informational":true } },
+  "env":{ "platform":"macos", "engine":"webkit", "engineVersion":620,
+           "sizeClass":"lg", "accounts":1, "foreground":0.94 } }
 ```
 
 ### 4.1 Field rules
 
-1. **`v` is a schema version.** The review skill refuses to parse an unknown major version rather
+1. **`v` is a schema version.** The review tool rejects and reports an unknown major version rather
    than silently misreading it.
 2. **`sid` is a `crypto.randomUUID()`** generated once per process in a module-level singleton, so
    it survives the StrictMode remount (§3.4) and cannot collide across days or concurrent Dev runs.
@@ -291,7 +296,7 @@ rest of the session — and the log would look like a healthy quiet day. Require
   attempt per record.
 
 **Flush on `visibilitychange` / exit is best effort.** The WebView gives no guarantee that
-asynchronous I/O completes during teardown, so the final digest may be lost. The review skill must
+asynchronous I/O completes during teardown, so the final digest may be lost. The review tool must
 therefore treat a missing trailing digest as normal, not as a signal, and never infer session length
 from its absence.
 
@@ -338,7 +343,7 @@ the leak the rule exists to prevent. A rejected record is a visible bug in a det
 one is a silent disclosure.
 
 The wire format is unchanged — records still serialize to `"c:7f3a…"` and `"focus"` — so the
-patterns below remain the *reader's* contract for the review skill. They are simply no longer the
+patterns below remain the *reader's* contract for the review tool. They are simply no longer the
 writer's authorization check.
 
 **Two identifier classes, because one mechanism cannot serve both.** JIDs are not the only
@@ -397,7 +402,7 @@ is the correct scope anyway — cross-session correlation of a single stanza is 
 review asks. Entity identity keeps cross-session stability via `Token`.
 
 **`c:unresolved` remains possible only for the entity class.** Its current causes and recorder-health
-signals are owned by `docs/ANOMALY_INVARIANTS.md`. The review skill **must never correlate two
+signals are owned by `docs/ANOMALY_INVARIANTS.md`. The review process **must never correlate two
 `c:unresolved` values with each other**; they are explicitly not an identity.
 
 - **Key persistence:** 32 random bytes from `crypto.getRandomValues`, generated once and stored in
@@ -410,7 +415,7 @@ signals are owned by `docs/ANOMALY_INVARIANTS.md`. The review skill **must never
   in the digest alone, because a short session — or a close before the first flush, which §4.3
   declares normal since the exit flush is best effort — yields anomaly records with no digest at
   all, leaving their tokens unattributable. Eight characters per record is the right price for that.
-  The review skill treats a `tokenKeyId` change as a hard correlation boundary and refuses to join
+  The review process treats a `tokenKeyId` change as a hard correlation boundary and refuses to join
   records across it.
 - **Raw identifiers never enter a record object.** Not in the breadcrumb ring, not in a generic
   record field, and **not transiently inside the write queue**. Tokenization happens at the
@@ -547,26 +552,27 @@ No pass/fail; drift only. But **raw counters are not a usable baseline**: compar
 `render.MessageList: 1840` against a committed number mostly measures how much the app was used that
 day. A quiet day and a fixed regression are indistinguishable, and so are a busy day and a new one.
 
-Every drift metric is therefore a **normalized rate with an explicit denominator**:
+Every drift metric is therefore a **normalized rate with an explicit denominator**. Stage 4 can
+observe two pairings, both informational until their remaining measurement ambiguity is removed:
 
-| Metric | Denominator |
-|---|---|
-| `render.MessageList` | per message arrival, and per room switch |
-| `mam.queries` | per reconnect |
-| `mam.rowsRetained` | per query |
-| `idb.writes` | per retained row |
-| `scroll.writes` | per positioning operation (live-edge stick, anchor restore, jump) |
+| Rate | Denominator | Stage 4 status |
+|---|---|---|
+| `render.MessageList/roomSwitch` | conversation or room switch | Informational: renders also scale with traffic, and room arrivals are not observable separately from MAM merges |
+| `scroll.writes/positioning` | positioning operation (live-edge stick, anchor restore, jump) | Informational: the frame-loop signal does not distinguish an issued write from actual movement |
 
-Raw counters are still emitted — they are the numerators, and they remain useful for spotting an
+The message-arrival, MAM, and IndexedDB pairings wait for the stage 5 seams that can measure their
+denominators without substituting a nearby but different quantity.
+
+Raw counters are still emitted — they are the rate inputs and remain useful for spotting an
 absolute explosion — but **drift verdicts are computed only on rates**.
 
 Two further requirements, without which a rate is still misleading:
 
-- **Sample counts travel with every rate**, and the review skill **suppresses a drift verdict below
+- **Sample counts travel with every rate**, and the review tool **suppresses a drift verdict below
   a minimum sample size** (default 30 denominator events). Three room switches producing a high
   render rate is noise, not a regression.
 - **Environment travels with the digest** — platform, WebView engine and version, window size class,
-  account count, and whether the session was mostly foreground. A WebKitGTK session and a macOS
+  account count, and the window's foreground share. A WebKitGTK session and a macOS
   session are not comparable, and a baseline that silently mixes them will drift forever.
 
 ### 5.5 SDK seams (stage 5)
@@ -691,9 +697,10 @@ spec should not pretend otherwise:
 - **`docs/ANOMALY_INVARIANTS.md`** — registry keyed by `id`: what the invariant means, likely
   causes, where to look.
 - **`docs/anomaly-baseline.json`** — committed digest baseline for drift comparison.
-- **`/fluux-anomaly-review` skill** — reads the last 7 days of JSONL by default, refuses unknown
-  schema majors, groups by `id`, folds in `suppressed` counts, diffs digest against baseline,
-  reports. It **reports findings; it does not fix them.** Findings become issues.
+- **`npm run anomaly:review`** — reads the last 7 UTC days of JSONL by default, rejects and reports
+  unknown schema majors, groups by `id`, folds in `suppressed` counts, compares rates with the
+  baseline, and reports. `--prune` explicitly applies the 30-day retention boundary. It **reports
+  findings; it does not fix them.** Findings become issues.
 - **Cadence** — invoked manually, optionally driven by `/loop`.
 
 ### 6.1 The maintenance hazard, named
@@ -815,7 +822,7 @@ Each stage is independently useful and independently revertable.
 | 1 | Schema + constrained serializer, recorder with cooldown/ceiling, single-flight `writeFile` sink, build-audit plugin, paired CI assertions, registry skeleton | Production cost is zero, Dev actually runs, privacy holds at runtime | none |
 | 2 | Scroll/stall sentinel **fan-out** | The pipe works end to end with no new detection logic, and the prose log is untouched | none |
 | 3 | `read-state/` (unread-survives-focus) + `scroll/` (fab-at-live-edge, jump-target-miss) | Real detectors on state observable from public surfaces alone | none |
-| 4 | `resource/` **rates with denominators**, baseline, `/fluux-anomaly-review` skill incl. retention pruning | The review loop closes and drift detection starts | none |
+| 4 | `resource/` **rates with denominators**, baseline, `npm run anomaly:review` incl. explicit retention pruning | The review loop closes and drift detection starts | none |
 | 5 | Four SDK seams (§5.5), then `xmpp-traffic/`, `badge-vs-pointer` and `pointer-regression` | Everything requiring new SDK visibility | four read-only additions, measured (§5.5) |
 
 Stage 0 is separated out because the gate correction is a live pre-existing bug (§2.1) that is worth
@@ -834,7 +841,7 @@ public API is extended.
   ever changes.
 - A native append command, and therefore any Cargo feature matrix (§3.5).
 - Any new entry in `capabilities/default.json`. In-app log pruning is excluded for this reason —
-  retention lives in the review skill (§3.5).
+  retention lives in the review command (§3.5).
 - Transport-level outbound instrumentation, and therefore `iq-unanswered` coverage of connection
   pings and SM nonzas (§5.5).
 - Automatic fixing of anomalies. The review reports; a human triages.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "prebuild:app": "npm run guard:sdk-link",
     "build:app": "npm run build -w @xmpp/fluux",
     "check:comments": "node --test scripts/check-comment-provenance.test.mjs scripts/check-orphaned-jsdoc.test.mjs && node scripts/check-comment-provenance.mjs && node scripts/check-orphaned-jsdoc.mjs",
+    "anomaly:review": "node scripts/anomaly-review.mjs",
+    "check:anomaly-review": "node --test scripts/anomaly-review.test.mjs",
     "check:examples": "node --test scripts/check-jsdoc-examples.test.mjs && node scripts/check-jsdoc-examples.mjs",
     "check:anomaly:prod": "npm run build:app && node scripts/check-anomaly-elimination.mjs",
     "check:anomaly:dev": "FLUUX_ANOMALY=1 npm run build:app && FLUUX_ANOMALY=1 node scripts/check-anomaly-elimination.mjs",

--- a/scripts/anomaly-review.mjs
+++ b/scripts/anomaly-review.mjs
@@ -1,0 +1,692 @@
+#!/usr/bin/env node
+/**
+ * Read the anomaly sidecar logs and report what changed.
+ *
+ * This is the arithmetic half of the review loop. It groups, folds, aggregates and
+ * diffs; it forms no opinion about what a finding means and it never edits code. The
+ * maintainer or reviewing agent does the judging, and findings become issues.
+ *
+ * The arithmetic lives here rather than in the calling agent for two reasons: a week
+ * of JSONL is a lot of context to spend on counting, and the rules that decide
+ * whether a number is worth reporting — the minimum sample size, the tolerance, the
+ * environment split — are exact. An agent re-deriving them each run would eventually
+ * derive them differently.
+ */
+import { readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { join, posix, win32 } from 'node:path'
+
+/**
+ * The record schema this tool understands.
+ *
+ * A record carrying a higher major is REFUSED rather than parsed. Fields get
+ * renamed and re-scoped between majors, so reading one with these rules produces
+ * numbers that are wrong rather than absent — and a wrong number in a review costs
+ * more than a review that declines to run.
+ */
+export const SCHEMA_MAJOR = 1
+export const BASELINE_VERSION = 1
+
+/** Default retention. Long enough to see a weekly pattern, short enough to stay small. */
+export const DEFAULT_RETENTION_DAYS = 30
+
+export const MIN_FOREGROUND_SHARE = 0.2
+
+const LOG_NAME = /^anomalies\.(\d{4}-\d{2}-\d{2})\.jsonl$/
+const RECORD_KINDS = new Set(['anomaly', 'digest'])
+const ANOMALY_SEVERITIES = new Set(['bug', 'suspect', 'drift'])
+const ENV_FIELDS = ['platform', 'engine', 'engineVersion', 'sizeClass', 'accounts', 'foreground']
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonNegativeFinite(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function dictionary() {
+  return Object.create(null)
+}
+
+function validateCountMap(value, reason, t) {
+  if (!isRecord(value)) return { reason, field: reason.replace('invalid-', ''), t }
+  for (const count of Object.values(value)) {
+    if (!isNonNegativeFinite(count)) return { reason, field: reason.replace('invalid-', ''), t }
+  }
+  return null
+}
+
+function validateRecord(record) {
+  if (!isRecord(record)) return { reason: 'record-shape', t: null }
+  const t = typeof record.t === 'string' ? record.t : null
+  if (record.v !== SCHEMA_MAJOR) return { reason: 'schema-major', v: record.v ?? null, t }
+  if (typeof record.kind !== 'string' || !RECORD_KINDS.has(record.kind)) {
+    return { reason: 'unknown-kind', kind: record.kind ?? null, t }
+  }
+  for (const field of ['t', 'sid', 'build']) {
+    if (typeof record[field] !== 'string') return { reason: 'invalid-envelope', field, t }
+  }
+
+  if (record.kind === 'anomaly') {
+    if (typeof record.id !== 'string' || !ANOMALY_SEVERITIES.has(record.sev)) {
+      return { reason: 'invalid-anomaly', t }
+    }
+    return null
+  }
+
+  if (!isNonNegativeFinite(record.windowMs) || record.windowMs === 0) {
+    return { reason: 'invalid-window', field: 'windowMs', t }
+  }
+  const invalidCounters = validateCountMap(record.counters, 'invalid-counter', t)
+  if (invalidCounters) return invalidCounters
+  const invalidSuppressed = validateCountMap(record.suppressed, 'invalid-suppressed', t)
+  if (invalidSuppressed) return invalidSuppressed
+
+  if (record.rates !== undefined && !isRecord(record.rates)) {
+    return { reason: 'invalid-rate', field: 'rates', t }
+  }
+  const rateValues = Object.values(record.rates ?? {})
+  for (const value of rateValues) {
+    if (
+      !isRecord(value) ||
+      !isNonNegativeFinite(value.n) ||
+      !isNonNegativeFinite(value.d) ||
+      (value.informational !== undefined && value.informational !== true)
+    ) {
+      return { reason: 'invalid-rate', field: 'rates', t }
+    }
+  }
+
+  const env = record.env
+  if (
+    env !== undefined &&
+    (!isRecord(env) ||
+      Object.keys(env).some((field) => !ENV_FIELDS.includes(field)) ||
+      (Object.hasOwn(env, 'platform') && typeof env.platform !== 'string') ||
+      (Object.hasOwn(env, 'engine') && typeof env.engine !== 'string') ||
+      (Object.hasOwn(env, 'sizeClass') && typeof env.sizeClass !== 'string') ||
+      (Object.hasOwn(env, 'engineVersion') && !isNonNegativeFinite(env.engineVersion)) ||
+      (Object.hasOwn(env, 'accounts') && !isNonNegativeFinite(env.accounts)) ||
+      (Object.hasOwn(env, 'foreground') &&
+        (typeof env.foreground !== 'number' ||
+          !Number.isFinite(env.foreground) ||
+          env.foreground < 0 ||
+          env.foreground > 1)))
+  ) {
+    return { reason: 'invalid-env', field: 'env', t }
+  }
+  if (
+    rateValues.length > 0 &&
+    (!isRecord(env) || ENV_FIELDS.some((field) => !Object.hasOwn(env, field)))
+  ) {
+    return { reason: 'invalid-env', field: 'env', t }
+  }
+  return null
+}
+
+/**
+ * Which series a digest belongs to.
+ *
+ * Platform and engine only. Engine VERSION moves every few weeks, and keying on it
+ * would start a fresh series each time the browser updated — so nothing would ever
+ * accumulate the samples a verdict needs. Size class varies within a single session,
+ * so it describes a window rather than a series and is reported as a distribution.
+ */
+export function environmentKey(env = {}) {
+  return `${env.platform ?? 'unknown'}/${env.engine ?? 'unknown'}`
+}
+
+/**
+ * Fold a flat record stream into the shapes the report is built from.
+ *
+ * Returns rejected records rather than throwing: one unreadable line must not cost
+ * the whole week, and a silent skip would make a truncated log look like a quiet one.
+ */
+export function foldRecords(records) {
+  const rejected = []
+  const digests = []
+  const anomalies = dictionary()
+  const rates = dictionary()
+  const rateContexts = dictionary()
+  const counters = dictionary()
+  const sessions = new Set()
+  const builds = new Set()
+  let excludedBackgroundWindows = 0
+
+  for (const record of records) {
+    const invalid = validateRecord(record)
+    if (invalid) {
+      rejected.push(invalid)
+      continue
+    }
+    const rateEntries = record.kind === 'digest' ? Object.entries(record.rates ?? {}) : []
+
+    if (record.kind === 'digest') {
+      const suppressedOverflow = Object.entries(record.suppressed).some(([id, n]) => {
+        const entry = anomalies[id]
+        return (
+          !Number.isFinite((entry?.suppressed ?? 0) + n) ||
+          !Number.isFinite((entry?.total ?? 0) + n)
+        )
+      })
+      if (suppressedOverflow) {
+        rejected.push({ reason: 'suppressed-overflow', t: record.t })
+        continue
+      }
+
+      const counterOverflow = Object.entries(record.counters).some(
+        ([name, n]) => !Number.isFinite((counters[name] ?? 0) + n),
+      )
+      if (counterOverflow) {
+        rejected.push({ reason: 'counter-overflow', t: record.t })
+        continue
+      }
+    }
+
+    if (
+      record.kind === 'digest' &&
+      rateEntries.length > 0 &&
+      record.env.foreground >= MIN_FOREGROUND_SHARE
+    ) {
+      const currentSeries = rates[record.build]?.[environmentKey(record.env)]
+      const overflows = rateEntries.some(([name, value]) => {
+        const totals = currentSeries?.[name]
+        return (
+          !Number.isFinite((totals?.n ?? 0) + value.n) ||
+          !Number.isFinite((totals?.d ?? 0) + value.d)
+        )
+      })
+      if (overflows) {
+        rejected.push({ reason: 'rate-overflow', t: record.t })
+        continue
+      }
+    }
+
+    sessions.add(record.sid)
+    builds.add(record.build)
+
+    if (record.kind === 'anomaly') {
+      const entry = (anomalies[record.id] ??= { recorded: 0, suppressed: 0, total: 0, sev: record.sev })
+      entry.recorded++
+      entry.total++
+      continue
+    }
+
+    digests.push(record)
+
+    // Suppressed counts belong to the SAME id as the records they stand for. The
+    // per-id cooldown means the stream deliberately under-reports frequency, so a
+    // review counting only records would call a storm a single event.
+    for (const [id, n] of Object.entries(record.suppressed ?? {})) {
+      const entry = (anomalies[id] ??= { recorded: 0, suppressed: 0, total: 0, sev: null })
+      entry.suppressed += n
+      entry.total += n
+    }
+
+    for (const [name, n] of Object.entries(record.counters ?? {})) {
+      counters[name] = (counters[name] ?? 0) + n
+    }
+
+    if (rateEntries.length === 0) continue
+
+    if (record.env.foreground < MIN_FOREGROUND_SHARE) {
+      excludedBackgroundWindows++
+      continue
+    }
+
+    const build = record.build
+    const key = environmentKey(record.env)
+    const series = ((rates[build] ??= dictionary())[key] ??= dictionary())
+    const contexts = ((rateContexts[build] ??= dictionary())[key] ??= dictionary())
+
+    for (const [name, value] of rateEntries) {
+      const totals = (series[name] ??= { n: 0, d: 0, windows: 0, informational: false })
+      totals.n += value?.n ?? 0
+      totals.d += value?.d ?? 0
+      totals.windows++
+      totals.informational ||= value?.informational === true
+
+      const context = (contexts[name] ??= {
+        windows: 0,
+        foregroundTotal: 0,
+        foregroundSamples: 0,
+        sizeClasses: dictionary(),
+      })
+      context.windows++
+      context.foregroundTotal += record.env.foreground
+      context.foregroundSamples++
+      const sizeClass = record.env.sizeClass
+      context.sizeClasses[sizeClass] = (context.sizeClasses[sizeClass] ?? 0) + 1
+    }
+  }
+
+  return {
+    digests,
+    anomalies,
+    rates,
+    rateContexts,
+    counters,
+    sessions,
+    builds,
+    rejected,
+    excludedBackgroundWindows,
+  }
+}
+
+function requirePositiveFinite(value, path) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${path} must be a positive finite number`)
+  }
+}
+
+function validateBaseline(baseline) {
+  if (!isRecord(baseline)) throw new Error('baseline must be an object')
+  if (baseline.version !== BASELINE_VERSION) {
+    throw new Error(
+      `version must be ${BASELINE_VERSION}; received ${JSON.stringify(baseline.version ?? null)}`,
+    )
+  }
+  requirePositiveFinite(baseline.minSamples, 'minSamples')
+  if (!isRecord(baseline.rates)) throw new Error('rates must be an object')
+
+  for (const [environment, metrics] of Object.entries(baseline.rates)) {
+    if (!isRecord(metrics)) throw new Error(`rates[${JSON.stringify(environment)}] must be an object`)
+    for (const [metric, expected] of Object.entries(metrics)) {
+      const path = `rates[${JSON.stringify(environment)}][${JSON.stringify(metric)}]`
+      if (!isRecord(expected)) throw new Error(`${path} must be an object`)
+      requirePositiveFinite(expected.rate, `${path}.rate`)
+      if (expected.tolerance !== undefined) {
+        requirePositiveFinite(expected.tolerance, `${path}.tolerance`)
+      }
+    }
+  }
+
+  return baseline
+}
+
+/**
+ * Compare each aggregated rate against the baseline.
+ *
+ * Statuses:
+ *
+ * | status | meaning |
+ * | --- | --- |
+ * | informational | reported without a verdict |
+ * | insufficient-samples | judged rate below the baseline's sample floor |
+ * | unbaselined | judged rate with no accepted baseline |
+ * | drift | judged rate outside its accepted tolerance |
+ * | ok | judged rate inside its accepted tolerance |
+ */
+export function judgeRates(rates, baseline, rateContexts = {}) {
+  const acceptedBaseline = validateBaseline(baseline)
+  const minSamples = acceptedBaseline.minSamples
+  const verdicts = []
+
+  for (const [build, environments] of Object.entries(rates)) {
+    for (const [key, series] of Object.entries(environments)) {
+      for (const [name, totals] of Object.entries(series)) {
+        const context = rateContexts[build]?.[key]?.[name]
+        const contextWindows = context?.windows ?? 0
+        const sizeClassPercentages = dictionary()
+        for (const [sizeClass, count] of Object.entries(context?.sizeClasses ?? {})) {
+          sizeClassPercentages[sizeClass] = contextWindows > 0 ? (count / contextWindows) * 100 : 0
+        }
+        const meanForeground =
+          context?.foregroundSamples > 0 ? context.foregroundTotal / context.foregroundSamples : null
+        const rate = totals.d > 0 ? totals.n / totals.d : null
+        const expected = acceptedBaseline.rates[key]?.[name]
+        const common = {
+          build,
+          environment: key,
+          metric: name,
+          rate,
+          samples: totals.d,
+          numerator: totals.n,
+          windows: totals.windows,
+          sizeClassPercentages,
+          meanForeground,
+        }
+
+        if (totals.informational) {
+          verdicts.push({ ...common, status: 'informational' })
+          continue
+        }
+        if (rate === null || totals.d < minSamples) {
+          verdicts.push({ ...common, status: 'insufficient-samples', minSamples })
+          continue
+        }
+        if (!expected || typeof expected.rate !== 'number') {
+          verdicts.push({ ...common, status: 'unbaselined' })
+          continue
+        }
+
+        const tolerance = expected.tolerance ?? 0.3
+        // Relative to the BASELINE, so the band is symmetric in the units a reader
+        // thinks in: "within 30% of what we accepted", not within 30% of today.
+        const drifted = Math.abs(rate - expected.rate) > expected.rate * tolerance
+        verdicts.push({
+          ...common,
+          status: drifted ? 'drift' : 'ok',
+          baseline: expected.rate,
+          tolerance,
+        })
+      }
+    }
+  }
+
+  return verdicts
+}
+
+/** Daily log files whose whole UTC day is older than the retention boundary. */
+export function selectPrunable(files, now, retentionDays) {
+  const cutoff = new Date(now.getTime() - retentionDays * 86400000)
+  cutoff.setUTCHours(0, 0, 0, 0)
+  return files.filter((file) => {
+    const dated = new Date(`${file.date}T00:00:00Z`)
+    // One comparison decides everything, and it is deliberately the ONLY one.
+    //
+    // The cutoff is a UTC day boundary, so a file date below it represents a whole
+    // day that ended before the boundary. Both dangerous cases also fall out of the
+    // comparison rather than needing a guard. A date ahead of `now` is ahead of the
+    // cutoff too, so clock skew cannot make this delete a log. A name matching
+    // YYYY-MM-DD whose numbers are not a real date — `2026-13-45` — parses to NaN,
+    // and every comparison against NaN is false, so it is kept.
+    //
+    // Guards for both were written here first and neither was falsifiable: no test
+    // could tell their presence from their absence. The cases are covered by tests
+    // held against THIS line, which fails all three when it is mutated.
+    return dated < cutoff
+  })
+}
+
+/** Log files in a directory, oldest first. */
+export function listLogs(dir) {
+  return readdirSync(dir)
+    .map((name) => ({ name, match: LOG_NAME.exec(name) }))
+    .filter(({ match }) => match !== null)
+    .map(({ name, match }) => ({ name, date: match[1], path: join(dir, name) }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function parseUtcLogDate(date) {
+  const parsed = new Date(`${date}T00:00:00Z`)
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== date) return null
+  return parsed
+}
+
+/** Parse one JSONL file, keeping malformed lines as rejections rather than throwing. */
+export function readLog(path) {
+  const records = []
+  const rejected = []
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (line.trim() === '') continue
+    try {
+      records.push(JSON.parse(line))
+    } catch {
+      rejected.push({ reason: 'unparseable', path })
+    }
+  }
+  return { records, rejected }
+}
+
+/**
+ * Where the sidecar is written, per platform.
+ *
+ * Probed rather than assumed: this toolchain runs on more than one machine, and a
+ * hardcoded path would make the review silently report an empty week on the others.
+ */
+export function defaultLogDirs(env = process.env, platform = process.platform) {
+  const home = env.HOME ?? env.USERPROFILE ?? ''
+  if (platform === 'darwin') return [posix.join(home, 'Library/Logs/com.processone.fluux')]
+  if (platform === 'win32') {
+    const profile = env.USERPROFILE ?? env.HOME ?? ''
+    const localData = env.LOCALAPPDATA || win32.join(profile, 'AppData', 'Local')
+    return [win32.join(localData, 'com.processone.fluux', 'logs')]
+  }
+  return [
+    posix.join(env.XDG_DATA_HOME ?? posix.join(home, '.local/share'), 'com.processone.fluux/logs'),
+    posix.join(home, '.local/share/com.processone.fluux/logs'),
+  ]
+}
+
+function parseArgs(argv) {
+  const args = {
+    days: 7,
+    daysInput: '7',
+    retention: DEFAULT_RETENTION_DAYS,
+    retentionInput: String(DEFAULT_RETENTION_DAYS),
+    prune: false,
+    json: false,
+    dir: null,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--prune') {
+      args.prune = true
+      continue
+    }
+    if (arg === '--json') {
+      args.json = true
+      continue
+    }
+    if (!['--dir', '--days', '--retention', '--baseline'].includes(arg)) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const value = argv[i + 1]
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`${arg} requires a value`)
+    }
+    i++
+
+    if (arg === '--dir') args.dir = value
+    else if (arg === '--days') {
+      args.daysInput = value
+      args.days = Number(value)
+    } else if (arg === '--retention') {
+      args.retentionInput = value
+      args.retention = Number(value)
+    } else args.baseline = value
+  }
+  return args
+}
+
+function validateDaysArg(value, input) {
+  if (!Number.isFinite(value) || value <= 0 || !Number.isInteger(value)) {
+    console.error(`--days must be a positive integer number of UTC days; received ${JSON.stringify(input)}.`)
+    process.exit(2)
+  }
+}
+
+function validateDurationArg(name, value, input) {
+  if (!Number.isFinite(value) || value <= 0) {
+    console.error(`${name} must be a positive finite number of days; received ${JSON.stringify(input)}.`)
+    process.exit(2)
+  }
+}
+
+function resolveDir(explicit) {
+  if (explicit) return explicit
+  for (const dir of defaultLogDirs()) {
+    try {
+      if (statSync(dir).isDirectory()) return dir
+    } catch {
+      // Not this one.
+    }
+  }
+  return null
+}
+
+function main() {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(2)
+  }
+  validateDaysArg(args.days, args.daysInput)
+  validateDurationArg('--retention', args.retention, args.retentionInput)
+  const dir = resolveDir(args.dir)
+  if (!dir) {
+    console.error(
+      'No anomaly log directory found. Looked in:\n  ' +
+        defaultLogDirs().join('\n  ') +
+        '\nPass --dir <path> if the Dev build writes elsewhere, or on another machine.',
+    )
+    process.exit(2)
+  }
+
+  const all = listLogs(dir)
+  const now = new Date()
+  const today = new Date(now)
+  today.setUTCHours(0, 0, 0, 0)
+  const cutoff = new Date(today)
+  cutoff.setUTCDate(cutoff.getUTCDate() - (args.days - 1))
+  const tomorrow = new Date(today)
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+  const recent = []
+  const skippedFiles = []
+  for (const file of all) {
+    const dated = parseUtcLogDate(file.date)
+    if (dated === null) skippedFiles.push({ name: file.name, reason: 'invalid-date' })
+    else if (dated >= tomorrow) skippedFiles.push({ name: file.name, reason: 'future-date' })
+    else if (dated < cutoff) skippedFiles.push({ name: file.name, reason: 'outside-window' })
+    else recent.push(file)
+  }
+  const skippedFuture = skippedFiles.filter((file) => file.reason === 'future-date')
+
+  const records = []
+  const rejected = []
+  for (const file of recent) {
+    const read = readLog(file.path)
+    records.push(...read.records)
+    rejected.push(...read.rejected)
+  }
+
+  const folded = foldRecords(records)
+  folded.rejected.push(...rejected)
+
+  let baseline = { version: BASELINE_VERSION, minSamples: 30, rates: {} }
+  const baselinePath = args.baseline ?? 'docs/anomaly-baseline.json'
+  let baselineText = null
+  try {
+    baselineText = readFileSync(baselinePath, 'utf8')
+  } catch (error) {
+    if (args.baseline !== undefined) {
+      console.error(
+        `Cannot read baseline at ${baselinePath}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      )
+      process.exit(2)
+    }
+    console.error(`No baseline at ${baselinePath}; every rate will report as unbaselined.`)
+  }
+  if (baselineText !== null) {
+    try {
+      baseline = JSON.parse(baselineText)
+    } catch (error) {
+      console.error(
+        `Invalid baseline at ${baselinePath}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      )
+      process.exit(2)
+    }
+  }
+
+  let verdicts
+  try {
+    verdicts = judgeRates(folded.rates, baseline, folded.rateContexts)
+  } catch (error) {
+    console.error(
+      `Invalid baseline at ${baselinePath}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    )
+    process.exit(2)
+  }
+
+  const pruned = []
+  if (args.prune) {
+    for (const file of selectPrunable(all, new Date(), args.retention)) {
+      rmSync(file.path)
+      pruned.push(file.name)
+    }
+  }
+
+  const judgeableRateCount = verdicts.filter((verdict) => verdict.status !== 'informational').length
+  const report = {
+    directory: dir,
+    days: args.days,
+    filesRead: recent.map((f) => f.name),
+    skippedFiles,
+    skippedFutureFiles: skippedFuture.map((f) => f.name),
+    sessions: folded.sessions.size,
+    builds: [...folded.builds],
+    anomalies: folded.anomalies,
+    counters: folded.counters,
+    rates: verdicts,
+    judgeableRateCount,
+    excludedBackgroundWindows: folded.excludedBackgroundWindows,
+    rejected: folded.rejected,
+    pruned,
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+    return
+  }
+
+  console.log(`Anomaly review — ${dir}`)
+  console.log(`${recent.length} file(s), last ${args.days} day(s), ${report.sessions} session(s)`)
+  if (report.builds.length > 0) console.log(`Builds: ${report.builds.join(', ')}`)
+  if (report.skippedFiles.length > 0) {
+    console.log(
+      `Skipped input files: ${report.skippedFiles.map((file) => `${file.name} (${file.reason})`).join(', ')}`,
+    )
+  }
+  console.log(
+    `Excluded background windows: ${report.excludedBackgroundWindows} ` +
+      `(foreground < ${MIN_FOREGROUND_SHARE})`,
+  )
+
+  const ids = Object.entries(report.anomalies).sort((a, b) => b[1].total - a[1].total)
+  console.log(`\nInvariants (${ids.length}):`)
+  if (ids.length === 0) console.log('  none')
+  for (const [id, entry] of ids) {
+    console.log(`  ${id}: ${entry.total} (${entry.recorded} recorded, ${entry.suppressed} suppressed)`)
+  }
+
+  console.log(`\nRates (${verdicts.length}):`)
+  if (verdicts.length === 0) console.log('  none')
+  if (verdicts.length > 0 && report.judgeableRateCount === 0) {
+    console.log('  No judgeable rates; informational measurements are not a clean verdict.')
+  }
+  for (const v of verdicts) {
+    const shown = v.rate === null ? 'n/a' : v.rate.toFixed(2)
+    const sizes = Object.entries(v.sizeClassPercentages)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([sizeClass, percentage]) => `${sizeClass} ${percentage.toFixed(0)}%`)
+      .join(', ')
+    const foreground = v.meanForeground === null ? 'n/a' : `${(v.meanForeground * 100).toFixed(0)}%`
+    const suffix =
+      v.status === 'drift'
+        ? ` — DRIFT from ${v.baseline} (±${Math.round(v.tolerance * 100)}%)`
+        : v.status === 'informational'
+          ? ' — informational only'
+          : v.status === 'insufficient-samples'
+            ? ` — only ${v.samples} samples, needs ${v.minSamples}`
+            : v.status === 'unbaselined'
+              ? ' — no accepted baseline yet'
+              : ''
+    console.log(
+      `  [${v.status}] build=${v.build} ${v.environment} ${v.metric} = ${shown} ` +
+        `(n=${v.numerator}, d=${v.samples}; sizes=${sizes || 'n/a'}; foreground=${foreground})${suffix}`,
+    )
+  }
+
+  if (report.rejected.length > 0) console.log(`\nRejected records: ${report.rejected.length}`)
+  if (pruned.length > 0) console.log(`\nPruned ${pruned.length} file(s) older than ${args.retention} days`)
+}
+
+// Only when run directly, so the tests can import the pure functions.
+if (process.argv[1] && process.argv[1].endsWith('anomaly-review.mjs')) main()

--- a/scripts/anomaly-review.test.mjs
+++ b/scripts/anomaly-review.test.mjs
@@ -1,0 +1,911 @@
+import { strict as assert } from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+import {
+  BASELINE_VERSION,
+  SCHEMA_MAJOR,
+  defaultLogDirs,
+  environmentKey,
+  foldRecords,
+  judgeRates,
+  selectPrunable,
+} from './anomaly-review.mjs'
+
+const baselineDocument = (over = {}) => ({
+  version: BASELINE_VERSION,
+  minSamples: 30,
+  rates: {},
+  ...over,
+})
+
+const environment = (over = {}) => ({
+  platform: 'macos',
+  engine: 'webkit',
+  engineVersion: 605,
+  sizeClass: 'lg',
+  accounts: 1,
+  foreground: 1,
+  ...over,
+})
+
+const digest = (over = {}) => ({
+  v: 1,
+  kind: 'digest',
+  t: '2026-08-20T10:00:00.000Z',
+  sid: 's1',
+  build: '0.17.2+abc',
+  windowMs: 300000,
+  counters: {},
+  suppressed: {},
+  rates: {},
+  env: environment(),
+  ...over,
+})
+
+const anomaly = (id, over = {}) => ({
+  v: 1,
+  kind: 'anomaly',
+  t: '2026-08-20T10:00:00.000Z',
+  sid: 's1',
+  build: '0.17.2+abc',
+  id,
+  sev: 'suspect',
+  ...over,
+})
+
+test('refuses a schema major it was not written for, instead of misreading it', () => {
+  // Silently parsing a future record is the failure that matters: the fields it
+  // reports would be wrong rather than missing, and a wrong number in a review is
+  // worse than a review that declines to run.
+  const result = foldRecords([digest(), { ...digest(), v: SCHEMA_MAJOR + 1 }])
+  assert.equal(result.rejected.length, 1)
+  assert.equal(result.rejected[0].reason, 'schema-major')
+  assert.equal(result.digests.length, 1)
+})
+
+test('rejects malformed v1 records before any field reaches aggregation', () => {
+  const rateWithoutEnv = digest({ rates: { 'r/x': { n: 20, d: 40 } } })
+  delete rateWithoutEnv.env
+  const records = [
+    digest({ counters: { bad: -1 } }),
+    digest({ suppressed: { bad: Number.NaN } }),
+    digest({ rates: { 'r/x': { n: 'bad', d: 40 } } }),
+    digest({ rates: { 'r/x': { n: 20, d: Number.POSITIVE_INFINITY } } }),
+    digest({ env: environment({ foreground: false }) }),
+    rateWithoutEnv,
+    anomaly('read-state/unread-survives-focus', { sev: 'unknown' }),
+    { ...digest(), kind: 'other' },
+  ]
+  const result = foldRecords(records)
+
+  assert.deepEqual(
+    result.rejected.map(({ reason }) => reason),
+    [
+      'invalid-counter',
+      'invalid-suppressed',
+      'invalid-rate',
+      'invalid-rate',
+      'invalid-env',
+      'invalid-env',
+      'invalid-anomaly',
+      'unknown-kind',
+    ],
+  )
+  assert.equal(result.digests.length, 0)
+  assert.equal(Object.keys(result.rates).length, 0)
+  assert.equal(Object.keys(result.counters).length, 0)
+  assert.equal(Object.keys(result.anomalies).length, 0)
+})
+
+test('folds a pre-Stage-4 v1 digest without rates or environment', () => {
+  const legacy = {
+    v: 1,
+    kind: 'digest',
+    t: '2026-08-20T10:00:00.000Z',
+    sid: 'legacy-session',
+    build: '0.17.1+legacy',
+    windowMs: 300000,
+    counters: { 'legacy.counter': 3 },
+    suppressed: { 'read-state/unread-survives-focus': 7 },
+  }
+  const result = foldRecords([legacy])
+
+  assert.deepEqual(result.rejected, [])
+  assert.equal(result.digests.length, 1)
+  assert.equal(result.counters['legacy.counter'], 3)
+  assert.equal(result.anomalies['read-state/unread-survives-focus'].suppressed, 7)
+  assert.equal(result.anomalies['read-state/unread-survives-focus'].total, 7)
+  assert.equal(Object.keys(result.rates).length, 0)
+})
+
+test('rejects zero and negative digest windows before judgment', () => {
+  const result = foldRecords([
+    digest({ windowMs: 0, rates: { 'r/x': { n: 40, d: 40 } } }),
+    digest({ windowMs: -1, rates: { 'r/x': { n: 40, d: 40 } } }),
+  ])
+
+  assert.deepEqual(result.rejected.map(({ reason }) => reason), ['invalid-window', 'invalid-window'])
+  assert.equal(result.digests.length, 0)
+  assert.equal(Object.keys(result.rates).length, 0)
+})
+
+test('rejects a string foreground before background filtering or judgment', () => {
+  const result = foldRecords([
+    digest({
+      env: environment({ foreground: '0' }),
+      rates: { 'r/x': { n: 40, d: 40 } },
+    }),
+  ])
+
+  assert.deepEqual(result.rejected.map(({ reason }) => reason), ['invalid-env'])
+  assert.equal(result.excludedBackgroundWindows, 0)
+  assert.equal(Object.keys(result.rates).length, 0)
+  assert.deepEqual(judgeRates(result.rates, baselineDocument({ minSamples: 1 })), [])
+})
+
+test('validates each environment field by its exact type and range', () => {
+  const environments = [
+    environment({ platform: 1 }),
+    environment({ engine: 1 }),
+    environment({ sizeClass: 1 }),
+    environment({ engineVersion: -1 }),
+    environment({ accounts: Number.POSITIVE_INFINITY }),
+    environment({ foreground: -0.01 }),
+    environment({ foreground: 1.01 }),
+    { ...environment(), unknown: 'value' },
+  ]
+  const result = foldRecords(environments.map((env) => digest({ env })))
+
+  assert.deepEqual(result.rejected.map(({ reason }) => reason), environments.map(() => 'invalid-env'))
+  assert.equal(result.digests.length, 0)
+})
+
+test('groups anomalies by id and folds the suppressed counts into the same total', () => {
+  // The per-id cooldown means the record stream under-reports frequency by design.
+  // A review that counted only records would call a storm a single event.
+  const result = foldRecords([
+    anomaly('read-state/unread-survives-focus'),
+    anomaly('read-state/unread-survives-focus'),
+    digest({ suppressed: { 'read-state/unread-survives-focus': 7 } }),
+  ])
+  const found = result.anomalies['read-state/unread-survives-focus']
+  assert.equal(found.recorded, 2)
+  assert.equal(found.suppressed, 7)
+  assert.equal(found.total, 9)
+})
+
+test('aggregates prototype-named external keys without inherited state', () => {
+  const result = foldRecords([
+    anomaly('__proto__'),
+    anomaly('constructor'),
+    digest({
+      build: '__proto__',
+      counters: Object.fromEntries([
+        ['__proto__', 3],
+        ['constructor', 4],
+      ]),
+      suppressed: Object.fromEntries([
+        ['__proto__', 5],
+        ['constructor', 6],
+      ]),
+      rates: Object.fromEntries([
+        ['__proto__', { n: 10, d: 5 }],
+        ['constructor', { n: 12, d: 6 }],
+      ]),
+      env: environment({ platform: 'host', engine: 'engine', sizeClass: '__proto__' }),
+    }),
+    digest({
+      build: 'constructor',
+      rates: Object.fromEntries([['constructor', { n: 4, d: 2 }]]),
+      env: environment({ sizeClass: 'constructor' }),
+    }),
+  ])
+
+  assert.equal(Object.getPrototypeOf(result.anomalies), null)
+  assert.equal(Object.getPrototypeOf(result.counters), null)
+  assert.equal(Object.getPrototypeOf(result.rates), null)
+  assert.equal(Object.getPrototypeOf(result.rateContexts), null)
+  assert.deepEqual(result.anomalies.__proto__, {
+    recorded: 1,
+    suppressed: 5,
+    total: 6,
+    sev: 'suspect',
+  })
+  assert.deepEqual(result.anomalies.constructor, {
+    recorded: 1,
+    suppressed: 6,
+    total: 7,
+    sev: 'suspect',
+  })
+  assert.equal(result.counters.__proto__, 3)
+  assert.equal(result.counters.constructor, 4)
+  assert.equal(result.rates.__proto__['host/engine'].__proto__.n, 10)
+  assert.equal(result.rates.__proto__['host/engine'].constructor.n, 12)
+  assert.equal(result.rates.constructor['macos/webkit'].constructor.n, 4)
+
+  const hostileContext = result.rateContexts.__proto__['host/engine'].__proto__
+  assert.equal(Object.getPrototypeOf(hostileContext.sizeClasses), null)
+  assert.equal(hostileContext.sizeClasses.__proto__, 1)
+  const constructorContext = result.rateContexts.constructor['macos/webkit'].constructor
+  assert.equal(constructorContext.sizeClasses.constructor, 1)
+
+  const verdicts = judgeRates(result.rates, baselineDocument({ minSamples: 1 }), result.rateContexts)
+  assert.equal(verdicts.length, 3)
+  assert.ok(verdicts.every(({ status }) => status === 'unbaselined'))
+  assert.equal(Object.getPrototypeOf(verdicts[0].sizeClassPercentages), null)
+  assert.equal(verdicts[0].sizeClassPercentages.__proto__, 100)
+  assert.deepEqual(
+    verdicts.map(({ build, metric }) => ({ build, metric })),
+    [
+      { build: '__proto__', metric: '__proto__' },
+      { build: '__proto__', metric: 'constructor' },
+      { build: 'constructor', metric: 'constructor' },
+    ],
+  )
+})
+
+test('keeps environments apart, because a rate from one says nothing about the other', () => {
+  const macos = digest({ rates: { 'scroll.writes/positioning': { n: 100, d: 50 } } })
+  const linux = digest({
+    env: environment({ platform: 'linux' }),
+    rates: { 'scroll.writes/positioning': { n: 900, d: 50 } },
+  })
+  const result = foldRecords([macos, linux])
+  const rates = result.rates['0.17.2+abc']
+  assert.deepEqual(Object.keys(rates).sort(), ['linux/webkit', 'macos/webkit'])
+  assert.equal(rates['macos/webkit']['scroll.writes/positioning'].n, 100)
+  assert.equal(rates['linux/webkit']['scroll.writes/positioning'].n, 900)
+})
+
+test('sums a rate across every window before judging it', () => {
+  const result = foldRecords([
+    digest({ rates: { 'scroll.writes/positioning': { n: 10, d: 5 } } }),
+    digest({ rates: { 'scroll.writes/positioning': { n: 30, d: 15 } } }),
+  ])
+  const totals = result.rates['0.17.2+abc']['macos/webkit']['scroll.writes/positioning']
+  assert.equal(totals.n, 40)
+  assert.equal(totals.d, 20)
+})
+
+test('rejects a rate record before finite totals can overflow', () => {
+  const result = foldRecords([
+    digest({ sid: 'accepted', rates: { 'r/x': { n: 1e308, d: 1e308 } } }),
+    digest({ sid: 'rejected', rates: { 'r/x': { n: 1e308, d: 1e308 } } }),
+  ])
+  const totals = result.rates['0.17.2+abc']['macos/webkit']['r/x']
+
+  assert.equal(result.rejected.length, 1)
+  assert.equal(result.rejected[0].reason, 'rate-overflow')
+  assert.equal(result.digests.length, 1)
+  assert.deepEqual([...result.sessions], ['accepted'])
+  assert.equal(totals.n, 1e308)
+  assert.equal(totals.d, 1e308)
+  assert.equal(totals.windows, 1)
+  const [verdict] = judgeRates(
+    result.rates,
+    baselineDocument({
+      minSamples: 1,
+      rates: { 'macos/webkit': { 'r/x': { rate: 1, tolerance: 0.3 } } },
+    }),
+    result.rateContexts,
+  )
+  assert.equal(verdict.status, 'ok')
+  assert.equal(verdict.rate, 1)
+  assert.ok(Number.isFinite(verdict.numerator))
+  assert.ok(Number.isFinite(verdict.samples))
+})
+
+test('rejects counter and suppression overflows before mutating folded state', () => {
+  const cases = [
+    {
+      first: digest({ sid: 'accepted', counters: { huge: 1e308 } }),
+      second: digest({ sid: 'rejected', counters: { huge: 1e308 }, suppressed: { safe: 4 } }),
+      reason: 'counter-overflow',
+      assertAccepted(result) {
+        assert.equal(result.counters.huge, 1e308)
+        assert.equal(result.anomalies.safe, undefined)
+      },
+    },
+    {
+      first: digest({ sid: 'accepted', suppressed: { huge: 1e308 } }),
+      second: digest({ sid: 'rejected', suppressed: { huge: 1e308 }, counters: { safe: 4 } }),
+      reason: 'suppressed-overflow',
+      assertAccepted(result) {
+        assert.equal(result.anomalies.huge.suppressed, 1e308)
+        assert.equal(result.anomalies.huge.total, 1e308)
+        assert.equal(result.counters.safe, undefined)
+      },
+    },
+  ]
+
+  for (const scenario of cases) {
+    const result = foldRecords([scenario.first, scenario.second])
+    assert.deepEqual(result.rejected.map(({ reason }) => reason), [scenario.reason])
+    assert.equal(result.digests.length, 1)
+    assert.deepEqual([...result.sessions], ['accepted'])
+    scenario.assertAccepted(result)
+  }
+})
+
+test('judges each build separately so a regressed build cannot be diluted', () => {
+  const result = foldRecords([
+    digest({ build: 'build-a', rates: { 'r/x': { n: 200, d: 100 } } }),
+    digest({ build: 'build-b', rates: { 'r/x': { n: 80, d: 20 } } }),
+  ])
+  const baseline = baselineDocument({
+    minSamples: 20,
+    rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: 0.3 } } },
+  })
+  const verdicts = judgeRates(result.rates, baseline, result.rateContexts)
+
+  assert.deepEqual(
+    verdicts.map(({ build, status, rate }) => ({ build, status, rate })),
+    [
+      { build: 'build-a', status: 'ok', rate: 2 },
+      { build: 'build-b', status: 'drift', rate: 4 },
+    ],
+  )
+})
+
+test('excludes background windows and reports retained-window context', () => {
+  const result = foldRecords([
+    digest({
+      env: environment({ sizeClass: 'sm', foreground: 0.1 }),
+      rates: { 'r/x': { n: 900, d: 10 } },
+    }),
+    digest({
+      env: environment({ sizeClass: 'sm', foreground: 0.1 }),
+      rates: {},
+    }),
+    digest({
+      env: environment({ sizeClass: 'sm', foreground: 0.5 }),
+      rates: { 'r/x': { n: 10, d: 10 } },
+    }),
+    digest({
+      env: environment({ sizeClass: 'lg', foreground: 1 }),
+      rates: { 'r/x': { n: 30, d: 10 } },
+    }),
+  ])
+  const [verdict] = judgeRates(result.rates, baselineDocument({ minSamples: 1 }), result.rateContexts)
+
+  assert.equal(result.excludedBackgroundWindows, 1)
+  assert.equal(verdict.rate, 2)
+  assert.deepEqual({ ...verdict.sizeClassPercentages }, { sm: 50, lg: 50 })
+  assert.equal(verdict.meanForeground, 0.75)
+})
+
+test('reports every current stage-4 rate without judging it against a baseline', () => {
+  const result = foldRecords([
+    digest({
+      rates: {
+        'render.MessageList/roomSwitch': { n: 400, d: 40, informational: true },
+        'scroll.writes/positioning': { n: 400, d: 40, informational: true },
+      },
+    }),
+  ])
+  const baseline = baselineDocument({
+    minSamples: 30,
+    rates: {
+      'macos/webkit': {
+        'render.MessageList/roomSwitch': { rate: 2, tolerance: 0.3 },
+        'scroll.writes/positioning': { rate: 2, tolerance: 0.3 },
+      },
+    },
+  })
+  const verdicts = judgeRates(result.rates, baseline, result.rateContexts)
+  const render = verdicts.find((verdict) => verdict.metric === 'render.MessageList/roomSwitch')
+  const scroll = verdicts.find((verdict) => verdict.metric === 'scroll.writes/positioning')
+
+  assert.deepEqual(
+    { status: render.status, rate: render.rate, numerator: render.numerator, samples: render.samples },
+    { status: 'informational', rate: 10, numerator: 400, samples: 40 },
+  )
+  assert.deepEqual(
+    { status: scroll.status, rate: scroll.rate, numerator: scroll.numerator, samples: scroll.samples },
+    { status: 'informational', rate: 10, numerator: 400, samples: 40 },
+  )
+})
+
+test('withholds a verdict below the minimum sample size, but still reports the numbers', () => {
+  // Three room switches producing a high render rate is noise. Reporting it as drift
+  // is how a review starts crying wolf, and by the design a review nobody reads is
+  // worse than no review.
+  const baseline = baselineDocument({
+    rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: 0.3 } } },
+  })
+  const [verdict] = judgeRates({ build: { 'macos/webkit': { 'r/x': { n: 100, d: 4 } } } }, baseline)
+  assert.equal(verdict.status, 'insufficient-samples')
+  assert.equal(verdict.samples, 4)
+  assert.equal(verdict.rate, 25)
+})
+
+test('reports drift only outside the tolerance the baseline sets', () => {
+  const baseline = baselineDocument({
+    rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: 0.3 } } },
+  })
+  const within = judgeRates({ build: { 'macos/webkit': { 'r/x': { n: 90, d: 40 } } } }, baseline)
+  assert.equal(within[0].status, 'ok', 'rate 2.25 is inside a 30% tolerance')
+
+  const beyond = judgeRates({ build: { 'macos/webkit': { 'r/x': { n: 400, d: 40 } } } }, baseline)
+  assert.equal(beyond[0].status, 'drift')
+  assert.equal(beyond[0].rate, 10)
+  assert.equal(beyond[0].baseline, 2)
+})
+
+test('calls a rate with no baseline unbaselined rather than drifting', () => {
+  // The baseline ships empty on purpose. Treating absence as a zero baseline would
+  // make every rate drift on the first run.
+  const [verdict] = judgeRates(
+    { build: { 'macos/webkit': { 'r/x': { n: 100, d: 40 } } } },
+    baselineDocument(),
+  )
+  assert.equal(verdict.status, 'unbaselined')
+})
+
+test('rejects invalid baseline fields before producing verdicts', () => {
+  const rates = { build: { 'macos/webkit': { 'r/x': { n: 100, d: 40 } } } }
+  const cases = [
+    [baselineDocument({ version: undefined }), /version/],
+    [baselineDocument({ version: 2 }), /version/],
+    [baselineDocument({ version: '1' }), /version/],
+    [baselineDocument({ minSamples: 0 }), /minSamples/],
+    [baselineDocument({ minSamples: Number.NaN }), /minSamples/],
+    [baselineDocument({ rates: { 'macos/webkit': { 'r/x': { rate: 0 } } } }), /\.rate/],
+    [baselineDocument({ rates: { 'macos/webkit': { 'r/x': { rate: Number.NaN } } } }), /\.rate/],
+    [
+      baselineDocument({ rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: 0 } } } }),
+      /\.tolerance/,
+    ],
+    [
+      baselineDocument({
+        rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: Number.NaN } } },
+      }),
+      /\.tolerance/,
+    ],
+  ]
+
+  for (const [baseline, message] of cases) {
+    assert.throws(() => judgeRates(rates, baseline), message)
+  }
+})
+
+test('never compares a zero-denominator rate with the baseline', () => {
+  const [verdict] = judgeRates(
+    { build: { 'macos/webkit': { 'r/x': { n: 100, d: 0 } } } },
+    baselineDocument({ minSamples: 1, rates: { 'macos/webkit': { 'r/x': { rate: 2 } } } }),
+  )
+  assert.equal(verdict.status, 'insufficient-samples')
+  assert.equal(verdict.rate, null)
+  assert.equal('baseline' in verdict, false)
+})
+
+test('prunes only what is older than the retention window', () => {
+  const files = [
+    { name: 'anomalies.2026-08-20.jsonl', date: '2026-08-20' },
+    { name: 'anomalies.2026-08-01.jsonl', date: '2026-08-01' },
+    { name: 'anomalies.2026-07-04.jsonl', date: '2026-07-04' },
+  ]
+  const prunable = selectPrunable(files, new Date('2026-08-20T12:00:00Z'), 30)
+  assert.deepEqual(
+    prunable.map((f) => f.name),
+    ['anomalies.2026-07-04.jsonl'],
+  )
+})
+
+test('keeps the UTC boundary day when pruning at midday', () => {
+  const files = [
+    { name: 'anomalies.2026-07-21.jsonl', date: '2026-07-21' },
+    { name: 'anomalies.2026-07-20.jsonl', date: '2026-07-20' },
+  ]
+  assert.deepEqual(
+    selectPrunable(files, new Date('2026-08-20T12:00:00Z'), 30).map((file) => file.name),
+    ['anomalies.2026-07-20.jsonl'],
+  )
+})
+
+test('keeps a file dated in the future rather than deleting what it cannot place', () => {
+  // A clock skew must never be a reason to destroy logs.
+  const files = [{ name: 'anomalies.2027-01-01.jsonl', date: '2027-01-01' }]
+  assert.deepEqual(selectPrunable(files, new Date('2026-08-20T12:00:00Z'), 30), [])
+})
+
+test('leaves a file whose name parses to no real date alone', () => {
+  // The filename pattern accepts any three number groups, so `2026-13-45` reaches
+  // here and parses to NaN. Every comparison against NaN is false, so without an
+  // explicit decision such a file would be neither kept nor pruned by accident —
+  // and "accidentally kept" is one refactor away from "accidentally deleted".
+  const files = [{ name: 'anomalies.2026-13-45.jsonl', date: '2026-13-45' }]
+  assert.deepEqual(selectPrunable(files, new Date('2027-08-20T12:00:00Z'), 30), [])
+})
+
+test('names the environment by platform and engine, not by a version that moves monthly', () => {
+  assert.equal(environmentKey({ platform: 'linux', engine: 'blink', engineVersion: 120 }), 'linux/blink')
+  assert.equal(environmentKey({}), 'unknown/unknown')
+})
+
+test('uses Local AppData for Windows sidecar logs', () => {
+  assert.deepEqual(defaultLogDirs({ LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local' }, 'win32'), [
+    'C:\\Users\\me\\AppData\\Local\\com.processone.fluux\\logs',
+  ])
+  assert.deepEqual(defaultLogDirs({ USERPROFILE: 'C:\\Users\\me' }, 'win32'), [
+    'C:\\Users\\me\\AppData\\Local\\com.processone.fluux\\logs',
+  ])
+})
+
+test('prints rate context without presenting an informational week as clean', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-report-'))
+  const date = new Date().toISOString().slice(0, 10)
+  const log = join(dir, `anomalies.${date}.jsonl`)
+  const baseline = join(dir, 'baseline.json')
+  const records = [
+    digest({ build: 'build-a', rates: { 'r/x': { n: 20, d: 10, informational: true } } }),
+    digest({
+      build: 'build-b',
+      env: environment({ sizeClass: 'sm', foreground: 0.5 }),
+      rates: { 'r/x': { n: 30, d: 10, informational: true } },
+    }),
+    digest({
+      build: 'build-b',
+      env: environment({ sizeClass: 'sm', foreground: 0.1 }),
+      rates: { 'r/x': { n: 900, d: 10 } },
+    }),
+  ]
+  writeFileSync(log, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`)
+  writeFileSync(baseline, JSON.stringify(baselineDocument({ minSamples: 1 })))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Excluded background windows: 1/)
+    assert.match(result.stdout, /No judgeable rates; informational measurements are not a clean verdict\./)
+    const rateLines = result.stdout.split('\n').filter((line) => line.startsWith('  ['))
+    assert.equal(rateLines.length, 2)
+    assert.ok(
+      rateLines.some(
+        (line) =>
+          line.includes('[informational] build=build-a macos/webkit') &&
+          line.endsWith('— informational only'),
+      ),
+    )
+    assert.ok(
+      rateLines.some(
+        (line) =>
+          line.includes('[informational] build=build-b macos/webkit') &&
+          line.endsWith('— informational only'),
+      ),
+    )
+    for (const line of rateLines) {
+      assert.match(line, /sizes=(lg|sm) 100%; foreground=(100|50)%/)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reports sessions and builds from accepted anomaly-only records', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-anomaly-only-'))
+  const date = new Date().toISOString().slice(0, 10)
+  const baseline = join(dir, 'baseline.json')
+  const records = [
+    anomaly('recorder/session-start', { sid: 'short-1', build: 'build-a' }),
+    anomaly('recorder/session-start', { sid: 'short-2', build: 'build-b' }),
+    anomaly('read-state/unread-survives-focus', { sid: 'short-2', build: 'build-b' }),
+  ]
+  writeFileSync(
+    join(dir, `anomalies.${date}.jsonl`),
+    `${records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+  )
+  writeFileSync(baseline, JSON.stringify(baselineDocument()))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.equal(report.sessions, 2)
+    assert.deepEqual(report.builds, ['build-a', 'build-b'])
+    assert.equal(report.anomalies['recorder/session-start'].total, 2)
+    assert.deepEqual(report.rates, [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('skips and reports future-dated logs instead of folding them', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-future-'))
+  const now = new Date()
+  const future = new Date(now)
+  future.setUTCDate(future.getUTCDate() + 2)
+  const todayName = `anomalies.${now.toISOString().slice(0, 10)}.jsonl`
+  const futureName = `anomalies.${future.toISOString().slice(0, 10)}.jsonl`
+  const baseline = join(dir, 'baseline.json')
+  writeFileSync(
+    join(dir, todayName),
+    `${JSON.stringify(digest({ rates: { 'r/x': { n: 20, d: 10, informational: true } } }))}\n`,
+  )
+  writeFileSync(
+    join(dir, futureName),
+    `${JSON.stringify(digest({ rates: { 'r/x': { n: 900, d: 10, informational: true } } }))}\n`,
+  )
+  writeFileSync(baseline, JSON.stringify(baselineDocument({ minSamples: 1 })))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.deepEqual(report.filesRead, [todayName])
+    assert.deepEqual(report.skippedFiles, [{ name: futureName, reason: 'future-date' }])
+    assert.deepEqual(report.skippedFutureFiles, [futureName])
+    assert.equal(report.rates[0].rate, 2)
+    assert.equal(report.judgeableRateCount, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reports impossible sidecar dates as skipped input errors', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-invalid-date-'))
+  const todayName = `anomalies.${new Date().toISOString().slice(0, 10)}.jsonl`
+  const invalidName = 'anomalies.2026-13-45.jsonl'
+  const baseline = join(dir, 'baseline.json')
+  writeFileSync(join(dir, todayName), `${JSON.stringify(digest())}\n`)
+  writeFileSync(join(dir, invalidName), `${JSON.stringify(digest())}\n`)
+  writeFileSync(baseline, JSON.stringify(baselineDocument()))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.deepEqual(report.filesRead, [todayName])
+    assert.deepEqual(report.skippedFiles, [{ name: invalidName, reason: 'invalid-date' }])
+    assert.deepEqual(report.skippedFutureFiles, [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('rejects malformed rates without emitting a verdict', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-invalid-rate-'))
+  const date = new Date().toISOString().slice(0, 10)
+  const baseline = join(dir, 'baseline.json')
+  writeFileSync(
+    join(dir, `anomalies.${date}.jsonl`),
+    `${JSON.stringify(digest({ rates: { 'r/x': { n: 'bad', d: 40 } } }))}\n`,
+  )
+  writeFileSync(
+    baseline,
+    JSON.stringify(
+      baselineDocument({
+        minSamples: 1,
+        rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: 0.3 } } },
+      }),
+    ),
+  )
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.deepEqual(report.rates, [])
+    assert.equal(report.judgeableRateCount, 0)
+    assert.deepEqual(report.rejected.map(({ reason }) => reason), ['invalid-rate'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('selects exactly the requested number of whole UTC days including today', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-days-range-'))
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+  const names = []
+  const baseline = join(dir, 'baseline.json')
+
+  for (let offset = 0; offset < 8; offset++) {
+    const date = new Date(today)
+    date.setUTCDate(date.getUTCDate() - offset)
+    const name = `anomalies.${date.toISOString().slice(0, 10)}.jsonl`
+    names.push(name)
+    writeFileSync(join(dir, name), `${JSON.stringify(digest())}\n`)
+  }
+  writeFileSync(baseline, JSON.stringify(baselineDocument({ minSamples: 1 })))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)),
+        '--dir',
+        dir,
+        '--baseline',
+        baseline,
+        '--days',
+        '7',
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.equal(report.filesRead.length, 7)
+    assert.equal(report.filesRead.includes(names[7]), false)
+    assert.deepEqual(report.filesRead, names.slice(0, 7).reverse())
+    assert.deepEqual(report.skippedFiles, [{ name: names[7], reason: 'outside-window' }])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('rejects invalid whole-day windows before scanning', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-days-'))
+
+  try {
+    for (const input of ['0', '-1', '1.5', 'nope', 'Infinity']) {
+      const result = spawnSync(
+        process.execPath,
+        [fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)), '--dir', dir, '--days', input],
+        { encoding: 'utf8' },
+      )
+      assert.equal(result.status, 2)
+      assert.match(result.stderr, /--days must be a positive integer number of UTC days/)
+      assert.ok(result.stderr.includes(JSON.stringify(input)))
+      assert.equal(result.stdout, '')
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('rejects unknown arguments and missing option values before scanning', () => {
+  const cases = [
+    { args: ['--day', '30'], offending: '--day', message: /Unknown argument/ },
+    { args: ['--dir'], offending: '--dir', message: /requires a value/ },
+    { args: ['--baseline'], offending: '--baseline', message: /requires a value/ },
+    { args: ['--dir', '--json'], offending: '--dir', message: /requires a value/ },
+  ]
+
+  for (const current of cases) {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)), ...current.args],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 2)
+    assert.match(result.stderr, current.message)
+    assert.ok(result.stderr.includes(current.offending))
+    assert.equal(result.stdout, '')
+  }
+})
+
+test('rejects a malformed baseline instead of emitting verdicts', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-baseline-'))
+  const date = new Date().toISOString().slice(0, 10)
+  const baseline = join(dir, 'baseline.json')
+  writeFileSync(
+    join(dir, `anomalies.${date}.jsonl`),
+    `${JSON.stringify(digest({ rates: { 'r/x': { n: 100, d: 40 } } }))}\n`,
+  )
+  writeFileSync(
+    baseline,
+    JSON.stringify(baselineDocument({
+      minSamples: 30,
+      rates: { 'macos/webkit': { 'r/x': { rate: 2, tolerance: -0.1 } } },
+    })),
+  )
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)), '--dir', dir, '--baseline', baseline],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 2)
+    assert.match(result.stderr, /Invalid baseline/)
+    assert.match(result.stderr, /tolerance must be a positive finite number/)
+    assert.equal(result.stdout, '')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('rejects an unsupported baseline version before producing verdicts', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-baseline-version-'))
+  const date = new Date().toISOString().slice(0, 10)
+  const baseline = join(dir, 'baseline.json')
+  writeFileSync(join(dir, `anomalies.${date}.jsonl`), `${JSON.stringify(digest())}\n`)
+  writeFileSync(baseline, JSON.stringify(baselineDocument({ version: 2 })))
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)), '--dir', dir, '--baseline', baseline],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 2)
+    assert.match(result.stderr, /Invalid baseline/)
+    assert.match(result.stderr, /version must be 1/)
+    assert.match(result.stderr, /2/)
+    assert.equal(result.stdout, '')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('rejects invalid retention before pruning any logs', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fluux-anomaly-review-'))
+  const log = join(dir, 'anomalies.2026-07-04.jsonl')
+  const contents = `${JSON.stringify(digest())}\n`
+  writeFileSync(log, contents)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('./anomaly-review.mjs', import.meta.url)), '--dir', dir, '--prune', '--retention', '-1'],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 2)
+    assert.match(result.stderr, /positive finite number/)
+    assert.match(result.stderr, /-1/)
+    assert.equal(result.signal, null)
+    assert.equal(readFileSync(log, 'utf8'), contents)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -608,4 +608,74 @@ test.describe('anomaly runtime', () => {
     expect(ctx.heldMs).toBeGreaterThanOrEqual(2000)
     expect(record.tokenKeyId).toMatch(/^[0-9a-f]{8}$/)
   })
+
+  /**
+   * The rates, end to end, in a real browser.
+   *
+   * Every layer below this has its own unit test, and all of them would still pass
+   * if the render counter never fired: the seam is a null check when nothing
+   * registers, and a digest with no rates is a legal digest. Only a real render
+   * reaching a real digest proves the chain — component body, neutral seam, handler,
+   * registry constant, recorder, serializer — is actually connected.
+   */
+  test('a real render reaches the digest as a rate', async ({ page }) => {
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    await openDemoRoom(page)
+
+    // Digests are on a five-minute timer, which no test can wait for. Hiding the
+    // document flushes one — the same path a real session takes when it is
+    // backgrounded, so this exercises production behaviour rather than a test hook.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+              .map((line) => JSON.parse(line) as { kind?: string })
+              .some((record) => record.kind === 'digest'),
+          ),
+        { timeout: 15_000, message: 'hiding the document flushed no digest' },
+      )
+      .toBe(true)
+
+    const digest = await page.evaluate(
+      () =>
+        (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+          .find((record) => record.kind === 'digest')!,
+    )
+
+    // Opening a room renders the list, so the numerator cannot legitimately be zero,
+    // and activating one IS the denominator — a switch.
+    const rates = digest.rates as Record<string, { n: number; d: number }>
+    expect(Object.keys(rates)).toContain('render.MessageList/roomSwitch')
+    expect(rates['render.MessageList/roomSwitch'].n).toBeGreaterThan(0)
+    expect(rates['render.MessageList/roomSwitch'].d).toBeGreaterThan(0)
+
+    // Environment travels with it, or the rate cannot be compared with anything.
+    const env = digest.env as Record<string, unknown>
+    expect(env.engine).toBe('blink')
+    expect(env.platform).toBeTruthy()
+    expect(typeof env.foreground).toBe('number')
+  })
 })


### PR DESCRIPTION
Raw counters cannot be compared against a committed number: `render.MessageList: 1840` mostly measures how much the app was used that day, so a quiet day and a fixed regression look alike. The digest now carries rates — a numerator beside the denominator that makes it comparable — with the sample count travelling with each one, plus the environment the session ran in.

The recorder does no division. The denominator *is* the sample count, and a quotient computed there would discard the one number that says whether the quotient is worth believing. The numerator/denominator pairing lives in the registry rather than in the review, so the log carries its own meaning.

Five metrics are wired at no cost to release builds: the counters behind the gate disappear entirely, and both denominators are derived from store state rather than from new call sites.

`scripts/anomaly-review.mjs` sweeps the sidecar logs — grouping by invariant, folding the suppressed counts the cooldown hides, aggregating rates per build and environment, diffing against a baseline, and pruning past retention. Every input is either aggregated or reported as rejected with a reason: nothing leaves the report silently, and nothing unvalidated reaches a verdict.

## Both rates ship informational, not judged

MessageList renders have several causes while only the switch denominator is observable, and the scroll monitor's write flag mixes an issued call with observed movement — so either would report a busy week as a regression. They report their numbers but never a verdict, and become judgeable in stage 5 with the seams they need.

`docs/anomaly-baseline.json` therefore ships empty. A baseline invented from no measurement puts every rate outside tolerance on the first run, and a review that cries wolf stops being read.

## Deferred, with the reason recorded next to the rates

`mam.rowsRetained`, `idb.writes` and `mam.queries` need SDK seams that do not exist: retention is decided downstream of the typed MAM event, and nothing MAM-related is exported. `render.MessageList/arrival` is deferred too — `lastArrivedMessage` distinguishes a real arrival from a preview update but lives on the chat store alone, and `roomMeta.lastMessage` also moves on a MAM merge, so a room arrival cannot be told from a history fetch.