### PR TITLE
feat(console): report unread recount deferrals in the log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 ### Power User Tools
 - **Command Palette** - Keyboard-accessible launcher for conversations, contacts, rooms, and actions
 - **Keyboard Shortcuts** - Shortcuts for navigation and message actions, with a categorized help overlay and AZERTY support
-- **Built-in XMPP Console** - Live stanza inspector with exportable connection-health diagnostics for scheduler suspension, sleep, and reconnection troubleshooting
+- **Built-in XMPP Console** - Live stanza inspector with exportable connection-health diagnostics for scheduler suspension, sleep, reconnection, and deferred unread-badge updates
 - **Server Administration** - Manage users, rooms, and server commands right from the client (for admins)
 - **User Profiles** - User info popovers with vCard details, connected devices, timezone, and last seen status
 

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
 import { X, Trash2, Send, ChevronDown, ChevronUp, Search, Download, Server, ArrowDownToLine } from 'lucide-react'
-import { useConsole, useXMPP, type XmppPacket } from '@fluux/sdk'
+import { readRecountDeferrals, useConsole, useXMPP, type XmppPacket } from '@fluux/sdk'
 import { useConnectionStore } from '@fluux/sdk/react'
 import { formatStanzaPreview, formatStanzaXml } from '@/utils/stanzaPreviewFormatter'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -455,6 +455,9 @@ export function XmppConsole() {
           ? { inbound: streamManagement.inbound, outbound: streamManagement.outbound }
           : null,
       },
+      // Read-only: the export renders these tallies and never feeds one back into a
+      // recount decision, which is what keeps the SDK counter passive.
+      recountDeferrals: readRecountDeferrals(),
     })
     const defaultFilename = `xmpp-log-${format(exportedAt, 'yyyy-MM-dd-HHmmss')}.txt`
 

--- a/apps/fluux/src/utils/xmppConsoleExport.test.ts
+++ b/apps/fluux/src/utils/xmppConsoleExport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { XmppPacket } from '@fluux/sdk'
-import { buildXmppConsoleExport } from './xmppConsoleExport'
+import { buildXmppConsoleExport, type XmppConsoleHealthSnapshot } from './xmppConsoleExport'
 
 describe('buildXmppConsoleExport', () => {
   it('includes a privacy-safe connection health snapshot and recent traffic', () => {
@@ -47,6 +47,7 @@ describe('buildXmppConsoleExport', () => {
         focused: false,
         streamManagement: { inbound: 42, outbound: 39 },
       },
+      recountDeferrals: {},
     })
 
     expect(output).toContain('Connection health')
@@ -83,11 +84,98 @@ describe('buildXmppConsoleExport', () => {
         focused: null,
         streamManagement: null,
       },
+      recountDeferrals: {},
     })
 
     expect(output).toContain('Browser: network=unknown visibility=unknown focused=unknown')
     expect(output).toContain('Stream management: unavailable')
     expect(output).toContain('Last incoming traffic: unavailable')
     expect(output).toContain('Latest health event: unavailable')
+  })
+  const HEALTH: XmppConsoleHealthSnapshot = {
+    status: 'online',
+    machineState: { connected: 'healthy' },
+    reconnectAttempt: 0,
+    nextRetryDelayMs: 0,
+    reconnectTargetTime: null,
+    smResumeViable: true,
+    displayAsleep: false,
+    browserOnline: true,
+    visibilityState: 'visible',
+    focused: true,
+    streamManagement: null,
+  }
+
+  function exportWithDeferrals(recountDeferrals: Record<string, number>): string {
+    return buildXmppConsoleExport({
+      entries: [],
+      appVersion: '0.18.0',
+      gitCommit: 'abcdef0',
+      exportedAt: new Date('2026-08-18T12:00:10.000Z'),
+      connectionMethod: 'websocket',
+      serverInfo: null,
+      health: HEALTH,
+      recountDeferrals,
+    })
+  }
+
+  describe('unread recount deferrals', () => {
+    it('reports both scopes as none when no recount has ever deferred', () => {
+      const output = exportWithDeferrals({})
+
+      expect(output).toContain('Unread recount deferrals (cumulative)')
+      expect(output).toContain('  Chat: none')
+      expect(output).toContain('  Room: none')
+    })
+
+    it('keeps chat and room tallies separately readable', () => {
+      const output = exportWithDeferrals({
+        'chat:no-meta': 2,
+        'room:coverage-missing': 7,
+        'room:pointer-changed': 1,
+      })
+
+      const section = output.slice(output.indexOf('Unread recount deferrals'))
+      expect(section).toContain('  Chat (2):\n    no-meta: 2')
+      expect(section).toContain('  Room (8):\n    coverage-missing: 7\n    pointer-changed: 1')
+    })
+
+    it('renders one scope populated while the other stays none', () => {
+      const output = exportWithDeferrals({ 'room:history-not-caught-up': 3 })
+
+      expect(output).toContain('  Chat: none')
+      expect(output).toContain('  Room (3):')
+      expect(output).toContain('    history-not-caught-up: 3')
+    })
+
+    it('orders reasons by count so the dominant guard leads', () => {
+      const output = exportWithDeferrals({
+        'room:no-floor': 1,
+        'room:coverage-short-of-floor': 9,
+        'room:cache-unavailable': 4,
+      })
+
+      const section = output.slice(output.indexOf('  Room ('))
+      expect(section).toContain(
+        '    coverage-short-of-floor: 9\n    cache-unavailable: 4\n    no-floor: 1'
+      )
+    })
+
+    it('surfaces an unrecognised scope rather than dropping its counts', () => {
+      const output = exportWithDeferrals({ 'thread:no-meta': 5 })
+
+      expect(output).toContain('  Unknown scope "thread" (5):')
+      expect(output).toContain('    no-meta: 5')
+    })
+
+    it('records reasons and counts only, never conversation identifiers', () => {
+      const output = exportWithDeferrals({ 'room:coverage-missing': 2 })
+
+      const section = output.slice(output.indexOf('Unread recount deferrals'))
+      expect(section).not.toContain('@')
+      expect(section.split('\n').filter((line) => line.startsWith('    '))).toEqual([
+        '    coverage-missing: 2',
+      ])
+    })
   })
 })

--- a/apps/fluux/src/utils/xmppConsoleExport.ts
+++ b/apps/fluux/src/utils/xmppConsoleExport.ts
@@ -29,6 +29,16 @@ interface XmppConsoleExportOptions {
   connectionMethod: ConnectionMethod | null
   serverInfo: ServerInfo | null
   health: XmppConsoleHealthSnapshot
+  /**
+   * Cumulative unread-recount deferral tallies, keyed `<kind>:<reason>`, exactly as
+   * the SDK's `readRecountDeferrals()` returns them.
+   *
+   * Read-only input: the export renders these and nothing feeds them back into any
+   * decision, which is what keeps the SDK counter passive. The tallies carry reasons
+   * and counts only — never an entity id, message id or unread total — so nothing
+   * here can identify a conversation.
+   */
+  recountDeferrals: Record<string, number>
 }
 
 function formatMachineState(state: ConnectionStateValue): string {
@@ -100,8 +110,79 @@ function buildHealthSection(
     latestHealthEvent
       ? `  Latest health event: ${latestHealthEvent.timestamp.toISOString()} ${latestHealthEvent.content}`
       : '  Latest health event: unavailable',
+  ]
+}
+
+/** Scopes rendered in a fixed order so two exports can be compared line by line. */
+const RECOUNT_SCOPES: ReadonlyArray<{ prefix: string; label: string }> = [
+  { prefix: 'chat', label: 'Chat' },
+  { prefix: 'room', label: 'Room' },
+]
+
+function scopeOf(key: string): string {
+  const separator = key.indexOf(':')
+  return separator === -1 ? '' : key.slice(0, separator)
+}
+
+function reasonOf(key: string): string {
+  const separator = key.indexOf(':')
+  return separator === -1 ? key : key.slice(separator + 1)
+}
+
+/**
+ * One scope's tallies, heaviest first so the dominant reason leads.
+ *
+ * `readRecountDeferrals()` only holds keys that were actually incremented, so a
+ * zero-count reason never reaches here and the list stays free of noise.
+ */
+function formatScopeTallies(
+  deferrals: Record<string, number>,
+  prefix: string,
+  label: string
+): string[] {
+  const entries = Object.entries(deferrals)
+    .filter(([key]) => scopeOf(key) === prefix)
+    .sort(([leftKey, left], [rightKey, right]) =>
+      right - left || reasonOf(leftKey).localeCompare(reasonOf(rightKey))
+    )
+
+  if (entries.length === 0) return [`  ${label}: none`]
+
+  const total = entries.reduce((sum, [, count]) => sum + count, 0)
+  return [
+    `  ${label} (${total}):`,
+    ...entries.map(([key, count]) => `    ${reasonOf(key)}: ${count}`),
+  ]
+}
+
+/**
+ * Why unread badges kept their value, as reasons and counts.
+ *
+ * The tallies accumulate in every build, including release; only the anomaly
+ * digest's reader is eliminated from production. Rendering them here is what lets a
+ * field report from a shipped build say which guard stood down, and how often, for a
+ * chat as opposed to a room.
+ *
+ * A healthy session defers nothing, so an empty tally set is the normal case and
+ * renders as an explicit `none` per scope rather than a missing or alarming section.
+ */
+function buildRecountDeferralSection(deferrals: Record<string, number>): string[] {
+  const knownPrefixes = new Set(RECOUNT_SCOPES.map((scope) => scope.prefix))
+  // A scope this build has no label for means the SDK grew one; show it rather than
+  // silently dropping counts a bug report may depend on.
+  const unknownScopes = [...new Set(Object.keys(deferrals).map(scopeOf))]
+    .filter((prefix) => !knownPrefixes.has(prefix))
+    .sort()
+
+  return [
     '',
-    '================================================================================',
+    'Unread recount deferrals (cumulative)',
+    ...RECOUNT_SCOPES.flatMap((scope) =>
+      formatScopeTallies(deferrals, scope.prefix, scope.label)
+    ),
+    ...unknownScopes.flatMap((prefix) =>
+      formatScopeTallies(deferrals, prefix, `Unknown scope "${prefix}"`)
+    ),
   ]
 }
 
@@ -114,6 +195,7 @@ export function buildXmppConsoleExport(options: XmppConsoleExportOptions): strin
     connectionMethod,
     serverInfo,
     health,
+    recountDeferrals,
   } = options
   const header = [
     '================================================================================',
@@ -151,6 +233,9 @@ export function buildXmppConsoleExport(options: XmppConsoleExportOptions): strin
     ...header,
     ...serverSection,
     ...buildHealthSection(entries, health, exportedAt),
+    ...buildRecountDeferralSection(recountDeferrals),
+    '',
+    '================================================================================',
     '',
     ...lines,
   ].join('\n')

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -82,7 +82,12 @@ Counter names (digest only, not invariant ids):
 
 ## Recount deferrals
 
-`recount.deferred.<chat|room>.<reason>`, in the digest counters.
+The same privacy-safe tallies have two read-only diagnostic views:
+
+- `recount.deferred.<chat|room>.<reason>` in anomaly digest counters, reported as
+  deltas for each digest window.
+- `Unread recount deferrals (cumulative)` in an exported XMPP console log,
+  reported as process-lifetime totals with separate Chat and Room sections.
 
 An unread recount is a chain of about twenty guards, most of which decline to count
 rather than risk a wrong number. Each is correct alone, but from outside the store they
@@ -90,12 +95,13 @@ are indistinguishable: the badge simply keeps its old value. These tallies say w
 guard stood down, so a stale badge can be attributed instead of guessed at (issue
 #1211).
 
-Read them **alongside** `read-state/unread-survives-focus`. That record flags the stale
-badge episode; these counters show which guards deferred during the same window.
+In an anomaly digest, read the counters **alongside**
+`read-state/unread-survives-focus`. That record flags the stale badge episode; the
+counter deltas show which guards deferred during the same window.
 
-The counters are aggregate deltas for one digest window, split by chat or room but
-carrying no entity id. Use the kind and timing to correlate them with an observed
-badge; recounts for other entities in the same window can contribute to the tally.
+Both views are split by chat or room but carry no entity id. Recounts for other
+entities can contribute to the same digest window; the console export is broader
+still because its cumulative totals cover the entire process lifetime.
 
 | reason | Meaning |
 |---|---|

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -113,8 +113,8 @@ export type { RebuildProgress, ParsedQuery } from './utils/searchIndex'
 export { buildScopedStorageKey, getStorageScopeJid } from './utils/storageScope'
 
 // Read-only diagnostic: why an unread recount declined to commit (issue #1211).
-// A tally of reasons — no entity ids or unread totals — so a dev build can
-// attribute a stale badge instead of guessing which of ~20 guards stood down.
+// A tally of reasons — no entity ids or unread totals — so a shipped XMPP console
+// export can attribute a stale badge instead of guessing which guard stood down.
 export { readRecountDeferrals } from './stores/shared/recountDiagnostics'
 export type {
   RecountDeferralReason,


### PR DESCRIPTION
When an unread badge keeps a stale value, the store's recount did not fail — it declined to commit, for one of about twenty named reasons. Those reasons are already tallied at runtime and the tallies accumulate in release builds, but the only reader lived inside the anomaly tree that production builds eliminate. A field report from a shipped build could therefore not say which guard stood down.

This adds the tallies to the XMPP console log export, which is not anomaly-gated, following the shape of the existing `Connection health` section. Chat and room scopes are rendered separately (the scope is what tells otherwise identical symptoms apart), reasons are ordered heaviest first, and a session that never deferred reports an explicit `none` per scope.

The tallies are read only through the existing public `readRecountDeferrals()` SDK export, are never fed back into any decision, and carry reasons and counts only — never entity ids, message ids or unread totals — so the export cannot identify a conversation. The `__FLUUX_ANOMALY__` elimination is untouched.

Noted while reading, not addressed here: `input-version-changed` is the only reason that also schedules a retry, so its tally counts scheduled retries rather than terminal give-ups and reads differently from the other reasons in the section.