### PR TITLE
docs: state comment invariants in the present tense (#1236)

### DIFF
--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -179,8 +179,8 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
           })
           .catch(() => {
             // Still swallowed so a failed warm cannot surface as an unhandled
-            // rejection, and `warmedFor` stays unset so the next tick retries. What
-            // changes is that the failure is no longer invisible.
+            // rejection, and `warmedFor` stays unset so the next tick retries. The
+            // counter below is what keeps the failure from being invisible.
             consecutiveWarmFailures++
             if (!warmFailureReported && consecutiveWarmFailures >= WARM_FAILURE_THRESHOLD) {
               warmFailureReported = true

--- a/apps/fluux/src/anomaly/serializer.ts
+++ b/apps/fluux/src/anomaly/serializer.ts
@@ -29,8 +29,8 @@ const SEVERITIES: ReadonlySet<string> = new Set(['bug', 'suspect', 'drift'])
  *
  * A record is rejected when it carries a key not listed here. The anomaly path
  * builds its output field by field and would silently drop an extra property, but
- * silence hides the detector bug that produced it; the digest path previously
- * spread the record and emitted such a property verbatim. One rule for both.
+ * silence hides the detector bug that produced it, and a spread-based digest
+ * path would emit such a property verbatim. One rule for both.
  */
 const ANOMALY_KEYS: ReadonlySet<string> = new Set([
   'v', 't', 'sid', 'build', 'tokenKeyId', 'kind', 'id', 'sev', 'expected', 'observed', 'ctx',

--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -370,8 +370,8 @@ function EncryptionIcon({
   // `tofu-new` (freshly TOFU-pinned, unchanged, not yet OOB-verified) renders
   // the same neutral gray Shield as `unverified` — homogeneous with the Settings
   // → Encryption screen and the Security tab. `tofuNew` survives only to pick a
-  // gentler tooltip below. The yellow ShieldAlert is now reserved exclusively
-  // for the genuine `blocked` (key-changed) alert, so the two states no longer
+  // gentler tooltip below. The yellow ShieldAlert is reserved exclusively
+  // for the genuine `blocked` (key-changed) alert, so the two states do not
   // share an alarming icon.
   const Icon = verified ? ShieldCheck : Shield
   const colorClass = verified

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -64,8 +64,9 @@ export function ChatLayout() {
  * notification events). By isolating them here, their re-renders don't cascade to
  * the ChatLayout tree. Re-rendering a null component is essentially free.
  *
- * Previously, these hooks lived in ChatLayoutContent, causing 100+ re-renders/sec
- * during MAM loading because useNotificationBadge subscribes to per-message state.
+ * They must not be hosted in ChatLayoutContent: useNotificationBadge subscribes
+ * to per-message state, which drives 100+ re-renders/sec of that tree during MAM
+ * loading.
  */
 function GlobalEffects() {
   // Update dock/favicon badge with unread count
@@ -182,7 +183,7 @@ function ChatLayoutContent() {
   }, [])
 
   // Modal management from context
-  // Only stable action subscriptions remain — ChatLayout no longer reads any modal
+  // Only stable action subscriptions here — ChatLayout reads no modal
   // OPEN state reactively (ModalHost renders the modals; Escape reads the store
   // directly), so a modal toggle does not re-render ChatLayout or its children.
   const modalOpen = useModalStore((s) => s.open)

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -107,7 +107,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   // Latest messages in a ref so the stable callbacks below don't close over
   // `activeMessages` (which changes on every incoming message). This keeps the
   // props passed to the memoized MessageInput referentially stable, so the
-  // composer no longer re-renders once per message (RenderLoopDetector warning).
+  // composer does not re-render once per message (RenderLoopDetector warning).
   const activeMessagesRef = useRef(activeMessages)
   activeMessagesRef.current = activeMessages
 
@@ -225,9 +225,9 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   useMessageCopy(scrollRef)
 
   // Reply targets are resolved reactively per-row via useReferencedMessage (in
-  // ChatMessageBubble), so this view no longer holds a render-time lookup map — a
-  // value derived from one froze inside the memoized row when the quoted message
-  // only loaded later. Store subscription = reactive, no freeze.
+  // ChatMessageBubble), so this view holds no render-time lookup map: a value
+  // derived from one would freeze inside the memoized row when the quoted
+  // message only loads later. Store subscription = reactive, no freeze.
 
   // Track pendingAttachment in a ref for cleanup (not a trigger)
   const pendingAttachmentRef = useRef(pendingAttachment)

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -308,9 +308,9 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   useMessageCopy(scrollRef)
 
   // Reply targets are resolved reactively per-row via useReferencedMessage (in
-  // RoomMessageBubbleWrapper), so the list no longer holds a render-time lookup
-  // map here — a value derived from such a map froze inside the memoized row when
-  // the target only loaded later. Store subscription = reactive, no freeze.
+  // RoomMessageBubbleWrapper), so the list holds no render-time lookup map
+  // here: a value derived from such a map would freeze inside the memoized row
+  // when the target only loads later. Store subscription = reactive, no freeze.
 
   // Track pendingAttachment in a ref for cleanup (not a trigger)
   const pendingAttachmentRef = useRef(pendingAttachment)
@@ -1098,9 +1098,9 @@ export const RoomMessageList = memo(function RoomMessageList({
   // from cheap Map lookups — then pass only reference-stable objects (the live
   // `occupant`, which roomStore.addOccupant preserves for unchanged occupants) and
   // primitives down to the memoized row. A presence change for occupant X thus changes
-  // props only for X's rows; every other row's shallow memo bails. The row no longer
-  // sees `room` (a fresh Map ref every presence stanza), so it stops re-rendering on
-  // unrelated presence churn.
+  // props only for X's rows; every other row's shallow memo bails. The row never
+  // sees `room` (a fresh Map ref every presence stanza), so unrelated presence
+  // churn does not re-render it.
   // Clipboard metadata for a message, faithful to the row's resolvedSenderName so a
   // virtualized multi-message copy reconstructs identically from the array (see
   // MessageList formatMessageForCopy). Called only at copy time, so per-render cost is nil.
@@ -1419,7 +1419,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
 
   // Resolve the replied-to message reactively from the store. Reading a render-time
   // lookup here would freeze this memoized row on the XEP-0428 fallback when the quoted
-  // message only paginates in later. Uses the roomJid prop (the row no longer sees `room`).
+  // message only paginates in later. Uses the roomJid prop (the row never sees `room`).
   const replyTarget = useReferencedMessage({ type: 'groupchat', roomJid, id: message.replyTo?.id })
 
   const contact = senderBareJid ? contactsByJid.get(senderBareJid) : undefined

--- a/apps/fluux/src/components/brand/AppIconMark.tsx
+++ b/apps/fluux/src/components/brand/AppIconMark.tsx
@@ -68,7 +68,7 @@ export function AppIconMark({ size = 72, className }: AppIconMarkProps) {
       <rect x="63.5" y="63.5" width="897" height="897" rx="222.5" fill="none" stroke="#FFFFFF" strokeOpacity="0.15" strokeWidth="3" />
 
       {/* Body + tail as ONE continuous path (a rounded rect whose bottom edge
-          dips into the tail), so there's no seam where the two used to meet. */}
+          dips into the tail), so the two meet with no seam. */}
       <path
         filter={`url(#${id('depth')})`}
         fill={`url(#${id('bubble')})`}

--- a/apps/fluux/src/components/conversation/bottomAnchor.ts
+++ b/apps/fluux/src/components/conversation/bottomAnchor.ts
@@ -9,11 +9,11 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
  *
  * Storing a fraction (not a pixel gap) makes the position INDEPENDENT OF RENDERING: on return we
  * re-derive pixels from the message's CURRENT measured height, so a re-measure, a width change, or
- * a virtualization re-window can't corrupt it. The previous implementation stored a pixel gap found
- * via a BINARY SEARCH over `offsetTop` assuming rows were in sorted document order — false under
- * virtualization (the DOM holds an unsorted/stale window), which produced a wildly wrong gap and
- * flung the view to the bottom on return. This is a linear max-scan over the (small) rendered
- * window using each row's own `offsetTop`/`offsetHeight`, so DOM order no longer matters.
+ * a virtualization re-window can't corrupt it. A pixel gap found via a BINARY SEARCH over
+ * `offsetTop` would assume rows are in sorted document order — false under virtualization (the
+ * DOM holds an unsorted/stale window), producing a wildly wrong gap that flings the view to the
+ * bottom on return. This is a linear max-scan over the small rendered window using each row's
+ * bounding rectangle relative to the scroller, so DOM order does not matter.
  */
 export function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
   const rows = scroller.querySelectorAll('.message-row[data-message-id]')

--- a/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
+++ b/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
@@ -13,7 +13,7 @@
  *
  * DELIBERATELY NOT A CASE: the row not existing at all. That is a load or windowing
  * failure with a different cause and a different fix, and folding it in would give
- * one invariant id two meanings — so a review could no longer tell from the id what
+ * one invariant id two meanings — so a review could not tell from the id what
  * went wrong. It is recorded as a non-case in the invariant registry.
  *
  * PURE: rectangles are passed in, so this is testable without a layout engine.

--- a/apps/fluux/src/components/conversation/roomLoadingState.ts
+++ b/apps/fluux/src/components/conversation/roomLoadingState.ts
@@ -2,15 +2,15 @@
  * Decides whether the room message area should show its full-view loading
  * indicator (the centered spinner) rather than message content or an empty state.
  *
- * There are two distinct "still loading" phases when entering a room, and only
- * the first one used to be covered:
+ * There are two distinct "still loading" phases when entering a room, and both
+ * are covered here:
  *
  *   1. Joining — presence sent, waiting for the server's self-presence (status
  *      110). `isJoining` is true, `joined` is false.
  *   2. First catch-up — the room is joined (the "Joining…" spinner is gone), but
  *      MAM history is still being fetched and there is nothing cached to render.
- *      Without this, the view fell through to the "No messages" empty state while
- *      messages were actively loading, reading as a silent, animation-less wait.
+ *      Without this, the view falls through to the "No messages" empty state while
+ *      messages are actively loading, reading as a silent, animation-less wait.
  *
  * Once any message is on screen (cache hit), the inline gap marker / older-history
  * spinner owns the catch-up affordance, so the full-view loader steps aside.

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -77,10 +77,10 @@ type BackupConfirmVariant = keyof typeof BACKUP_CONFIRM_KEYS
 /**
  * Server-probe state for the secret-key backup node.
  *
- * `unknown` is deliberately distinct from `absent`: a failed probe used to
- * be coerced to "no backup", which skipped the replace confirmation and let
- * a transient network failure overwrite a real backup. Consumers treat
- * `unknown` as "a backup might exist".
+ * `unknown` is deliberately distinct from `absent`: coercing a failed probe
+ * to "no backup" would skip the replace confirmation and let a transient
+ * network failure overwrite a real backup. Consumers treat `unknown` as "a
+ * backup might exist".
  */
 type BackupProbeState = 'checking' | BackupProbeResult
 

--- a/apps/fluux/src/components/ui/Toggle.tsx
+++ b/apps/fluux/src/components/ui/Toggle.tsx
@@ -5,8 +5,8 @@ interface ToggleProps {
   /**
    * Async-pending affordance: while true the toggle reads as "busy" rather
    * than "blocked" — it renders `cursor-wait` (taking precedence over the
-   * `disabled` `cursor-not-allowed`) and ignores clicks. Mirrors the
-   * isToggling state the inline EncryptionSettings toggle used to show.
+   * `disabled` `cursor-not-allowed`) and ignores clicks. Carries the
+   * `isToggling` state EncryptionSettings passes in.
    */
   loading?: boolean
   id?: string

--- a/apps/fluux/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/fluux/src/hooks/useKeyboardShortcuts.ts
@@ -37,7 +37,7 @@ interface UseKeyboardShortcutsOptions {
   // Escape hierarchy state and handlers
   // Modals (command palette, shortcut help, presence menu, quick chat) are closed
   // by reading the modalStore directly in handleEscape — they are NOT passed here,
-  // so ChatLayout no longer has to subscribe to modal state just to drive Escape.
+  // so ChatLayout does not have to subscribe to modal state just to drive Escape.
   // Only the non-modal escape targets are passed in.
   escapeHierarchy?: {
     isConsoleOpen: boolean

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -631,8 +631,8 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
   // profile, own resources) is handled inside the SDK via StateSnapshot:
   // it subscribes to each store, writes through to StorageAdapter with a
   // 500ms debounce, and flushes on beforeunload via XMPPProvider. The
-  // standalone save*() functions remain exported for tests and legacy
-  // migration but are no longer wired to an auto-save effect here.
+  // standalone save*() functions are exported for tests and legacy
+  // migration only; nothing wires them to an auto-save effect here.
   //
   // Presence state is saved automatically by XState's native persistence
   // in XMPPProvider (key: 'fluux:presence-machine').

--- a/apps/fluux/src/platform/capabilities.ts
+++ b/apps/fluux/src/platform/capabilities.ts
@@ -1,7 +1,7 @@
 /**
  * What this build of Fluux can do, as a value rather than a runtime probe.
  *
- * The app used to ask `isTauri()` at each decision point. That reads as one
+ * Asking `isTauri()` at each decision point reads as one
  * question but is at least six: whether there is an OS keychain, whether links
  * open in the system browser, whether the window can ask for attention. Some
  * answers already diverge — in-app updates are desktop-except-Linux, the tray

--- a/apps/fluux/src/utils/serviceWorkerUpdate.ts
+++ b/apps/fluux/src/utils/serviceWorkerUpdate.ts
@@ -1,15 +1,14 @@
 /**
  * Service worker registration + user-triggered update (browser/PWA only).
  *
- * The custom service worker (`sw.ts`) no longer calls `skipWaiting()` on install:
+ * The custom service worker (`sw.ts`) does not call `skipWaiting()` on install:
  * a freshly deployed build installs and then PARKS in the `waiting` state instead
  * of seizing control. That keeps the running page on its current (matching) build
  * — no mixed old/new assets, no surprise reload — until the user opts in.
  *
- * Previously we reloaded the page automatically as soon as the new worker took
- * control. On an installed PWA that fires on nearly every foreground-after-deploy
- * (see the focus update check below), so the app reloaded out from under the user
- * mid-session. Now, when an update installs mid-session we flag
+ * Automatically reloading the page as soon as the new worker takes control would
+ * interrupt the user on nearly every foreground-after-deploy in an installed PWA
+ * (see the focus update check below). An update installed mid-session instead flags
  * `appUpdateStore.webUpdateReady` so the sidebar surfaces an "update available"
  * button; clicking it runs `applyWaitingUpdate`, which tells the waiting worker to
  * `skipWaiting()` and reloads once it takes control.

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1767,8 +1767,8 @@ export class XMPPClient {
     // When a plugin reports the local key just became usable (passphrase
     // entered, server backup restored, key file imported, identity replaced),
     // run the same retry as notifyE2EEKeyUnlocked. Driving this from the plugin
-    // means every restore site is covered automatically — UI code no longer
-    // has to remember to call notifyE2EEKeyUnlocked at each one.
+    // means every restore site is covered automatically — UI code does not
+    // have to remember to call notifyE2EEKeyUnlocked at each one.
     this.e2ee.onKeyUnlocked(() => {
       this.notifyE2EEKeyUnlocked()
     })

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -93,8 +93,8 @@ export function setupBackgroundSyncSideEffects(
 
   // --- Late-MAM room retry (issue D) ---
   // A room whose disco resolves supportsMAM AFTER the single 10s catch-up pass
-  // was previously dropped with no retry (only the ACTIVE room has a supportsMAM
-  // watcher in roomSideEffects). We track rooms already handled this session and,
+  // has no other retry path (only the ACTIVE room has a supportsMAM watcher in
+  // roomSideEffects). We track rooms already handled this session and,
   // once the initial pass has run, catch up any non-active room that becomes
   // MAM-ready afterwards.
   const mamHandledRooms = new Set<string>()

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -52,7 +52,7 @@ function bindStoreMethods<S, K extends keyof S>(
  * Create default StoreBindings using the global Zustand stores.
  *
  * This is the standard way to create store bindings for XMPPClient. Presence
- * is no longer part of the store bindings — it is a separate PresenceReader
+ * is not part of the store bindings — it is a separate PresenceReader
  * dependency (see `presenceReader.ts`), since presence is machine state, not
  * connection-store state.
  *

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -577,12 +577,10 @@ export function setupMdsSideEffects(
    *
    * Mirrors Gajim's `if not MAM.is_catch_up_finished(contact): return` guard.
    *
-   * The original reason — "a read position derived mid-catch-up is computed
-   * against a partial window" — no longer applies: catch-up stopped being a
-   * pointer writer, so no position originates here.
+   * The gate is not about where a read position comes from: catch-up writes no
+   * pointer, so no position originates here.
    *
-   * The gate stays as a PUBLISH-SIDE backstop, which is a different and still
-   * valid job. Every local writer that remains (viewport, remote marker,
+   * It is a PUBLISH-SIDE backstop instead. Every local writer that remains (viewport, remote marker,
    * mark-read) can fire while the archive is incomplete. A publish here reaches
    * this account's other devices too: `publishDisplayed` writes the XEP-0490 PEP
    * node, which pushes to every subscribed resource, and a peer's marker (or our
@@ -935,11 +933,11 @@ export function setupMdsSideEffects(
 
       // A fresh session starts with NOTHING recorded as handled.
       //
-      // This used to re-snapshot the current pointers from both stores, which
-      // re-recorded an UNPUBLISHED position as handled: consider() then
-      // short-circuited on it for the whole session, and only a further local
-      // read advance could ever recover it (#1145). The seed does not need that
-      // snapshot to avoid republishing itself — `lastKnownNodeStanzaId` was just
+      // Deliberately not a re-snapshot of the current pointers from both
+      // stores: that would re-record an UNPUBLISHED position as handled,
+      // consider() would short-circuit on it for the whole session, and only a
+      // further local read advance could recover it (#1145). The seed does not
+      // need that snapshot to avoid republishing itself — `lastKnownNodeStanzaId` was just
       // set for every node marker, so publishDecision() answers `skip` for a
       // position the node already holds and `retry` for one it holds a marker we
       // could not order against.

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1494,7 +1494,7 @@ export class MAM extends BaseModule {
       // fresh sessions and gap closure — Codex r3 #3). Seeding from it (not
       // the global-oldest cache row) keeps the backward walk inside the
       // contiguous region — a disjoint search/context island (with or without
-      // a recorded gap) can no longer mis-seed the descent (finding 9).
+      // a recorded gap) cannot mis-seed the descent (finding 9).
       const seamBottom = io.getGapEndId() ?? io.getCoverageBottomId()
       if (seamBottom) {
         windowBottom = seamBottom

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -2641,9 +2641,8 @@ export class MUC extends BaseModule {
    *    field's options
    * 3. For jid-single fields: use a jid value from the original fields
    *
-   * A renamed plain `text-single` matches none of those, which is how the
-   * destroy command used to submit an empty form (see the positional rule
-   * below).
+   * A renamed plain `text-single` matches none of those and would submit an
+   * empty form, which is what the positional rule below exists to prevent.
    */
   private buildCompletionFields(
     command: Element,

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -80,7 +80,7 @@ export class Roster extends BaseModule {
   /**
    * All presence that is not MUC's. Deliberately broad: MUC's narrower claims
    * (muc#user, and error presence for an in-flight join) outrank this one, so
-   * the split no longer depends on which module was listed first.
+   * the split does not depend on which module was listed first.
    */
   readonly claims = ROSTER_CLAIMS
 
@@ -397,18 +397,9 @@ export class Roster extends BaseModule {
       // authoritative source and will sync the correct state to the store when
       // the user's activity/wake detection triggers a machine transition.
     }
-    // NOTE: Removed the 'currentPresence === away' branch.
-    // Previously, if currentPresence was 'away' and isAutoAway was false, we
-    // assumed it was "manual away". But this caused issues on reconnect:
-    // - isAutoAway and savedPresenceShow are transient (not persisted)
-    // - currentPresence IS persisted
-    // So after app restart/reconnect, a previous auto-away state would appear
-    // as "manual away" and presence would stay 'away' even though user is active.
-    //
-    // Now we default to online unless:
-    // - DND is set (user explicitly set it, likely important)
-    // - Auto-away is active (isAutoAway or savedPresenceShow is set)
-    // If user wants to be away manually, they can set it again after reconnect.
+    // Presence defaults to online unless DND is set or auto-away is active
+    // (`isAutoAway` or `preAutoAwayState`). A manually set away is not restored;
+    // the user sets it again if they want it.
 
     const presence = xml('presence', {},
       showToSend ? xml('show', {}, showToSend) : undefined,

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
@@ -83,9 +83,9 @@ interface SerializedRoom {
   supportsHats?: boolean
   isIrcGateway?: boolean
   /**
-   * Where the user has read to (#1081), replacing the `lastReadAt` this shape
-   * used to carry. A snapshot without it restores rooms with no read position at
-   * all, and a pointerless room then counts from its `historyFloor` creation
+   * Where the user has read to (#1081). A snapshot without it restores rooms
+   * with no read position at all, and a pointerless room then counts from its
+   * `historyFloor` creation
    * watermark instead — so history older than the restore is silently treated as
    * read. The pointer is forward-only, so that is permanent.
    */

--- a/packages/fluux-sdk/src/core/sideEffectHost.ts
+++ b/packages/fluux-sdk/src/core/sideEffectHost.ts
@@ -1,10 +1,10 @@
 /**
  * What a store-based side effect needs from the client that drives it.
  *
- * The side effects used to name `XMPPClient` itself. That single type import
- * was enough to tie them together: the client constructs the side effects, the
- * side effects name the client, and everything reachable from either ended up
- * in one strongly connected component that no part could be read or typechecked
+ * Deliberately not `XMPPClient` itself. That single type import is enough to
+ * tie the two together: the client constructs the side effects, the side
+ * effects name the client, and everything reachable from either lands in one
+ * strongly connected component that no part can be read or typechecked
  * without.
  *
  * Nothing about a side effect actually needs the whole client. Each one reacts

--- a/packages/fluux-sdk/src/core/stanzaRouting.ts
+++ b/packages/fluux-sdk/src/core/stanzaRouting.ts
@@ -10,8 +10,7 @@
  * change in flight for that room. A claim narrows the candidates and fixes the
  * order; it does not promise to consume.
  *
- * The order used to be the position of a module in a hand-written array, with a
- * comment explaining why MUC had to precede Roster. Specificity now derives it:
+ * Specificity derives the order rather than a hand-written module array:
  * a claim naming a child element outranks one naming only a stanza type, which
  * outranks a bare kind. Two modules claiming the SAME shape is the one case
  * specificity cannot settle, so it is a declared conflict — see

--- a/packages/fluux-sdk/src/core/types/message-internal.ts
+++ b/packages/fluux-sdk/src/core/types/message-internal.ts
@@ -1,10 +1,10 @@
 /**
  * Internal message implementation-state.
  *
- * These fields are SDK-internal bookkeeping that used to live on the public
- * {@link BaseMessage} and thus leaked onto `Message` / `RoomMessage`. They are
- * not part of a message's public shape — no application code reads them — so
- * they are kept here, off the exported types.
+ * These fields are SDK-internal bookkeeping. On the public {@link BaseMessage}
+ * they would leak onto `Message` / `RoomMessage`, and they are not part of a
+ * message's public shape — no application code reads them — so they are kept
+ * here, off the exported types.
  *
  * This module is deliberately NOT re-exported from the package index: it is an
  * internal seam. SDK code that needs the fields uses {@link StoredMessage} /

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -2,11 +2,11 @@
  * The state surface {@link XMPPClient} writes through.
  *
  * This is a PORT: it is declared here, in the SDK's leaf type layer, in terms
- * of domain types only. It used to be derived from the Zustand stores with
- * `Pick<ChatState, …>`, which made the contract a shadow of one particular
- * implementation and pulled every store into the core's dependency graph.
+ * of domain types only. Deriving it from the Zustand stores with
+ * `Pick<ChatState, …>` would make the contract a shadow of one particular
+ * implementation and pull every store into the core's dependency graph.
  *
- * The conformance direction is now the other way round: each store proves it
+ * The conformance direction runs the other way round: each store proves it
  * satisfies its interface here (`stores/storeBindingsConformance.ts`), and the
  * key lists in `core/storeBindingKeys.ts` are checked against these interfaces
  * rather than against the store state. Adding a method to the client surface

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -86,8 +86,7 @@ const EMPTY_TYPING_ARRAY: string[] = []
 export function useChat() {
   // Actions live in useChatActions (zero store subscriptions). useChat composes
   // it and adds the conversation-list/active-conversation state subscriptions
-  // below — so the action definitions exist ONCE (they previously drifted
-  // between the two hooks).
+  // below — so the action definitions exist ONCE (two copies drift).
   const actions = useChatActions()
 
   // Use useShallow for derived arrays to properly detect changes

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -105,11 +105,9 @@ export function useChatActive() {
   })
   // The canonical, pointer-derived unread count for the active
   // conversation — used to feed the ONE shared count into every UI surface (sidebar,
-  // divider, floating pill, FAB badge) via ChatView. Previously hardcoded to 0 here
-  // ("not used by active view components"); that force-zero is exactly what the single
-  // canonical count model removes — active conversations are no longer force-zeroed, the
-  // pointer/derivation already produces the right number (see chatStore's recount +
-  // on-arrival paths).
+  // divider, floating pill, FAB badge) via ChatView. The active conversation is
+  // deliberately NOT force-zeroed here: the pointer/derivation already produces
+  // the right number (see chatStore's recount + on-arrival paths).
   const activeConvUnreadCount = useChatStore((s) => {
     if (!s.activeConversationId) return 0
     return s.conversationMeta.get(s.activeConversationId)?.unreadCount ?? 0

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -87,7 +87,7 @@ const EMPTY_TYPING_ARRAY: string[] = []
 export function useRoom() {
   // Actions live in useRoomActions (zero store subscriptions). useRoom composes
   // it and adds the room-list/active-room state subscriptions below — so the
-  // action definitions exist ONCE (they previously drifted between the two).
+  // action definitions exist ONCE (two copies drift).
   const actions = useRoomActions()
 
   // NOTE: We intentionally do NOT subscribe to the rooms Map here.

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -899,10 +899,10 @@ function applyMigratedReadPointer(conversationId: string, migrated: ReadPointer)
  * so this runs fire-and-forget after the restored state lands — the same shape
  * as the localStorage-messages → IndexedDB migration below it. Conversations
  * persisted before #1081 carry only `lastSeenMessageId` / `lastReadAt`, which
- * are no longer live fields; without this pass they would have no pointer at
- * all. `legacyReadState` is what the blob held for each conversation, read off
- * the persisted shape (see {@link PersistedReadState}) rather than off the
- * restored metadata, which no longer has anywhere to keep it.
+ * are not live fields; without this pass they would have no pointer at all.
+ * `legacyReadState` is what the blob held for each conversation, read off the
+ * persisted shape (see {@link PersistedReadState}) rather than off the restored
+ * metadata, which has nowhere to keep it.
  *
  * The "already has one" skip deliberately consults the RESTORED pointer, not
  * the raw persisted value: a corrupt on-disk pointer deserializes to
@@ -1115,7 +1115,7 @@ function deserializeState(persisted: PersistedState, storageKey: string): Pick<C
 
     // Rebuild the combined map from the separated maps. This — not the blob —
     // is where `conversations` comes from on every new-format load, which is
-    // why the map is no longer persisted at all. `shared/conversationMaps`
+    // why the map is not persisted at all. `shared/conversationMaps`
     // holds the same expression and is the only writer while the store is live,
     // so a restored map and a mutated one cannot disagree.
     conversations = new Map()
@@ -1458,7 +1458,7 @@ export const chatStore = createStore<ChatState>()(
             // below the final fallback `set()` for the full rationale, including
             // the `worthReconcilingOnDeactivate` guard). By this point activeConversationId
             // already reads `id`, not `prevId`, so the ordinary (non-allowActive)
-            // guard in recomputeUnreadForConversation no longer sees prevId as
+            // guard in recomputeUnreadForConversation does not see prevId as
             // active and proceeds normally.
             if (prevId && prevId !== id && worthReconcilingOnDeactivate(get().conversationMeta.get(prevId))) {
               void get().recomputeUnreadForConversation(prevId)
@@ -2661,14 +2661,13 @@ export const chatStore = createStore<ChatState>()(
         // cannot be told apart from a real "all read", and the count it would
         // overwrite was accumulated live.
         //
-        // This derivation NEVER writes the read pointer.
-        // The pointer-writing recount that used to run here — snapping a
-        // pointerless entity to the newest message, and advancing the pointer
-        // onto any outgoing message in range — is gone: both were inferences
-        // about what the user had read, and the pointer is forward-only, so a
-        // wrong inference is unrecoverable. A pointerless entity now counts
-        // from its `historyFloor` creation watermark, and a cross-device reply
-        // moves the read position only through XEP-0490.
+        // This derivation NEVER writes the read pointer. Neither snapping a
+        // pointerless entity to the newest message nor advancing the pointer
+        // onto an outgoing message in range belongs here: both are inferences
+        // about what the user has read, and the pointer is forward-only, so a
+        // wrong inference is unrecoverable. A pointerless entity counts from
+        // its `historyFloor` creation watermark, and a cross-device reply moves
+        // the read position only through XEP-0490.
         const metaNow = get().conversationMeta.get(conversationId)
         if (!metaNow) return defer('no-meta')
         if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
@@ -3141,11 +3140,10 @@ export const chatStore = createStore<ChatState>()(
             // regain its badge after catch-up — the COUNT is derived from the
             // archive (see recomputeUnreadForConversation), never from this
             // page-scoped merged slice. The merge itself writes NO read
-            // pointer: the fresh-entity snap it used to
-            // apply here is replaced by the entity's `historyFloor`, and the
-            // outgoing-message advance was an inference the forward-only
-            // pointer cannot take back. Backward merges only prepend older
-            // history (nothing after the pointer changes).
+            // pointer: a fresh entity's floor comes from its `historyFloor`,
+            // and an outgoing-message advance would be an inference the
+            // forward-only pointer cannot take back. Backward merges only
+            // prepend older history (nothing after the pointer changes).
             if (direction === 'forward' && newMessages.length > 0) shouldRecountAfterMerge = true
 
             if (previewUpdate) {
@@ -3600,7 +3598,7 @@ export const chatStore = createStore<ChatState>()(
         conversationMeta: state.conversationMeta,
         // Empty, like `messages` below: the partialized shape has to match what
         // `getItem` hands back (deserializeState rebuilds the compat map, so it
-        // is present there), but `serializeState` no longer reads this field and
+        // is present there), but `serializeState` does not read this field and
         // nothing about it reaches disk.
         conversations: new Map<string, Conversation>(),
         // Note: messages are NOT persisted in localStorage anymore - they're in IndexedDB

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -478,10 +478,10 @@ function roomViewportEvidenceKey(roomJid: string): ViewportEvidenceKey {
 /**
  * Test-only: forget every persisted room read position, in memory and on disk.
  *
- * Room read state is durable now, so wiping `roomMeta` with a bare `setState`
- * no longer gives a test a clean room: the next `addRoom` folds the previous
- * test's pointer back in — which is the whole point in production. A test that
- * resets the store by hand needs this too.
+ * Room read state is durable, so wiping `roomMeta` with a bare `setState` does
+ * not give a test a clean room: the next `addRoom` folds the previous test's
+ * pointer back in — which is the whole point in production. A test that resets
+ * the store by hand needs this too.
  *
  * Clears the rows for EVERY account scope written this session, not just the
  * ambient one: callers reset the storage scope first, so the ambient key at this
@@ -729,16 +729,8 @@ function resolveRoomPendingRetractions(
 /**
  * The single writer for a room's resident message window.
  *
- * The window lives in two maps: the `rooms` compat entry and `roomRuntime`.
- * Seven call sites used to set both by hand, and the two writes were not even
- * decided the same way — the compat write was unconditional while the runtime
- * write sat behind `if (existingRuntime)`. Two independent decisions per write
- * is exactly what a reader has to trust when it falls back from one map to the
- * other, and the fallbacks in this file are the trace of that doubt.
- *
- * Copy-on-write, and deliberately so on each map separately: a fresh map
- * reference re-renders every subscriber to it, so a window that is already what
- * it would become leaves `roomRuntime` untouched.
+ * It changes `rooms` only for the caller's `roomPatch`, and keeps the `messages`
+ * map reference stable when the requested slice is already resident.
  *
  * @returns the maps to return from `set()`, or `null` when the room is unknown
  *   — the same miss the call sites already guarded on.
@@ -757,8 +749,8 @@ function withRoomMessageWindow(
   const existing = state.rooms.get(roomJid)
   if (!existing) return null
 
-  // `rooms` is touched only for the caller's own patch now — the window itself
-  // lives in the two maps below and nowhere else.
+  // `rooms` is touched only for the caller's own patch. The resident window
+  // itself lives in `messages` and nowhere else.
   const rooms = options.roomPatch
     ? new Map(state.rooms).set(roomJid, { ...existing, ...options.roomPatch })
     : state.rooms
@@ -1037,10 +1029,9 @@ export interface RoomState {
    *  FAB jump-to-present so the jump-to-last-read pill can offer a return; clearing is owned by the
    *  explicit read-through / mark-read paths. No-op when no divider exists.
    *  Touches nothing but firstNewMessageMarkers.
-   *  Only meaningful for the ACTIVE room: that is where the resident `messages` array lives. On a
-   *  deactivated room `setActiveRoom` empties the roomRuntime/rooms messages, so the recompute sees
-   *  an empty array and would SILENTLY clear the divider — callers must only invoke this for the
-   *  active room. */
+   *  Only meaningful for the ACTIVE room: deactivation clears its marker and evicts its resident
+   *  `messages` window, so the recompute would see an empty array and SILENTLY clear the divider —
+   *  callers must only invoke this for the active room. */
   resyncDividerToReadPointer: (roomJid: string) => void
   advanceReadPointer: (roomJid: string, messageId: string) => void
   /**
@@ -2183,10 +2174,9 @@ export const roomStore = createStore<RoomState>()(
       // last regression review caught (room-pointer-count-divergence) — a
       // count computed relative to one position, filed under a different one.
       // This is also what makes the outgoing-message unread clear (and any
-      // other pointer-advancing branch of `onMessageReceived`) actually stick:
-      // previously this path discarded the advance, so a room's read position
-      // never moved on send, unlike chatStore.addMessage — a chat/room parity
-      // gap. `onMessageReceived` only ever advances via `advance()`, which is
+      // other pointer-advancing branch of `onMessageReceived`) stick, keeping a
+      // room's read position at parity with chatStore.addMessage on send.
+      // `onMessageReceived` only ever advances via `advance()`, which is
       // forward-only, so committing it here unconditionally cannot regress it.
       const written = withRoomMessageWindow(state, roomJid, newMessages, {
         roomPatch: {
@@ -2509,13 +2499,12 @@ export const roomStore = createStore<RoomState>()(
     // read position cannot be told apart from a real "all read", and the count
     // it would overwrite was accumulated live.
     //
-    // This derivation NEVER writes the read pointer.
-    // The pointer-writing recount that used to run here — snapping a
-    // pointerless room to the newest message, and advancing the pointer onto
-    // any outgoing message in range — is gone. The second was worse in a MUC
+    // This derivation NEVER writes the read pointer. Neither snapping a
+    // pointerless room to the newest message nor advancing the pointer onto an
+    // outgoing message in range belongs here, and the second is worse in a MUC
     // than anywhere else: `isOutgoing` is attributed by nick, so a
-    // misattribution silently destroyed the read position, permanently (the
-    // pointer is forward-only). A pointerless room now counts from its
+    // misattribution would silently destroy the read position, permanently (the
+    // pointer is forward-only). A pointerless room counts from its
     // `historyFloor` creation watermark, and a reply sent from another device
     // moves the read position only through XEP-0490.
     const metaNow = get().roomMeta.get(roomJid)
@@ -2644,7 +2633,7 @@ export const roomStore = createStore<RoomState>()(
         // every non-active room — so the only recounts that get here are the
         // `allowActive` ones, both triggered by a pointer advance.
         // `computeFloor` is pointer-wins.
-        // This also reads only the resident `roomRuntime` messages array, with
+        // This also reads only the resident `messages` array, with
         // no cache fallback. For a room holding a parked marker over an EMPTY
         // resident array `onActivate` finds no divider position, and the
         // `parkedDivider` fallback below then decides by activity: an ACTIVE
@@ -2807,19 +2796,15 @@ export const roomStore = createStore<RoomState>()(
     if (prevJid) remoteDividerAdvances.clear(prevJid)
     if (roomJid) remoteDividerAdvances.clear(roomJid)
 
-    // Deactivate previous room: clear its "new messages" marker (if any) and
-    // EVICT its message array from RAM. Only the active room keeps its messages
-    // resident — the durable copy stays in IndexedDB and is rehydrated by
-    // activateRoom on return. Entity / meta / lastMessage / occupants are kept,
-    // so the sidebar preview and unread badge are unaffected. This bounds memory
-    // (no longer every visited room holds up to getResidentWindowSize()) and shrinks
-    // the DOM mounted on the next switch into a large room.
+    // Deactivating the previous room clears its "new messages" marker (if any)
+    // and evicts its resident window. The durable copy stays in IndexedDB and
+    // is rehydrated by `activateRoom` on return.
     if (prevJid && prevJid !== roomJid) {
       const hadMarker = get().firstNewMessageMarkers.has(prevJid)
 
       set((state) => {
-        // Drop the deactivated room's window; the writer leaves `roomRuntime`
-        // untouched when it is already empty.
+        // Drop the deactivated room's window; the writer keeps the `messages`
+        // map reference stable when that window is already empty.
         const evicted = withRoomMessageWindow(state, prevJid, [])
 
         const newMarkers = new Map(state.firstNewMessageMarkers)
@@ -2889,7 +2874,7 @@ export const roomStore = createStore<RoomState>()(
         // the final fallback `set()` for the full rationale, including the
         // `worthReconcilingOnDeactivate` guard). By this point activeRoomJid
         // already reads `roomJid`, not `prevJid`, so the ordinary
-        // (non-allowActive) guard in recomputeUnreadForRoom no longer sees
+        // (non-allowActive) guard in recomputeUnreadForRoom does not see
         // prevJid as active and proceeds normally.
         if (prevJid && prevJid !== roomJid && worthReconcilingOnDeactivate(get().roomMeta.get(prevJid))) {
           void get().recomputeUnreadForRoom(prevJid)
@@ -4165,12 +4150,11 @@ export const roomStore = createStore<RoomState>()(
         // history past the read pointer, so an unopened room may regain its
         // badge after catch-up — the COUNT is derived from the archive (see
         // recomputeUnreadForRoom), never from this page-scoped merged slice.
-        // The merge itself writes NO read pointer: the
-        // fresh-entity snap it used to apply here is replaced by the room's
-        // `historyFloor`, and the outgoing-message advance was an inference
-        // built on nick-attributed `isOutgoing` that the forward-only pointer
-        // cannot take back. Backward merges only prepend older history
-        // (nothing after the pointer changes).
+        // The merge itself writes NO read pointer: a fresh entity's floor
+        // comes from the room's `historyFloor`, and an outgoing-message advance
+        // would be an inference built on nick-attributed `isOutgoing` that the
+        // forward-only pointer cannot take back. Backward merges only prepend
+        // older history (nothing after the pointer changes).
         if (direction === 'forward' && newFromMAM.length > 0) shouldRecountAfterMerge = true
 
         // roomRuntime deliberately untouched.

--- a/packages/fluux-sdk/src/stores/shared/conversationMaps.ts
+++ b/packages/fluux-sdk/src/stores/shared/conversationMaps.ts
@@ -11,9 +11,9 @@
  * expression on every reload rather than reading the persisted copy. Which
  * means any field written into `conversations` alone — updated in one map and
  * left stale in the other — survives in memory and then silently disappears on
- * the next launch. Twenty-two call sites used to mirror each metadata write by
- * hand, several of them naming a subset of the fields they had just changed;
- * that mirroring is what this module replaces.
+ * the next launch. Mirroring each metadata write into `conversations` by hand
+ * at the call site is what this module replaces: a hand-written mirror naming a
+ * subset of the fields it just changed is exactly how that drift appears.
  *
  * The guarantee is structural rather than remembered: the compat entry is never
  * patched, only DERIVED, with the same expression the rebuild uses. A new write

--- a/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
+++ b/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
@@ -121,7 +121,7 @@ interface Baseline {
   /**
    * Ids carrying a record at the previous write.
    *
-   * Deliberately not the `bottomId`s: a `bottomId` change is no longer a
+   * Deliberately not the `bottomId`s: a `bottomId` change is not a
    * durability signal on its own (see the module doc), and keeping the values
    * would invite a future reader to resurrect the comparison that #1138
    * measured out.

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -9,10 +9,11 @@
  * live-edge bookkeeping in their own state shape) and act on the returned
  * flags.
  *
- * Historical context: every transition here previously existed twice — once
- * per store — and drifted (chat missed the live-append trim and pagination
- * dedupe; room missed the archive-id backfill). See messageTimeline.test.ts
- * for the single behavioral specification.
+ * One implementation deliberately, not one per store: a second copy of these
+ * transitions drifts from the first, and the drift is silent — a missing
+ * live-append trim, a missing pagination dedupe, a missing archive-id
+ * backfill. See messageTimeline.test.ts for the single behavioral
+ * specification.
  */
 
 import type { ArchiveIdentifiableMessage, TimestampedMessage } from './messageArrayUtils'

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -161,17 +161,17 @@ export interface MessageReceivedOptions {
  * There is NO outgoing early return. "I sent this, so I must have
  * read up to here" is an inference, and `isOutgoing` is true for a carbon from another
  * device and for a nick-misattributed MUC reflection — the vector #1081 exists to close.
- * An outgoing message now advances the pointer only via `userSeesMessage`, i.e. for the
+ * An outgoing message advances the pointer only via `userSeesMessage`, i.e. for the
  * same reason any VISIBLE message does. Note the consequence for a DELAYED outgoing
- * message: it returns at the delayed guard, so a MUC history replay of our own message no
- * longer dismisses the divider (deliberate — see the spec's D1 table).
+ * message: it returns at the delayed guard, so a MUC history replay of our own message
+ * does not dismiss the divider (deliberate — see the spec's D1 table).
  *
  * "User sees message" requires all three of: the entity is active,
  * the window is visible/focused, AND the viewport is demonstrably at the live
  * edge for the CURRENT activation generation (`ctx.viewportAtLiveEdge ===
  * true`). An active, focused conversation the user has scrolled UP in is
  * exactly the case this precondition exists to catch: `isActive &&
- * windowVisible` alone used to advance the pointer there, silently marking
+ * windowVisible` alone would advance the pointer there, silently marking
  * unseen history as read. Missing/stale/unknown viewport evidence (the
  * `undefined` default) is treated conservatively as NOT at the edge — see
  * `EntityContext.viewportAtLiveEdge` and `viewportEvidence.ts`.
@@ -281,16 +281,16 @@ export function isUnseenIncomingMessage(
  * construction rather than by coincidence — see `countUnreadInArchive`.
  *
  * `isDelayed` plays no part: with a timestamp floor, a delayed message after the
- * boundary simply IS new. That is why this function no longer takes
- * `treatDelayedAsNew` (the live arrival paths still do — chat and room genuinely
+ * boundary simply IS new. That is why this function does not take
+ * `treatDelayedAsNew` (the live arrival paths do — chat and room genuinely
  * differ there; see `onMessageReceived`).
  *
  * This function NEVER moves the read pointer and never changes `unreadCount`.
- * The old fallback ladder — a `lastReadAt` timestamp probe, an Nth-from-end
- * placement driven by `unreadCount`, and a resume-preserving snap — is gone. All
- * of it existed because the pointer could not be located outside the resident
- * slice, which a durably reconstructible `tiebreak` now solves, and the
- * snap was a pointer write inside a function whose job is to place a divider.
+ * No fallback ladder stands behind it — no `lastReadAt` timestamp probe, no
+ * Nth-from-end placement driven by `unreadCount`, no resume-preserving snap: a
+ * durably reconstructible `tiebreak` locates the pointer outside the resident
+ * slice, and a snap would be a pointer write inside a function whose job is to
+ * place a divider.
  *
  * With neither a pointer nor a `historyFloor` there is no boundary, so there is
  * no divider — the same stand-down the count makes when `computeFloor` yields
@@ -474,7 +474,7 @@ export function onMessageSeen(
   // No read position yet: any resolvable message is an advancement.
   if (!state.readPointer) return advanced()
 
-  // EXACT pointer: compare cache POSITIONS. The pointer no longer has to be
+  // EXACT pointer: compare cache POSITIONS. The pointer does not have to be
   // resident, and a same-millisecond sibling that sorts after it is a genuine
   // advance. Safe against the resident array because `messageArrayUtils`
   // uses the same tie-break, so array index and cache order

--- a/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
@@ -1,11 +1,11 @@
 /**
  * Pending retractions (XEP-0424) — shared by the chat and room stores.
  *
- * A retraction can arrive while its target is not in the resident window: only
- * the ACTIVE conversation keeps its messages in RAM, and a target older than the
- * loaded slice is absent even there. The live path used to give up in that case,
- * which let the retraction's XEP-0428 fallback body fall through and surface as a
- * normal message. Instead the retraction is recorded here and replayed the moment
+ * A retraction can arrive while its target is not in the resident window: a
+ * deactivated conversation has been evicted, and a target older than the loaded
+ * slice is absent even in a populated window. Giving up in that case would let the
+ * retraction's XEP-0428 fallback body fall through and surface as a normal
+ * message. Instead the retraction is recorded here and replayed the moment
  * the target becomes resident (live arrival or a cache/MAM load), so the tombstone
  * lands late rather than never.
  *

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -169,9 +169,9 @@ export function withArchiveId(pointer: ReadPointer, archiveId: string): ReadPoin
  * floor rule and must never be substituted here — it would let any exact
  * candidate overtake a migrated floor pointer sharing its millisecond,
  * advancing a forward-only position past messages nothing has proven were read.
- * That used to be guarded by this comment alone (#1173); it is now guarded by
- * the type — `isAfterBoundary` takes an `ExactPosition` row, which a pointer's
- * order, being possibly a floor, is not. See `readState.enforcement.test.ts`.
+ * The type guards that, not this comment (#1173): `isAfterBoundary` takes an
+ * `ExactPosition` row, which a pointer's order, being possibly a floor, is
+ * not. See `readState.enforcement.test.ts`.
  *
  * Identity plays NO part here. A pointer is not further along for having
  * acquired a wire name, which is why {@link withArchiveId} cannot move a cursor

--- a/packages/fluux-sdk/src/stores/shared/viewportEvidence.ts
+++ b/packages/fluux-sdk/src/stores/shared/viewportEvidence.ts
@@ -1,10 +1,10 @@
 /**
  * SDK-owned, generation-scoped viewport evidence.
  *
- * `onMessageReceived` (`notificationState.ts`) used to treat `isActive &&
- * windowVisible` as "the user saw this" and advance the read pointer on
- * arrival — so a conversation that is open and focused but SCROLLED UP in
- * history wrongly marked new messages read. This module supplies the missing
+ * For `onMessageReceived` (`notificationState.ts`), `isActive &&
+ * windowVisible` is not "the user saw this": a conversation that is open and
+ * focused but SCROLLED UP in history would wrongly mark new messages read on
+ * arrival. This module supplies the missing
  * ingredient: whether the viewport is genuinely at the live edge, scoped to
  * the CURRENT activation so a stale/delayed report from a previous activation
  * (or a previous entity) can never be mistaken for current truth.

--- a/packages/fluux-sdk/src/stores/storeBindingsConformance.ts
+++ b/packages/fluux-sdk/src/stores/storeBindingsConformance.ts
@@ -1,12 +1,12 @@
 /**
  * Compile-time proof that each Zustand store implements its binding port.
  *
- * `StoreBindings` used to be `Pick<ChatState, …>`: the contract was derived
- * from the implementation, so it could not disagree with it — but it also made
- * the SDK's leaf type layer depend on the stores, and left the package unable
+ * A `Pick<ChatState, …>` binding type would derive the contract from the
+ * implementation, so it could not disagree with it — but it would also make
+ * the SDK's leaf type layer depend on the stores, and leave the package unable
  * to describe its own state surface without naming Zustand.
  *
- * The port is now declared independently in `core/types/storeBindings.ts`, and
+ * The port is declared independently in `core/types/storeBindings.ts`, and
  * the drift protection lives here instead, pointing the other way: if a store
  * drops a member the port promises, or narrows a signature the port requires,
  * these assignments stop compiling. If a store ADDS a member the port does not

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -79,8 +79,9 @@ export const MAM_POINTER_SEED_PROBE_LIMIT = 25
  * Walks the array backwards (most recent first) and returns the first
  * entry that has a `timestamp`. Including delayed messages ensures the
  * catch-up always uses a forward query, which merges correctly via full
- * sort. Previously skipping delayed messages caused backward queries
- * whose prepend-based merge put newer messages at the wrong position.
+ * sort. If every cached message is delayed, skipping them leaves no cursor and
+ * yields a backward query whose prepend-based merge puts newer messages at the
+ * wrong position.
  */
 export function findNewestMessage(messages: Array<{ timestamp?: Date }>): { timestamp: Date } | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Second half of the #1236 comment clean-up: category 2, historical narration. Category 1 (development-session identifiers) is already done and guarded by `scripts/check-comment-provenance.mjs`; category 3 (real issue references) is kept, as the doctrine recommends.

## Triage

Scanned by parsing comment text rather than the issue's line-anchored grep, which misses block-comment continuation lines. **162 occurrences** of `used to` / `previously` / `no longer` in non-test comments:

- **63 genuine narration, treated** — 59 rewritten in the present tense, 4 dropped as changelog prose.
- **121 false positives, untouched** — `used to <verb>` meaning "employed to", `previously-delivered`, `previouslyJoinedRooms`.
- **37 already correct, untouched** — present-tense statements about *runtime* state, not code history: "messages that no longer exist", "the occupant is no longer present in the room".

The line between the last two groups and the first: narration is about the **code's** past. A sentence describing a runtime condition that has ceased to hold is already in the present tense and stays. Within the treated group, a sentence was rewritten when it stated a current invariant or explained why a plausible alternative fails, and deleted when it only recorded a past change.

## What the review cycle found

Four rewrites stated the invariant more confidently than the code supports, and are corrected here — `roomStore`'s resident-window ownership (the two-map story was obsolete), the active-room residency bound (the live-append path has no such gate), `bottomAnchor`'s geometry (it measures with `getBoundingClientRect`, not `offsetTop`), and the delayed-message cursor rule in `mamCatchUpUtils` (only true when every cached message is delayed). A `Roster.ts` rationale about what is persisted versus transient was removed rather than reworded, since the premise could not be established.

**The lesson worth keeping: rewriting narration in the present tense can inherit a stale premise and restate it as verified fact, which is worse for a reader than the vague sentence it replaced.** Where current behaviour could not be established by reading the code, the sentence was deleted instead.

## Constraint

Comment-only. Every added and removed line begins with `//`, `*`, `/*` or `*/`, apart from two continuation lines inside a JSX `{/* … */}` block in `AppIconMark.tsx`.

## Noticed, deliberately not fixed

Three development-session identifiers slip past `check-comment-provenance.mjs` and are left exactly as they were: `Codex r4 #5` (`chatStore.ts`, `roomStore.ts`), `final-fix-2:` (both stores), `finding 9` (`MAM.ts`).

One open product question, surfaced by the `Roster.ts` comment and not addressed here: a manually set away is not restored on reconnect, and `presenceMachine.ts` now preserves `lastUserPreference` across CONNECT. Whether that reset is still intended is worth its own issue.