### PR TITLE
fix(unread): bootstrap coverage from a completed timestamp-resumed catch-up

### DIFF
--- a/docs/MAM_CATCHUP.md
+++ b/docs/MAM_CATCHUP.md
@@ -39,8 +39,19 @@ Chains after the preview refresh completes.
 
 - Calls `catchUpAllConversations()`.
 - For each non-archived conversation:
-  - If there are cached messages: sends a **forward query** with `start` = newest cached timestamp + 1 ms, `max=100`. This fetches only messages newer than what is already in the store.
+  - If there are cached messages: sends a **forward query** with `max=100`,
+    preferring an id-exact `after` cursor from the held archive edge. When the
+    edge has no archive id, such as the user's own last send, it falls back to
+    an inclusive `start` timestamp.
   - If no cached messages exist: sends a **backward query** with `before=""`, `max=50` to fetch the latest messages.
+- A completed forward walk can seed a missing contiguous-coverage record. The
+  resume cursor is the preferred bottom; a timestamp-resumed walk instead uses
+  the oldest persistable archive id returned by that whole walk. An incomplete
+  walk never seeds coverage.
+- Coverage is committed only after the messages and archive-id backfills that
+  make its bottom resolvable are durable. For a timestamp-resumed bootstrap,
+  the unread recount then runs against that committed coverage, including when
+  the conversation is active.
 - Runs at **concurrency 2** to be gentle on the server.
 - Errors are silently ignored per conversation (best-effort).
 
@@ -61,8 +72,9 @@ Triggered 10 seconds after fresh-session setup, giving rooms time to finish join
 
 - Filters rooms to those that confirmed self-presence in the current session,
   are still joined, support MAM, are not Quick Chat rooms, and are not active.
-- Peeks at each room's cached messages and uses the same forward/backward query
-  pattern as conversation catch-up.
+- Peeks at each room's cached messages and uses the same forward/backward query,
+  coverage-bootstrap, durability, and unread-recount rules as conversation
+  catch-up.
 - Revalidates the session, membership, active room, and foreground ownership
   after cache hydration so an obsolete background attempt cannot query MAM.
 - Rooms that join or discover MAM after the initial pass are caught up once
@@ -89,7 +101,8 @@ therefore joins and is caught up as it becomes eligible, once per session.
 
 Triggered by side effects when the user opens a conversation or room.
 
-- If the conversation/room has cached messages: forward query from the newest cached timestamp.
+- If the conversation/room has cached messages: use the same id-exact forward
+  cursor or inclusive timestamp fallback as background catch-up.
 - If no cached messages: backward query for recent history.
 - On a fresh session, the active room may display hydrated cache immediately,
   but it waits for successful self-presence (`room:joined`) in that session
@@ -136,6 +149,8 @@ Lower concurrency for catch-up keeps server load reasonable during background wo
 | `packages/fluux-sdk/src/core/backgroundSync.ts` | Orchestrates all background sync stages on connect |
 | `packages/fluux-sdk/src/core/chatSideEffects.ts` and `roomSideEffects.ts` | Active conversation/room cache and MAM triggers |
 | `packages/fluux-sdk/src/core/roomMamHandoff.ts` and `roomMembershipEpoch.ts` | Coordinates foreground/background room ownership across membership changes |
+| `packages/fluux-sdk/src/utils/mamCatchUpUtils.ts` | Selects id or timestamp catch-up anchors and derives a walk's persistable extent |
+| `packages/fluux-sdk/src/stores/shared/mamCoverage.ts` | Owns coverage bootstrap and extension rules |
 | `packages/fluux-sdk/src/utils/concurrencyUtils.ts` | `executeWithConcurrency()` utility |
 | `packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts` | Tests for catch-up and discovery methods |
 | `packages/fluux-sdk/src/core/roomSideEffects.test.ts` and `backgroundSync.test.ts` | Tests for room trigger, ownership, and handoff wiring |

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -286,9 +286,9 @@ export function createStoreBindings(
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:history-messages', ({ conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('chat:history-messages', ({ conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId }) => {
     const stores = getStores()
-    stores.chat.mergeMAMMessages(conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
+    stores.chat.mergeMAMMessages(conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId })
   })
 
   // A purged id-exact anchor (item-not-found degrade): strip the matching
@@ -477,9 +477,9 @@ export function createStoreBindings(
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:history-messages', ({ roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
+  on('room:history-messages', ({ roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId }) => {
     const stores = getStores()
-    stores.room.mergeRoomMAMMessages(roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
+    stores.room.mergeRoomMAMMessages(roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId })
   })
 
   // Room twin of chat:mam-anchor-purged (see above).

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -3601,6 +3601,78 @@ describe('XMPPClient MAM', () => {
       }))
     })
 
+    it('carries the oldest persistable id across forward room pages', async () => {
+      let stanzaListener: ((stanza: any) => void) | null = null
+      const originalOn = mockXmppClientInstance.on
+      mockXmppClientInstance.on = vi.fn().mockImplementation((event: string, listener: Function) => {
+        if (event === 'stanza') stanzaListener = listener as (stanza: any) => void
+        return originalOn.call(mockXmppClientInstance, event, listener)
+      }) as typeof mockXmppClientInstance.on
+      await connectClient()
+
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({
+        jid: roomJid,
+        name: 'Test Room',
+        nickname: 'MyNick',
+        joined: true,
+        isBookmarked: false,
+        occupants: new Map(),
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set<string>(),
+      })
+
+      let callCount = 0
+      mockXmppClientInstance.iqCaller.request = vi.fn().mockImplementation(async (iq) => {
+        callCount++
+        const query = iq.children?.find((child: any) => child.name === 'query')
+        const queryId = query?.attrs?.queryid || 'test'
+        const archiveId = callCount === 1 ? 'walk-oldest' : 'walk-newest'
+        const stamp = callCount === 1 ? '2024-01-15T09:00:00Z' : '2024-01-15T10:00:00Z'
+        stanzaListener?.(createMockElement('message', { from: roomJid }, [{
+          name: 'result',
+          attrs: { xmlns: 'urn:xmpp:mam:2', queryid: queryId, id: archiveId },
+          children: [{
+            name: 'forwarded',
+            attrs: { xmlns: 'urn:xmpp:forward:0' },
+            children: [
+              { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp } },
+              {
+                name: 'message',
+                attrs: { from: `${roomJid}/OtherUser`, type: 'groupchat', id: `message-${callCount}` },
+                children: [{ name: 'body', text: `page ${callCount}` }],
+              },
+            ],
+          }],
+        }]))
+        return createMockElement('iq', { type: 'result' }, [{
+          name: 'fin',
+          attrs: { xmlns: 'urn:xmpp:mam:2', complete: callCount === 2 ? 'true' : 'false' },
+          children: [{
+            name: 'set',
+            attrs: { xmlns: 'http://jabber.org/protocol/rsm' },
+            children: [
+              { name: 'first', text: archiveId },
+              { name: 'last', text: archiveId },
+            ],
+          }],
+        }])
+      })
+
+      await xmppClient.messages.queryRoomMAM({
+        roomJid,
+        start: '2024-01-15T08:00:00Z',
+        maxAutoPages: 2,
+      })
+
+      const mamEmits = emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:history-messages')
+      expect(mamEmits).toHaveLength(2)
+      expect(mamEmits[1][1]).toEqual(expect.objectContaining({
+        complete: true,
+        walkOldestId: 'walk-oldest',
+      }))
+    })
+
     it('backward fetch-latest: retries past a signal-only page and emits ONE accumulated batch (parity with 1:1)', async () => {
       // IMPORTANT: Set up capture BEFORE connectClient() so we capture the listener
       let stanzaListener: ((stanza: any) => void) | null = null

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -57,6 +57,7 @@ import {
   MAM_POINTER_STITCH_MAX_PAGES,
   MAM_POINTER_SEED_PROBE_LIMIT,
   oldestMessageWithStanzaId,
+  walkExtentBottomId,
 } from '../../utils/mamCatchUpUtils'
 import {
   NS_MAM,
@@ -436,6 +437,7 @@ export class MAM extends BaseModule {
           // The cursor this walk resumed from — anchors the coverage bottom
           // when the catch-up reports complete (mamCoverage.ts).
           initialAfter: after,
+          walkOldestId: walkExtentBottomId(allMessages),
         }),
       })
 
@@ -641,6 +643,8 @@ export class MAM extends BaseModule {
             // Emit modifications targeting messages already in the store (from prior queries/cache)
             this.emitUnresolvedRoomModifications(roomJid, unresolved)
 
+            allMessages.push(...collectedMessages)
+
             // Emit each page's messages immediately so the store can update incrementally
             this.deps.emitSDK('room:history-messages', {
               roomJid,
@@ -653,11 +657,13 @@ export class MAM extends BaseModule {
               // The cursor the WALK resumed from (not this page's), so the
               // completing page can anchor a coverage bottom (mamCoverage.ts).
               initialAfter: after,
+              walkOldestId: walkExtentBottomId(allMessages),
               walkCarriedModifications: forwardWalkCarriedModifications,
             })
+          } else {
+            allMessages.push(...collectedMessages)
           }
 
-          allMessages.push(...collectedMessages)
           isComplete = complete
           lastPage = pageInfo
           if (page === 0 && !isForward) fetchLatestTopId = pageInfo.last

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -318,4 +318,6 @@ export interface MergeArchiveExtras {
   /** FORWARD only: the `after` cursor the catch-up resumed from — the bootstrap
    *  anchor when that catch-up reports complete. */
   initialAfter?: string
+  /** FORWARD only: the oldest persistable archive id carried by the whole walk. */
+  walkOldestId?: string
 }

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -246,6 +246,8 @@ export interface ChatEvents {
     /** FORWARD only: the `after` cursor the catch-up resumed from. With
      *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */
     initialAfter?: string
+    /** FORWARD only: the oldest persistable archive id carried by the whole walk. */
+    walkOldestId?: string
   }
 
   /**
@@ -510,6 +512,8 @@ export interface RoomEvents {
     /** FORWARD only: the `after` cursor the catch-up resumed from. With
      *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */
     initialAfter?: string
+    /** FORWARD only: the oldest persistable archive id carried by the whole walk. */
+    walkOldestId?: string
   }
 
   /**

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -1734,3 +1734,190 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     })
   })
 })
+
+/**
+ * A timestamp-resumed catch-up has no `initialAfter`. The fixture uses an own
+ * send without an archive id as that edge, so a completed walk must anchor
+ * missing coverage on the oldest persistable archive id it carried itself.
+ */
+describe('chatStore — `start`-filtered catch-up bootstraps coverage from its walk extent', () => {
+  const SELF = 'me@example.com'
+
+  /** Our own last send: persisted with an origin-id and NO archive id. */
+  function ownSend(overrides: Partial<Message> = {}): Message {
+    return archiveMsg('own', 1000, {
+      from: SELF,
+      isOutgoing: true,
+      originId: 'own-origin',
+      body: 'last word',
+      ...overrides,
+    })
+  }
+
+  const POINTER_ON_OWN_SEND = {
+    order: { role: 'exact' as const, timestamp: 1000, tiebreak: { kind: 'chat' as const, id: 'own' } },
+    identity: { state: 'local' as const, messageId: 'own' },
+  }
+
+  function markCaughtUpWithoutCoverage(): void {
+    chatStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(CID, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: true, isCaughtUpToLive: true })
+      return { mamQueryStates }
+    })
+  }
+
+  /** The walk's messages carry archive ids: `start` is inclusive, so the
+   *  anchor own send comes back down with the id the archive gave it. */
+  function catchUp(complete: boolean): void {
+    chatStore.getState().mergeMAMMessages(
+      CID,
+      [ownSend({ stanzaId: 'own-archive-id' })],
+      { first: 'own-archive-id' },
+      complete,
+      'forward',
+      false,
+      false,
+      // No `initialAfter`: this walk resumed from a timestamp, not a cursor.
+      { walkCarriedModifications: false, walkOldestId: 'own-archive-id' }
+    )
+  }
+
+  /** Let the archive write, and the coverage commit gated on it, settle. */
+  async function settle(): Promise<void> {
+    await vi.waitFor(() => {
+      expect(chatStore.getState().getConversationCoverage(CID)).toBeDefined()
+    }, { timeout: 2000 })
+  }
+
+  beforeEach(async () => {
+    _resetStorageScopeForTesting()
+    globalThis.indexedDB = new IDBFactory()
+    ;(messageCache as unknown as { _resetDBForTesting?: () => void })._resetDBForTesting?.()
+    localStorageMock.clear()
+    chatStore.getState().reset()
+    resetRecountDeferralsForTesting()
+    clearTransientScope(getStorageScopeJid() ?? '')
+    chatStore.getState().addConversation(createConversation(CID))
+
+    await messageCache.saveMessages([ownSend()])
+    chatStore.setState({ activeConversationId: 'someone-else@example.com' })
+    setMeta({ unreadCount: 4, readPointer: POINTER_ON_OWN_SEND })
+    markCaughtUpWithoutCoverage()
+    expect(chatStore.getState().getConversationCoverage(CID)).toBeUndefined()
+  })
+
+  it('gets a coverage record, and the frozen badge finally recomputes', async () => {
+    catchUp(true)
+    await settle()
+
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id' })
+
+    // Nothing sits after the pointer, so the seeded count of 4 converges to 0 with
+    // no further prodding — the merge re-derives once its record commits.
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+    expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(0)
+
+    expect(readRecountDeferrals()['chat:coverage-missing']).toBeUndefined()
+  })
+
+  it('gates an active dedupe backfill and then recomputes it once', async () => {
+    let releaseWrite!: () => void
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve })
+    vi.mocked(messageCache.saveMessages).mockClear()
+    vi.mocked(messageCache.saveMessages).mockImplementationOnce(async (messages) => {
+      const committed = await saveMessagesImplementation(messages)
+      await writeGate
+      return committed
+    })
+    chatStore.setState((state) => ({
+      activeConversationId: CID,
+      messages: new Map(state.messages).set(CID, [ownSend()]),
+    }))
+
+    catchUp(true)
+    await vi.waitFor(() => {
+      expect(messageCache.saveMessages).toHaveBeenCalled()
+    })
+    expect(chatStore.getState().getConversationCoverage(CID)).toBeUndefined()
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(4)
+
+    releaseWrite()
+    await settle()
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+
+    expect(readRecountDeferrals()['chat:coverage-missing']).toBeUndefined()
+    expect(readRecountDeferrals()['chat:active-skipped']).toBeUndefined()
+  })
+
+  it('an INCOMPLETE walk still leaves no coverage, and the badge still freezes', async () => {
+    // Completion is the whole warrant for trusting the walk's extent.
+    catchUp(false)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(chatStore.getState().getConversationCoverage(CID)).toBeUndefined()
+
+    resetRecountDeferralsForTesting()
+    await chatStore.getState().recomputeUnreadForConversation(CID)
+
+    // An unfinished walk also clears `isCaughtUpToLive`, so the recount stands
+    // down one guard earlier. Re-assert caught-up to reach the coverage gate
+    // itself and show the door it used to leak through is still shut.
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['chat:history-not-caught-up']).toBe(1)
+
+    markCaughtUpWithoutCoverage()
+    resetRecountDeferralsForTesting()
+    await chatStore.getState().recomputeUnreadForConversation(CID)
+
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['chat:coverage-missing']).toBe(1)
+  })
+
+  it('re-establishes coverage after an unresolvable bottom dropped the record', async () => {
+    // An unresolvable bottom drops the record. A later completed timestamp
+    // catch-up must be able to establish durable coverage again.
+    seedCoverage('evicted-stanza-id')
+    await chatStore.getState().recomputeUnreadForConversation(CID)
+    expect(chatStore.getState().getConversationCoverage(CID)).toBeUndefined()
+    expect(readRecountDeferrals()['chat:coverage-unresolvable']).toBe(1)
+
+    catchUp(true)
+    await settle()
+
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id' })
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+    expect(readRecountDeferrals()['chat:coverage-missing']).toBeUndefined()
+  })
+
+  it('leaves the other deferral reasons standing in their own conditions', async () => {
+    // Closing this exit must not open the others: a walk that reached live is
+    // not a licence to count from history that has not caught up.
+    catchUp(true)
+    await settle()
+    await vi.waitFor(() => {
+      expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+
+    // Coverage is now proven, so only the OTHER guards can stand between a
+    // stale badge and the archive. Re-stale it and take one away.
+    setMeta({ unreadCount: 4 })
+    chatStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(CID, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: false, isCaughtUpToLive: false })
+      return { mamQueryStates }
+    })
+
+    resetRecountDeferralsForTesting()
+    await chatStore.getState().recomputeUnreadForConversation(CID)
+
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['chat:history-not-caught-up']).toBe(1)
+  })
+})

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -3250,9 +3250,13 @@ describe('chatStore', () => {
         const messages = chatStore.getState().messages.get('alice@example.com')
         expect(messages?.length).toBe(1) // still deduplicated
         expect(messages?.[0].stanzaId).toBe('archive-99') // but now backfilled
-        expect(messageCache.updateMessage).toHaveBeenCalledWith(
-          'uuid-sent',
-          expect.objectContaining({ stanzaId: 'archive-99' })
+        // The backfill rides the merge's DURABLE archive write, not a
+        // fire-and-forget update: a coverage bottom may name this row, so its
+        // write has to be the one the gap/coverage commit gates on.
+        expect(messageCache.saveMessages).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ id: 'uuid-sent', stanzaId: 'archive-99' }),
+          ])
         )
       })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -12,6 +12,7 @@ import type { HistoryQueryDirection } from './shared/mamState'
 import { syncGapAfterArchiveMerge, messagePageExtent, newestMessageStanzaId, type GapInterval } from './shared/mamGap'
 import {
   syncCoverageAfterArchiveMerge,
+  walkExtentBottomId,
   isCaughtUpForCounting,
   resolveCoverageBottom,
   type CoverageRecord,
@@ -445,11 +446,9 @@ interface ChatState {
    * reconciled for the active conversation by their own synchronous path
    * (`onMessageReceived`'s live-edge convergence), so racing an async
    * archive recompute against that would be redundant at best. The one
-   * exception is `{ allowActive: true }`: a remote XEP-0490 marker can advance
-   * the ACTIVE entity's read position without that convergence path running at
-   * all, and activation writes no unconditional zero, so nothing
-   * else re-derives the active entity's count after such an advance — pass
-   * `allowActive: true` ONLY from that trigger.
+   * exception is `{ allowActive: true }`: callers that establish new durable
+   * counting input while the entity is active must opt into the guarded
+   * archive derivation.
    */
   recomputeUnreadForConversation: (conversationId: string, options?: { allowActive?: boolean }) => Promise<void>
   /**
@@ -2622,10 +2621,8 @@ export const chatStore = createStore<ChatState>()(
           }
         }
         // Active conversation counts are usually reconciled by their own
-        // synchronous path (the live-edge convergence) — skip here to
-        // avoid a redundant race, UNLESS the caller explicitly opted in
-        // (a remote XEP-0490 advance on the active entity, which that
-        // convergence path never runs for).
+        // synchronous path (the live-edge convergence) — skip here unless the
+        // caller explicitly opted into the guarded archive derivation.
         if (!allowActive && get().activeConversationId === conversationId) return defer('active-skipped')
 
         // --- Defer conditions ---------------------------------------------
@@ -2904,6 +2901,7 @@ export const chatStore = createStore<ChatState>()(
         let shouldRecountAfterMerge = false
         let archiveCommitGate: Promise<boolean> | undefined
         let durableMessages: Message[] = []
+        let coverageBootstrappedFromWalkExtent = false
         set((state) => {
           // Get existing messages for this conversation
           const rawExisting = state.messages.get(conversationId) || []
@@ -2918,10 +2916,6 @@ export const chatStore = createStore<ChatState>()(
             chatTimelineConfig(),
             isFetchLatest
           )
-          // Persist backfilled archive ids so pagination cursors survive a reload.
-          for (const p of patched) {
-            void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
-          }
           mergedForMarker = trimmed
 
           // Newest fetched message timestamp marks the gap edge for an incomplete
@@ -3005,16 +2999,24 @@ export const chatStore = createStore<ChatState>()(
           // no crash window and the transition applies immediately.
           const prevGap = state.conversationGaps.get(conversationId)
           const persistableMessages = newMessages.filter(msg => !isNoLocalStore(msg))
+          const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
+          const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
           durableMessages = persistableMessages
           // A merge with nothing persistable still defers when earlier pages
           // of this conversation are in flight (or failed): its cursor must
           // not leap them.
-          const mustGateOnChain = persistableMessages.length > 0 || conversationArchiveSaves.has(conversationId)
+          const mustGateOnChain = archiveWriteMessages.length > 0 || conversationArchiveSaves.has(conversationId)
           const deferGapCommit =
             newGaps !== state.conversationGaps &&
             mustGateOnChain
           const gapsAfterMerge = deferGapCommit ? state.conversationGaps : newGaps
 
+          // The walk's own extent, the bootstrap's anchor when a `start`-filtered
+          // catch-up leaves `initialAfter` undefined. Scanned only for the
+          // direction that can use it.
+          const walkOldestId = direction !== 'backward'
+            ? extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
+            : undefined
           // Persisted coverage record; see mamCoverage.ts for the durability
           // invariant this defers on. A merge with nothing persistable
           // (signal-only give-up) applies now.
@@ -3031,12 +3033,18 @@ export const chatStore = createStore<ChatState>()(
             walkCarriedModifications: extras?.walkCarriedModifications ?? false,
             complete,
             initialAfter: extras?.initialAfter,
+            walkOldestId,
           })
           const prevCoverage = state.conversationCoverage.get(conversationId)
           const deferCoverageCommit =
             newCoverage !== state.conversationCoverage &&
             mustGateOnChain
           const coverageAfterMerge = deferCoverageCommit ? state.conversationCoverage : newCoverage
+          coverageBootstrappedFromWalkExtent =
+            coverageTransition === 'created' &&
+            extras?.initialAfter === undefined &&
+            walkOldestId !== undefined &&
+            newCoverage.get(conversationId)?.bottomId === walkOldestId
           // Reported where the value actually enters the state (#1138):
           // reporting at merge time on the DEFERRED path would arm the flush for
           // a write that still carries the old record, and leave the real one
@@ -3085,6 +3093,17 @@ export const chatStore = createStore<ChatState>()(
             })
           }
 
+          if (archiveWriteMessages.length > 0) {
+            const savePromise = messageCache.saveMessages(archiveWriteMessages)
+            archiveCommitGate = conversationArchiveSaves.chain(conversationId, savePromise)
+            if (deferGapCommit || deferCoverageCommit) {
+              scheduleDeferredCommit(archiveCommitGate)
+            }
+            if (persistableMessages.length > 0) {
+              searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
+            }
+          }
+
           // If no new messages (all duplicates), only update MAM state to avoid
           // unnecessary re-renders. Exception: a stanzaId backfill onto existing
           // RAM messages must persist — but only for the ACTIVE conversation
@@ -3094,7 +3113,7 @@ export const chatStore = createStore<ChatState>()(
             // Nothing of our own to persist, but earlier in-flight pages may
             // still gate this merge's transitions: chain a no-op save so the
             // transition applies (or is dropped) with the same ordering rules.
-            if (deferGapCommit || deferCoverageCommit) {
+            if (!archiveCommitGate && (deferGapCommit || deferCoverageCommit)) {
               archiveCommitGate = conversationArchiveSaves.chain(conversationId, Promise.resolve(true))
               scheduleDeferredCommit(archiveCommitGate)
             }
@@ -3104,20 +3123,6 @@ export const chatStore = createStore<ChatState>()(
             const backfilledMap = new Map(state.messages)
             backfilledMap.set(conversationId, trimmed)
             return { messages: backfilledMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge }
-          }
-
-          // Persist to IndexedDB regardless of active state (durable history).
-          if (persistableMessages.length > 0) {
-            const savePromise = messageCache.saveMessages(persistableMessages)
-            // Serialize through the per-conversation chain: the gate resolves
-            // true only when THIS page and every earlier in-flight page
-            // committed.
-            const commitGate = conversationArchiveSaves.chain(conversationId, savePromise)
-            archiveCommitGate = commitGate
-            if (deferGapCommit || deferCoverageCommit) {
-              scheduleDeferredCommit(commitGate)
-            }
-            searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
           }
 
           // Sidebar preview via the shared policy: the newest previewable message
@@ -3144,7 +3149,9 @@ export const chatStore = createStore<ChatState>()(
             // and an outgoing-message advance would be an inference the
             // forward-only pointer cannot take back. Backward merges only
             // prepend older history (nothing after the pointer changes).
-            if (direction === 'forward' && newMessages.length > 0) shouldRecountAfterMerge = true
+            if (direction === 'forward' && newMessages.length > 0 && !coverageBootstrappedFromWalkExtent) {
+              shouldRecountAfterMerge = true
+            }
 
             if (previewUpdate) {
               const draft = draftConversationMaps(state)
@@ -3222,6 +3229,9 @@ export const chatStore = createStore<ChatState>()(
           const resume = () => {
             if (chatCacheEpoch !== cacheEpochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
             chatRecountRetry.resume(conversationId)
+            if (coverageBootstrappedFromWalkExtent) {
+              void get().recomputeUnreadForConversation(conversationId, { allowActive: true })
+            }
           }
           if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
           else resume()

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -1640,3 +1640,207 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     })
   })
 })
+
+/**
+ * A room timestamp resume can come from a gap boundary without an id or a local
+ * edge without an archive id. With no `initialAfter`, a completed walk must
+ * anchor missing coverage on the oldest persistable archive id it carried.
+ */
+describe('roomStore — `start`-filtered catch-up bootstraps coverage from its walk extent', () => {
+  /** The room's newest cached entry, held with no archive id. */
+  function edgeMsg(overrides: Partial<RoomMessage> = {}): RoomMessage {
+    return archiveMsg('edge', 1000, { from: ROOM + '/alice', nick: 'alice', body: 'last word', ...overrides })
+  }
+
+  const POINTER_ON_EDGE = {
+    order: { role: 'exact' as const, timestamp: 1000, tiebreak: { kind: 'room' as const, from: ROOM + '/alice', id: 'edge' } },
+    identity: { state: 'local' as const, messageId: 'edge' },
+  }
+
+  function markCaughtUpWithoutCoverage(): void {
+    roomStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(ROOM, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: true, isCaughtUpToLive: true })
+      return { mamQueryStates }
+    })
+  }
+
+  /** `start` is inclusive, so the anchor entry comes back down carrying the
+   *  archive id it never had locally. */
+  function catchUp(complete: boolean): void {
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [edgeMsg({ stanzaId: 'edge-archive-id' })],
+      { first: 'edge-archive-id' },
+      complete,
+      'forward',
+      false,
+      false,
+      // No `initialAfter`: this walk resumed from a timestamp, not a cursor.
+      { walkCarriedModifications: false, walkOldestId: 'edge-archive-id' }
+    )
+  }
+
+  async function settle(): Promise<void> {
+    await vi.waitFor(() => {
+      expect(roomStore.getState().getRoomCoverage(ROOM)).toBeDefined()
+    }, { timeout: 2000 })
+  }
+
+  beforeEach(async () => {
+    _resetStorageScopeForTesting()
+    globalThis.indexedDB = new IDBFactory()
+    ;(messageCache as unknown as { _resetDBForTesting?: () => void })._resetDBForTesting?.()
+    localStorageMock.clear()
+    roomStore.getState().reset()
+    _resetRoomReadStateForTesting()
+    resetRecountDeferralsForTesting()
+    clearTransientScope(getStorageScopeJid() ?? '')
+    roomStore.getState().addRoom(createRoom(ROOM))
+
+    await messageCache.saveRoomMessages([edgeMsg()])
+    roomStore.setState({ activeRoomJid: 'someone-else@conference.example.com' })
+    setMeta({ unreadCount: 4, readPointer: POINTER_ON_EDGE })
+    markCaughtUpWithoutCoverage()
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toBeUndefined()
+  })
+
+  it('gets a coverage record, and the frozen badge finally recomputes', async () => {
+    catchUp(true)
+    await settle()
+
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+    expect(roomStore.getState().rooms.get(ROOM)?.unreadCount).toBe(0)
+
+    expect(readRecountDeferrals()['room:coverage-missing']).toBeUndefined()
+  })
+
+  it('gates an active dedupe backfill and then recomputes it once', async () => {
+    let releaseWrite!: () => void
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve })
+    vi.mocked(messageCache.saveRoomMessages).mockClear()
+    vi.mocked(messageCache.saveRoomMessages).mockImplementationOnce(async (messages) => {
+      const committed = await saveRoomMessagesImplementation(messages)
+      await writeGate
+      return committed
+    })
+    roomStore.setState((state) => ({
+      activeRoomJid: ROOM,
+      messages: new Map(state.messages).set(ROOM, [edgeMsg()]),
+    }))
+
+    catchUp(true)
+    await vi.waitFor(() => {
+      expect(messageCache.saveRoomMessages).toHaveBeenCalled()
+    })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toBeUndefined()
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
+
+    releaseWrite()
+    await settle()
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+
+    expect(readRecountDeferrals()['room:coverage-missing']).toBeUndefined()
+    expect(readRecountDeferrals()['room:active-skipped']).toBeUndefined()
+  })
+
+  it('uses the whole forward walk extent when the completing page is newer', async () => {
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [edgeMsg({ stanzaId: 'edge-archive-id' })],
+      { first: 'edge-archive-id', last: 'edge-archive-id' },
+      false,
+      'forward',
+      false,
+      false,
+      { walkCarriedModifications: false, walkOldestId: 'edge-archive-id' }
+    )
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [archiveMsg('newer', 1100, { stanzaId: 'newer-archive-id' })],
+      { first: 'newer-archive-id', last: 'newer-archive-id' },
+      true,
+      'forward',
+      false,
+      false,
+      { walkCarriedModifications: false, walkOldestId: 'edge-archive-id' }
+    )
+
+    await settle()
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
+    }, { timeout: 2000 })
+    expect(readRecountDeferrals()['room:coverage-missing']).toBeUndefined()
+    expect(readRecountDeferrals()['room:coverage-short-of-floor']).toBeUndefined()
+  })
+
+  it('an INCOMPLETE walk still leaves no coverage, and the badge still freezes', async () => {
+    catchUp(false)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toBeUndefined()
+
+    // An unfinished walk also clears `isCaughtUpToLive`, so the recount stands
+    // down one guard earlier. Re-assert caught-up to exercise the independent
+    // coverage guard as well.
+    resetRecountDeferralsForTesting()
+    await roomStore.getState().recomputeUnreadForRoom(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['room:history-not-caught-up']).toBe(1)
+
+    markCaughtUpWithoutCoverage()
+    resetRecountDeferralsForTesting()
+    await roomStore.getState().recomputeUnreadForRoom(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['room:coverage-missing']).toBe(1)
+  })
+
+  it('re-establishes coverage after an unresolvable bottom dropped the record', async () => {
+    seedCoverage('evicted-stanza-id')
+    await roomStore.getState().recomputeUnreadForRoom(ROOM)
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toBeUndefined()
+    expect(readRecountDeferrals()['room:coverage-unresolvable']).toBe(1)
+
+    catchUp(true)
+    await settle()
+
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+
+    expect(readRecountDeferrals()['room:coverage-missing']).toBeUndefined()
+  })
+
+  it('leaves the other deferral reasons standing in their own conditions', async () => {
+    catchUp(true)
+    await settle()
+    await vi.waitFor(() => {
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    }, { timeout: 2000 })
+
+    // Coverage is now proven, so only the OTHER guards can stand between a
+    // stale badge and the archive. Re-stale it and take one away.
+    setMeta({ unreadCount: 4 })
+    roomStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(ROOM, { isLoading: false, error: null, hasQueried: true, isHistoryComplete: false, isCaughtUpToLive: false })
+      return { mamQueryStates }
+    })
+
+    resetRecountDeferralsForTesting()
+    await roomStore.getState().recomputeUnreadForRoom(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(4)
+    expect(readRecountDeferrals()['room:history-not-caught-up']).toBe(1)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -6706,11 +6706,15 @@ describe('roomStore parity drift regressions', () => {
       expect(messages).toHaveLength(1)
       expect(messages[0].stanzaId).toBe('arch-merge')
       expect(roomStore.getState().messages.get(roomJid)?.[0]?.stanzaId).toBe('arch-merge')
-      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
-        roomJid,
-        'own-1',
-        expect.objectContaining({ stanzaId: 'arch-merge' }),
-        `${roomJid}/testuser`
+      // The backfill rides the merge's DURABLE archive write, not a
+      // fire-and-forget update: a coverage bottom may name this row, so its
+      // write has to be the one the gap/coverage commit gates on.
+      // saveRoomMessages upserts by identity, so the row stays findable by the
+      // archive id it just gained.
+      expect(messageCache.saveRoomMessages).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'own-1', stanzaId: 'arch-merge' }),
+        ])
       )
     })
   })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -26,6 +26,7 @@ import type { HistoryQueryDirection } from './shared/mamState'
 import { syncGapAfterArchiveMerge, messagePageExtent, newestMessageStanzaId, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import {
   syncCoverageAfterArchiveMerge,
+  walkExtentBottomId,
   isCaughtUpForCounting,
   resolveCoverageBottom,
   serializeCoverage,
@@ -977,11 +978,9 @@ export interface RoomState {
    * No-op for the active room by default: most triggers are already
    * reconciled for the active room by their own synchronous path
    * (`onMessageReceived`'s live-edge convergence). The one exception
-   * is `{ allowActive: true }`: a remote XEP-0490 marker can advance the
-   * ACTIVE room's read position without that convergence path running at
-   * all, and activation writes no unconditional zero, so nothing re-derives the
-   * active room's count after such an advance — pass `allowActive: true`
-   * ONLY from that trigger.
+   * is `{ allowActive: true }`: callers that establish new durable counting
+   * input while the room is active must opt into the guarded archive
+   * derivation.
    */
   recomputeUnreadForRoom: (roomJid: string, options?: { allowActive?: boolean }) => Promise<void>
   /**
@@ -2461,9 +2460,8 @@ export const roomStore = createStore<RoomState>()(
       }
     }
     // Active room counts are usually reconciled by their own synchronous path
-    // (the live-edge convergence) — skip here to avoid a redundant
-    // race, UNLESS the caller explicitly opted in (a remote XEP-0490
-    // advance on the active room, which that convergence path never runs for).
+    // (the live-edge convergence) — skip here unless the caller explicitly
+    // opted into the guarded archive derivation.
     if (!allowActive && get().activeRoomJid === roomJid) return defer('active-skipped')
 
     // --- Defer conditions -----------------------------------------------
@@ -3907,6 +3905,7 @@ export const roomStore = createStore<RoomState>()(
     let shouldRecountAfterMerge = false
     let archiveCommitGate: Promise<boolean> | undefined
     let durableMessages: RoomMessage[] = []
+    let coverageBootstrappedFromWalkExtent = false
     set((state) => {
       const room = state.rooms.get(roomJid)
       if (!room) return state
@@ -3926,10 +3925,6 @@ export const roomStore = createStore<RoomState>()(
         roomTimelineConfig(),
         isFetchLatest
       )
-      // Persist backfilled archive ids so pagination cursors survive a reload.
-      for (const p of patched) {
-        void messageCache.updateRoomMessage(roomJid, p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) }, p.from)
-      }
       mergedForMarker = merged
 
       // Compute the newest fetched timestamp for gap marker positioning.
@@ -4014,16 +4009,24 @@ export const roomStore = createStore<RoomState>()(
       // applies immediately.
       const prevGap = state.roomGaps.get(roomJid)
       const persistableMessages = newFromMAM.filter(msg => !isNoLocalStore(msg))
+      const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
+      const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
       durableMessages = persistableMessages
       // A merge with nothing persistable still defers when earlier pages of
       // this room are in flight (or failed): its cursor must not leap them.
-      const mustGateOnChain = persistableMessages.length > 0 || roomArchiveSaves.has(roomJid)
+      const mustGateOnChain = archiveWriteMessages.length > 0 || roomArchiveSaves.has(roomJid)
       const deferGapCommit =
         newGaps !== state.roomGaps &&
         mustGateOnChain
       const gapsAfterMerge = deferGapCommit ? state.roomGaps : newGaps
       if (gapsAfterMerge !== state.roomGaps) saveGapsToStorage(gapsAfterMerge)
 
+      // The walk's own extent, the bootstrap's anchor when a `start`-filtered
+      // catch-up leaves `initialAfter` undefined. Scanned only for the
+      // direction that can use it.
+      const walkOldestId = direction !== 'backward'
+        ? extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
+        : undefined
       // Persisted coverage record; see mamCoverage.ts for the durability
       // invariant this defers on. A merge with nothing persistable
       // (signal-only give-up) applies now.
@@ -4040,12 +4043,18 @@ export const roomStore = createStore<RoomState>()(
         walkCarriedModifications: extras?.walkCarriedModifications ?? false,
         complete,
         initialAfter: extras?.initialAfter,
+        walkOldestId,
       })
       const prevCoverage = state.roomCoverage.get(roomJid)
       const deferCoverageCommit =
         newCoverage !== state.roomCoverage &&
         mustGateOnChain
       const coverageAfterMerge = deferCoverageCommit ? state.roomCoverage : newCoverage
+      coverageBootstrappedFromWalkExtent =
+        coverageTransition === 'created' &&
+        extras?.initialAfter === undefined &&
+        walkOldestId !== undefined &&
+        newCoverage.get(roomJid)?.bottomId === walkOldestId
       if (coverageAfterMerge !== state.roomCoverage) {
         saveCoverageToStorage(coverageAfterMerge, undefined, { roomJid, kind: coverageTransition })
       }
@@ -4090,6 +4099,17 @@ export const roomStore = createStore<RoomState>()(
         })
       }
 
+      if (archiveWriteMessages.length > 0) {
+        const savePromise = messageCache.saveRoomMessages(archiveWriteMessages)
+        archiveCommitGate = roomArchiveSaves.chain(roomJid, savePromise)
+        if (deferGapCommit || deferCoverageCommit) {
+          scheduleDeferredCommit(archiveCommitGate)
+        }
+        if (persistableMessages.length > 0) {
+          searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
+        }
+      }
+
       // If no new messages (all duplicates), only update MAM state - skip room messages
       // This prevents unnecessary re-renders when merging duplicates.
       // Exception: a stanzaId backfill onto existing RAM messages must persist —
@@ -4098,7 +4118,7 @@ export const roomStore = createStore<RoomState>()(
         // Nothing of our own to persist, but earlier in-flight pages may
         // still gate this merge's transitions: chain a no-op save so the
         // transition applies (or is dropped) with the same ordering rules.
-        if (deferGapCommit || deferCoverageCommit) {
+        if (!archiveCommitGate && (deferGapCommit || deferCoverageCommit)) {
           archiveCommitGate = roomArchiveSaves.chain(roomJid, Promise.resolve(true))
           scheduleDeferredCommit(archiveCommitGate)
         }
@@ -4107,20 +4127,6 @@ export const roomStore = createStore<RoomState>()(
         }
         const backfilled = withRoomMessageWindow(state, roomJid, merged)
         return { ...backfilled, mamQueryStates: newStates, roomGaps: gapsAfterMerge, roomCoverage: coverageAfterMerge }
-      }
-
-      // Persist to IndexedDB regardless of active state — this is the durable
-      // history that rehydrates on open (search index too).
-      if (persistableMessages.length > 0) {
-        const savePromise = messageCache.saveRoomMessages(persistableMessages)
-        // Serialize through the per-room chain: the gate resolves true only
-        // when THIS page and every earlier in-flight page committed.
-        const commitGate = roomArchiveSaves.chain(roomJid, savePromise)
-        archiveCommitGate = commitGate
-        if (deferGapCommit || deferCoverageCommit) {
-          scheduleDeferredCommit(commitGate)
-        }
-        searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
       }
 
       // Sidebar preview via the shared policy: only replace when the merged set's
@@ -4155,7 +4161,9 @@ export const roomStore = createStore<RoomState>()(
         // would be an inference built on nick-attributed `isOutgoing` that the
         // forward-only pointer cannot take back. Backward merges only prepend
         // older history (nothing after the pointer changes).
-        if (direction === 'forward' && newFromMAM.length > 0) shouldRecountAfterMerge = true
+        if (direction === 'forward' && newFromMAM.length > 0 && !coverageBootstrappedFromWalkExtent) {
+          shouldRecountAfterMerge = true
+        }
 
         // roomRuntime deliberately untouched.
         return { rooms: newRooms, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
@@ -4231,6 +4239,9 @@ export const roomStore = createStore<RoomState>()(
       const resume = () => {
         if (roomCacheEpoch !== cacheEpochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
         roomRecountRetry.resume(roomJid)
+        if (coverageBootstrappedFromWalkExtent) {
+          void get().recomputeUnreadForRoom(roomJid, { allowActive: true })
+        }
       }
       if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
       else resume()

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.property.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.property.test.ts
@@ -46,6 +46,7 @@ const inputArb: fc.Arbitrary<ArchiveMergeCoverageInput> = fc.record({
   isFetchLatest: fc.boolean(),
   complete: fc.option(fc.boolean(), { nil: undefined }),
   initialAfter: maybeArchiveId,
+  walkOldestId: maybeArchiveId,
   preserveGapMarker: fc.boolean(),
   rsmFirst: maybeArchiveId,
   fetchLatestTopId: maybeArchiveId,
@@ -150,6 +151,24 @@ describe('coverage map discipline', () => {
           expect(coverage.has(key)).toBe(true)
           if (key !== input.id) expect(coverage.get(key)).toBe(value)
         }
+      }),
+      { numRuns: 5000 },
+    )
+  })
+
+  it('never seeds a forward record from an unfinished walk', () => {
+    // The bootstrap accepts two anchors — the resume cursor and, for a
+    // `start`-filtered catch-up, the walk's own extent — and `complete` is the
+    // warrant for BOTH. An unfinished walk never reached the live edge, so
+    // neither anchor describes coverage.
+    fc.assert(
+      fc.property(inputArb, (input) => {
+        if (input.direction !== 'forward') return
+        const { coverage, transition } = syncCoverageAfterArchiveMerge(input)
+        if (transition === 'none') return
+
+        expect(input.complete).toBe(true)
+        expect(coverage.get(input.id)!.bottomId).toBe(input.initialAfter ?? input.walkOldestId)
       }),
       { numRuns: 5000 },
     )

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -11,6 +11,7 @@ import {
   deserializeCoverage,
   isCaughtUpForCounting,
   resolveCoverageBottom,
+  walkExtentBottomId,
   type CoverageRecord,
   type ArchiveMergeCoverageInput,
 } from './mamCoverage'
@@ -134,10 +135,70 @@ describe('syncCoverageAfterArchiveMerge', () => {
       ).toBe(coverage)
     })
 
-    it('a completed forward catch-up with no resume cursor seeds nothing', () => {
-      // `start`-filtered or cursorless catch-up: no archive id to anchor on.
+    it('a completed `start`-filtered catch-up seeds from its own walk extent', () => {
+      // No resume cursor (the local edge was an own send with no archive id),
+      // so the anchor is the oldest entry the completed walk carried itself.
+      const out = syncCoverageAfterArchiveMerge(fwd({ complete: true, walkOldestId: 'walk-oldest' }))
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'walk-oldest' })
+      expect(out.transition).toBe('created')
+    })
+
+    it('an INCOMPLETE catch-up seeds nothing from its walk extent either', () => {
+      // Completion is the whole warrant for trusting the extent: without it
+      // nothing connects the walk's oldest entry to the live edge.
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: false, walkOldestId: 'walk-oldest' })).coverage
+      ).toBe(coverage)
+    })
+
+    it('the resume cursor still wins over the walk extent when both are present', () => {
+      const out = syncCoverageAfterArchiveMerge(
+        fwd({ complete: true, initialAfter: 'local-edge', walkOldestId: 'walk-oldest' })
+      )
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge' })
+    })
+
+    it('a completed forward catch-up with neither cursor nor extent seeds nothing', () => {
+      // An empty `start`-filtered walk has no extent to claim.
       const coverage = new Map<string, CoverageRecord>()
       expect(syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true })).coverage).toBe(coverage)
+    })
+
+    it('a walk extent never shallows an existing, deeper record', () => {
+      const coverage = new Map([['a@b', { bottomId: 'much-deeper', topId: 'top' }]])
+      expect(
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true, walkOldestId: 'walk-oldest' })).coverage
+      ).toBe(coverage)
+    })
+
+    it('a walk extent from a walk that carried modifications never seeds', () => {
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(
+          fwd({ coverage, complete: true, walkOldestId: 'walk-oldest', walkCarriedModifications: true })
+        ).coverage
+      ).toBe(coverage)
+    })
+
+    it('a bounded windowed query never seeds from its walk extent', () => {
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(
+          fwd({ coverage, complete: true, walkOldestId: 'walk-oldest', preserveGapMarker: true })
+        ).coverage
+      ).toBe(coverage)
+    })
+
+    it('a BACKWARD merge never seeds from a walk extent', () => {
+      // The extent is a forward-catch-up claim only: a backward page proves
+      // nothing about the live edge it never reached.
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(
+          base({ coverage, isFetchLatest: false, complete: true, walkOldestId: 'walk-oldest' })
+        ).coverage
+      ).toBe(coverage)
     })
 
     it('a completed forward catch-up that carried modifications never seeds', () => {
@@ -231,6 +292,40 @@ describe('syncCoverageAfterArchiveMerge — reported transition', () => {
     expect(none({ rsmFirst: 'deep', fetchLatestTopId: 'top' })).toBe('none') // identical record
     expect(none({ isFetchLatest: false, initialBefore: 'elsewhere', rsmFirst: 'x' })).toBe('none')
     expect(none({ direction: 'forward', isFetchLatest: false, complete: true, initialAfter: 'edge' })).toBe('none')
+  })
+})
+
+describe('walkExtentBottomId', () => {
+  const msg = (over: Record<string, unknown>) => ({ id: 'x', ...over }) as unknown as Message
+
+  it('returns the oldest archived entry the walk carried', () => {
+    expect(walkExtentBottomId([
+      msg({ stanzaId: 'mid', timestamp: new Date(2000) }),
+      msg({ stanzaId: 'oldest', timestamp: new Date(1000) }),
+      msg({ stanzaId: 'newest', timestamp: new Date(3000) }),
+    ])).toBe('oldest')
+  })
+
+  it('skips id-less entries rather than giving up on the whole anchor', () => {
+    // An own send still awaiting its archive id cannot name a bottom; the
+    // next-oldest archived entry is a shallower but equally true one.
+    expect(walkExtentBottomId([
+      msg({ originId: 'own', timestamp: new Date(1000) }),
+      msg({ stanzaId: 'archived', timestamp: new Date(2000) }),
+    ])).toBe('archived')
+  })
+
+  it('skips `noLocalStore` entries — they never reach the cache the record resolves against', () => {
+    expect(walkExtentBottomId([
+      msg({ stanzaId: 'transient', timestamp: new Date(1000), noLocalStore: true }),
+      msg({ stanzaId: 'stored', timestamp: new Date(2000) }),
+    ])).toBe('stored')
+  })
+
+  it('has no extent for an empty walk, or one with nothing anchorable', () => {
+    expect(walkExtentBottomId([])).toBeUndefined()
+    expect(walkExtentBottomId([msg({ stanzaId: 'no-timestamp' })])).toBeUndefined()
+    expect(walkExtentBottomId([msg({ originId: 'own', timestamp: new Date(1000) })])).toBeUndefined()
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -8,6 +8,8 @@
 import { resolveArchivePosition } from '../../utils/messageCache'
 import type { CoverageRecord, ExactPosition } from '../../core/types'
 
+export { walkExtentBottomId } from '../../utils/mamCatchUpUtils'
+
 /**
  * The coverage shapes are declared in `core/types/pagination.ts` — they ride on
  * SDK events, so `core/types` must be able to name them without depending on a
@@ -80,6 +82,10 @@ export interface ArchiveMergeCoverageInput {
   /** The `after` cursor a forward catch-up resumed from (the local downloaded
    *  edge). Undefined for `start`-filtered or cursorless catch-ups. */
   initialAfter?: string
+  /** Oldest archive id the forward walk itself carried — its own extent, from
+   *  {@link walkExtentBottomId}. The bootstrap's fallback anchor when the
+   *  catch-up resumed by timestamp and so has no `initialAfter`. */
+  walkOldestId?: string
   /** Bounded windowed query — proves nothing about live contiguity. */
   preserveGapMarker: boolean
   /** page.first of the merge's LAST page (deepest entry seen, signals included). */
@@ -105,8 +111,9 @@ export interface ArchiveMergeCoverageInput {
  *   give-up with zero displayable messages) → replace with the walk extent;
  * - plain backward page → extend the bottom ONLY when the query resumed
  *   id-exactly from it (initialBefore === bottomId);
- * - COMPLETED forward catch-up with a resume cursor → seed the bottom from that
- *   cursor when no record exists yet (bootstrap, see below);
+ * - COMPLETED forward catch-up → seed the bottom when no record exists yet,
+ *   from the resume cursor, or from the walk's own extent when the catch-up
+ *   resumed by timestamp and has none (bootstrap, see below);
  * - incomplete forward merges and preserveGapMarker (bounded windowed) queries
  *   prove nothing about the live-contiguous bottom → no-op.
  *
@@ -118,7 +125,8 @@ export interface ArchiveMergeCoverageInput {
 export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput): CoverageSyncResult {
   const {
     coverage, id, direction, isFetchLatest, preserveGapMarker, complete, initialAfter,
-    rsmFirst, fetchLatestTopId, initialBefore, sawCoverageTop, walkCarriedModifications,
+    walkOldestId, rsmFirst, fetchLatestTopId, initialBefore, sawCoverageTop,
+    walkCarriedModifications,
   } = input
   const unchanged: CoverageSyncResult = { coverage, transition: 'none' }
   if (preserveGapMarker) return unchanged
@@ -137,16 +145,35 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
     //
     // A forward catch-up that resumed at `initialAfter` and came back complete
     // has downloaded everything from that cursor to the live edge — which is
-    // precisely "oldest entry proven contiguous with live". The claim is
-    // deliberately conservative: it anchors on the cursor we resumed from, never
-    // on how deep the cache happens to reach, and it never overwrites an
-    // existing record, so a bottom already proven deeper always wins. Erring
-    // shallow only costs Phase B a re-walk of covered ground; erring deep would
-    // skip real history, and this path cannot do that.
-    if (!complete || !initialAfter) return unchanged
+    // precisely "oldest entry proven contiguous with live".
+    //
+    // `initialAfter` is undefined whenever the catch-up resumed by TIMESTAMP
+    // (`selectCatchUpQuery` falls back to a `start` filter when the local edge
+    // carries no archive id — the user's own last send, which the server never
+    // echoes back with one). Such a walk then anchors on `walkOldestId`, the
+    // oldest archive id it carried itself.
+    //
+    // Anchoring on the walk's extent is a WEAKER premise than a resume cursor
+    // and it is admitted only for a `complete` walk. Completion is the whole
+    // warrant: the server said the walk exhausted its direction, so everything
+    // from its oldest entry to the live edge came down in it, and no gap can
+    // hide between the two. An INCOMPLETE walk proves nothing about the live
+    // edge, so `complete` stays a hard condition, and a `start`-filtered walk
+    // that returned nothing has no extent to claim.
+    //
+    // What is still refused, and why the older, narrower rule is not simply
+    // relaxed: depth the cache reached by some OTHER means — an earlier
+    // fetchContext island, a scroll-up page, whatever a previous session left
+    // behind — is not evidence and is never consulted here. The anchor is the
+    // extent of THIS walk or nothing. The rest of the caution stands unchanged:
+    // this never overwrites an existing record, so a bottom already proven
+    // deeper always wins, and erring shallow only costs Phase B a re-walk of
+    // covered ground, while erring deep would skip real history.
+    const bootstrapBottom = initialAfter ?? walkOldestId
+    if (!complete || !bootstrapBottom) return unchanged
     if (coverage.get(id)) return unchanged
     const next = new Map(coverage)
-    next.set(id, { bottomId: initialAfter })
+    next.set(id, { bottomId: bootstrapBottom })
     return { coverage: next, transition: 'created' }
   }
 

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -8,6 +8,9 @@
  * @module Utils/MAMCatchUp
  */
 
+import { isNoLocalStore } from '../core/types/message-internal'
+import type { Message, RoomMessage } from '../core/types'
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -156,6 +159,15 @@ export function oldestMessageWithStanzaId<T extends { timestamp?: Date; stanzaId
     if (!oldest || ts < oldest.timestamp!.getTime()) oldest = message
   }
   return oldest
+}
+
+/**
+ * The bottom of a walk's own extent: the oldest message it carried that can
+ * anchor durable coverage. Messages without archive ids and messages excluded
+ * from the local cache cannot provide a resolvable bottom.
+ */
+export function walkExtentBottomId(messages: Array<Message | RoomMessage>): string | undefined {
+  return oldestMessageWithStanzaId(messages.filter((message) => !isNoLocalStore(message)))?.stanzaId
 }
 
 /** Result of {@link selectCatchUpQuery}: an id-exact forward `after` cursor


### PR DESCRIPTION
A conversation or room could keep an unread badge that reading never cleared, with no new-message divider to explain it — because there were no new messages: the read pointer was already on the newest one. The count was a leftover.

## Cause

A catch-up resumes by **timestamp** instead of by archive id whenever the local edge carries no archive id — which is exactly what the user's own last send is, since the server never echoes one back with one. Such a walk completed without ever creating a coverage record, so every later recount stood down on missing coverage and the badge kept its value for the rest of the session.

A second route reached the same state: a record whose bottom no longer resolves in the cache is dropped, returning the entity to missing coverage indefinitely.

## Change

A completed forward walk now anchors its coverage bottom on **its own extent** when no resume cursor is available.

This is a deliberate departure from the previous rule at that branch, which anchored only on the cursor the walk resumed from and never on the depth the cache happened to reach. Completion is what makes it defensible: the server reported the walk exhausted its direction, so nothing can hide between its oldest entry and the live edge. Completeness stays a **hard** condition — an incomplete walk still seeds nothing — and cache depth reached by any other means is still never consulted.

Supporting pieces:

- the extent is carried across the **whole walk**, not taken from the page that completes it, which matters for rooms since their forward pages are emitted one at a time;
- the archive-id backfill now rides the merge's gated durable write rather than a fire-and-forget cache update, because a coverage bottom can name the row it patches;
- the recount for this transition runs once, after the record commits, and covers the **active** entity as well as a backgrounded one.

No other recount guard is relaxed — each still defers in its own conditions.

## On the two modified backfill tests

They were **retargeted, not weakened**. They asserted the fire-and-forget cache update that this change replaces; they now assert the durable write that supersedes it. That is the stronger claim, and it is the path coverage resolution depends on.

## Result

On the reproduced scenario the missing-coverage deferral is no longer counted at all. Both twins go from a stale badge of 4 with no coverage to 0 with a resolvable coverage bottom, with the missing-coverage and active-skipped counters at zero in the console log export:

```
chat: badge 4 → 0, coverage bottomId own-archive-id,  coverage-missing=0, active-skipped=0
room: badge 4 → 0, coverage bottomId edge-archive-id, coverage-missing=0, active-skipped=0
```
