### PR TITLE
fix(read-state): stop the "New messages" line coming back on a read conversation

### DIFF
--- a/packages/fluux-sdk/src/core/types/readState.ts
+++ b/packages/fluux-sdk/src/core/types/readState.ts
@@ -20,8 +20,8 @@
  * kind-discriminated because chat and room break same-millisecond ties
  * differently:
  *
- * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'`,
- *   `messageCache.ts:140`).
+ * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'` in
+ *   `messageCache.ts`).
  * - Room breaks ties by `from` then `id` (the `room_ts_from_id` index).
  *
  * Chat messages also carry `from`, so a generic "from then id" comparator
@@ -133,10 +133,22 @@ export type PointerIdentity =
  * unrecoverable. Only `order` is used for ordering; nothing derives a message
  * from it.
  *
+ * ONE resolution is legitimate, and only on evidence: `onMessageSeen` accepts a
+ * matching XEP-0359 server ID as proof, or confines a local chat pointer to the
+ * unique newest resident row under the cache's `id` key. It replaces only the
+ * approximate order. The position does not move — it stays on the message the
+ * identity already names. Resolving onto any OTHER message is the forward move
+ * forbidden above.
+ *
  * @category Read state
  */
 export interface ReadPointer {
-  /** Where this position sits in message-cache order. NEVER rewritten. */
+  /**
+   * Where this position sits in message-cache order. Never rewritten to a
+   * different position; server identity proof or constrained local evidence may
+   * replace a floor with the exact position of the same named message without
+   * changing `identity`.
+   */
   readonly order: PointerOrder
   /** What this position is called — locally, and on the wire when we can. */
   readonly identity: PointerIdentity

--- a/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
@@ -1,0 +1,110 @@
+/**
+ * A floor read pointer naming the NEWEST message, driven through the REAL
+ * chatStore rather than the pure `notificationState` helpers.
+ *
+ * The pure pass (`shared/notificationState.test.ts`, "resolves a floor onto the
+ * message it names") proves the rule. This file proves the WIRING it depends
+ * on: `advanceReadPointer` commits on a reference check, so a resolution that
+ * handed back the same object would be silently dropped, and the symptom —
+ * "Nouveaux messages" back at every reopen — would survive a green unit test.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { chatStore } from './chatStore'
+import { connectionStore } from './connectionStore'
+import type { Message, Conversation } from '../core'
+import type { ReadPointer } from './shared/readPointer'
+import { _clearAllTransientForTesting } from './shared/transientUnread'
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessages: vi.fn().mockResolvedValue(true),
+    getMessages: vi.fn().mockResolvedValue([]),
+    getMessagesAround: vi.fn().mockResolvedValue([]),
+  }
+})
+
+const CID = 'alice@example.com'
+
+function msg(id: string, minute: number): Message {
+  return {
+    type: 'chat',
+    id,
+    conversationId: CID,
+    from: CID,
+    body: id,
+    timestamp: new Date(`2025-01-15T09:${String(minute).padStart(2, '0')}:00Z`),
+    isOutgoing: false,
+  }
+}
+
+const MESSAGES = [msg('m1', 1), msg('m2', 2)]
+
+/**
+ * A keyless pointer from the #1081 migration of the legacy
+ * `lastSeenMessageId` + `lastReadAt` pair carries `lastReadAt` as the floor's
+ * millisecond. It is not the named message's own timestamp, and this fixture
+ * names the newest message in the conversation.
+ */
+const FLOOR_ON_NEWEST: ReadPointer = {
+  order: { role: 'floor', timestamp: new Date('2025-01-15T09:01:30Z').getTime() },
+  identity: { state: 'local', messageId: 'm2' },
+}
+
+function seed(): void {
+  const conversation: Conversation = { id: CID, name: 'alice', type: 'chat', unreadCount: 1 }
+  chatStore.setState({
+    conversations: new Map([[CID, conversation]]),
+    conversationMeta: new Map([[CID, { unreadCount: 1, readPointer: FLOOR_ON_NEWEST }]]),
+    messages: new Map([[CID, MESSAGES]]),
+    firstNewMessageMarkers: new Map(),
+    activeConversationId: null,
+  })
+}
+
+function dividerAfterOpening(): string | undefined {
+  chatStore.getState().setActiveConversation(CID)
+  return chatStore.getState().firstNewMessageMarkers.get(CID)
+}
+
+describe('chatStore — a floor pointer naming the newest message', () => {
+  beforeEach(() => {
+    _clearAllTransientForTesting()
+    connectionStore.setState({ windowVisible: true })
+    seed()
+  })
+
+  it('stops re-showing the divider once the named message has been read', () => {
+    // Opening puts the divider on the very message the pointer names: the
+    // counting rule is at-or-after, so that message reads as unread.
+    expect(dividerAfterOpening()).toBe('m2')
+
+    // This viewport report resolves the floor onto its named message.
+    chatStore.getState().advanceReadPointer(CID, 'm2')
+
+    const pointer = chatStore.getState().conversationMeta.get(CID)?.readPointer
+    expect(pointer?.identity.messageId).toBe('m2') // still the same message
+    expect(pointer?.order.role).toBe('exact')
+
+    // Leave, clear the line, come back.
+    chatStore.getState().clearFirstNewMessageId(CID)
+    chatStore.getState().setActiveConversation(null)
+    expect(dividerAfterOpening()).toBeUndefined()
+  })
+
+  // The invariant the resolution has to keep: it makes a position exact, it
+  // never relocates it. A pointer naming any other message moves a forward-only
+  // position, which is unrecoverable.
+  it('leaves the pointer on the message it named — never on another one', () => {
+    chatStore.getState().setActiveConversation(CID)
+    chatStore.getState().advanceReadPointer(CID, 'm2')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.identity.messageId).toBe('m2')
+
+    // A second report is a no-op: the pointer is exact now and settles.
+    const settled = chatStore.getState().conversationMeta.get(CID)?.readPointer
+    chatStore.getState().advanceReadPointer(CID, 'm2')
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).toBe(settled)
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -1043,10 +1043,21 @@ describe('onMessageSeen', () => {
     expect(result).toBe(state)
   })
 
-  it('returns same reference for same message', () => {
-    const state = makeState({ readPointer: pointerAt('msg-3') })
-    const result = onMessageSeen(state, 'msg-3', messages, 'chat')
-    expect(result).toBe(state)
+  // A FLOOR reported on its own named live-edge message is RESOLVED once — it
+  // keeps the message and gains the tie-break — and settles from there. See
+  // "onMessageSeen — resolves a floor onto the message it names" for why the
+  // resolution has to happen at all.
+  it('resolves a floor on its own message once, then returns the same reference', () => {
+    const state = makeState({ readPointer: pointerAt('msg-5') })
+    const resolved = onMessageSeen(state, 'msg-5', messages, 'chat')
+    expect(resolved.readPointer?.identity.messageId).toBe('msg-5')
+    expect(resolved.readPointer?.order.role).toBe('exact')
+    expect(onMessageSeen(resolved, 'msg-5', messages, 'chat')).toBe(resolved)
+  })
+
+  it('returns same reference for same message when the pointer is already exact', () => {
+    const state = makeState({ readPointer: makeReadPointer(messages[2], 'chat') })
+    expect(onMessageSeen(state, 'msg-3', messages, 'chat')).toBe(state)
   })
 
   // #1081 constraint: the id and the timestamp of a read position move together
@@ -1871,5 +1882,218 @@ describe('onMessageReceived — outgoing collapse (PR C, D1)', () => {
       { isActive: true, windowVisible: true, viewportAtLiveEdge: false }, 'room')
     expect(r).toBe(state)
     expect(r.firstNewMessageId).toBe('old')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// onMessageSeen — resolving a floor onto the message it already names
+// ---------------------------------------------------------------------------
+
+/**
+ * A floor pointer naming the NEWEST message is a trap the two comparators build
+ * between them, each correct on its own: `isAfterBoundary` is at-or-after, so
+ * the named message counts as unread and takes the divider; `mayAdvanceTo` is
+ * strictly-after, so no read of that same message can ever move past it. The
+ * divider comes back at every activation, for good.
+ *
+ * `onMessageSeen` breaks it by RESOLVING the floor — rebuilding it, exact, on
+ * the very message it already names. Nothing here relaxes either comparator:
+ * `readState.test.ts` owns their deliberately opposite semantics — at-or-after
+ * for counting and divider placement, strictly-after for advancing — and the
+ * resolution changes neither.
+ */
+describe('onMessageSeen — resolves a floor onto the message it names', () => {
+  const src = (id: string, ms: number) => ({ id, timestamp: new Date(ms) })
+  const inc = (id: string, ms: number): NotificationMessage =>
+    ({ id, timestamp: new Date(ms), isOutgoing: false, body: 'hi' })
+
+  const floorAt = (messageId: string, ms: number): ReadPointer => ({
+    order: { role: 'floor', timestamp: ms },
+    identity: { state: 'local', messageId },
+  })
+
+  const addressableFloorAt = (messageId: string, archiveId: string, ms: number): ReadPointer => ({
+    order: { role: 'floor', timestamp: ms },
+    identity: { state: 'addressable', messageId, archiveId },
+  })
+
+  const stateWith = (pointer: ReadPointer, unreadCount = 1): EntityNotificationState =>
+    ({ unreadCount, mentionsCount: 0, readPointer: pointer, firstNewMessageId: undefined })
+
+  it('turns the floor into an exact position WITHOUT changing which message it names', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const out = onMessageSeen(stateWith(floorAt('m2', 1500)), 'm2', messages, 'chat')
+
+    expect(out.readPointer?.identity.messageId).toBe('m2') // same message, still
+    expect(out.readPointer?.order.role).toBe('exact')
+    expect(out.readPointer?.order.timestamp).toBe(2000) // the named message's OWN timestamp
+  })
+
+  // THE SYMPTOM, end to end at the level that owns it: open, read, leave,
+  // come back. Without the resolution the second activation puts the divider
+  // straight back on 'm2' — this assertion is the counterfactual.
+  it('clears the divider for good: activate, read the named message, re-activate', () => {
+    const messages = [inc('m1', 1000), inc('m2', 2000)]
+    const sources = messages.map((m) => ({ id: m.id, timestamp: m.timestamp }))
+
+    // A floor naming the newest message places the divider ON that message.
+    const opened = onActivate(stateWith(floorAt('m2', 1500)), messages, 'chat')
+    expect(opened.firstNewMessageId).toBe('m2')
+
+    // The user reads it: the viewport reports the divider's own message.
+    const read = onMessageSeen(opened, 'm2', sources, 'chat')
+    expect(read.readPointer?.order.role).toBe('exact')
+
+    // Leaving clears the marker; returning must NOT put it back.
+    const reopened = onActivate(onDeactivate(read), messages, 'chat')
+    expect(reopened.firstNewMessageId).toBeUndefined()
+  })
+
+  it('resolves an addressable room floor when the archive identity matches', () => {
+    const pointer = addressableFloorAt('m2', 'archive-m2', 1500)
+    const identity = pointer.identity
+    const messages = [
+      { id: 'm1', from: 'room/a', timestamp: new Date(1000), stanzaId: 'archive-m1' },
+      { id: 'm2', from: 'room/z', timestamp: new Date(2000), stanzaId: 'archive-m2' },
+    ]
+    const out = onMessageSeen(stateWith(pointer), 'm2', messages, 'room')
+
+    expect(out.readPointer?.order.role).toBe('exact')
+    expect(out.readPointer?.identity).toBe(identity)
+    expect(out.readPointer?.identity).toEqual({
+      state: 'addressable',
+      messageId: 'm2',
+      archiveId: 'archive-m2',
+    })
+  })
+
+  it('leaves an addressable room floor unchanged when only another sender\'s row is resident', () => {
+    const pointer = addressableFloorAt('dup', 'archive-room-z', 2000)
+    const state = stateWith(pointer)
+    const messages = [
+      { id: 'dup', from: 'room/a', timestamp: new Date(3000), stanzaId: 'archive-room-a' },
+    ]
+
+    const out = onMessageSeen(state, 'dup', messages, 'room')
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(pointer)
+    expect(out.readPointer?.order.role).toBe('floor')
+  })
+
+  it('preserves an addressable floor when a chat row has no archive ID', () => {
+    const pointer = addressableFloorAt('m2', 'archive-m2', 1500)
+    const state = stateWith(pointer)
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const out = onMessageSeen(state, 'm2', messages, 'chat')
+
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(pointer)
+    expect(out.readPointer?.identity).toBe(pointer.identity)
+    expect(out.readPointer?.identity).toEqual({
+      state: 'addressable',
+      messageId: 'm2',
+      archiveId: 'archive-m2',
+    })
+  })
+
+  it('leaves a local room floor unchanged when its ID appears once in the resident slice', () => {
+    const pointer = floorAt('m2', 1500)
+    const state = stateWith(pointer)
+    const messages = [{ id: 'm2', from: 'room/a', timestamp: new Date(2000) }]
+    const out = onMessageSeen(state, 'm2', messages, 'room')
+
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(pointer)
+    expect(out.readPointer?.order.role).toBe('floor')
+  })
+
+  it('leaves an ambiguous room floor unchanged when two senders share an ID', () => {
+    const messages = [
+      { id: 'dup', from: 'room/a', timestamp: new Date(2000) },
+      { id: 'dup', from: 'room/z', timestamp: new Date(2000) },
+    ]
+    const state = stateWith(floorAt('dup', 1500))
+    const out = onMessageSeen(state, 'dup', messages, 'room')
+
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(state.readPointer)
+    expect(out.readPointer?.order.role).toBe('floor')
+  })
+
+  it('resolves a local chat floor at the unique resident live edge', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const out = onMessageSeen(stateWith(floorAt('m2', 1500)), 'm2', messages, 'chat')
+
+    expect(out.readPointer?.identity.messageId).toBe('m2')
+    expect(out.readPointer?.order.role).toBe('exact')
+  })
+
+  it('leaves a local chat floor unchanged when its client ID is duplicated', () => {
+    const pointer = floorAt('dup', 500)
+    const state = stateWith(pointer)
+    const messages = [src('dup', 1000), src('dup', 2000)]
+    const out = onMessageSeen(state, 'dup', messages, 'chat')
+
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(pointer)
+    expect(out.readPointer?.order.role).toBe('floor')
+  })
+
+  it('leaves a local chat floor unchanged when its message is not the newest resident row', () => {
+    const pointer = floorAt('m2', 1500)
+    const state = stateWith(pointer)
+    const messages = [src('m1', 1000), src('m2', 2000), src('m3', 3000)]
+    const out = onMessageSeen(state, 'm2', messages, 'chat')
+
+    expect(out).toBe(state)
+    expect(out.readPointer).toBe(pointer)
+    expect(out.readPointer?.order.role).toBe('floor')
+  })
+
+  // NEGATIVE POLARITY. Resolving is only ever legitimate onto the pointer's OWN
+  // named message; every other target is an ADVANCE, which the floor rules
+  // already govern. A relaxation to `>=` on anything but identity is caught here.
+  it('does NOT resolve onto a DIFFERENT message at the floor\'s own millisecond', () => {
+    const messages = [src('m1', 1500), src('m2', 2000)]
+    // The floor names m2 but the viewport reports m1, which sits before it.
+    const state = stateWith(floorAt('m2', 1500))
+    expect(onMessageSeen(state, 'm1', messages, 'chat')).toBe(state)
+  })
+
+  // The forward-only rule cuts both ways: a floor whose millisecond sits AHEAD
+  // of its named message must stay put. Resolving there would drag the boundary
+  // backwards and re-surface messages the user has already read — the very
+  // symptom, inverted.
+  it('refuses when the floor sits AHEAD of the message it names', () => {
+    const messages = [src('m1', 1000), src('m2', 2000), src('m3', 3000)]
+    const state = stateWith(floorAt('m2', 2500))
+    expect(onMessageSeen(state, 'm2', messages, 'chat')).toBe(state)
+  })
+
+  it('resolves when the floor already sits exactly on its named message\'s millisecond', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const out = onMessageSeen(stateWith(floorAt('m2', 2000)), 'm2', messages, 'chat')
+    expect(out.readPointer?.order).toEqual({ role: 'exact', timestamp: 2000, tiebreak: expect.anything() })
+    expect(out.readPointer?.identity.messageId).toBe('m2')
+  })
+
+  // CONTROL: the off-slice live-edge escape hatch is a DIFFERENT rule with its
+  // own guards. Resolution does not widen it.
+  it('preserves the off-slice live-edge hatch', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const offSlice = stateWith(floorAt('evicted', 500))
+    expect(onMessageSeen(offSlice, 'm2', messages, 'chat', { atLiveEdge: true }).readPointer?.identity.messageId).toBe('m2')
+    expect(onMessageSeen(offSlice, 'm2', messages, 'chat', { atLiveEdge: false })).toBe(offSlice)
+    expect(onMessageSeen(offSlice, 'm1', messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
+  })
+
+  // Idempotence: the resolved pointer is exact, so the next viewport report of
+  // the same message goes down the exact branch and hands the state back by
+  // reference. Both stores commit on a reference check, so a pointer that kept
+  // minting fresh objects would write on every scroll tick.
+  it('settles: a second report of the same message changes nothing', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const once = onMessageSeen(stateWith(floorAt('m2', 1500)), 'm2', messages, 'chat')
+    expect(onMessageSeen(once, 'm2', messages, 'chat')).toBe(once)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -20,7 +20,13 @@
  * permanent (the pointer is forward-only).
  */
 
-import { advance, makeReadPointer, type PointerSource, type ReadPointer } from './readPointer'
+import {
+  advance,
+  hasFloorResolutionEvidence,
+  makeReadPointer,
+  type PointerSource,
+  type ReadPointer,
+} from './readPointer'
 import {
   isAfterBoundary,
   mayAdvanceTo,
@@ -427,11 +433,11 @@ export function onWindowBecameVisible(
 }
 
 /**
- * Advance the read pointer when a message becomes visible in the viewport.
+ * Update the read pointer when a message becomes visible in the viewport.
  *
- * Only advances forward in the message list (never goes backwards).
- * The `messages` array is used to determine ordering — the message must be
- * at a later position than the one the current pointer names.
+ * An exact pointer advances only to a later cache position. A floor may also
+ * become exact on the message it already names when the evidence below proves
+ * the identity; this refines the position without moving it to another message.
  *
  * A `messageId` that is absent from `messages` is NEVER advanced to (#1081).
  * The pointer is one object: its timestamp has to be the named message's own,
@@ -445,14 +451,19 @@ export function onWindowBecameVisible(
  *
  * An EXACT current pointer (`order.role === 'exact'`) is ordered by cache
  * POSITION via `mayAdvanceTo`, not by array index — its position is provable
- * without being resident in `messages`. The off-slice guard and the
- * `atLiveEdge` escape hatch below apply only to a FLOOR (migrated) pointer,
- * whose bare timestamp cannot certify a position.
+ * without being resident in `messages`. The off-slice guard, the `atLiveEdge`
+ * escape hatch and the same-message resolution below apply only to a FLOOR
+ * (migrated) pointer, whose bare timestamp cannot certify a position.
+ *
+ * A floor reported on the message it already NAMES is resolved to an exact
+ * position only with a matching XEP-0359 server ID, or for a local chat pointer
+ * confined to a unique newest resident row under the cache's `id` key. Resolution
+ * preserves the pointer's identity and replaces only its approximate order.
  *
  * @param state - Current notification state
  * @param messageId - ID of the message that became visible
  * @param messages - Full messages array, for ordering and for the timestamp the
- *   advanced pointer is built from. Every caller already holds full messages.
+ *   updated pointer is built from. Every caller already holds full messages.
  * @returns Updated state (or same reference if no change)
  */
 export function onMessageSeen(
@@ -494,7 +505,26 @@ export function onMessageSeen(
     return state
   }
   if (newIdx > currentIdx) return advanced()
-  return state
+
+  // RESOLVE, do not advance. Server identity proof or constrained local evidence
+  // licenses replacing only the floor's approximate order; the pointer's
+  // existing identity remains the authority.
+  //
+  // Without this, a floor naming the NEWEST message is unreachable: the divider
+  // and the count are at-or-after (`isAfterBoundary`), so that message reads as
+  // unread, while the advance rule is strictly-after (`mayAdvanceTo`), so no
+  // read of it can move past. Both rules are right; the pointer resolves the
+  // deadlock, not the comparators.
+  //
+  if (newIdx !== currentIdx) return state
+  if (!hasFloorResolutionEvidence(state.readPointer, messages, newIdx, kind)) return state
+
+  const reportedPosition = exactPosition(messages[newIdx], kind)
+  const identity = state.readPointer.identity
+  return {
+    ...state,
+    readPointer: { order: reportedPosition, identity },
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -5,7 +5,9 @@
  * questions:
  *
  * - **order** — `(timestamp, tiebreak)`. The only comparable data. Local,
- *   derived from the message cache's own cursor order, and never rewritten.
+ *   derived from the message cache's own cursor order, and never rewritten to
+ *   a different position. Server identity proof or constrained local evidence
+ *   may resolve a floor to the exact position of the same named message.
  * - **local name** — `messageId`. Resolves against the cache and the DOM, which
  *   is keyed by it. Every pointer has one.
  * - **wire name** — the XEP-0359 archive id. The only cross-device identity, and
@@ -15,7 +17,9 @@
  * opaque strings that carry no ordering and are unique only per archive. And the
  * order cannot address the wire: a receiver MUST ignore an id it cannot find,
  * and the tie-break holds the CLIENT message id. So the pointer carries both,
- * minted together from one message, never independently writable.
+ * minted together from one message. Resolution may refine a floor's order only
+ * with server identity proof or constrained local evidence, and name convergence
+ * may enrich its identity without moving its order.
  *
  * "We cannot address this position yet" is therefore a STATE
  * ({@link PointerIdentity}'s `local` variant), not an absent field each consumer
@@ -100,6 +104,47 @@ export interface PointerSource {
    * name, which is the defect this whole shape exists to make unrepresentable.
    */
   stanzaId?: string
+}
+
+const CLIENT_MESSAGE_ID_IS_COMPLETE_CACHE_NAME = {
+  chat: true,
+  room: false,
+} as const
+
+/**
+ * Whether the reported row carries enough evidence to refine a floor without
+ * changing its identity.
+ *
+ * An `addressable` identity and matching `stanzaId` are XEP-0359 server-assigned
+ * proof. A `local` identity has no server ID, so its client-generated ID is not
+ * proof: resolution is confined to the unique newest resident row, and only for
+ * chat where IndexedDB uses `keyPath: 'id'`. Room IndexedDB uses
+ * `keyPath: 'cacheKey'`, and its lowest identity tier is sender + ID, so a local
+ * room floor always abstains. Both paths refuse a reported message whose
+ * timestamp sits behind the floor.
+ */
+export function hasFloorResolutionEvidence(
+  pointer: ReadPointer,
+  messages: ReadonlyArray<PointerSource>,
+  reportedIndex: number,
+  kind: 'chat' | 'room'
+): boolean {
+  const reportedMessage = messages[reportedIndex]
+  if (!reportedMessage || pointer.order.role !== 'floor') return false
+  if (reportedMessage.timestamp.getTime() < pointer.order.timestamp) return false
+  if (pointer.identity.messageId !== reportedMessage.id) return false
+
+  if (pointer.identity.state === 'addressable') {
+    return Boolean(
+      reportedMessage.stanzaId && pointer.identity.archiveId === reportedMessage.stanzaId
+    )
+  }
+
+  return (
+    CLIENT_MESSAGE_ID_IS_COMPLETE_CACHE_NAME[kind] &&
+    reportedIndex === messages.length - 1 &&
+    messages.every((message, index) => index === reportedIndex || message.id !== reportedMessage.id)
+  )
 }
 
 /**
@@ -345,12 +390,13 @@ function hydrateNested(raw: Record<string, unknown>): ReadPointer | undefined {
  *   defect. They converge the first time the position advances onto a message
  *   that carries an archive id.
  * - **Keyless legacy pointers** — the #1081 migration's
- *   `{ messageId, lastReadAt }`, which never had a tie-break. They become
- *   `floor`, which is what they always meant. They can never converge, and that
- *   is honest rather than a defect: converging one means resolving the named
- *   message's real timestamp, which could move the floor FORWARD on a
- *   forward-only pointer. They self-heal instead, the first time the user reads
- *   in that entity — any fresh `exact` pointer is ahead, and `advance` takes it.
+ *   `{ messageId, lastReadAt }`, which has no tie-break. It hydrates as a
+ *   `floor`, the only position that shape can honestly support. A local floor
+ *   resolves when its client ID is a complete cache name and identifies the
+ *   unique newest resident row without violating the timestamp guard. This is
+ *   not a forward move: the position stays on the message the identity already
+ *   names and merely becomes exact. Otherwise it self-heals by advancing onto a
+ *   later message.
  *
  * (The third population, pointerless entities, has nothing to migrate: no
  * pointer in, no pointer out.)


### PR DESCRIPTION
An already-read one-to-one conversation showed the "New messages" line for ever: it was there on open, and it came back on the same message at every reopen, with nothing unread.

## Cause

A read pointer migrated from the legacy `lastSeenMessageId` + `lastReadAt` pair carries a `floor` order. When that floor names the newest message, the two read-state comparators trap it between them, each correct on its own:

- counting and divider placement are **at-or-after** (`isAfterBoundary`), so the named message reads as unread and takes the line;
- advancing is **strictly-after** (`mayAdvanceTo`), so no read of that same message can move past it.

## Fix

`onMessageSeen` now **resolves** such a floor instead of advancing it. When the viewport reports the very message the pointer already names, the pointer keeps its identity and only its approximate order is replaced by that message's exact position.

This satisfies the forward-only rule stated in `core/types/readState.ts` rather than working around it: the position does not move to another message, it stops being approximate where it already was. Advancing a floor onto a different message remains forbidden.

## Two paths, chosen by where the id came from

Resolution never assumes a message id identifies a message. `hasFloorResolutionEvidence` is one predicate that both the chat and room paths call, and it reads the id's provenance:

- **Proof.** An `addressable` pointer whose archive id matches the reported row's XEP-0359 server-assigned `stanzaId` resolves. This is the ordinary room case, since a MUC stamps a stanza-id on live reflections as well as on archive copies.
- **Confinement.** A `local` pointer has no server-assigned id, so its client-generated id is not proof. Resolution is confined to the unique newest resident row, and only where a client id is a complete cache name — chat, whose IndexedDB store uses `keyPath: 'id'`. Any residual mistake is bounded to the row the reader is looking at. This is the path the legacy one-to-one population takes, and it matches the reported symptom exactly.
- **Abstention.** A local room floor always abstains: the room store keys on `cacheKey` and the room identity ladder's lowest tier is sender plus id, so a client id alone names no message there.

The ambiguous case is handled by abstaining, not by a guess.

## Unchanged

Both comparators are untouched, and the test protecting their deliberately opposite rules still passes. The off-slice live-edge escape hatch and the forward advance keep rebuilding identity from the message they move to. The persisted pointer shape is unchanged.

## Scope

Escape (mark-all-read) and a message arriving at the live edge already cured a conversation. What this fixes is the quiet conversations nobody ever exits with Escape, which kept the line indefinitely.