### PR TITLE
chore(comments): gate three more development-session identifier families (#1236)

### DIFF
--- a/apps/fluux/src/demo/perfHarness.ts
+++ b/apps/fluux/src/demo/perfHarness.ts
@@ -75,7 +75,7 @@ export async function installPerfHarness(opts: { scan?: boolean } = {}): Promise
   // Render-perf baseline scenarios.
   // Each scenario reads live entities from the vanilla stores, targets a
   // NON-active conversation/room where relevant, fires a deterministic burst,
-  // then reports cumulative render counts for the components Codex flagged.
+  // then reports cumulative render counts for TARGET_COMPONENTS.
   // Drive one: `await __perf.scenario('presenceFlap')`; all five: `await __perf.baseline()`.
   // ---------------------------------------------------------------------------
   type DemoLike = { emitSDK: (event: string, payload: unknown) => void }
@@ -86,7 +86,7 @@ export async function installPerfHarness(opts: { scan?: boolean } = {}): Promise
   }
   const TARGET_COMPONENTS = ['ChatLayout', 'Sidebar', 'ConversationList', 'ContactList', 'MemberList', 'ChatView', 'RoomView']
   // Space events by ~1 frame so React 18 does NOT batch the burst into a single
-  // coalesced render. Codex's criteria are PER-EVENT ("a presence change must not
+  // coalesced render. The criteria are PER-EVENT ("a presence change must not
   // re-render the whole list"), so each event needs its own render to be counted.
   // Pass stepMs:0 to measure the opposite (coalesced) case.
   const step = (ms: number) => (ms > 0 ? new Promise<void>((r) => setTimeout(r, ms)) : Promise.resolve())

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -2963,7 +2963,7 @@ describe('XMPPClient MAM', () => {
         fetchLatestTopId: 'p1-last',
         // The walked pages carried reactions: their cache effects are
         // fire-and-forget, so the store must NOT certify this walk as
-        // coverage (Codex r4 #2) — the flag blocks record formation.
+        // coverage — the flag blocks record formation.
         walkCarriedModifications: true,
       })
       expect((mamEmits[0][1] as { page: { first?: string } }).page.first).toBe('p5-first')

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -226,7 +226,7 @@ export class MAM extends BaseModule {
     // pageInfo.last of the FIRST backward page — the newest archive entry seen by
     // this walk; stamped as the coverage record's topId (mamCoverage.ts).
     let fetchLatestTopId: string | undefined
-    // Persisted coverage record (Codex r3 #4): floor for the signal-only walk
+    // Persisted coverage record: floor for the signal-only walk
     // and purge-detection anchor for a coverage-seeded before-cursor.
     const coverageRecord = !isForwardPaginate
       ? this.deps.stores?.chat.getConversationCoverage?.(conversationId)
@@ -236,10 +236,10 @@ export class MAM extends BaseModule {
     const canJumpToFloor = before === ''
     let jumpedToFloor = false
     // The cursor the walk would have used had it not jumped — the recovery
-    // resume point when the jumped-to floor turns out purged (Codex r4 #6).
+    // resume point when the jumped-to floor turns out purged.
     let preJumpCursor: string | undefined
     // The walk contained the record's top entry — the only accepted proof of
-    // contiguity with the existing record (Codex r4 #3), and the trigger for
+    // contiguity with the existing record, and the trigger for
     // the floor jump.
     let sawCoverageTop = false
     const maxAutoPages = isForwardPaginate ? maxAutoPagesOpt : MAM_BACKWARD_SIGNAL_RETRY_PAGES // cap to avoid infinite loops
@@ -323,7 +323,7 @@ export class MAM extends BaseModule {
               // The jumped-to floor was purged MID-WALK (page > 0): drop the
               // stale record and resume from the pre-jump cursor instead of
               // aborting the walk — otherwise the record survives and every
-              // session re-jumps onto the dead id (Codex r4 #6).
+              // session re-jumps onto the dead id.
               logInfo(`MAM coverage floor purged mid-walk for ...@${getDomain(conversationId) || '*'} — resuming from pre-jump cursor`)
               this.deps.emitSDK('chat:history-coverage-purged', { conversationId, before: coverageRecord.bottomId })
               currentBefore = preJumpCursor
@@ -378,7 +378,7 @@ export class MAM extends BaseModule {
               // record's top entry), everything down to the record's bottom is
               // already proven signal-only — jump the cursor straight there so
               // successive sessions descend instead of re-walking the same
-              // newest pages (Codex r3 #4).
+              // newest pages.
               if (canJumpToFloor && coverageRecord && sawCoverageTop && !jumpedToFloor) {
                 preJumpCursor = pageInfo.first
                 currentBefore = coverageRecord.bottomId
@@ -413,7 +413,7 @@ export class MAM extends BaseModule {
       const unresolved = this.applyModifications(allMessages, modifications, (msg, from) => msg.from === from)
 
       // Reported for BOTH directions: coverage never certifies over a walk whose
-      // modification cache-writes are fire-and-forget (Codex r4 #2), and that
+      // modification cache-writes are fire-and-forget, and that
       // holds for the forward bootstrap anchor just as it does for a backward
       // extent. `modifications` accumulates across every page of this query.
       const walkCarriedModifications =
@@ -501,7 +501,7 @@ export class MAM extends BaseModule {
     // pageInfo.last of the FIRST backward page — the newest archive entry seen by
     // this walk; stamped as the coverage record's topId (mamCoverage.ts).
     let fetchLatestTopId: string | undefined
-    // Persisted coverage record (Codex r3 #4): floor for the signal-only walk
+    // Persisted coverage record: floor for the signal-only walk
     // and purge-detection anchor for a coverage-seeded before-cursor.
     const coverageRecord = !isForward
       ? this.deps.stores?.room.getRoomCoverage?.(roomJid)
@@ -511,10 +511,10 @@ export class MAM extends BaseModule {
     const canJumpToFloor = !before
     let jumpedToFloor = false
     // The cursor the walk would have used had it not jumped — the recovery
-    // resume point when the jumped-to floor turns out purged (Codex r4 #6).
+    // resume point when the jumped-to floor turns out purged.
     let preJumpCursor: string | undefined
     // The walk contained the record's top entry — contiguity proof and floor
-    // jump trigger (Codex r4 #3); see the 1:1 twin in queryArchive.
+    // jump trigger; see the 1:1 twin in queryArchive.
     let sawCoverageTop = false
     let currentAfter = after
     let currentBefore = before
@@ -526,7 +526,7 @@ export class MAM extends BaseModule {
     // Forward pages scope their modifications per page (see below), so the
     // walk-level fact has to be accumulated separately: the coverage bootstrap
     // is anchored by the page that reports `complete`, and it must know whether
-    // ANY earlier page of the same walk carried modifications (Codex r4 #2).
+    // ANY earlier page of the same walk carried modifications.
     let forwardWalkCarriedModifications = false
 
     const room = this.deps.stores?.room.getRoom(roomJid)
@@ -605,7 +605,7 @@ export class MAM extends BaseModule {
             }
             if (jumpedToFloor && preJumpCursor && coverageRecord && currentBefore === coverageRecord.bottomId && isItemNotFoundError(iqError)) {
               // Jumped-to floor purged mid-walk — resume from the pre-jump
-              // cursor (see the 1:1 twin in queryArchive; Codex r4 #6).
+              // cursor (see the 1:1 twin in queryArchive).
               logInfo(`Room MAM coverage floor purged mid-walk for ${roomJid} — resuming from pre-jump cursor`)
               this.deps.emitSDK('room:history-coverage-purged', { roomJid, before: coverageRecord.bottomId })
               currentBefore = preJumpCursor
@@ -1497,10 +1497,10 @@ export class MAM extends BaseModule {
     if (!windowBottom && io.getPendingStanzaId()) {
       // Contiguous coverage bottom: prefer the recorded gap's proven upper
       // edge, else the persisted coverage record (positive data that survives
-      // fresh sessions and gap closure — Codex r3 #3). Seeding from it (not
+      // fresh sessions and gap closure). Seeding from it (not
       // the global-oldest cache row) keeps the backward walk inside the
       // contiguous region — a disjoint search/context island (with or without
-      // a recorded gap) cannot mis-seed the descent (finding 9).
+      // a recorded gap) cannot mis-seed the descent.
       const seamBottom = io.getGapEndId() ?? io.getCoverageBottomId()
       if (seamBottom) {
         windowBottom = seamBottom
@@ -1513,7 +1513,7 @@ export class MAM extends BaseModule {
       // contiguous with live (a disjoint fetch-latest landed above held-below
       // history without anchoring a seam); leave windowBottom undefined so Phase B
       // no-ops this pass. A later fetch-latest that establishes a real boundary
-      // lets the next pass descend (finding 10).
+      // lets the next pass descend.
     }
     for (let page = 0; page < MAM_POINTER_STITCH_MAX_PAGES; page++) {
       // Re-check activity EVERY iteration, not just at dispatch: a walk is up

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -310,10 +310,10 @@ export interface MergeArchiveExtras {
   /** page.last of the FIRST page of a backward walk (newest covered entry). */
   fetchLatestTopId?: string
   /** The walk contained the existing coverage record's top entry — the only
-   *  accepted proof of contiguity with the record (Codex r4 #3). */
+   *  accepted proof of contiguity with the record. */
   sawCoverageTop?: boolean
   /** The walk carried corrections/retractions/reactions/fastenings, whose
-   *  cache effects are fire-and-forget — certification is blocked (r4 #2). */
+   *  cache effects are fire-and-forget — certification is blocked. */
   walkCarriedModifications?: boolean
   /** FORWARD only: the `after` cursor the catch-up resumed from — the bootstrap
    *  anchor when that catch-up reports complete. */

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -238,11 +238,11 @@ export interface ChatEvents {
      *  the coverage record's `topId`. */
     fetchLatestTopId?: string
     /** The walk contained the existing coverage record's top entry (id-exact
-     *  contiguity proof — Codex r4 #3). */
+     *  contiguity proof). */
     sawCoverageTop?: boolean
     /** The walk carried corrections/retractions/reactions/fastenings — their
      *  cache effects are fire-and-forget, so coverage must not certify over
-     *  them (Codex r4 #2). */
+     *  them. */
     walkCarriedModifications?: boolean
     /** FORWARD only: the `after` cursor the catch-up resumed from. With
      *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */
@@ -505,11 +505,11 @@ export interface RoomEvents {
      *  the coverage record's `topId`. */
     fetchLatestTopId?: string
     /** The walk contained the existing coverage record's top entry (id-exact
-     *  contiguity proof — Codex r4 #3). */
+     *  contiguity proof). */
     sawCoverageTop?: boolean
     /** The walk carried corrections/retractions/reactions/fastenings — their
      *  cache effects are fire-and-forget, so coverage must not certify over
-     *  them (Codex r4 #2). */
+     *  them. */
     walkCarriedModifications?: boolean
     /** FORWARD only: the `after` cursor the catch-up resumed from. With
      *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -229,7 +229,7 @@ export interface ChatBindings {
   /**
    * True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
    * as unproven (no gap edge, no resident boundary) — the seeder must not
-   * trust cache-oldest as contiguous-to-live (finding 10).
+   * trust cache-oldest as contiguous-to-live.
    */
   getConversationCoverageUnproven?: (conversationId: string) => boolean | undefined
   /**
@@ -498,7 +498,7 @@ export interface RoomBindings {
   /**
    * True when a disjoint fetch-latest flagged the contiguous coverage BOTTOM
    * as unproven (no gap edge, no resident boundary) — the seeder must not
-   * trust cache-oldest as contiguous-to-live (finding 10).
+   * trust cache-oldest as contiguous-to-live.
    */
   getRoomCoverageUnproven?: (roomJid: string) => boolean | undefined
   /**

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -989,15 +989,13 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(1)
   })
 
-  // final-fix-2: the race the re-reviewer flagged. An `allowActive` recompute
-  // (this fix's new advanceReadPointer trigger runs one) can be in flight
+  // An `allowActive` recompute (advanceReadPointer runs one) can be in flight
   // while a DIRECT writer — onMessageReceived's own live-edge convergence,
   // which commits straight to conversationMeta and does NOT bump
   // chatRecountVersion — advances the pointer and writes a fresh, correct
   // count in the meantime. chatRecountVersion's "latest-wins" guard above
   // only orders a recompute against ANOTHER recompute; it does nothing here.
-  // Re-reading the pointer at commit time (added by this fix) is what closes
-  // this specific gap.
+  // Re-reading the pointer at commit time is what closes this gap.
   it('a stale allowActive recompute does not clobber a pointer/count that moved via a direct write while it awaited the archive read', async () => {
     await messageCache.saveMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
@@ -1363,15 +1361,11 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   })
 
   // ---------------------------------------------------------------------
-  // final-fix-2: the previous fix wave removed onActivate's force-zero for
-  // the active entity but added no replacement trigger — a pointer that
-  // advances (live-edge convergence) or an entity that deactivates
-  // never re-derived the COUNT to match. These tests pin the two triggers
-  // this fix adds: advanceReadPointer and setActiveConversation's
-  // deactivation branch. Every seed below is a NONZERO value distinct from
-  // the correct outcome, per the reviewer's "seven hollow tests" finding —
-  // a seed-0/assert-0 fixture cannot distinguish a real recompute from a
-  // no-op.
+  // Activation does not force the active entity's count to zero, so the COUNT
+  // is re-derived by two triggers, both pinned below: advanceReadPointer and
+  // setActiveConversation's deactivation branch. Every seed below is a NONZERO
+  // value distinct from the correct outcome — a seed-0/assert-0 fixture cannot
+  // distinguish a real recompute from a no-op.
   // ---------------------------------------------------------------------
 
   describe('final-fix-2: pointer-advance and deactivation triggers re-derive the count', () => {
@@ -1463,11 +1457,11 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       }, { timeout: 2000 })
     })
 
-    // final-fix-3: the test above (fully read, pointer already at the
+    // The test above (fully read, pointer already at the
     // newest message) converges to 0 — but 0 is ALSO exactly what a naive
     // "just write 0 on deactivation" implementation would produce, which is
-    // precisely the force-zero behaviour this whole PR is walking back from
-    // onActivate. A seed-5/assert-0 fixture where the pointer sits at the
+    // precisely the force-zero behaviour activation must avoid. A
+    // seed-5/assert-0 fixture where the pointer sits at the
     // newest message cannot tell "recount ran and correctly derived 0" apart
     // from "deactivation force-zeroed it" — the two are indistinguishable
     // here. This test isolates the deactivation trigger with the pointer at
@@ -1670,8 +1664,8 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
   // ---------------------------------------------------------------------
   // The ACTIVATION trigger (room twin: roomStore.archiveUnread.test.ts).
-  // final-fix-2's two triggers are both reached only by the read pointer
-  // MOVING: advanceReadPointer recounts `if (pointerAdvanced)`, and
+  // The pointer-advance and deactivation triggers are both reached only by the
+  // read pointer MOVING: advanceReadPointer recounts `if (pointerAdvanced)`, and
   // onMessageSeen returns its input unchanged once the pointer sits on the
   // newest loaded message. Opening a conversation already at the live edge
   // with the pointer already at newest therefore moves nothing and triggers
@@ -1705,10 +1699,10 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       expect(chatStore.getState().activeConversationId).toBe(CID)
     })
 
-    // Discrimination control, per final-fix-3 above: seed-5/assert-0 would
+    // Discrimination control, as in the test above: seed-5/assert-0 would
     // also be satisfied by a force-zero on activation — the very behaviour
-    // that was walked back. With the pointer SHORT of newest, force-zero lands on
-    // 0 (wrong), a missing trigger leaves 5 (wrong), only a real derivation
+    // activation must avoid. With the pointer SHORT of newest, force-zero lands
+    // on 0 (wrong), a missing trigger leaves 5 (wrong), only a real derivation
     // lands on 2.
     it('opening a conversation with the pointer short of the newest message derives the true remainder, not zero', async () => {
       const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -323,22 +323,17 @@ describe('chatStore.applyRemoteDisplayed', () => {
     expect(chatStore.getState().conversations.get(cid)?.unreadCount).toBe(8)
   })
 
-  // NOTE (final-fix-3, consistency with roomStore.internal.mds.test.ts's twin under
-  // final-fix-2): this test's title used to claim it isolated the
-  // active-conversation guard ("skips the archive recount commit when the
-  // conversation became active meanwhile"). It doesn't: this conversation has
-  // no coverage record/mamQueryStates seeded, so `recomputeUnreadForConversation`
-  // ALSO defers at the (entirely separate) coverage gate regardless of
-  // `activeConversationId` — verified by deleting the active-conversation
-  // guards in recomputeUnreadForConversation and confirming this test still
-  // passes. The dedicated, genuinely isolating test for that guard lives in
-  // chatStore.archiveUnread.test.ts (the analogous room test is "does not
-  // touch the active room (activation owns its counts)"), which seeds real
-  // coverage so the guard is the ONLY thing standing between the seeded count
-  // and a different derived one. What THIS test actually proves: a stale
-  // recompute that settles after external state changed mid-flight
-  // (conversation became active, count set to a fresh value) does not clobber
-  // that fresher state — here, via the still-unproven coverage gate.
+  // NOTE: this test does NOT isolate the active-conversation guard. This
+  // conversation has no coverage record/mamQueryStates seeded, so
+  // the coverage gate alone makes `recomputeUnreadForConversation` defer
+  // regardless of `activeConversationId`. The dedicated, genuinely isolating
+  // test for that guard lives in chatStore.archiveUnread.test.ts (the analogous
+  // room test is "does not touch the active room (activation owns its counts)"),
+  // which seeds real coverage so the guard is the only thing standing between
+  // the seeded count and a different derived one. What this test actually proves:
+  // a stale recompute that settles after external state changes mid-flight
+  // (conversation becomes active, count is set to a fresh value) does not clobber
+  // that fresher state, here via the still-unproven coverage gate.
   it('a stale in-flight recount that settles after the conversation becomes active does not clobber the fresher count', async () => {
     const cid = 'juliet@capulet.example'
     const t = (min: number) => new Date(Date.UTC(2026, 0, 1, 0, min))

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -307,7 +307,7 @@ describe('chatStore', () => {
       const fetched = { ...createMessage(cid, 'edge'), id: 'edge', timestamp: new Date('2026-05-14T09:00:00Z') }
       chatStore.getState().mergeMAMMessages(cid, [fetched], {}, false, 'forward')
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       await vi.waitFor(() => {
         expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
           start: new Date('2026-05-14T09:00:00Z').getTime(), // newest fetched
@@ -334,7 +334,7 @@ describe('chatStore', () => {
       const fetched = { ...createMessage(cid, 'edge'), id: 'edge', timestamp: new Date('2026-05-14T09:00:00Z') }
       chatStore.getState().mergeMAMMessages(cid, [fetched], {}, false, 'forward')
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       await vi.waitFor(() => {
         expect(chatStore.getState().conversationGaps.has(cid)).toBe(true)
       })
@@ -356,7 +356,7 @@ describe('chatStore', () => {
       const fetched = { ...createMessage(cid, 'fresh'), id: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z') }
       chatStore.getState().mergeMAMMessages(cid, [fetched], {}, true, 'backward', true)
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       await vi.waitFor(() => {
         expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
           start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -432,7 +432,7 @@ describe('chatStore', () => {
       chatStore.getState().mergeMAMMessages(cid, [fresh], {}, true, 'backward', true)
 
       // Resident boundary proven → the seam is still recorded (deferred until
-      // the page is durably cached — Codex r4 #1).
+      // the page is durably cached).
       await vi.waitFor(() => {
         expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
           start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -518,9 +518,9 @@ describe('chatStore', () => {
     })
 
     it('forward ADVANCE of an existing gap is deferred until the page is durably cached', async () => {
-      // Codex r3 #1: the advance (startId → page.last) was persisted
-      // synchronously while the IndexedDB write was still in flight — a crash
-      // in between resumes `after: page.last` and skips the page forever.
+      // Persisting the advance (startId → page.last) synchronously, while the
+      // IndexedDB write is still in flight, opens a crash window: a crash in
+      // between resumes `after: page.last` and skips the page forever.
       chatStore.getState().addConversation(createConversation(cid))
       chatStore.setState({ conversationGaps: new Map([[cid, {
         start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -565,7 +565,7 @@ describe('chatStore', () => {
     })
 
     it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s page.last)', async () => {
-      // Codex r4 #1: a formed forward gap carries page.last as startId — a
+      // A formed forward gap carries page.last as startId — a
       // cursor INTO this very page. Publishing it before the write commits
       // has exactly the deletion/advance crash window: resume `after: startId`
       // skips the never-stored page. So formation defers as well; on a crash
@@ -680,7 +680,7 @@ describe('chatStore', () => {
     })
 
     it('a deferred commit captured before reset never lands in the fresh state', async () => {
-      // Codex r4 #5: the chain is cleared on reset, but a gate captured
+      // The chain is cleared on reset, but a gate captured
       // BEFORE the reset still resolves — its apply must be epoch-guarded.
       chatStore.getState().addConversation(createConversation(cid))
       let resolveSave!: (ok: boolean) => void
@@ -709,7 +709,7 @@ describe('chatStore', () => {
     })
 
     it('a later page cannot advance the gap past an earlier page whose write failed (per-conversation save chain)', async () => {
-      // Codex r4 #4 (chat twin): overlapping merges must not let page N+1's
+      // Chat twin: overlapping merges must not let page N+1's
       // cursor advance leap over a failed page N.
       chatStore.getState().addConversation(createConversation(cid))
       chatStore.setState({ conversationGaps: new Map([[cid, {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1453,7 +1453,7 @@ export const chatStore = createStore<ChatState>()(
               else newMarkers.delete(id)
               return { ...draft.commit(), activeConversationId: id, firstNewMessageMarkers: newMarkers }
             })
-            // final-fix-2: reconcile the entity we just LEFT (see the trigger
+            // Reconcile the entity we just LEFT (see the trigger
             // below the final fallback `set()` for the full rationale, including
             // the `worthReconcilingOnDeactivate` guard). By this point activeConversationId
             // already reads `id`, not `prevId`, so the ordinary (non-allowActive)
@@ -1483,8 +1483,8 @@ export const chatStore = createStore<ChatState>()(
         }
         // Default case: conversation not found, just set active
         set({ activeConversationId: id })
-        // final-fix-2: deactivation is the other trigger this fix adds (the
-        // twin of advanceReadPointer's live-edge trigger below). The
+        // Deactivation is the other trigger (the twin of advanceReadPointer's
+        // live-edge trigger below). The
         // convergence advances the READ POINTER while an entity is active but
         // never re-derives the COUNT for it — advanceReadPointer now schedules
         // that recount itself while still active, but a conversation that
@@ -1627,10 +1627,9 @@ export const chatStore = createStore<ChatState>()(
       deleteConversation: (id) => {
         // Delete messages from IndexedDB asynchronously
         void messageCache.deleteConversationMessages(id)
-        // The durable cursors describe messages that no longer exist (Codex
-        // r4 #5): drop them with the cache, and invalidate in-flight deferred
-        // commits so one can't resurrect an entry for the deleted
-        // conversation.
+        // The durable cursors describe messages that no longer exist: drop
+        // them with the cache, and invalidate in-flight deferred commits so
+        // one can't resurrect an entry for the deleted conversation.
         invalidateChatEntity(id)
 
         set((state) => {
@@ -1649,7 +1648,7 @@ export const chatStore = createStore<ChatState>()(
           const newArchived = new Set(state.archivedConversations)
           newArchived.delete(id)
 
-          // Drop the durable cursors with the cache (Codex r4 #5)
+          // Drop the durable cursors with the cache
           const newGaps = new Map(state.conversationGaps)
           newGaps.delete(id)
           const newCoverage = new Map(state.conversationCoverage)
@@ -2965,14 +2964,14 @@ export const chatStore = createStore<ChatState>()(
             // tombstone) above the true archive newest and would plant a spurious
             // seam. When the resident array is empty there is no proven boundary:
             // detectFetchLatestSeam returns undefined and coverageBottomUnproven is
-            // flagged below instead (finding 10).
+            // flagged below instead.
             newestHeldBelowTs: residentNewestTs,
             newestHeldBelowId: newestMessageStanzaId(rawExisting),
             lastFetchedArchiveId: page.last,
             preserveGapMarker,
           })
 
-          // Coverage-bottom proof (finding 10). A merge proves the contiguous
+          // Coverage-bottom proof. A merge proves the contiguous
           // bottom when a resident boundary exists OR a recorded gap now carries a
           // proven upper edge (endId) — clear any stale unproven flag. Otherwise,
           // when a disjoint fetch-latest lands above held-below history (proven by
@@ -2990,7 +2989,7 @@ export const chatStore = createStore<ChatState>()(
             }
           }
 
-          // Crash-window safety (Codex r3 #1/#2, r4 #1): the gap map is
+          // Crash-window safety: the gap map is
           // persisted synchronously (localStorage) while saveMessages to
           // IndexedDB is fire-and-forget AND absorbs errors. Persisting a
           // transition whose cursors reference THIS merge's page before the
@@ -3628,7 +3627,7 @@ export const chatStore = createStore<ChatState>()(
         drafts: state.drafts,
         // Persist history gaps so the "Load missing messages" marker survives reload
         conversationGaps: state.conversationGaps,
-        // Persist coverage records (contiguous-with-live bottom; Codex r3 #3)
+        // Persist coverage records (contiguous-with-live bottom)
         conversationCoverage: state.conversationCoverage,
         // Persist XEP-0424 retractions still waiting for their target to load,
         // so the tombstone lands even if the app restarts first

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -874,15 +874,14 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     expect(readRecountDeferrals()['room:context-changed']).toBe(1)
   })
 
-  // final-fix-2: the race the re-reviewer flagged, room twin of
-  // chatStore.archiveUnread.test.ts's. An `allowActive` recompute (this fix's
-  // new advanceReadPointer trigger runs one) can be in flight while a DIRECT
-  // writer — onMessageReceived's own live-edge convergence, which commits
-  // straight to roomMeta and does NOT bump roomRecountVersion — advances the
-  // pointer and writes a fresh, correct count in the meantime.
-  // roomRecountVersion's "latest-wins" guard above only orders a recompute
-  // against ANOTHER recompute; it does nothing here. Re-reading the pointer
-  // at commit time (added by this fix) is what closes this specific gap.
+  // Room twin of chatStore.archiveUnread.test.ts's. An `allowActive` recompute
+  // (advanceReadPointer runs one) can be in flight while a DIRECT writer —
+  // onMessageReceived's own live-edge convergence, which commits straight to
+  // roomMeta and does NOT bump roomRecountVersion — advances the pointer and
+  // writes a fresh, correct count in the meantime. roomRecountVersion's
+  // "latest-wins" guard above only orders a recompute against ANOTHER
+  // recompute; it does nothing here. Re-reading the pointer at commit time is
+  // what closes this gap.
   it('a stale allowActive recompute does not clobber a pointer/count that moved via a direct write while it awaited the archive read', async () => {
     await messageCache.saveRoomMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
@@ -1222,13 +1221,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   })
 
   // ---------------------------------------------------------------------
-  // final-fix-2: the previous fix wave removed onActivate's force-zero for
-  // the active entity but added no replacement trigger — a pointer that
-  // advances (live-edge convergence) or an entity that deactivates
-  // never re-derived the COUNT to match. These tests pin the two triggers
-  // this fix adds: advanceReadPointer and setActiveRoom's deactivation
-  // branch — the room twins of chatStore.archiveUnread.test.ts's. Every seed
-  // below is a NONZERO value distinct from the correct outcome.
+  // Activation does not force the active entity's count to zero, so the COUNT
+  // is re-derived by two triggers, both pinned below: advanceReadPointer and
+  // setActiveRoom's deactivation branch — the room twins of
+  // chatStore.archiveUnread.test.ts's. Every seed below is a NONZERO value
+  // distinct from the correct outcome.
   // ---------------------------------------------------------------------
 
   describe('final-fix-2: pointer-advance and deactivation triggers re-derive the count', () => {
@@ -1322,11 +1319,11 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       }, { timeout: 2000 })
     })
 
-    // final-fix-3: room twin of chatStore.archiveUnread.test.ts's. The test
+    // Room twin of chatStore.archiveUnread.test.ts's. The test
     // above (fully read, pointer already at the newest message) converges to
     // 0 — but 0 is ALSO exactly what a naive "just write 0 on deactivation"
-    // implementation would produce, the force-zero behaviour this PR is
-    // walking back from onActivate. A seed-5/assert-0 fixture with the
+    // implementation would produce, the force-zero behaviour activation must
+    // avoid. A seed-5/assert-0 fixture with the
     // pointer at the newest message can't tell "recount ran and correctly
     // derived 0" apart from "deactivation force-zeroed it". This test
     // isolates the deactivation trigger with the pointer at a NON-newest
@@ -1538,8 +1535,8 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   })
 
   // ---------------------------------------------------------------------
-  // The ACTIVATION trigger. final-fix-2 gave the count two triggers —
-  // advanceReadPointer and deactivation — but both are reached only by the
+  // The ACTIVATION trigger. The count's other two triggers —
+  // advanceReadPointer and deactivation — are both reached only by the
   // read pointer MOVING: advanceReadPointer recounts `if (pointerAdvanced)`,
   // and onMessageSeen returns its input unchanged once the pointer sits on
   // the newest loaded message. A reader who opens a room already at the live
@@ -1586,12 +1583,12 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       expect(roomStore.getState().activeRoomJid).toBe(ROOM)
     })
 
-    // The discrimination control, in the spirit of final-fix-3 above: the test
+    // The discrimination control, in the spirit of the one above: the test
     // above seeds 5 and asserts 0, which a naive "force-zero on activation"
     // would also satisfy — and force-zeroing on activation is exactly the
-    // behaviour that was walked back. Here the pointer stops SHORT of the newest
-    // message, so genuinely unread messages remain: force-zero lands on 0
-    // (wrong), a missing trigger leaves the stale 5 (wrong), and only a real
+    // behaviour activation must avoid. Here the pointer stops SHORT of the
+    // newest message, so genuinely unread messages remain: force-zero lands on
+    // 0 (wrong), a missing trigger leaves the stale 5 (wrong), and only a real
     // archive derivation lands on 2.
     it('opening a room with the pointer short of the newest message derives the true remainder, not zero', async () => {
       const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -481,20 +481,16 @@ describe('roomStore.applyRemoteDisplayed', () => {
     expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(3)
   })
 
-  // NOTE (final-fix-2): this test's title used to claim it isolated the
-  // active-room guard ("skips the archive recount commit when the room
-  // became active meanwhile"). It doesn't: this room has no coverage
-  // record/mamQueryStates seeded, so `recomputeUnreadForRoom` ALSO defers at
-  // the (entirely separate) coverage gate regardless of `activeRoomJid` —
-  // verified by deleting all three active-room guards in recomputeUnreadForRoom
-  // and confirming this test still passes. The dedicated, genuinely isolating
-  // test for that guard is roomStore.archiveUnread.test.ts's "does not touch
-  // the active room (activation owns its counts)", which seeds real coverage
-  // so the guard is the ONLY thing standing between the seeded count and a
-  // different derived one. What THIS test actually proves: a stale recompute
-  // that settles after external state changed mid-flight (room became active,
-  // count set to a fresh value) does not clobber that fresher state — here,
-  // via the still-unproven coverage gate.
+  // NOTE: this test does NOT isolate the active-room guard. This room has no
+  // coverage record/mamQueryStates seeded, so the coverage gate alone makes
+  // `recomputeUnreadForRoom` defer regardless of `activeRoomJid`. The dedicated,
+  // genuinely isolating test for that guard is roomStore.archiveUnread.test.ts's
+  // "does not touch the active room (activation owns its counts)", which seeds
+  // real coverage so the guard is the only thing standing between the seeded
+  // count and a different derived one. What this test actually proves: a stale
+  // recompute that settles after external state changes mid-flight (room becomes
+  // active, count is set to a fresh value) does not clobber that fresher state,
+  // here via the still-unproven coverage gate.
   it('a stale in-flight recount that settles after the room becomes active does not clobber the fresher count', async () => {
     seedRoom(ROOM, [])
     roomStore.getState().applyRemoteDisplayed(ROOM, 's-ptr')

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2663,7 +2663,7 @@ describe('roomStore', () => {
       // Forward catch-up truncated (complete=false) at the edge message.
       roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       await vi.waitFor(() => {
         expect(roomStore.getState().roomGaps.get(jid)).toEqual({
           start: new Date('2026-05-14T09:00:00Z').getTime(), // newest fetched
@@ -2696,7 +2696,7 @@ describe('roomStore', () => {
       // backward + isFetchLatest=true = a `before:''` fetch-latest page
       roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, true, 'backward', false, true)
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       await vi.waitFor(() => {
         expect(roomStore.getState().roomGaps.get(jid)).toEqual({
           start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -2981,9 +2981,9 @@ describe('roomStore', () => {
     })
 
     it('forward ADVANCE of an existing gap is deferred until the page is durably cached', async () => {
-      // Codex r3 #1: the advance (startId → page.last) was persisted
-      // synchronously while the IndexedDB write was still in flight — a crash
-      // in between resumes `after: page.last` and skips the page forever.
+      // Persisting the advance (startId → page.last) synchronously, while the
+      // IndexedDB write is still in flight, opens a crash window: a crash in
+      // between resumes `after: page.last` and skips the page forever.
       roomStore.getState().addRoom(createRoom(jid))
       roomStore.setState({ roomGaps: new Map([[jid, {
         start: new Date('2026-07-06T00:00:00Z').getTime(),
@@ -3034,7 +3034,7 @@ describe('roomStore', () => {
     })
 
     it('gap FORMATION with persistable messages is deferred too (its startId is this page\'s page.last)', async () => {
-      // Codex r4 #1: a formed forward gap carries page.last as startId — a
+      // A formed forward gap carries page.last as startId — a
       // cursor INTO this very page. Publishing it before the write commits
       // has exactly the deletion/advance crash window.
       roomStore.getState().addRoom(createRoom(jid))
@@ -3060,7 +3060,7 @@ describe('roomStore', () => {
     })
 
     it('a later page cannot advance the gap past an earlier page whose write failed (per-room save chain)', async () => {
-      // Codex r4 #4: room forward catch-up merges page by page, each with its
+      // Room forward catch-up merges page by page, each with its
       // own IndexedDB transaction. If page N's write fails but page N+1's
       // succeeds, N+1's deferred advance must NOT apply — the cursor would
       // leap over the never-stored page N.
@@ -3223,7 +3223,7 @@ describe('roomStore', () => {
     })
 
     it('a deferred commit captured before switchAccount never lands in the new account state', async () => {
-      // Codex r4 #5: the chain is cleared on switch, but a gate captured
+      // The chain is cleared on switch, but a gate captured
       // BEFORE the switch still resolves — its apply must be epoch-guarded.
       roomStore.getState().addRoom(createRoom(jid))
       let resolveSave!: (ok: boolean) => void
@@ -3327,7 +3327,7 @@ describe('roomStore', () => {
         }
         roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
 
-        // Formation defers until the page is durably cached (Codex r4 #1).
+        // Formation defers until the page is durably cached.
         await vi.waitFor(() => {
           expect(roomStore.getState().roomGaps.has(jid)).toBe(true)
         })
@@ -3380,7 +3380,7 @@ describe('roomStore', () => {
       }
       roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
 
-      // Formation defers until the page is durably cached (Codex r4 #1).
+      // Formation defers until the page is durably cached.
       //
       // Address the exact row this test writes. Scanning every value in the
       // mock store made this hollow: an earlier test in this describe merges

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -239,7 +239,7 @@ function saveGapsToStorage(gaps: Map<string, GapInterval>, jid?: string | null):
 
 /**
  * localStorage persistence for room coverage records (contiguous-with-live
- * bottom per room — positive twin of the gap map; Codex r3 #3). Survives
+ * bottom per room — positive twin of the gap map). Survives
  * fresh sessions and gap closure so Phase B and the signal-only walk resume
  * id-exactly across reloads.
  */
@@ -392,7 +392,7 @@ function savePendingRetractionsToStorage(pending: Map<string, PendingRetraction[
 // Serializes this store's archive-page writes; see shared/archiveSaveChain.ts.
 const roomArchiveSaves = createArchiveSaveChain()
 
-// Cache epoch (Codex r4 #5): bumped whenever the room cache lifecycle resets
+// Cache epoch: bumped whenever the room cache lifecycle resets
 // (logout reset or account switch). Deferred gap/coverage commits
 // capture the epoch at merge time and no-op when it moved — a gate that was
 // already in flight when the state was torn down must not resurrect entries.
@@ -1320,9 +1320,9 @@ export const roomStore = createStore<RoomState>()(
   removeRoom: (roomJid) => {
     // Delete messages from IndexedDB (non-blocking)
     void messageCache.deleteRoomMessages(roomJid)
-    // The durable cursors describe messages that no longer exist (Codex r4
-    // #5): drop them with the cache, and invalidate in-flight deferred
-    // commits so one can't resurrect an entry for the removed room.
+    // The durable cursors describe messages that no longer exist: drop them
+    // with the cache, and invalidate in-flight deferred commits so one can't
+    // resurrect an entry for the removed room.
     invalidateRoomEntity(roomJid)
 
     set((state) => {
@@ -2886,7 +2886,7 @@ export const roomStore = createStore<RoomState>()(
           else newMarkers.delete(roomJid)
           return { roomMeta: newMeta, rooms: newRooms, activeRoomJid: roomJid, firstNewMessageMarkers: newMarkers }
         })
-        // final-fix-2: reconcile the room we just LEFT (see the trigger below
+        // Reconcile the room we just LEFT (see the trigger below
         // the final fallback `set()` for the full rationale, including the
         // `worthReconcilingOnDeactivate` guard). By this point activeRoomJid
         // already reads `roomJid`, not `prevJid`, so the ordinary
@@ -2930,8 +2930,8 @@ export const roomStore = createStore<RoomState>()(
     }
     // Clearing active room or room not found
     set({ activeRoomJid: roomJid })
-    // final-fix-2: deactivation is the other trigger this fix adds (the twin
-    // of advanceReadPointer's live-edge trigger below). That convergence
+    // Deactivation is the other trigger (the twin of advanceReadPointer's
+    // live-edge trigger below). That convergence
     // advances the READ POINTER while a room is active but never re-derives
     // the COUNT for it — advanceReadPointer now schedules that recount itself
     // while still active, but a room that never received another arrival
@@ -3989,14 +3989,14 @@ export const roomStore = createStore<RoomState>()(
         // tombstone) above the true archive newest and would plant a spurious
         // seam. When the resident array is empty there is no proven boundary:
         // detectFetchLatestSeam returns undefined and coverageBottomUnproven is
-        // flagged below instead (finding 10).
+        // flagged below instead.
         newestHeldBelowTs: residentNewestTs,
         newestHeldBelowId: newestMessageStanzaId(existingMessages),
         lastFetchedArchiveId: page.last,
         preserveGapMarker,
       })
 
-      // Coverage-bottom proof (finding 10). A merge proves the contiguous bottom
+      // Coverage-bottom proof. A merge proves the contiguous bottom
       // when a resident boundary exists OR a recorded gap now carries a proven
       // upper edge (endId) — clear any stale unproven flag. Otherwise, when a
       // disjoint fetch-latest lands above held-below history (proven by the
@@ -4013,7 +4013,7 @@ export const roomStore = createStore<RoomState>()(
           newStates = mamState.setCoverageBottomUnproven(newStates, roomJid, true)
         }
       }
-      // Crash-window safety (Codex r3 #1/#2, r4 #1): the gap map is persisted
+      // Crash-window safety: the gap map is persisted
       // synchronously (localStorage) while saveRoomMessages to IndexedDB is
       // fire-and-forget AND absorbs errors. Persisting a transition whose
       // cursors reference THIS merge's page before the write commits lets a

--- a/packages/fluux-sdk/src/stores/shared/archiveSaveChain.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveSaveChain.ts
@@ -1,5 +1,5 @@
 /**
- * Per-entity serialization of archive-page write outcomes (Codex r4 #4).
+ * Per-entity serialization of archive-page write outcomes.
  *
  * Room forward catch-up merges one page at a time, each with its own
  * IndexedDB transaction. A deferred gap/coverage commit for page N+1 must not

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -34,7 +34,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
   })
 
   it('signal-only give-up (zero messages, page.first set) still establishes the record', () => {
-    // Codex r3 #4: the walked window IS proven contiguous coverage even with
+    // The walked window IS proven contiguous coverage even with
     // zero displayable messages — this is the durable resume for the cap.
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'page5-first', fetchLatestTopId: 'page1-last' }))
     expect(out.coverage.get('a@b')).toEqual({ bottomId: 'page5-first', topId: 'page1-last' })
@@ -47,7 +47,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
   })
 
   it('a walk that SAW the existing topId keeps the deeper bottom, refreshes topId', () => {
-    // Codex r4 #3: only re-entering the covered region (the walk contained
+    // Only re-entering the covered region (the walk contained
     // the record's top entry) proves contiguity with the existing record.
     const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'old-top' }]])
     const out = syncCoverageAfterArchiveMerge(
@@ -57,7 +57,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
   })
 
   it('dedupe against arbitrary local data does NOT keep the old bottom (island overlap is no proof)', () => {
-    // Codex r4 #3 scenario: coverage [100..200], fetchContext island
+    // Scenario: coverage [100..200], fetchContext island
     // [280..320] resident, fetch-latest [301..400] dedupes against the
     // island. Keeping bottomId=100 would certify the hole [201..279].
     // Without sighting the record's topId, the record must be REPLACED by
@@ -70,7 +70,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
   })
 
   it('a walk that carried modifications never certifies coverage (their cache writes are fire-and-forget)', () => {
-    // Codex r4 #2: corrections/retractions/reactions on walked pages are
+    // Corrections/retractions/reactions on walked pages are
     // applied via unawaited cache updates (and dropped entirely for
     // non-resident targets). Certifying the walk would let a later floor
     // jump skip them forever — so it must not form, extend, or refresh a
@@ -202,7 +202,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     })
 
     it('a completed forward catch-up that carried modifications never seeds', () => {
-      // Same invariant the backward branch enforces (Codex r4 #2): the walk's
+      // Same invariant the backward branch enforces: the walk's
       // modification cache-writes are fire-and-forget, so nothing it touched is
       // durably confirmed enough to certify coverage.
       const coverage = new Map<string, CoverageRecord>()

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -1,6 +1,6 @@
 /**
  * Coverage transitions for the persisted contiguous-with-live record
- * ({@link CoverageRecord}, Codex r3 #3/#4).
+ * ({@link CoverageRecord}).
  *
  * @module Stores/Shared/MamCoverage
  */
@@ -94,19 +94,19 @@ export interface ArchiveMergeCoverageInput {
   initialBefore?: string
   /** The walk contained the existing record's top entry (id-exact sighting).
    *  Dedupe against arbitrary resident data is NOT accepted: overlapping a
-   *  fetchContext island proves nothing about the record's region (r4 #3). */
+   *  fetchContext island proves nothing about the record's region. */
   sawCoverageTop: boolean
   /** The walk carried modifications (see MergeArchiveExtras) — blocks any
-   *  certification: their cache effects are not durably confirmed (r4 #2). */
+   *  certification: their cache effects are not durably confirmed. */
   walkCarriedModifications: boolean
 }
 
 /**
  * Pure coverage transition, called from both stores' archive merges.
  *
- * - a walk that carried modifications never certifies anything (r4 #2);
+ * - a walk that carried modifications never certifies anything;
  * - fetch-latest that SAW the existing record's top entry → the deeper
- *   existing bottom stands; only the walk top refreshes (r4 #3);
+ *   existing bottom stands; only the walk top refreshes;
  * - fetch-latest otherwise (disjoint or first-ever, INCLUDING a signal-only
  *   give-up with zero displayable messages) → replace with the walk extent;
  * - plain backward page → extend the bottom ONLY when the query resumed
@@ -132,7 +132,7 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
   if (preserveGapMarker) return unchanged
   // Applies to BOTH directions: a walk whose corrections/retractions/reactions
   // were written fire-and-forget is not durably confirmed, so it may not certify
-  // coverage — the forward bootstrap anchor included (Codex r4 #2).
+  // coverage — the forward bootstrap anchor included.
   if (walkCarriedModifications) return unchanged
 
   if (direction !== 'backward') {

--- a/packages/fluux-sdk/src/stores/shared/mamGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.ts
@@ -184,7 +184,7 @@ export function newestMessageStanzaId(
  * @param newestHeldBelowTs - Newest message held BEFORE this merge — a PROVEN
  *   resident boundary only (resident newest, or undefined when the resident
  *   array is empty). Never the persisted preview timestamp: an unarchived
- *   preview must not plant a seam (finding 10).
+ *   preview must not plant a seam.
  * @param newestHeldBelowId - Archive id of that newest-held-below message, when
  *   known — stamped as the seam's `startId` (id-exact resume cursor).
  * @returns The seam to record, or undefined when the page is connected/ambiguous
@@ -273,7 +273,7 @@ export interface ArchiveMergeGapInput {
   /** The query was a `before:''` fetch-latest. */
   isFetchLatest: boolean
   /** Newest message held BEFORE this merge — a proven resident boundary only
-   *  (resident newest, or undefined when empty); never the preview ts (finding 10). */
+   *  (resident newest, or undefined when empty); never the preview ts. */
   newestHeldBelowTs: number | undefined
   /** Archive id of the newest message held BEFORE this merge (mirrors
    *  `newestHeldBelowTs`) — stamped as a formed backward seam's `startId`. */

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -156,7 +156,7 @@ export function pointerlessDefers(pointer: ReadPointer | undefined, persistedUnr
 
 /**
  * Whether an entity's notification state has anything a deactivation-triggered
- * recount could possibly correct (read-state final-fix-2).
+ * recount could possibly correct.
  *
  * A truly fresh entity — never read (no pointer ever established) AND already
  * showing zero unread — has nothing to reconcile: there is no stale count to

--- a/scripts/check-comment-provenance.mjs
+++ b/scripts/check-comment-provenance.mjs
@@ -2,11 +2,11 @@
 //
 // Fail when a comment gains a development-session work-item identifier.
 //
-// `Task 9`, `PR C`, `Phase 6`, `FIX 3` and `requirement 2` name work items from
-// past development sessions. Nothing in the repository, the issue tracker or the
-// git history resolves them, so for the next reader they are noise wearing the
-// costume of information. The doctrine lives in AGENTS.md under Code style ->
-// Comments; the cleanup is tracked in #1236.
+// `Task 9`, `PR C`, `Phase 6`, `FIX 3`, `requirement 2`, `r4 #3`, `final-fix-2`
+// and `finding 9` name work items from past development sessions. Nothing in the
+// repository, the issue tracker or the git history resolves them, so for the next
+// reader they are noise wearing the costume of information. The doctrine lives in
+// AGENTS.md under Code style -> Comments; the cleanup is tracked in #1236.
 //
 // The tree carries none, and this keeps it that way: any occurrence fails.
 //
@@ -45,6 +45,25 @@ export const PROVENANCE_PATTERNS = [
   { family: 'Phase N', pattern: /\bPhase \d+(?:\.\d+)?\b/g },
   { family: 'FIX N', pattern: /\bFIX \d+\b/g },
   { family: 'requirement N', pattern: /\brequirement \d+\b/g },
+  // A review round and the finding number inside it (`Codex r4 #3`, `r3 #1/#2`).
+  // The tool name is optional in practice, so the round marker carries the match:
+  // any `r<round> #<finding>` is a session artefact whoever produced it.
+  { family: 'round rN #M', pattern: /\br\d+[ \t]+#\d+\b/g },
+  // The round alone, for a reference the finding number of which wrapped onto the
+  // next comment line. Skipped when `#N` follows, so `Codex r4 #3` is reported
+  // once, under `round rN #M`. Named literally: a bare `r4` is too weak to gate on,
+  // and only a tool name makes it unambiguous.
+  { family: 'Codex rN', pattern: /\bCodex r\d+\b(?![ \t]+#\d+\b)/g },
+  // A wave of fixes from one session. Kept literal: `[a-z]+-fix-\d+` would fire on
+  // any hyphenated identifier quoted in a comment.
+  { family: 'final-fix-N', pattern: /\bfinal-fix-\d+\b/g },
+  // A numbered review finding in one of the two observed tag forms:
+  // `(finding N)` or a `finding N:` clause at the start of a comment.
+  {
+    family: 'finding N',
+    pattern: /(?:\((finding \d+)\)|^(?:\/\*+|\/+|\*)[ \t]*(finding \d+):)/g,
+    extract: (match) => match[1] ?? match[2],
+  },
 ]
 
 /**
@@ -111,12 +130,12 @@ export function findProvenance(source) {
   for (let index = 0; index < lines.length; index++) {
     const comment = commentText(lines[index])
     if (!comment) continue
-    for (const { family, pattern } of PROVENANCE_PATTERNS) {
+    for (const { family, pattern, extract } of PROVENANCE_PATTERNS) {
       // Fresh lastIndex per line: the patterns are module-level and /g is stateful.
       pattern.lastIndex = 0
       let match
       while ((match = pattern.exec(comment)) !== null) {
-        found.push({ family, text: match[0], line: index + 1 })
+        found.push({ family, text: extract?.(match) ?? match[0], line: index + 1 })
       }
     }
   }

--- a/scripts/check-comment-provenance.test.mjs
+++ b/scripts/check-comment-provenance.test.mjs
@@ -20,6 +20,46 @@ test('flags every provenance family', () => {
   assert.deepEqual(families('// Phase 0.3 of the decoupling'), ['Phase 0.3'])
   assert.deepEqual(families('// FIX 5: sort before trimming'), ['FIX 5'])
   assert.deepEqual(families('// Rederive the divider (requirement 5)'), ['requirement 5'])
+  assert.deepEqual(families('// contiguity with the record (Codex r4 #3)'), ['r4 #3'])
+  assert.deepEqual(families('// certification is blocked (r4 #2)'), ['r4 #2'])
+  assert.deepEqual(families('// the gap map is persisted (r3 #1/#2, r4 #1)'), ['r3 #1', 'r4 #1'])
+  assert.deepEqual(families('// reconcile the entity we just LEFT (final-fix-2)'), ['final-fix-2'])
+  assert.deepEqual(families('// cannot mis-seed the descent (finding 9)'), ['finding 9'])
+  assert.deepEqual(families('// lets the next pass descend (finding 10).'), ['finding 10'])
+  assert.deepEqual(families('// finding 10: never the persisted preview'), ['finding 10'])
+  assert.deepEqual(findProvenance('/// finding 10: never the persisted preview'), [
+    { family: 'finding N', text: 'finding 10', line: 1 },
+  ])
+})
+
+// A round marker and a finding number are one identifier, so a fully written
+// reference is reported once rather than under two families.
+test('reports a tool-prefixed round reference once', () => {
+  assert.deepEqual(findProvenance('// see the twin (Codex r4 #6)'), [
+    { family: 'round rN #M', text: 'r4 #6', line: 1 },
+  ])
+  assert.deepEqual(findProvenance('// see the twin (Codex r4  #6)'), [
+    { family: 'round rN #M', text: 'r4  #6', line: 1 },
+  ])
+  assert.deepEqual(findProvenance('// see the twin (Codex r4\t#6)'), [
+    { family: 'round rN #M', text: 'r4\t#6', line: 1 },
+  ])
+  assert.deepEqual(findProvenance('// discussed in Codex r4 #draft'), [
+    { family: 'Codex rN', text: 'Codex r4', line: 1 },
+  ])
+  assert.deepEqual(findProvenance('// discussed in Codex r4 #2a'), [
+    { family: 'Codex rN', text: 'Codex r4', line: 1 },
+  ])
+})
+
+test('flags horizontal whitespace between a round and finding number', () => {
+  assert.deepEqual(families('// reviewed in r4  #2'), ['r4  #2'])
+  assert.deepEqual(families('// reviewed in r4\t#2'), ['r4\t#2'])
+})
+
+test('flags a round whose finding number wrapped onto the next comment line', () => {
+  const source = ['// The durable cursors describe messages that no longer exist (Codex r4', '// #5): drop them.'].join('\n')
+  assert.deepEqual(findProvenance(source), [{ family: 'Codex rN', text: 'Codex r4', line: 1 }])
 })
 
 test('reports the family alongside the match', () => {
@@ -50,9 +90,17 @@ test('ignores Step N, which numbers the stages of an algorithm', () => {
   assert.deepEqual(families('// Step 2: Background MAM fetch for catchup'), [])
 })
 
+test('ignores a gerund followed by a count, which is ordinary prose', () => {
+  assert.deepEqual(families('// Stop after finding 2, since two candidates establish both bounds.'), [])
+  assert.deepEqual(families('// We gave up after finding 3.'), [])
+  assert.deepEqual(families('// after finding 2 candidates, keep the deeper one'), [])
+  assert.deepEqual(families('// worth finding 10 more before giving up'), [])
+})
+
 test('ignores GitHub issue references, the supported durable trail', () => {
   assert.deepEqual(families('// A BOUNDARY test (#1173)'), [])
   assert.deepEqual(families('// See issue #1059 for the announced-keys case'), [])
+  assert.deepEqual(families('// Step 3 resolves the seam (#1236)'), [], 'Step N beside an issue ref')
 })
 
 test('documents what is deliberately allowed', () => {
@@ -84,6 +132,9 @@ test('requires the exact shapes, not near misses', () => {
   assert.deepEqual(families('// PR review pending'), [], 'PR must be followed by a single letter')
   assert.deepEqual(families('// the requirement is clear'), [])
   assert.deepEqual(families('// multitask 9'), [], 'word boundary')
+  assert.deepEqual(families('// the r4 branch'), [], 'a round needs a finding number or the tool name')
+  assert.deepEqual(families('// a hot-fix-2 landed'), [], 'final-fix-N is literal, not any -fix-N')
+  assert.deepEqual(families('// codex r4 #3'), ['r4 #3'], 'the round marker matches whatever named the tool')
 })
 
 test('counts every occurrence on one line', () => {


### PR DESCRIPTION
The comment-provenance gate (#1236) covered five families of past-session
work-item identifiers. Three more were in the tree and passed straight through
it: review-round references, fix-wave names, and numbered review findings.

**Real count.** Re-measured with the gate's own comment detector: **85 comment
occurrences across 18 source files**, plus `perfHarness.ts` cleaned by hand as a
nineteenth file no pattern covers. The forms are wider than they first look —
`Codex r3 #N` as well as `r4`, a bare `(r4 #2)` with no tool name at all in six
places, `final-fix-3` beside `final-fix-2`, and `finding 10` beside `finding 9`.

**Why extend the guard rather than clean by hand.** These are not isolated
accidents. The shape has already drifted on its own — six sites have shed the
tool name down to a bare `r4 #2` — and it reaches public SDK type files
(`sdk-events.ts`, `pagination.ts`, `storeBindings.ts`). A form that mutates
while spreading is exactly what a mechanical gate is for.

**Why each pattern has the shape it has.**

- `round rN #M` — the general family. The tool prefix is optional in practice,
  so the round marker carries the identifier; this caught the six bare sites a
  literal `Codex` pattern would have missed. Accepts horizontal whitespace, so
  `r4  #2` and `r4<tab>#2` cannot slip past.
- `Codex rN` — a literal, needed only for two references whose finding number
  wrapped onto the next comment line. It stands down only for a *complete*
  numeric reference, so `Codex r4 #3` is reported once rather than under two
  families, while `Codex r4 #draft` still fails.
- `final-fix-N` — kept literal. A broader `[a-z]+-fix-\d+` would fire on any
  hyphenated identifier quoted in a comment, and the tree shows no second wave
  name to generalise from.
- `finding N` — restricted to the two tag forms that actually occur,
  `(finding N)` and a clause-leading `finding N:`. A bare `\bfinding \d+\b`
  fires on ordinary prose ("Stop after finding 2, since ..."), and all ten real
  occurrences are still caught after the narrowing.

**The negative cases are the point.** `Step N` and `#1234` stay deliberately
unmatched, as ALLOWED_BY_DESIGN documents. The sibling test pins that boundary
directly: `Step 3` beside an issue reference, `hot-fix-2`, `the r4 branch`, and
the two prose sentences above all assert *no* match. A guard that fails the
build on correct code gets disabled rather than obeyed, so the tests that prove
what it will not catch matter more than the ones that prove what it will.

The cleanup keeps the technical content and drops only the identifier. Where
removing it would have left a sentence asserting something unverified, the
sentence is restated in the present tense against the code it describes.
Outside the guard the diff touches comments only. Test titles carrying these
strings are string literals, outside the gate's comment-only scope by design,
and are left untouched — a candidate for a separate pass.
