### PR TITLE
fix(sdk): stop calling replayed messages live arrivals

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.routing.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.routing.test.ts
@@ -612,5 +612,101 @@ describe('Message Routing', () => {
       expect(addedMessage).toHaveProperty('nick', 'sender')
       expect(addedMessage).not.toHaveProperty('conversationId')
     })
+  
+
+  describe('arrival classification', () => {
+    /**
+     * XEP-0045 replays recent history on join, each stanza carrying a delay. The
+     * notification layer already reads that marker this way — notificationState
+     * documents that for rooms `isDelayed` means MUC history replay, unlike 1:1
+     * where it means offline delivery — so this is the codebase's existing rule
+     * applied at the point that classifies an arrival, not a new inference.
+     */
+    it('does not call replayed MUC join history a live arrival', async () => {
+      await connectClient()
+      const mockRoom = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'user',
+      })
+      vi.mocked(mockStores.room.getRoom).mockImplementation((jid: string) =>
+        jid === 'room@conference.example.com' ? mockRoom : undefined
+      )
+
+      const historyStanza = createMockElement('message', {
+        from: 'room@conference.example.com/sender',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'history-1',
+      }, [
+        { name: 'body', text: 'Said before I joined' },
+        { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2026-08-01T10:00:00Z' } },
+      ])
+
+      mockXmppClientInstance._emit('stanza', historyStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
+        isLiveArrival: false,
+        message: expect.objectContaining({ id: 'history-1' }),
+      }))
+    })
+
+    it('still calls an undelayed room message a live arrival', async () => {
+      // The control: without this, classifying everything as replay would pass the
+      // test above while silencing every genuine arrival.
+      await connectClient()
+      const mockRoom = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'user',
+      })
+      vi.mocked(mockStores.room.getRoom).mockImplementation((jid: string) =>
+        jid === 'room@conference.example.com' ? mockRoom : undefined
+      )
+
+      const liveStanza = createMockElement('message', {
+        from: 'room@conference.example.com/sender',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'live-1',
+      }, [{ name: 'body', text: 'Said just now' }])
+
+      mockXmppClientInstance._emit('stanza', liveStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
+        isLiveArrival: true,
+        message: expect.objectContaining({ id: 'live-1' }),
+      }))
+    })
+
+    it('keeps a delayed 1:1 message a live arrival, because offline delivery is new', async () => {
+      // The opposite rule to rooms, and the reason one shared rule would be wrong:
+      // a message sent while the user was offline has never been seen, so it is an
+      // arrival however old its timestamp.
+      await connectClient()
+      const mockRoom = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'user',
+      })
+      vi.mocked(mockStores.room.getRoom).mockImplementation((jid: string) =>
+        jid === 'room@conference.example.com' ? mockRoom : undefined
+      )
+
+      const offlineStanza = createMockElement('message', {
+        from: 'contact@example.com/resource',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'offline-1',
+      }, [
+        { name: 'body', text: 'Sent while you were away' },
+        { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2026-08-01T10:00:00Z' } },
+      ])
+
+      mockXmppClientInstance._emit('stanza', offlineStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', expect.objectContaining({
+        isLiveArrival: true,
+        message: expect.objectContaining({ id: 'offline-1' }),
+      }))
+    })
+  })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -2335,7 +2335,12 @@ export class Chat extends BaseModule {
     this.deps.emitSDK('room:message', {
       roomJid,
       message,
-      isLiveArrival: true,
+      // XEP-0045 replays recent history on join, and each replayed stanza carries
+      // a delay. For a ROOM that marker means history replay — the same reading
+      // `notificationState` already documents and relies on — so a replayed
+      // message is not an arrival. The 1:1 path is deliberately the opposite:
+      // there a delay means offline delivery, which the user has never seen.
+      isLiveArrival: !message.isDelayed,
       incrementUnread: !message.isOutgoing,
       incrementMentions: message.isMention,
     })

--- a/packages/fluux-sdk/src/hooks/useEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useEvents.test.tsx
@@ -137,6 +137,12 @@ describe('useEvents hook', () => {
       const messages = chatStore.getState().messages.get('stranger@example.com')
       expect(messages).toHaveLength(2)
 
+      // Moved, not delivered. These were received and displayed as stranger
+      // messages before the user accepted, so re-announcing them would notify a
+      // second time for messages already seen — and record traffic that did not
+      // arrive at this moment.
+      expect(chatStore.getState().lastArrivedMessage.get('stranger@example.com')).toBeUndefined()
+
       // Should remove from stranger messages
       expect(result.current.strangerMessages).toHaveLength(0)
     })

--- a/packages/fluux-sdk/src/hooks/useEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useEvents.ts
@@ -129,18 +129,27 @@ export function useEvents() {
       }
       chatStore.getState().addConversation(conversation)
 
-      // Move stranger messages to the conversation
+      // Move stranger messages to the conversation.
+      //
+      // Not arrivals: these were received and shown as stranger messages before
+      // the user accepted, so this loop is a migration between stores rather than
+      // a delivery. Marking them live would re-announce messages already seen —
+      // a notification for each, and a breadcrumb claiming traffic that never
+      // arrived at this moment.
       const messages = strangerMessages.filter((m) => m.from === jid)
       for (const msg of messages) {
-        chatStore.getState().addMessage({
-          type: 'chat',
-          id: msg.id,
-          conversationId: jid,
-          from: jid,
-          body: msg.body,
-          timestamp: msg.timestamp,
-          isOutgoing: false,
-        })
+        chatStore.getState().addMessage(
+          {
+            type: 'chat',
+            id: msg.id,
+            conversationId: jid,
+            from: jid,
+            body: msg.body,
+            timestamp: msg.timestamp,
+            isOutgoing: false,
+          },
+          { isLiveArrival: false },
+        )
       }
 
       // Remove from stranger messages


### PR DESCRIPTION
Two paths announced messages that had not just arrived.

XEP-0045 replays recent history on join, and every replayed stanza was emitted as a live arrival — so joining a busy room could report up to fifty deliveries at once. Accepting a stranger re-announced their earlier messages the same way, having already shown them.

A room message carries a delay when it is replayed, and that is the reading `notificationState` already documents and relies on, so the room path now uses it. The 1:1 path deliberately does not: there a delay means offline delivery, which the user has never seen, and one shared rule would silence exactly the messages most worth announcing. All three cases are covered by tests, including the two controls.

Accepting a stranger moves messages between stores rather than delivering them, and now says so.

## Blast radius

`isLiveArrival` gates only `lastArrivedMessage`; `incrementUnread` and `incrementMentions` are separate options, so unread counts, mentions and the new-message divider are unaffected. That map has two consumers: notification delivery and the anomaly breadcrumb ring.

For rooms the notification path already ignored delayed messages (`treatDelayedAsNew` defaults to false), so there is no user-visible change there — the correction is to the arrival signal itself. Accepting a stranger no longer fires a notification for messages the user has just finished looking at, which is the intended behaviour change.