### PR TITLE
fix(anomaly): measure foreground against observed time, not wall clock

### DIFF
--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -461,3 +461,27 @@ describe('entity warming that keeps failing', () => {
     expect(seen.filter((s) => s.name === 'recorder/entity-warm-failing')).toEqual([])
   })
 })
+
+describe('the sampler reports that the app is alive', () => {
+  it('calls onSample once per sample, before any detector runs', () => {
+    // The foreground accumulator can only distinguish a suspended hour from an
+    // hour of use by being told the app was alive at a given instant — wall clock
+    // cannot, because the WebView freezes timers while hidden. Without this call
+    // the bound in `createForegroundShare` is unreachable and every resumed
+    // window still reads as background.
+    const seen: number[] = []
+    let clock = 1000
+    const tick = startDetectorTick({
+      ...world(),
+      now: () => clock,
+      onSample: (now) => seen.push(now),
+    })
+
+    tick.sample()
+    clock = 2000
+    tick.sample()
+    tick.stop()
+
+    expect(seen).toEqual([1000, 2000])
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -67,6 +67,15 @@ export interface TickWorld {
   /** Independently measured distance to the content bottom, or null. */
   distFromBottom(kind: ViewportKind, id: string): number | null
   now(): number
+  /**
+   * Called once per sample, before any detector runs.
+   *
+   * The foreground accumulator needs to know the app was alive at this instant.
+   * Wall clock cannot tell it: the WebView freezes timers while hidden, so an
+   * hour asleep and an hour of use look identical after the fact. Only the
+   * sampler's own cadence distinguishes them.
+   */
+  onSample?(now: number): void
 }
 
 /** Read the real app. */
@@ -156,6 +165,7 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
 
   function sample(): void {
     const now = world.now()
+    world.onSample?.(now)
     const active = world.activeConversation()
 
     // Warm the token BEFORE any record can reference this conversation. `tokenSync`

--- a/apps/fluux/src/anomaly/environment.test.ts
+++ b/apps/fluux/src/anomaly/environment.test.ts
@@ -85,3 +85,43 @@ describe('foreground share', () => {
     expect(share.take(0)).toBe(1)
   })
 })
+
+describe('a suspended window is not charged against the active period', () => {
+  it('counts an unsampled gap as at most one sampling step', () => {
+    // The WebView freezes timers while hidden, so an hour asleep produces no
+    // samples at all. Charging it as elapsed reports five real minutes as a 5/65
+    // share, the review excludes the window as background, and the only stretch
+    // with anything to say is discarded. Nothing was observed during the gap, so
+    // nothing beyond one step is claimed about it — the same rule the unread
+    // detector applies when its own sampling goes quiet.
+    const share = createForegroundShare(true, 0)
+    share.note(false, 1000)
+    expect(share.take(1000)).toBeCloseTo(1, 5)
+
+    // An hour of frozen timers produces no samples at all; the sampler then
+    // resumes at its normal cadence.
+    share.note(true, 3_601_000)
+    for (let t = 3_602_000; t <= 3_661_000; t += 1000) share.sample(t)
+
+    // A minute of foreground against one step of unknown. Without the bound this
+    // reads 0.016 and the window is thrown away as background.
+    expect(share.take(3_661_000)).toBeGreaterThan(0.9)
+  })
+
+  it('still averages a mixed window whose gaps were sampled', () => {
+    // The control: an ordinary hidden stretch inside one window is real elapsed
+    // time and must still dilute the share, or the exclusion filter stops
+    // excluding anything.
+    const share = createForegroundShare(true, 0)
+    share.note(false, 1000)
+    share.note(true, 3000)
+    expect(share.take(4000)).toBeCloseTo(0.5, 5)
+  })
+
+  it('accrues sampled time between transitions, so a quiet foreground window reads 1', () => {
+    const share = createForegroundShare(true, 0)
+    share.sample(1000)
+    share.sample(2000)
+    expect(share.take(3000)).toBeCloseTo(1, 5)
+  })
+})

--- a/apps/fluux/src/anomaly/environment.ts
+++ b/apps/fluux/src/anomaly/environment.ts
@@ -82,10 +82,21 @@ export function createEnvironmentReader(inputs: EnvironmentInputs): () => Array<
   ]
 }
 
+/**
+ * Largest gap between observations that still counts as continuous time.
+ *
+ * Matches the unread detector's sampling rule, for the same reason: beyond this,
+ * nothing was watching, so nothing is known about what happened. The sampler runs
+ * once a second, so five seconds is five missed turns.
+ */
+const MAX_GAP_MS = 5_000
+
 export interface ForegroundShare {
   /** Record a visibility transition. `visible` is the state being ENTERED. */
   note(visible: boolean, at: number): void
-  /** Visible fraction since the last take, and start a fresh window. */
+  /** Record that the app was still running, on the sampler's cadence. */
+  sample(at: number): void
+  /** Visible fraction of the OBSERVED time since the last take, then reset. */
   take(at: number): number
 }
 
@@ -100,26 +111,43 @@ export interface ForegroundShare {
 export function createForegroundShare(visible: boolean, at: number): ForegroundShare {
   let current = visible
   let since = at
-  let windowStart = at
   let visibleMs = 0
+  // Accumulated rather than derived from a window start: wall clock is the wrong
+  // denominator when the WebView freezes timers. A suspended hour produces no
+  // observations, and counting it as elapsed would report the active minutes that
+  // follow as a mostly-background window — excluding the one stretch that ran.
+  let observedMs = 0
+
+  /** Credit the time since the last observation, bounded by what was observed. */
+  function accrue(when: number): void {
+    const gap = when - since
+    since = when
+    if (!Number.isFinite(gap) || gap <= 0) return
+    // A gap past the sampling bound means nothing was watching. One step is
+    // claimed, because the app was demonstrably alive at both ends; the rest is
+    // unknown and is not invented in either direction.
+    const observed = Math.min(gap, MAX_GAP_MS)
+    observedMs += observed
+    if (current) visibleMs += observed
+  }
 
   return {
     note(next: boolean, when: number): void {
       if (next === current) return
-      if (current) visibleMs += when - since
+      accrue(when)
       current = next
-      since = when
+    },
+    sample(when: number): void {
+      accrue(when)
     },
     take(when: number): number {
-      if (current) visibleMs += when - since
-      const elapsed = when - windowStart
-      // A window with no elapsed time is fully whatever it currently is. Dividing
-      // would yield NaN, which the serializer rejects — costing the whole digest its
-      // environment over an arithmetic edge case at session start.
-      const share = elapsed > 0 ? visibleMs / elapsed : current ? 1 : 0
+      accrue(when)
+      // A window that observed nothing is fully whatever it currently is.
+      // Dividing would yield NaN, which the serializer rejects — costing the whole
+      // digest its environment over an arithmetic edge case at session start.
+      const share = observedMs > 0 ? visibleMs / observedMs : current ? 1 : 0
       visibleMs = 0
-      since = when
-      windowStart = when
+      observedMs = 0
       return share
     },
   }

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -388,14 +388,18 @@ export function install(): () => void {
     // The timed detectors. Started here rather than at module scope so it shares the
     // refcount: a StrictMode remount must not leave two intervals sampling, which
     // would double every verdict and turn the duplicate into a phantom suppression.
-    detectorTick = startDetectorTick(
-      browserWorld(
+    detectorTick = startDetectorTick({
+      ...browserWorld(
         readActiveConversation,
         readUnreadCount,
         () => getStorageScopeJid() ?? '',
         readWindowAtLiveEdge,
       ),
-    )
+      // The sampler is the only thing that can say the app was alive at a given
+      // instant. Wall clock cannot: the WebView freezes timers while hidden, so a
+      // suspended hour and an hour of use are indistinguishable afterwards.
+      onSample: (now) => foregroundShare.sample(now),
+    })
 
     digestTimer = setInterval(() => {
       foldRecountDeferrals(rec)


### PR DESCRIPTION
The WebView freezes timers while hidden, so an hour asleep produced no samples but still counted as elapsed. A session resumed after one reported roughly a 5/65 foreground share, the review excluded the window as background, and the only five minutes that ran anything were discarded — the one window with something to say.

Foreground is now accrued per observation, and a gap past the sampling bound contributes a single step: the app was demonstrably alive at both ends, and nothing is invented about the middle in either direction. That is the rule `unreadSurvivesFocus` already applies when its own sampling goes quiet.

The sampler reports each turn through a hook on the tick, because only its cadence can distinguish a suspended hour from an hour of use. Wall clock cannot tell them apart after the fact.

## Why not simply reset on resume

The obvious fix — restart the measurement when the document becomes visible — was tried first and rejected. It makes the share read 1 for any window in which the app resumed, which is nearly all of them, leaving the exclusion filter unable to exclude anything. Two existing tests caught it. Bounding the unobserved gap keeps an ordinary hidden stretch diluting the share, as it should, while refusing to charge a frozen hour against the minutes that followed.

An ordinary sampled gap is unaffected: the control asserting that a mixed window still reads 0.5 passes unchanged.