### PR TITLE
fix(scroll): re-arm follow-live from geometry when a re-pin has no owner

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -181,6 +181,19 @@ describe('MessageList — live-edge executor cost control', () => {
     expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight)
   })
 
+  it('re-pins late row growth after input pauses follow-live at the bottom', () => {
+    const isAtBottomRef = { current: true }
+    const { view, scroller } = renderWithLinkMessage(isAtBottomRef)
+
+    act(() => { scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true })) })
+    geo.scrollHeight += PREVIEW_CARD_PX
+    fastenPreview(view, isAtBottomRef)
+    flush(10)
+
+    expect(scrollToEndCalls.count).toBeGreaterThan(0)
+    expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight)
+  })
+
   it('re-pins when a virtual row reports growth after the original reaction pin has settled', () => {
     const isAtBottomRef = { current: true }
     const messages = makeMessages(50)

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -967,11 +967,13 @@ export function MessageList<T extends BaseMessage>({
           scrollport simply ends above it.
 
           Geometry is unchanged from the overlay: pt-2 above the pill + the footer's pb-2 inside the
-          scroller put ~16px between the last message and the pill, and pb-0.5 leaves it just off the
-          composer. Sizing the band from the pill (rather than a fixed height) keeps that true if the
-          pill's height changes, which is what lets the label take a second line: a crowded room or a
-          wordier locale wraps instead of being cut off (issue #1151). Two lines is the cap — beyond
-          that the band would take enough of the message area that clipping is the better trade.
+          scroller put ~16px between the last message and the pill whenever the scroller is at the
+          live edge — half that clearance lives in the scroll CONTENT, so it sits below the fold as
+          soon as it is not — and pb-0.5 leaves it just off the composer. Sizing the band from the
+          pill (rather than a fixed height) keeps that true if the pill's height changes, which is
+          what lets the label take a second line: a crowded room or a wordier locale wraps instead
+          of being cut off (issue #1151). Two lines is the cap — beyond that the band would take
+          enough of the message area that clipping is the better trade.
           max-w keeps it clear of the bottom-end FAB, which still floats at its own bottom-4 and so
           does not move when the band appears. */}
       {typingUsers.length > 0 && (

--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -180,9 +180,6 @@ describe('live message-list scroll ownership', () => {
 
   it('keeps viewport and container resize scheduling behind one dedicated hook', () => {
     expect(existsSync(viewportResizeHookPath)).toBe(true)
-    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('viewport-resize')")
-    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('container-shrink')")
-    expect(viewportResizeHookSource).toContain("reconcileLiveEdge('width-change')")
     expect(hookSource).not.toMatch(/\bnew ResizeObserver\b/)
     expect(hookSource).not.toMatch(/\brequestAnimationFrame\b/)
     expect(hookSource).not.toMatch(/addEventListener\(['"]resize['"]/)

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -694,6 +694,7 @@ describe('positioning controller live-edge ownership', () => {
     expect(controller.reconcileLiveEdge({
       conversationId,
       executor: second.executor,
+      rearmEligibleFromGeometry: true,
     })).toBe(true)
     expect(controller.snapshot().active?.request.generation).toBe(
       request.generation,
@@ -893,6 +894,173 @@ describe('positioning controller live-edge ownership', () => {
     expect(positionFrame).toHaveBeenCalledOnce()
     expect(complete).toHaveBeenCalledWith(request, 'settled')
     expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+  })
+
+  it('re-arms follow-live when an ambient stimulus finds a paused request at the bottom', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })!
+
+    // A wheel down at the resident bottom pauses the request and fires no scroll event, so the
+    // only carrier that could lift the pause never arrives.
+    controller.observeUserInput(conversationId)
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'paused-user-input',
+    })
+
+    const ambient = liveEdgeHarness()
+    expect(controller.reconcileLiveEdge({
+      conversationId,
+      executor: ambient.executor,
+      rearmEligibleFromGeometry: true,
+    })).toBe(true)
+
+    const active = controller.snapshot().active
+    expect(active?.request.source).toEqual({
+      kind: 'ambient-live-edge',
+      reason: 'geometry-rearm',
+    })
+    expect(active?.request.generation).toBeGreaterThan(request.generation)
+    expect(active?.phase.kind).not.toBe('paused-user-input')
+    expect(ambient.positionFrame).toHaveBeenCalled()
+  })
+
+  it.each([
+    ['row growth', 'paused-user-input'],
+    ['row growth', 'null-active'],
+    ['container shrink', 'paused-user-input'],
+    ['container shrink', 'null-active'],
+  ] as const)(
+    're-arms %s beyond the plain band from %s',
+    (stimulus, deadState) => {
+      const harness = liveEdgeHarness()
+      const controller = new PositioningController()
+      controller.beginLiveEdgeEntry({
+        conversationId,
+        entryFacts: liveEntryFacts(),
+        executor: harness.executor,
+      })
+      const generation = controller.observeUserInput(conversationId)
+      if (deadState === 'null-active') {
+        controller.observeSettledUserGeometry({
+          conversationId,
+          generation,
+          atLiveEdge: false,
+        })
+        expect(controller.snapshot().active).toBeNull()
+      } else {
+        expect(controller.snapshot().active?.phase).toEqual({
+          kind: 'paused-user-input',
+        })
+      }
+
+      const displacement = 200
+      const postChangeDistance = 200
+      const callerEligible = stimulus === 'row growth'
+        ? postChangeDistance - displacement < AT_BOTTOM_THRESHOLD
+        : postChangeDistance <= displacement + AT_BOTTOM_THRESHOLD
+      const ambient = liveEdgeHarness()
+
+      expect(controller.reconcileLiveEdge({
+        conversationId,
+        executor: ambient.executor,
+        rearmEligibleFromGeometry: callerEligible,
+      })).toBe(true)
+      expect(controller.snapshot().active?.request.source).toEqual({
+        kind: 'ambient-live-edge',
+        reason: 'geometry-rearm',
+      })
+    },
+  )
+
+  it('leaves a reader who moved off the bottom exactly where they are', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })!
+    controller.observeUserInput(conversationId)
+
+    // Same paused state, same ambient stimulus — only the caller's geometry verdict differs. A
+    // refused stimulus must not create a position the reader did not ask for.
+    const ambient = liveEdgeHarness()
+    expect(controller.reconcileLiveEdge({
+      conversationId,
+      executor: ambient.executor,
+      rearmEligibleFromGeometry: false,
+    })).toBe(false)
+
+    const active = controller.snapshot().active
+    expect(active?.request.generation).toBe(request.generation)
+    expect(active?.phase).toEqual({ kind: 'paused-user-input' })
+    expect(ambient.positionFrame).not.toHaveBeenCalled()
+  })
+
+  it('re-arms follow-live after user takeover cancelled the owner outright', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })
+    const generation = controller.observeUserInput(conversationId)
+    controller.observeSettledUserGeometry({
+      conversationId,
+      generation,
+      atLiveEdge: false,
+    })
+    expect(controller.snapshot().active).toBeNull()
+
+    // The reader scrolls back down by hand. A remeasure mid-gesture declassifies the scroll events,
+    // so nothing re-arms through the settle path; geometry is all that is left.
+    const ambient = liveEdgeHarness()
+    expect(controller.reconcileLiveEdge({
+      conversationId,
+      executor: ambient.executor,
+      rearmEligibleFromGeometry: true,
+    })).toBe(true)
+    expect(controller.snapshot().active?.request.desired).toEqual(liveEdge)
+  })
+
+  it('does not convert a settled anchor owner into a follow because geometry sits at the bottom', () => {
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const anchorExecutor: AnchorPreservationExecutor = {
+      reachability: () => ({
+        kind: 'available',
+        index: 4,
+        mounted: true,
+        placement: 'viable',
+      }),
+      beginLoop: vi.fn(() => null),
+      positionFrame: () => ({ kind: 'positioned', scrollTop: 420, reassert: false }),
+      complete: vi.fn(),
+    }
+    controller.beginMediaPreservation({
+      conversationId,
+      desired: {
+        kind: 'anchor',
+        messageId: 'message-4',
+        placement: { kind: 'bottom-fraction', fraction: messageFraction(0.4) },
+      },
+      executor: anchorExecutor,
+    })
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+
+    const ambient = liveEdgeHarness()
+    expect(controller.reconcileLiveEdge({
+      conversationId,
+      executor: ambient.executor,
+      rearmEligibleFromGeometry: true,
+    })).toBe(false)
+    expect(controller.snapshot().active?.request.desired.kind).toBe('anchor')
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -9,6 +9,7 @@ import {
   selectEntryPosition,
   selectLiveEdgeNavigation,
   settleUserPosition,
+  shouldRearmLiveEdgeFromGeometry,
   shouldReconcileAfterAppend,
   type AnchorPreservationRequest,
   type DirectionalHistoryRequest,
@@ -796,12 +797,14 @@ export class PositioningController {
   }
 
   /**
-   * Re-open bottom reconciliation for appended or remeasured content without minting a competing
-   * request. The current live-edge generation remains the sole follow-live owner.
+   * Re-open bottom reconciliation for appended or remeasured content. The current live-edge
+   * generation stays the sole follow-live owner; only an eligible dead follow with no owner left
+   * to re-open mints a fresh one — see {@link rearmLiveEdgeFromGeometry}.
    */
   reconcileLiveEdge(input: {
     conversationId: string
     executor: LiveEdgeExecutor
+    rearmEligibleFromGeometry: boolean
   }): boolean {
     return runScrollShadowSafely({
       event: 'live-edge-reconcile',
@@ -809,7 +812,11 @@ export class PositioningController {
       fallback: false,
       observe: () => {
         if (!shouldReconcileAfterAppend(this.model, input.conversationId)) {
-          return false
+          return this.rearmLiveEdgeFromGeometry(
+            input.conversationId,
+            input.executor,
+            input.rearmEligibleFromGeometry,
+          )
         }
         const active = this.model.active
         if (!active || active.request.desired.kind !== 'live-edge') return false
@@ -841,6 +848,26 @@ export class PositioningController {
         return true
       },
     })
+  }
+
+  /**
+   * Re-opening needs an owner to re-open. When there is none, an ambient stimulus may still re-arm
+   * follow-live only when the caller's own live geometry guard remains eligible. The ordinary
+   * re-open path and geometry recovery therefore use the same stimulus-aware verdict, including any
+   * row growth or viewport shrink already present in the post-change distance.
+   */
+  private rearmLiveEdgeFromGeometry(
+    conversationId: string,
+    executor: LiveEdgeExecutor,
+    rearmEligibleFromGeometry: boolean,
+  ): boolean {
+    if (!shouldRearmLiveEdgeFromGeometry(this.model, conversationId)) return false
+    if (!rearmEligibleFromGeometry) return false
+    return this.acceptLiveEdgeRequest(
+      conversationId,
+      { kind: 'ambient-live-edge', reason: 'geometry-rearm' },
+      executor,
+    ) !== null
   }
 
   refreshLiveEdge(input: {

--- a/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
@@ -12,6 +12,7 @@ import {
   selectEntryPosition,
   selectLiveEdgeNavigation,
   settleUserPosition,
+  shouldRearmLiveEdgeFromGeometry,
   shouldReconcileAfterAppend,
   type BottomFractionAnchorPosition,
   type PixelOffset,
@@ -89,6 +90,15 @@ function outgoingMessage(generation: number): PositionRequest {
     generation,
     conversationId,
     source: { kind: 'live-update', reason: 'outgoing-message' },
+    desired: liveEdge,
+  }
+}
+
+function ambientRearm(generation: number): PositionRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'ambient-live-edge', reason: 'geometry-rearm' },
     desired: liveEdge,
   }
 }
@@ -210,6 +220,42 @@ describe('scroll position model', () => {
     expect(shouldReconcileAfterAppend(model, conversationId)).toBe(false)
   })
 
+  it('re-arms follow-live only from a state no scroll event can resolve', () => {
+    const live = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    // An armed follow already has an owner: the ordinary re-open path handles it, and re-arming
+    // would mint a competing generation for nothing.
+    expect(shouldReconcileAfterAppend(live, conversationId)).toBe(true)
+    expect(shouldRearmLiveEdgeFromGeometry(live, conversationId)).toBe(false)
+
+    // Dead state one: a wheel that cannot move the scroller pauses the request, and the scroll
+    // event that would resolve the pause never fires.
+    const paused = cancelReconciliationForUserInput(live, conversationId, 1)
+    expect(shouldReconcileAfterAppend(paused, conversationId)).toBe(false)
+    expect(shouldRearmLiveEdgeFromGeometry(paused, conversationId)).toBe(true)
+
+    // Dead state two: leaving the edge drops the owner outright, so a manual return has nothing
+    // left to re-open.
+    const left = settleUserPosition(paused, conversationId, 1, false)
+    expect(left.active).toBeNull()
+    expect(shouldRearmLiveEdgeFromGeometry(left, conversationId)).toBe(true)
+
+    // Ownership stays per-conversation: a stimulus in another room re-arms nothing here.
+    expect(shouldRearmLiveEdgeFromGeometry(left, otherConversationId)).toBe(false)
+  })
+
+  it('never turns a fixed reading position into a follow, settled or not', () => {
+    const navigating = acceptPositionRequest(
+      acceptPositionRequest(initialPositioningModel(), liveEntry(1)),
+      explicitMessage(2),
+    )
+    expect(shouldRearmLiveEdgeFromGeometry(navigating, conversationId)).toBe(false)
+
+    const settled = advancePhaseIfCurrent(navigating, conversationId, 2, {
+      kind: 'settled',
+    })
+    expect(shouldRearmLiveEdgeFromGeometry(settled, conversationId)).toBe(false)
+  })
+
   it('does not let ambient divider preservation supersede an in-flight user navigation', () => {
     const entered = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
     const navigating = acceptPositionRequest(entered, explicitMessage(2))
@@ -246,7 +292,7 @@ describe('scroll position model', () => {
       { kind: 'reconciling' },
       { kind: 'position-applied' },
     ]
-    const ambientRequests = [mediaPreservation(3), windowShift(3)]
+    const ambientRequests = [mediaPreservation(3), windowShift(3), ambientRearm(3)]
 
     unsettledPhases.forEach((phase) => {
       const navigating = advancePhaseIfCurrent(

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -155,6 +155,10 @@ export type PositionRequest =
   | UserNavigationRequest
   | Request<{ kind: 'live-update'; reason: 'outgoing-message' }, LiveEdgePosition>
   | Request<
+      { kind: 'ambient-live-edge'; reason: 'geometry-rearm' },
+      LiveEdgePosition
+    >
+  | Request<
       { kind: 'history-preservation'; reason: 'window-shift' },
       TopOffsetAnchorPosition,
       Extract<UnavailablePolicy, { kind: 'distance-from-bottom' }>
@@ -449,6 +453,12 @@ const REQUEST_PRECEDENCE: Record<PositionRequestSource['kind'], RequestPrecedenc
    * by the `preservationPending` rule below.
    */
   'live-update': 'supersedes',
+  /**
+   * An ambient stimulus re-asserting follow-live from live geometry alone. Same class as the other
+   * ambient corrections: it stands aside for an explicit navigation, but a live-edge follow is a
+   * policy it may re-assert. See {@link shouldRearmLiveEdgeFromGeometry}.
+   */
+  'ambient-live-edge': 'yields-to-navigation',
   /**
    * Divider movement and mid-array insertion: layout changes ABOVE the reader that nobody asked
    * for. Strictest class — see `LayoutPreservationReason`.
@@ -853,5 +863,26 @@ export function shouldReconcileAfterAppend(
     model.currentConversationId === conversationId &&
     model.active?.request.desired.kind === 'live-edge' &&
     model.active.phase.kind !== 'paused-user-input'
+  )
+}
+
+/**
+ * A refused re-open may re-arm follow-live only when there is no active request or the live-edge
+ * request is paused for user input. The caller separately owns stimulus-aware geometry eligibility,
+ * including any displacement already present in the post-change distance.
+ *
+ * A request whose desired position is NOT the live edge is excluded even when settled: that is a
+ * reading position somebody asked for, and ambient geometry cannot replace it with a follow.
+ */
+export function shouldRearmLiveEdgeFromGeometry(
+  model: PositioningModel,
+  conversationId: string,
+): boolean {
+  if (model.currentConversationId !== conversationId) return false
+  const active = model.active
+  if (active === null) return true
+  return (
+    active.request.desired.kind === 'live-edge' &&
+    active.phase.kind === 'paused-user-input'
   )
 }

--- a/apps/fluux/src/components/conversation/useMediaGrowthPreservation.ts
+++ b/apps/fluux/src/components/conversation/useMediaGrowthPreservation.ts
@@ -33,7 +33,7 @@ interface MediaBatchSnapshot {
 export interface MediaGrowthPorts {
   getScroller: () => HTMLElement | null
   isAtBottom: () => boolean
-  reconcileLiveEdge: (trigger: string) => void
+  reconcileLiveEdge: (trigger: string, rearmEligibleFromGeometry: boolean) => void
   beginMediaPreservation: (input: {
     conversationId: string
     desired: AnchorPreservationRequest['desired']
@@ -154,7 +154,7 @@ export function useMediaGrowthPreservation({
           userScrolled,
           scrollHeight: currentScroller.scrollHeight,
         })
-        settled.reconcileLiveEdge('media-load')
+        settled.reconcileLiveEdge('media-load', wasAtBottom && !userScrolled)
       } else if (outcome.kind === 'preserve-anchor' && anchor) {
         // Media that decoded ABOVE the viewport grew the content and pushed the reading position
         // down. Re-pin to the anchor captured BEFORE the growth so the reader stays put. Mirrors

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -420,7 +420,10 @@ export function useMessageListScroll({
       observe: () => new PositioningController(),
     })
   }
-  const reconcileLiveEdgeRef = useRef<(trigger: string) => boolean>(
+  const reconcileLiveEdgeRef = useRef<(
+    trigger: string,
+    rearmEligibleFromGeometry: boolean,
+  ) => boolean>(
     () => false,
   )
   // The resident window as it is NOW, for reachability probes that run outside the render that
@@ -590,12 +593,16 @@ export function useMessageListScroll({
     rememberCurrentScrollSnapshot,
   })
 
-  const reconcileLiveEdge = useCallback((trigger: string): boolean => {
+  const reconcileLiveEdge = useCallback((
+    trigger: string,
+    rearmEligibleFromGeometry: boolean,
+  ): boolean => {
     const controller = positioningControllerRef.current
     if (!controller) return false
     return controller.reconcileLiveEdge({
       conversationId,
       executor: createLiveEdgeExecutor(trigger),
+      rearmEligibleFromGeometry,
     })
   }, [conversationId, createLiveEdgeExecutor])
   reconcileLiveEdgeRef.current = reconcileLiveEdge
@@ -622,7 +629,7 @@ export function useMessageListScroll({
         active.phase.kind !== 'settled',
       ),
     })
-    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth', true)
   }
 
   const handleVirtualRowMeasuredGrowth = useCallback((
@@ -867,7 +874,9 @@ export function useMessageListScroll({
     ports: {
       getScroller: () => scrollerRef.current,
       isAtBottom: () => isAtBottomRef.current,
-      reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
+      reconcileLiveEdge: (trigger, rearmEligibleFromGeometry) => {
+        reconcileLiveEdgeRef.current(trigger, rearmEligibleFromGeometry)
+      },
       beginMediaPreservation: (input) =>
         positioningControllerRef.current?.beginMediaPreservation(input),
       log: debugLog,
@@ -898,7 +907,9 @@ export function useMessageListScroll({
     isDirectionalHistoryPending: (id) =>
       positioningControllerRef.current?.isDirectionalHistoryPending(id) ?? false,
     isMediaLoadBatchActive: isMediaBatchActive,
-    reconcileLiveEdge: (trigger) => { reconcileLiveEdgeRef.current(trigger) },
+    reconcileLiveEdge: (trigger, rearmEligibleFromGeometry) => {
+      reconcileLiveEdgeRef.current(trigger, rearmEligibleFromGeometry)
+    },
     recordUserInput: (id, at) =>
       viewportSessionRef.current?.recordUserInput(id, at),
     observeUserInput: (id) =>
@@ -910,8 +921,8 @@ export function useMessageListScroll({
     ports: {
       getScroller: () => scrollerRef.current,
       isAtBottom: () => isAtBottomRef.current,
-      reconcileLiveEdge: (trigger) => {
-        reconcileLiveEdgeRef.current(trigger)
+      reconcileLiveEdge: (trigger, rearmEligibleFromGeometry) => {
+        reconcileLiveEdgeRef.current(trigger, rearmEligibleFromGeometry)
       },
     },
     conversationId,
@@ -1783,7 +1794,7 @@ export function useMessageListScroll({
         })
         if (!request) emergencyLiveEdgeWrite()
       } else {
-        reconcileLiveEdge('new-message')
+        reconcileLiveEdge('new-message', isAtBottomRef.current)
       }
       debugLog('NEW MSG SCROLL TO BOTTOM', {
         messageCount,
@@ -1853,7 +1864,7 @@ export function useMessageListScroll({
     const wasLoading = prevIsLoadingOlderRef.current
     prevIsLoadingOlderRef.current = isLoadingOlder
     if (wasLoading && !isLoadingOlder && isAtBottomRef.current && !staticMode) {
-      reconcileLiveEdge('mam-catchup-complete')
+      reconcileLiveEdge('mam-catchup-complete', isAtBottomRef.current)
     }
   }, [isLoadingOlder, isAtBottomRef, reconcileLiveEdge, staticMode])
 
@@ -1947,7 +1958,7 @@ export function useMessageListScroll({
         active.phase.kind !== 'settled',
       ),
     })
-    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth', true)
   }, [rowGrowthSignature, conversationId, staticMode])
 
   // ==========================================================================
@@ -1984,7 +1995,7 @@ export function useMessageListScroll({
     })
     if (decision === 'skip') return
 
-    reconcileLiveEdge('typing')
+    reconcileLiveEdge('typing', decision === 'pin')
   }, [hasTypingIndicator, conversationId, reconcileLiveEdge, staticMode])
 
   // ==========================================================================

--- a/apps/fluux/src/components/conversation/useScrollContainerBinding.test.ts
+++ b/apps/fluux/src/components/conversation/useScrollContainerBinding.test.ts
@@ -193,7 +193,7 @@ describe('useScrollContainerBinding growth correction', () => {
     scope.scroller.grow(1_400)
     observers[0].fire()
     flushFrames()
-    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('content-growth')
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('content-growth', true)
   })
 
   it('coalesces a burst of observer fires into a single correction frame', () => {

--- a/apps/fluux/src/components/conversation/useScrollContainerBinding.ts
+++ b/apps/fluux/src/components/conversation/useScrollContainerBinding.ts
@@ -43,7 +43,7 @@ export interface ScrollContainerBindingPorts {
   getLoggedConversationId: () => string
   isDirectionalHistoryPending: (conversationId: string) => boolean
   isMediaLoadBatchActive: () => boolean
-  reconcileLiveEdge: (trigger: string) => void
+  reconcileLiveEdge: (trigger: string, rearmEligibleFromGeometry: boolean) => void
   recordUserInput: (conversationId: string, at: number) => void
   observeUserInput: (conversationId: string) => void
   log: (action: string, data?: Record<string, unknown>) => void
@@ -199,7 +199,7 @@ export function useScrollContainerBinding(
             isAtBottom: atBottom,
             scrollTopBefore: currentScrollTop,
           })
-          portsRef.current.reconcileLiveEdge('content-growth')
+          portsRef.current.reconcileLiveEdge('content-growth', atBottom)
         } else if (newHeight !== lastHeight) {
           portsRef.current.log('RESIZE NO SCROLL', {
             newHeight,

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
@@ -132,8 +132,8 @@ describe('useViewportResizeReconciliation', () => {
     scope.state.atBottom = true
     window.dispatchEvent(new Event('resize'))
     visualViewport.dispatchEvent(new Event('resize'))
-    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(1, 'viewport-resize')
-    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(2, 'viewport-resize')
+    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(1, 'viewport-resize', true)
+    expect(scope.reconcileLiveEdge).toHaveBeenNthCalledWith(2, 'viewport-resize', true)
 
     scope.unmount()
     window.dispatchEvent(new Event('resize'))
@@ -148,23 +148,23 @@ describe('useViewportResizeReconciliation', () => {
     expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
   })
 
-  it('coalesces height observations and requests container-shrink after the frame', () => {
+  it('carries container-shrink eligibility beyond the plain at-bottom band', () => {
     const scope = mount()
     expect(observers).toHaveLength(1)
     expect(observers[0].target).toBe(scope.scroller.element)
 
     observers[0].fire(600, 800)
     flushFrames()
-    scope.scroller.geometry.clientHeight = 480
-    scope.scroller.geometry.scrollTop = 390
-    observers[0].fire(500, 800)
-    observers[0].fire(480, 800)
+    scope.scroller.geometry.clientHeight = 400
+    scope.scroller.geometry.scrollTop = 400
+    observers[0].fire(450, 800)
+    observers[0].fire(400, 800)
 
     expect(frames).toHaveLength(1)
     expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
     flushFrames()
     expect(scope.reconcileLiveEdge).toHaveBeenCalledOnce()
-    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink')
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink', true)
   })
 
   it('requests width-change only when the reader remains at the live edge', () => {
@@ -174,7 +174,7 @@ describe('useViewportResizeReconciliation', () => {
 
     observers[0].fire(600, 700)
     flushFrames()
-    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('width-change')
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('width-change', true)
 
     scope.reconcileLiveEdge.mockClear()
     scope.state.atBottom = false

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
@@ -20,7 +20,10 @@ export type ViewportResizeReconciliationTrigger =
 export interface ViewportResizeReconciliationPorts {
   getScroller: () => HTMLDivElement | null
   isAtBottom: () => boolean
-  reconcileLiveEdge: (trigger: ViewportResizeReconciliationTrigger) => void
+  reconcileLiveEdge: (
+    trigger: ViewportResizeReconciliationTrigger,
+    rearmEligibleFromGeometry: boolean,
+  ) => void
 }
 
 export interface UseViewportResizeReconciliationInput {
@@ -46,7 +49,8 @@ export function useViewportResizeReconciliation({
     if (staticMode) return
     const onViewportResize = () => {
       const active = portsRef.current
-      if (active.isAtBottom()) active.reconcileLiveEdge('viewport-resize')
+      const atBottom = active.isAtBottom()
+      if (atBottom) active.reconcileLiveEdge('viewport-resize', atBottom)
     }
     window.addEventListener('resize', onViewportResize)
     const visualViewport = window.visualViewport
@@ -93,7 +97,7 @@ export function useViewportResizeReconciliation({
         const distance = distanceFromBottom(liveScroller)
         const wasNear = distance <= shrunk + AT_BOTTOM_THRESHOLD
         if (wasNear && distance > BOTTOM_PIN_TOLERANCE) {
-          active.reconcileLiveEdge('container-shrink')
+          active.reconcileLiveEdge('container-shrink', wasNear)
         }
       } else if (
         newWidth !== null &&
@@ -102,7 +106,7 @@ export function useViewportResizeReconciliation({
         liveScroller &&
         active.isAtBottom()
       ) {
-        active.reconcileLiveEdge('width-change')
+        active.reconcileLiveEdge('width-change', true)
       }
 
       lastHeight = newHeight

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -220,6 +220,8 @@ Sources distinguish:
   adapter to discard obsolete saved state;
 - explicit user navigation;
 - an outgoing message that deliberately returns the sender to live edge;
+- ambient live-edge recovery when a reconciliation stimulus remains eligible but has no live-edge
+  owner to re-open;
 - directional history preservation;
 - media remeasurement preservation;
 - ambient layout preservation when the unread divider moves or a delayed live-path message is
@@ -227,14 +229,16 @@ Sources distinguish:
 - late XEP-0490/MDS supersession.
 
 Incoming messages at the resident live edge, reactions, typing, composer/container/viewport resize,
-media measurement, and MAM completion are normally **reconciliation stimuli for the current
-request**, not new competing requests. A delayed live-path message placed inside the resident
-window is the ambient-layout exception described above. An outgoing send is different: current
-behavior deliberately moves a reader out of history, so it creates a live-edge request. The attempt
-is dropped while a directional-load or entry-restore preservation step is still pending, matching
-the existing send-stick suppression; the preservation owner releases after its first position is
-applied, not after the entire measurement-settle loop. Later ordinary stimuli handle content from
-any dropped attempt.
+media measurement, and MAM completion normally reconcile the current request. When there is no
+live-edge owner to re-open, an otherwise eligible stimulus may instead create an ambient live-edge
+request from its own stimulus-aware geometry verdict. It may recover only a paused live-edge or null
+active state; it never converts a fixed reading position into follow-live. A delayed live-path
+message placed inside the resident window is the ambient-layout exception described above. An
+outgoing send is different: current behavior deliberately moves a reader out of history, so it
+creates a live-edge request. The attempt is dropped while a directional-load or entry-restore
+preservation step is still pending, matching the existing send-stick suppression; the preservation
+owner releases after its first position is applied, not after the entire measurement-settle loop.
+Later ordinary stimuli handle content from any dropped attempt.
 
 ## Entry arbitration and later supersession
 
@@ -265,17 +269,21 @@ Request precedence is classified exhaustively by source. Layout preservation is 
 ambient class: it yields to every unsettled position, including live-edge follow. Media and
 directional-history preservation yield while a non-live-edge reader-intent position is still
 converging, but may re-anchor an unsettled live-edge follow because following the bottom is a policy,
-not a destination the reader is waiting to reach. Unknown future sources default to the strictest
-class until deliberately classified. An outgoing-message live-edge request is the deliberate
-exception: sending is reader intent and may supersede an in-flight navigation, subject to the
-unfinished restore or history-preservation ownership rule above.
+not a destination the reader is waiting to reach. Ambient live-edge recovery uses that same
+`yields-to-navigation` class. Unknown future sources default to the strictest class until
+deliberately classified. An outgoing-message live-edge request is the deliberate exception: sending
+is reader intent and may supersede an in-flight navigation, subject to the unfinished restore or
+history-preservation ownership rule above.
 
 User input and follow-live are separate facts. Genuine input cancels the current reconciliation
 run immediately. A live-edge request retains its generation in a paused-user-input phase until
 settled geometry shows whether the reader left the edge; stale callbacks cannot resume that pause.
 Input that remains within the bottom threshold settles the same request and keeps following.
 Manually returning to the bottom after another position was cancelled creates a fresh
-generation-bearing live-edge request without reopening late-MDS eligibility.
+generation-bearing live-edge request without reopening late-MDS eligibility. An ambient stimulus
+may also mint a fresh generation from a paused or null state, but only when the caller's existing
+geometry guard says the same stimulus is eligible for ordinary live-edge reconciliation. This keeps
+the verdict displacement-aware for row growth and viewport shrink.
 
 When the message list unmounts or navigation leaves conversations, a generation-guarded deactivation
 clears the current conversation, active request, and MDS eligibility while retaining the watermark.
@@ -370,15 +378,15 @@ abort valid deep growth and media-settle runs.
 | Jump-to-last-read | Message at start | Reuses unread-marker placement |
 | FAB or live-edge keyboard command | Unread marker, then live edge | If the marker is still below the viewport, first activation visits it (virtualized start alignment; current non-virtualized path uses top-third); a later activation goes live |
 | Outgoing message | Live edge | Deliberately supersedes a fixed historical position after its first landing releases preservation ownership; it need not wait for full convergence |
-| Incoming message at the resident live edge | Existing live edge only | Must not make a fixed anchor follow |
+| Incoming message at the resident live edge | Current or geometry-rearmed live edge | Must not make a fixed anchor follow; recovery is limited to paused/null ownership and the caller's geometry guard |
 | Delayed live-path message inserted inside the resident window while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; subject to ambient request precedence above |
 | Late MDS live-edge state | Live edge | Newer automatic request only before user takeover |
-| Media at live edge | Existing live edge | Debounced measurement stimulus |
+| Media at live edge | Current or geometry-rearmed live edge | Debounced measurement stimulus; recovery uses the pre-growth eligibility captured by the caller |
 | Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement; subject to ambient request precedence above |
 | Unread divider moves while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; subject to ambient request precedence above |
 | Load older/newer | Fixed top-relative offset anchor | Subject to ambient request precedence above; wait for the directional window change and release if the load settles without one; if the anchor disappears after a shift, preserve captured distance from bottom and clamp |
 | Home / resident-top command | Resident top | Does not itself trigger load-older; later genuine user travel can re-arm ordinary boundary loading |
-| Reaction, typing, resize, MAM completion | Current live edge, when active | Geometry stimulus, not a new position request |
+| Reaction, typing, resize, MAM completion | Current or geometry-rearmed live edge | Normally a reconciliation stimulus; an eligible paused/null state creates an ambient live-edge request that yields to navigation |
 
 The FAB/End choice is made from current geometry, not a remembered click state. If the unread marker
 is already visible or above the viewport, the same activation goes directly to live edge.

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1878,6 +1878,214 @@ test.describe('At-bottom stick diagnostic (1:1)', () => {
   })
 })
 
+// ── Ambient re-pin re-arms follow-live from GEOMETRY, not from a scroll event ─────────────────
+// Two ordinary gestures pause follow-live and then produce no scroll event able to resolve the
+// pause: wheeling DOWN while already at the resident bottom (the scroller cannot move, and
+// `overscroll-contain` blocks chaining), and a manual return whose scroll events a concurrent row
+// remeasure declassifies. Every ambient re-pin — typing band, container shrink, late row growth,
+// incoming message — shares one gate, so from those states all four are refused and the view falls
+// behind by the band height plus one row per unfollowed message. Every other wheel gesture in this
+// file scrolls UP, which is exactly why none of them covered this.
+test.describe('Ambient re-pin re-arms follow-live from geometry', () => {
+  /**
+   * "Still glued to the bottom", not merely "near" it: BOTTOM_PIN_TOLERANCE is what a converged pin
+   * run leaves. Asserting at the band instead (AT_BOTTOM_OK_PX is 150) would pass on the defect,
+   * whose whole signature is a 40px typing band and ~42px per unfollowed message.
+   */
+  const PIN_TOLERANCE_PX = 4
+  /**
+   * How far the held reading position may drift while ambient stimuli fire around it. Two orders of
+   * magnitude below the ~800px a wrongful re-pin would move it, so it still falsifies one.
+   */
+  const HELD_POSITION_PX = 24
+
+  async function hoverList(page: Page): Promise<void> {
+    const box = await page.locator('[data-message-list]').first().boundingBox()
+    if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  }
+
+  async function readGeometry(page: Page): Promise<{ scrollTop: number; distFromBottom: number }> {
+    return page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { scrollTop: -1, distFromBottom: -1 }
+      return {
+        scrollTop: Math.round(s.scrollTop),
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      }
+    })
+  }
+
+  async function setTyping(page: Page, isTyping: boolean): Promise<void> {
+    await page.evaluate(([jid, on]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      if (!c) throw new Error('no __demoClient')
+      c.emitSDK('room:typing', { roomJid: jid as string, nick: 'U0_1', isTyping: on as boolean })
+    }, [STRESS_ROOM_JID, isTyping] as const)
+  }
+
+  /**
+   * `awaitRow` only for a reader at the edge: a scrolled-up reader never mounts the new tail row,
+   * so waiting for it there would time out on correct behaviour.
+   */
+  async function emitRoomMessage(page: Page, id: string, awaitRow = true): Promise<void> {
+    await page.evaluate(([jid, msgId]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      if (!c) throw new Error('no __demoClient')
+      c.emitSDK('room:message', {
+        roomJid: jid as string,
+        isLiveArrival: true,
+        message: {
+          type: 'groupchat', id: msgId as string, from: `${jid}/U0_1`, nick: 'U0_1',
+          body: `live arrival ${msgId} — the view must follow it`,
+          timestamp: new Date(), isOutgoing: false,
+          roomJid: jid as string, stanzaId: `sid-${msgId}`,
+        },
+      })
+    }, [STRESS_ROOM_JID, id] as const)
+    if (awaitRow) await page.waitForSelector(`[data-message-id="${id}"]`, { timeout: 5_000 })
+  }
+
+  /** Enter the stress room and take the live edge the way a reader does, then hover the list. */
+  async function enterAtBottom(page: Page): Promise<void> {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+    await page.keyboard.press('End')
+    await page.waitForTimeout(SETTLE_MS)
+    await hoverList(page)
+    expect(
+      (await readGeometry(page)).distFromBottom,
+      'precondition: the reader starts glued to the live edge',
+    ).toBeLessThanOrEqual(PIN_TOLERANCE_PX)
+  }
+
+  test('a wheel DOWN at the bottom still lets the typing band hold the view at the edge', async ({ page }) => {
+    await enterAtBottom(page)
+
+    // A trusted wheel that cannot move anything. It pauses follow-live and fires no scroll event.
+    await page.mouse.wheel(0, 120)
+    await page.waitForTimeout(SETTLE_MS)
+
+    await setTyping(page, true)
+    await page.waitForSelector('[data-typing-pill]', { timeout: 5_000 })
+    await page.waitForTimeout(SETTLE_MS)
+
+    const after = await readGeometry(page)
+    expect(
+      after.distFromBottom,
+      'the typing band shrank the scrollport and the view did not follow it back to the edge',
+    ).toBeLessThanOrEqual(PIN_TOLERANCE_PX)
+  })
+
+  test('a manual return to the bottom still follows incoming messages', async ({ page }) => {
+    await enterAtBottom(page)
+
+    // Up, then a decaying burst back down — the trackpad shape. The virtualizer remeasures rows
+    // during the return, which declassifies its scroll events, so the return re-arms nothing.
+    await page.mouse.wheel(0, -400)
+    await page.waitForTimeout(120)
+    for (const delta of [200, 160, 120, 90, 60, 40, 25, 15, 8, 4]) {
+      await page.mouse.wheel(0, delta)
+      await page.waitForTimeout(16)
+    }
+    await page.waitForTimeout(SETTLE_MS)
+    expect(
+      (await readGeometry(page)).distFromBottom,
+      'precondition: the reader is back at the bottom by hand',
+    ).toBeLessThanOrEqual(PIN_TOLERANCE_PX)
+
+    let lastId = ''
+    for (let index = 0; index < 3; index += 1) {
+      lastId = `ambient-rearm-${Date.now()}-${index}`
+      await emitRoomMessage(page, lastId)
+      await page.waitForTimeout(400)
+    }
+
+    const after = await readGeometry(page)
+    expect(
+      after.distFromBottom,
+      'the view stopped following incoming messages after a manual return to the bottom',
+    ).toBeLessThanOrEqual(PIN_TOLERANCE_PX)
+    expect(
+      await page.evaluate((id) => {
+        const s = document.querySelector('[data-message-list]') as HTMLElement | null
+        const el = s?.querySelector(`[data-message-id="${CSS.escape(id)}"]`) as HTMLElement | null
+        if (!s || !el) return false
+        const sr = s.getBoundingClientRect()
+        const r = el.getBoundingClientRect()
+        return r.bottom <= sr.bottom + 2 && r.top >= sr.top - 5
+      }, lastId),
+      'the newest message is not fully visible at the bottom',
+    ).toBe(true)
+  })
+
+  test('deliberately re-pins a reader who stopped INSIDE the at-bottom band', async ({ page }) => {
+    // The permissive half of the boundary, pinned on purpose: a reader who stopped ~100px up is
+    // inside the at-bottom band and IS brought back. Every ordinary ambient re-pin already treats
+    // them that way. Recovery receives that same caller-owned geometry verdict, so the outcome
+    // cannot depend on whether the generation happens to be alive.
+    //
+    // What this test can and cannot see: the small move up here settles the pause at a distance
+    // still inside the band, so the LIVE path serves it. Caller-facing and controller unit tests
+    // cover delivery of that same verdict to dead-state recovery. This test fixes the user-visible
+    // half: at this distance the view returns to the bottom, by whichever path owns it. Being
+    // carried back from 100px is the intent; being carried back from a real reading position is not,
+    // which is what CLEAR_OF_BOTTOM_PX guards below.
+    const NEAR_OFFSET_PX = 100
+
+    await enterAtBottom(page)
+
+    // The dead state first: a wheel down that cannot move anything, then a small deliberate move up
+    // that leaves the reader inside the band.
+    await page.mouse.wheel(0, 120)
+    await page.waitForTimeout(300)
+    await page.mouse.wheel(0, -NEAR_OFFSET_PX)
+    await page.waitForTimeout(SETTLE_MS)
+    const before = await readGeometry(page)
+    expect(
+      before.distFromBottom,
+      'precondition: the reader is off the edge but still inside the at-bottom band',
+    ).toBeGreaterThan(PIN_TOLERANCE_PX)
+    expect(before.distFromBottom, 'precondition: inside the band').toBeLessThan(AT_BOTTOM_OK_PX)
+
+    await setTyping(page, true)
+    await page.waitForSelector('[data-typing-pill]', { timeout: 5_000 })
+    await page.waitForTimeout(SETTLE_MS)
+
+    expect(
+      (await readGeometry(page)).distFromBottom,
+      'a reader inside the band must be re-pinned, exactly as an armed follow already is',
+    ).toBeLessThanOrEqual(PIN_TOLERANCE_PX)
+  })
+
+  test('never re-pins a reader who deliberately scrolled up', async ({ page }) => {
+    await enterAtBottom(page)
+
+    await page.mouse.wheel(0, -2500)
+    await page.waitForTimeout(SETTLE_MS)
+    const before = await readGeometry(page)
+    expect(
+      before.distFromBottom,
+      'precondition: the reader is clear of the bottom band',
+    ).toBeGreaterThan(CLEAR_OF_BOTTOM_PX)
+
+    // Every ambient stimulus at once. None of them may infer intent from a reader who left.
+    await setTyping(page, true)
+    await page.waitForSelector('[data-typing-pill]', { timeout: 5_000 })
+    await page.waitForTimeout(300)
+    await emitRoomMessage(page, `stay-put-${Date.now()}`, false)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const after = await readGeometry(page)
+    expect(
+      Math.abs(after.scrollTop - before.scrollTop),
+      'a scrolled-up reader was dragged by an ambient re-pin',
+    ).toBeLessThanOrEqual(HELD_POSITION_PX)
+    expect(after.distFromBottom).toBeGreaterThan(CLEAR_OF_BOTTOM_PX)
+  })
+})
+
 // ── DIAGNOSTIC: send sticks to the bottom even when the optimistic row is reconciled ────────────
 // Regression for the overlay/content-coordinate mismatch documented beside the typing band in
 // MessageList. In the old layout a 30px pill had only 16px clearance at the exact bottom, and a


### PR DESCRIPTION
An active conversation silently stops following the bottom. The typing band is the most visible symptom — the last line of the last message is cut mid-glyph — but it is only the revealer: incoming messages go unshown too, about 40px for the band and ~42px per unfollowed message, staying below the 300px threshold that would show the jump-to-bottom button. Nothing expires it.

## Cause

Every ambient re-pin — typing band, container shrink, late row growth, incoming message — calls `reconcileLiveEdge`, which only RE-OPENS the current live-edge generation. There is nothing to re-open when that generation is paused or gone, and both states are reachable through ordinary gestures that produce no scroll event able to resolve them: wheeling down while already at the resident bottom (the scroller cannot move, and overscroll containment blocks chaining), and a manual return to the bottom whose scroll events a concurrent row remeasure declassifies. The paths that work — outgoing send, jump-to-bottom, End — all strike a *new* generation instead.

## Fix

When the re-open predicate refuses, an ambient stimulus may now mint a fresh live-edge request, under a new `ambient-live-edge` request class with `yields-to-navigation` precedence. That is the class whose existing documentation already described this case: it stands aside for an explicit navigation, but a live-edge follow is a policy it may re-assert. Recovery is restricted to the two dead states and never converts a reading position somebody asked for into a follow.

## On the threshold — for anyone who read the investigation

The investigation recommended gating recovery on the narrow pin tolerance (4px) rather than the at-bottom band. That was implemented first and measured: both regression cases still failed, at exactly 40px and 172px. Every ambient re-pin runs *after* the change it corrects, so a reader who never moved measures exactly the displacement being corrected, never zero; a pin-tolerance gate refuses every stimulus it exists to serve.

The first version replaced it with a fixed at-bottom band, arguing that recovery would then behave exactly like the ordinary path. Review showed that argument was only half true, and the PR now carries the correction. The existing ambient guards are stimulus-aware — `decideRowGrowth` subtracts the growth from the measured distance, and the container-shrink net compares against the shrink plus the band — so a fixed band refuses displacements larger than itself. A 200px row growth from the exact bottom passed with a live generation and failed with a dead one: precisely the aliveness-dependent split the parity argument claimed to eliminate.

Eligibility therefore comes from the caller, which passes the same verdict that admitted the stimulus. Recovery and the ordinary path now agree by construction, and where a caller guard is the plain band the plumbing degenerates to the plain band. That is what makes the parity claim true; it was not true in the first version.

## Boundaries, both pinned by tests

A reader clear of the bottom is never dragged by any ambient stimulus. A reader who stopped ~100px up, still inside the band, **is** carried back — deliberately, exactly as an armed follow already is — so nobody later tightens the threshold and silently re-splits dead-follow from live-follow behaviour.

## Regression coverage

`scripts/scroll-invariants.ts` never wheeled *down* from the bottom; every gesture in it was upward, which is the exact blind spot. Added: wheel down at the bottom then the typing band appears; scroll up and back down by hand then an incoming message. Both were proven red without the fix and green with it, on Chromium and WebKit, at pixel-identical values. Unit coverage adds both dead states against row growth and container shrink at 200px displacement.

The scroll classification guard (`genuineUserScroll`) is unchanged.