### PR TITLE
fix(anomaly): keep a hostile User Timing host from breaking or lying

### DIFF
--- a/apps/fluux/src/anomaly/perfMeasures.test.ts
+++ b/apps/fluux/src/anomaly/perfMeasures.test.ts
@@ -116,3 +116,52 @@ describe('performance measure watcher', () => {
     expect(QueuedPerformanceObserver.latest).toBeNull()
   })
 })
+
+describe('a hostile User Timing host cannot break installation', () => {
+  const realObserver = globalThis.PerformanceObserver
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = realObserver
+  })
+
+  function withObserver(impl: unknown): void {
+    ;(globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver = impl
+  }
+
+  it('returns null instead of throwing when the observer cannot be constructed', () => {
+    // A partial or hardened host can advertise the constructor and still refuse
+    // to build one. The module promises a missing diagnostic never breaks the
+    // app, and installation is where that promise is most easily broken.
+    class Hostile {
+      static supportedEntryTypes = ['measure']
+      constructor() {
+        throw new Error('observers unavailable')
+      }
+    }
+    withObserver(Hostile)
+
+    expect(() => watchPerfMeasures(() => {})).not.toThrow()
+    expect(watchPerfMeasures(() => {})).toBeNull()
+  })
+
+  it('does not throw when disconnecting on teardown fails', () => {
+    // Cleanup runs while the page is going away, which is exactly when a host is
+    // least cooperative — and an effect cleanup that throws takes the unmount
+    // with it.
+    class Flaky {
+      static supportedEntryTypes = ['measure']
+      observe(): void {}
+      takeRecords(): unknown[] {
+        return []
+      }
+      disconnect(): never {
+        throw new Error('disconnect failed')
+      }
+    }
+    withObserver(Flaky)
+
+    const watch = watchPerfMeasures(() => {})
+    expect(watch).not.toBeNull()
+    expect(() => watch!.stop()).not.toThrow()
+  })
+})

--- a/apps/fluux/src/anomaly/perfMeasures.ts
+++ b/apps/fluux/src/anomaly/perfMeasures.ts
@@ -89,18 +89,36 @@ export function watchPerfMeasures(crumb: (parts: Scalar[]) => void): PerfMeasure
     }
   }
 
-  const observer = new PerformanceObserver((list) => {
+  // Construction guarded too. A host can advertise the constructor and still
+  // refuse to build one, and this module's promise — that a missing diagnostic
+  // never breaks the app — is easiest to break at installation.
+  let observer: PerformanceObserver
+  try {
+    observer = new PerformanceObserver((list) => {
+      try {
+        consume(list.getEntries())
+      } catch {
+        return
+      }
+    })
+  } catch {
+    return null
+  }
+
+  /** Disconnect without letting a hostile host escape. */
+  const disconnect = (): void => {
     try {
-      consume(list.getEntries())
+      observer.disconnect()
     } catch {
-      return
+      // Teardown runs while the page is going away, which is when a host is least
+      // cooperative — and a cleanup that throws takes the unmount with it.
     }
-  })
+  }
 
   try {
     observer.observe({ entryTypes: ['measure'] })
   } catch {
-    observer.disconnect()
+    disconnect()
     return null
   }
   return {
@@ -111,6 +129,6 @@ export function watchPerfMeasures(crumb: (parts: Scalar[]) => void): PerfMeasure
         return
       }
     },
-    stop: () => observer.disconnect(),
+    stop: disconnect,
   }
 }

--- a/packages/fluux-sdk/src/utils/measure.test.ts
+++ b/packages/fluux-sdk/src/utils/measure.test.ts
@@ -90,3 +90,59 @@ describe('measured', () => {
     }
   })
 })
+
+describe('a failed mark must not borrow another invocation timing', () => {
+  it('emits no measure when its own start mark could not be made', () => {
+    // The dangerous shape: an earlier invocation's `clearMarks` failed and left a
+    // mark behind, and this one's `mark` fails too. Measuring anyway silently
+    // times from the LEAKED mark and reports a duration belonging to neither
+    // operation — a diagnostic that lies is worse than one that is absent.
+    setMeasurementEnabled(true)
+    performance.mark('fluux:persist:start') // the leaked mark
+    const realMark = performance.mark.bind(performance)
+    performance.mark = () => {
+      throw new Error('marks unavailable')
+    }
+    try {
+      expect(measured('persist', () => 'value')).toBe('value')
+    } finally {
+      performance.mark = realMark
+    }
+
+    expect(names()).toEqual([])
+  })
+
+  it('still runs the operation and returns its value when marking fails', () => {
+    setMeasurementEnabled(true)
+    const realMark = performance.mark.bind(performance)
+    performance.mark = () => {
+      throw new Error('marks unavailable')
+    }
+    let ran = false
+    try {
+      const out = measured('persist', () => {
+        ran = true
+        return 7
+      })
+      expect(out).toBe(7)
+    } finally {
+      performance.mark = realMark
+    }
+    expect(ran).toBe(true)
+  })
+
+  it('still lets the operation error through when marking fails', () => {
+    // The contract this module states: a diagnostic must never be the reason a
+    // store write fails, and never substitute its own outcome for the real one.
+    setMeasurementEnabled(true)
+    const realMark = performance.mark.bind(performance)
+    performance.mark = () => {
+      throw new Error('marks unavailable')
+    }
+    try {
+      expect(() => measured('persist', () => { throw new Error('quota') })).toThrow('quota')
+    } finally {
+      performance.mark = realMark
+    }
+  })
+})

--- a/packages/fluux-sdk/src/utils/measure.ts
+++ b/packages/fluux-sdk/src/utils/measure.ts
@@ -35,18 +35,25 @@ export function measured<T>(name: string, fn: () => T): T {
   if (!enabled || typeof performance === 'undefined') return fn()
 
   const startMark = `fluux:${name}:start`
+  let marked = false
   try {
     performance.mark(startMark)
+    marked = true
   } catch {
     // A dropped mark is not worth a failed store operation.
   }
   try {
     return fn()
   } finally {
+    // Only against a mark THIS call made. A previous invocation whose `clearMarks`
+    // also failed can leave one behind under the same name, and measuring from it
+    // reports a span belonging to neither operation — a diagnostic that lies is
+    // worse than one that is absent.
+    //
     // In `finally`, so an operation that throws is still measured — a persistence
     // write failing on quota is exactly the slow case worth seeing.
     try {
-      performance.measure(`fluux:${name}`, startMark)
+      if (marked) performance.measure(`fluux:${name}`, startMark)
     } catch {
       // A dropped measure is not worth a thrown store write.
     }


### PR DESCRIPTION
Two remaining ways the measurement layer could fail the contract it states — that a missing diagnostic never breaks the app, and never substitutes its own outcome for the real one.

**It could break the app.** A host can advertise `PerformanceObserver` and still refuse to construct one, and `disconnect()` can throw during teardown — which is when the page is going away and a cleanup that throws takes the unmount with it. Both are now guarded, so a missing diagnostic stays missing.

**It could lie.** A failed start mark no longer produces a measure. An earlier invocation whose `clearMarks` also failed can leave a mark behind under the same name; measuring from it reports a span belonging to neither operation. The test reproduces exactly that — a leaked mark plus a failing `mark` — and without the fix it emits a `fluux:persist` measure timed from the wrong start.

Both were raised during the review of #1339 and deliberately deferred there, since neither is data loss and the diff was already large.