### PR TITLE
fix(retraction): erase a deleted message from the cache and the search index

### DIFF
--- a/docs/MESSAGE_IDENTIFIERS.md
+++ b/docs/MESSAGE_IDENTIFIERS.md
@@ -24,7 +24,7 @@ part of XEP-0359 or XEP-0313, this document says so instead of restating the spe
 
 There is a fourth source of an archive id: the `<result id="…">` wrapper of a MAM page. The SDK
 prefers the message's own `<stanza-id>` and falls back to the wrapper id —
-`packages/fluux-sdk/src/core/modules/MAM.ts:2300` and `:2389`.
+`packages/fluux-sdk/src/core/modules/MAM.ts:2313` and `:2402`.
 
 ## 2. `stanzaId` is authoritative only relative to an archive
 
@@ -37,8 +37,8 @@ attribute, compared on a bare-JID basis —
 
 The expected archive is fixed per conversation kind by the call sites:
 
-- 1:1 chat → the user's own bare JID (`core/modules/MAM.ts:2284`, `core/modules/Chat.ts:2143`)
-- MUC → the room's bare JID (`core/modules/MAM.ts:2370`, `core/modules/Chat.ts:2227`)
+- 1:1 chat → the user's own bare JID (`core/modules/MAM.ts:2297`, `core/modules/Chat.ts:2143`)
+- MUC → the room's bare JID (`core/modules/MAM.ts:2383`, `core/modules/Chat.ts:2227`)
 
 **The fallback matters to callers.** When `expectedBy` is omitted, or when no `<stanza-id>` matches
 it, `parseStanzaId` returns the *first* id present — commented as preserved single-archive
@@ -49,8 +49,8 @@ must address an archive, pass `expectedBy`.
 
 An archive id can also be *revoked* after the fact: when an `after:`-anchored query hits
 `item-not-found`, the stale id is stripped from the message and from the persisted gap anchor,
-keeping the timestamp so catch-up can resume by time — `stores/chatStore.ts:2482` and `:494`,
-`stores/roomStore.ts:2382` and `:1137`. Treat a stored archive id as revocable, not permanent.
+keeping the timestamp so catch-up can resume by time — `stores/chatStore.ts:2507` and `:501`,
+`stores/roomStore.ts:2413` and `:1144`. Treat a stored archive id as revocable, not permanent.
 
 ## 3. Canonical identity is a tiered ladder, not a single field
 
@@ -72,18 +72,26 @@ Every room tier key is **scoped by room JID** (`scoped`, same file). `stanzaId` 
 assigned per archive and can repeat across rooms, while the `identityKeys` index spans the whole
 store; an unscoped key would let the finder merge messages from different rooms. The room cache
 carries the same rule: no unscoped `stanzaId`/`originId` index exists, and every such lookup goes
-through the room-scoped alias — `packages/fluux-sdk/src/utils/messageCache.ts:173-181`.
+through the room-scoped alias — `packages/fluux-sdk/src/utils/messageCache.ts:197-205`.
 
-The 1:1 side has the equivalent three tiers, unscoped, in `getChatMessageKeys`
-(`packages/fluux-sdk/src/stores/chatStore.ts:219-232`).
+The 1:1 side has the equivalent three tiers, unscoped, in `chatIdentityKeys`
+(`packages/fluux-sdk/src/utils/chatMessageIdentity.ts`), which `chatStore`'s
+`getChatMessageKeys` delegates to.
+
+Both ladders are also what a retraction is resolved through at the cache and search-index
+boundary — `packages/fluux-sdk/src/stores/shared/retractionStorage.ts`. A `<retract id="…">`
+names ONE tier, chosen by whatever the retracting client knew, so it has to be tried against
+the whole ladder; and the retracted identity is remembered for the session
+(`utils/retractedIdentities.ts`) because a target whose own cache write has not landed yet has
+no row to tombstone.
 
 ## 4. Why rooms and 1:1 conversations differ
 
 The cache stores them under different primary keys:
 
-- chat messages: `keyPath: 'id'` — the **client** id (`utils/messageCache.ts:152`)
+- chat messages: `keyPath: 'id'` — the **client** id (`utils/messageCache.ts:176`)
 - room messages: `keyPath: 'cacheKey'` — the **canonical identity key** above
-  (`utils/messageCache.ts:173`)
+  (`utils/messageCache.ts:197`)
 
 `CacheOrderKey` (`packages/fluux-sdk/src/core/types/readState.ts:14-33`) is discriminated by kind
 for the same reason, and states why an archive id could never serve here: XEP-0313 §6.2 makes
@@ -100,7 +108,7 @@ use a stanza-id. Retractions (`Chat.ts:1417`), reactions (`Chat.ts:1177`) and re
 reference is the `originId` (`Chat.ts:1865`).
 
 On the receiving side, an incoming reference is resolved by `id`/`stanzaId` first and only then by
-`originId` — `stores/chatStore.ts:2366` and `:2421`.
+`originId` — `stores/chatStore.ts:2374` and `:2429`.
 
 ## 5. When the archive id is missing
 
@@ -134,18 +142,18 @@ What a caller should do with a missing archive id:
 ## 6. Do not
 
 - **Do not treat a client `id` as an identity.** It is a name in one stream. It is the chat cache's
-  primary key (`messageCache.ts:152`) and the lowest identity tier only in combination with `from`
-  (`roomMessageIdentity.ts`, `chatStore.ts:219-232`).
+  primary key (`messageCache.ts:176`) and the lowest identity tier only in combination with `from`
+  (`roomMessageIdentity.ts`, `chatMessageIdentity.ts`).
 - **Do not compare archive ids from different archives.** A message can carry several
   `<stanza-id>`; only the one stamped `by` the archive you are addressing is meaningful there
   (`messagingUtils.ts:239-276`). Comparing across archives, or across rooms, is what the room
-  scoping exists to prevent (`roomMessageIdentity.ts`, `messageCache.ts:173-181`).
+  scoping exists to prevent (`roomMessageIdentity.ts`, `messageCache.ts:197-205`).
 - **Do not read stability as identity.** `originId` is stable and sender-assigned, which makes it a
   good echo-dedup key — but two rows can share one, which is why `withArchiveId` forbids binding
   through it (`readPointer.ts:126-146`) and why references resolve it last
-  (`chatStore.ts:2366`, `:2421`).
+  (`chatStore.ts:2374`, `:2429`).
 - **Do not assume an archive id, once seen, is permanent.** It can be revoked when the archive
-  purges it (`chatStore.ts:2482`, `roomStore.ts:2382`).
+  purges it (`chatStore.ts:2507`, `roomStore.ts:2413`).
 - **Do not use an archive id for ordering.** It carries none (`core/types/readState.ts:14-33`).
 
 ## Related

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -36,6 +36,14 @@ vi.mock('../utils/messageCache', () => ({
   resolveArchivePosition: vi.fn().mockResolvedValue(null),
   updateMessage: vi.fn().mockResolvedValue(undefined),
   updateMessageReactions: vi.fn().mockResolvedValue(false),
+  // The retraction sink resolves its target through the identity ladder before
+  // writing. This mock is deliberately explicit (no importOriginal) to keep the
+  // SDK barrel out of this file, so every cache export it reaches is listed here.
+  findChatRetractionTargets: vi.fn().mockResolvedValue(undefined),
+  findChatMessageCopies: vi.fn().mockResolvedValue([]),
+  findRoomRetractionTargets: vi.fn().mockResolvedValue(undefined),
+  findRoomMessageCopies: vi.fn().mockResolvedValue([]),
+  areRetractedInCache: vi.fn().mockResolvedValue([]),
   deleteMessage: vi.fn().mockResolvedValue(undefined),
   deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
   clearAllMessages: vi.fn().mockResolvedValue(undefined),

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -2571,17 +2571,14 @@ describe('XMPPClient MAM', () => {
 
       expect(result.messages.length).toBe(0)
 
-      // The unresolved retraction should have been emitted as a chat:message-updated event
-      const updateEvents = emitSDKSpy.mock.calls.filter(
-        ([event]: [string, ...unknown[]]) => event === 'chat:message-updated'
+      const pendingEvents = emitSDKSpy.mock.calls.filter(
+        ([event]: [string, ...unknown[]]) => event === 'chat:retraction-pending'
       )
-      expect(updateEvents.length).toBe(1)
-      expect(updateEvents[0][1]).toMatchObject({
+      expect(pendingEvents.length).toBe(1)
+      expect(pendingEvents[0][1]).toEqual({
         conversationId: 'alice@example.com',
-        messageId: 'old-msg-3',
-        updates: {
-          isRetracted: true,
-        },
+        targetId: 'old-msg-3',
+        actorJid: 'alice@example.com',
       })
     })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -875,6 +875,37 @@ describe('MAM E2EE wiring', () => {
       expect(updates.isEdited).toBe(true)
       expect(updates.encryptedPayload).toContain(ROOM_CT)
     })
+
+    it('routes an unresolved MUC retraction with its actor', async () => {
+      const roomJid = 'room@conference.example.com'
+      const retraction = xml(
+        'message',
+        { from: `${roomJid}/Bob`, type: 'groupchat', id: 'room-retraction' },
+        xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'cached-room-target' }),
+        xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob-new' }),
+      )
+
+      const resultPromise = harness.mam.queryRoomArchive({ roomJid, max: 10 })
+      await harness.iqPending()
+      const [queryId, collector] = [...harness.collectors.entries()][0]
+      const entry = buildMAMResult({ archiveId: 'room-retraction-archive', forwardedMessage: retraction })
+      entry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+      collector(entry)
+      harness.resolveNextIQ(
+        xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+      )
+      await resultPromise
+
+      expect(harness.emitted).toContainEqual({
+        event: 'room:retraction-pending',
+        payload: {
+          roomJid,
+          targetId: 'cached-room-target',
+          actorJid: `${roomJid}/Bob`,
+          actorOccupantId: 'occ-bob-new',
+        },
+      })
+    })
   })
 
   it('does NOT set isSelfOutgoing for an inbound archive entry (from === peer)', async () => {

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -116,7 +116,7 @@ interface RawArchiveEntry {
  * Internal type for collected modifications during MAM query
  */
 interface MAMModifications {
-  retractions: { targetId: string; from: string }[]
+  retractions: { targetId: string; from: string; occupantId?: string }[]
   corrections: { targetId: string; from: string; body: string; messageEl: Element; correctionStanzaId?: string }[]
   fastenings: { targetId: string; applyToEl: Element }[]
   reactions: { targetId: string; from: string; emojis: string[]; timestamp?: Date }[]
@@ -127,7 +127,7 @@ interface MAMModifications {
  * These target messages already in the store/cache and need to be emitted as events.
  */
 interface UnresolvedModifications {
-  retractions: { targetId: string; from: string }[]
+  retractions: { targetId: string; from: string; occupantId?: string }[]
   corrections: { targetId: string; from: string; body: string; messageEl: Element; correctionStanzaId?: string }[]
   fastenings: { targetId: string; applyToEl: Element }[]
   reactions: { targetId: string; from: string; emojis: string[]; timestamp?: Date }[]
@@ -1879,7 +1879,11 @@ export class MAM extends BaseModule {
     // Retraction
     const retraction = parseRetractionSignal(messageEl)
     if (retraction?.targetId) {
-      modifications.retractions.push({ targetId: retraction.targetId, from: normalizeFrom(from) })
+      modifications.retractions.push({
+        targetId: retraction.targetId,
+        from: normalizeFrom(from),
+        occupantId: messageEl.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id,
+      })
       return true
     }
 
@@ -1942,6 +1946,15 @@ export class MAM extends BaseModule {
       reactions: [],
     }
 
+    // In-page retractions use this local id-or-stanzaId match and a sender-only
+    // authorship callback instead of the shared tiered ladder. After nick
+    // reassignment, a new occupant can therefore retract the old occupant's
+    // same-nick/id message; an unrelated lower-tier id collision can also consume
+    // a valid retraction instead of leaving it for pending resolution. This window
+    // is bounded to targets resolved within one archive page. Closing it requires
+    // replacing the hand-rolled identity match and changing the callback contract
+    // shared by retractions, corrections, fastenings, and reactions so it can carry
+    // an XEP-0421 occupant-id.
     // Apply retractions
     for (const retraction of modifications.retractions) {
       const target = messages.find(m => m.id === retraction.targetId || m.stanzaId === retraction.targetId)
@@ -2050,10 +2063,10 @@ export class MAM extends BaseModule {
     unresolved: UnresolvedModifications
   ): void {
     for (const retraction of unresolved.retractions) {
-      this.deps.emitSDK('chat:message-updated', {
+      this.deps.emitSDK('chat:retraction-pending', {
         conversationId,
-        messageId: retraction.targetId,
-        updates: { isRetracted: true, retractedAt: new Date() },
+        targetId: retraction.targetId,
+        actorJid: retraction.from,
       })
     }
 
@@ -2114,10 +2127,11 @@ export class MAM extends BaseModule {
     unresolved: UnresolvedModifications
   ): void {
     for (const retraction of unresolved.retractions) {
-      this.deps.emitSDK('room:message-updated', {
+      this.deps.emitSDK('room:retraction-pending', {
         roomJid,
-        messageId: retraction.targetId,
-        updates: { isRetracted: true, retractedAt: new Date() },
+        targetId: retraction.targetId,
+        actorJid: retraction.from,
+        actorOccupantId: retraction.occupantId,
       })
     }
 

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -58,6 +58,14 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
 // Import the mocked module for assertions
 import * as messageCache from '../utils/messageCache'
 
+/**
+ * The durable half of a retraction resolves the identity ladder before it writes,
+ * so its cache calls land a few microtasks after the synchronous store update.
+ */
+async function flushRetractionStorage(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
 // Helper to create test conversations
 function createConversation(id: string, name?: string): Conversation {
   return {
@@ -98,6 +106,7 @@ describe('chatStore', () => {
       mamQueryStates: new Map(),
       conversationGaps: new Map(),
       conversationCoverage: new Map(),
+      pendingRetractions: new Map(),
       // Reset other ephemeral state
       typingStates: new Map(),
       drafts: new Map(),
@@ -2313,6 +2322,31 @@ describe('chatStore', () => {
       expect(chatStore.getState().getDraft('alice@example.com')).toBe('Alice draft')
     })
 
+    it('round-trips a flat legacy pending-retraction record', () => {
+      const pending = {
+        targetId: 'archive-1',
+        actorJid: 'alice@example.com',
+        retractedAt: 1_750_000_000_000,
+      }
+      localStorageMock._store['xmpp-chat-storage:alice@example.com'] = JSON.stringify({
+        state: {
+          conversations: [],
+          archivedConversations: [],
+          drafts: [],
+          pendingRetractions: [['alice@example.com', [pending]]],
+        },
+      })
+
+      setStorageScopeJid('alice@example.com')
+      chatStore.getState().switchAccount('alice@example.com')
+      expect(chatStore.getState().pendingRetractions.get('alice@example.com')).toEqual([pending])
+
+      chatStore.getState().setDraft('alice@example.com', 'flush')
+      flushThrottledStorage()
+      const stored = JSON.parse(localStorageMock._store['xmpp-chat-storage:alice@example.com'])
+      expect(stored.state.pendingRetractions).toEqual([['alice@example.com', [pending]]])
+    })
+
     it('should clear in-memory state when switching to an account without saved data', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
       chatStore.getState().setDraft('alice@example.com', 'local draft')
@@ -2751,7 +2785,9 @@ describe('chatStore', () => {
       vi.mocked(messageCache.updateMessageReactions).mockClear()
       chatStore.getState().updateReactions('alice@example.com', msg.id, 'bob@example.com', ['👍'])
 
-      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith(msg.id, 'bob@example.com', ['👍'])
+      // Conversation-scoped: the chat cache resolves the reference through the
+      // shared ladder, which repeats across conversations without that scope.
+      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith('alice@example.com', msg.id, 'bob@example.com', ['👍'])
       // No resident array to update — the reaction lands in the cache only,
       // to be picked up next time the conversation is activated.
       expect(chatStore.getState().messages.get('alice@example.com')).toBeUndefined()
@@ -4930,7 +4966,7 @@ describe('chatStore', () => {
       expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
     })
 
-    it('applies to a resident target without recording anything', () => {
+    it('applies to a resident target without recording anything', async () => {
       chatStore.setState({ activeConversationId: convId })
       chatStore.getState().addMessage(incoming('msg-1'))
 
@@ -4938,9 +4974,15 @@ describe('chatStore', () => {
 
       expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({ isRetracted: true })
       expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+      // The durable write resolves the identity ladder first, so it lands a few
+      // microtasks after the synchronous store update.
+      await flushRetractionStorage()
       expect(messageCache.updateMessage).toHaveBeenCalledWith(
         'msg-1',
-        expect.objectContaining({ isRetracted: true })
+        expect.objectContaining({ isRetracted: true }),
+        // The account scope captured before the first await; none is set here.
+        null,
+        expect.objectContaining({ conversationId: convId })
       )
     })
 
@@ -4950,7 +4992,7 @@ describe('chatStore', () => {
       chatStore.getState().addMessage(incoming('msg-1'))
 
       expect(chatStore.getState().messages.get(convId)?.[0].isRetracted).toBeUndefined()
-      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(1)
     })
 
     it('replays the record when the conversation hydrates from the cache', async () => {
@@ -4962,9 +5004,13 @@ describe('chatStore', () => {
       expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({ isRetracted: true })
       expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
       // Written through, so the tombstone survives a reload without the record.
+      await flushRetractionStorage()
       expect(messageCache.updateMessage).toHaveBeenCalledWith(
         'msg-1',
-        expect.objectContaining({ isRetracted: true })
+        expect.objectContaining({ isRetracted: true }),
+        // The account scope captured before the first await; none is set here.
+        null,
+        expect.objectContaining({ conversationId: convId })
       )
     })
 
@@ -5052,7 +5098,7 @@ describe('chatStore parity drift regressions', () => {
 
       chatStore.getState().updateReactions(convId, 'evicted-1', 'bob@example.com', ['👍'])
 
-      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith('evicted-1', 'bob@example.com', ['👍'])
+      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith(convId, 'evicted-1', 'bob@example.com', ['👍'])
       // The resident array is untouched — only the durable copy is patched.
       expect(chatStore.getState().messages.get(convId)).toBe(residentBefore)
     })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -4,6 +4,7 @@ import type { Message, Conversation, ConversationEntity, ConversationMetadata, H
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
+import { chatIdentityKeys, resolveChatMessageReference } from '../utils/chatMessageIdentity'
 import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
@@ -50,7 +51,8 @@ import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
 import { draftConversationMaps, rebuildCompatEntry } from './shared/conversationMaps'
-import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
+import { addPendingRetraction, applyPendingRetractions, chatRetractionAuthor, removePendingRetraction, type PendingRetraction } from './shared/pendingRetractions'
+import { retractChatMessageInStorage, retractUnresidentChatTarget } from './shared/retractionStorage'
 import { createRemoteDividerAdvanceTracker } from './shared/dividerAdvance'
 import { locallyPublishedDisplayed } from '../core/localMdsPublishes'
 import { isAhead } from './shared/readPointer'
@@ -172,9 +174,7 @@ function mergeCachedChatMessages(
   return { messages: newMessagesMap, ...retractionPatch }
 }
 
-/** XEP-0424 authorship gate: only a message's own author may retract it. */
-export const chatRetractionAuthor = (message: Message, record: PendingRetraction): boolean =>
-  message.from === record.actorJid
+export { chatRetractionAuthor }
 
 /**
  * Replay a conversation's pending retractions against a slice of its messages.
@@ -195,14 +195,17 @@ function resolvePendingRetractions(
   const pending = state.pendingRetractions.get(conversationId)
   if (!pending || pending.length === 0) return { messages: slice }
 
-  const { messages, applied, remaining } = applyPendingRetractions(slice, pending, chatRetractionAuthor)
+  const { messages, resolved, remaining } = applyPendingRetractions(
+    slice,
+    pending,
+    chatRetractionAuthor,
+    resolveChatMessageReference
+  )
   if (remaining.length === pending.length) return { messages }
 
   if (options.persist !== false) {
-    for (const { messageId, retractedAt } of applied) {
-      void messageCache.updateMessage(messageId, { isRetracted: true, retractedAt })
-      const retracted = findMessageById(messages, messageId)
-      if (retracted) void searchIndex.removeMessage(retracted)
+    for (const { message, retractedAt } of resolved) {
+      void retractChatMessageInStorage(conversationId, message, { retractedAt })
     }
   }
 
@@ -224,11 +227,7 @@ function getLegacyStorageKey(): string {
  * - from+id: stanza attribute combo (fallback for legacy/bridge messages)
  */
 function getChatMessageKeys(m: Message): string[] {
-  const keys: string[] = []
-  if (m.stanzaId) keys.push(`stanzaId:${m.stanzaId}`)
-  if (m.originId) keys.push(`originId:${m.originId}`)
-  keys.push(`from:${m.from}:id:${m.id}`)
-  return keys
+  return chatIdentityKeys(m)
 }
 
 /** Timeline config for the shared resident-window machine (see shared/messageTimeline.ts). */
@@ -415,7 +414,12 @@ interface ChatState {
   setTyping: (conversationId: string, jid: string, isTyping: boolean) => void
   clearAllTyping: () => void
   updateReactions: (conversationId: string, messageId: string, reactorJid: string, emojis: string[]) => void
-  updateMessage: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+  updateMessage: (
+    conversationId: string,
+    messageId: string,
+    updates: Partial<Message>,
+    retractionReference?: string
+  ) => void
   clearMessageStanzaId: (conversationId: string, stanzaId: string) => void
   /**
    * Hard-remove a message from the conversation, the search index, and the
@@ -2363,7 +2367,7 @@ export const chatStore = createStore<ChatState>()(
             // durable cache so the correct state loads when the conversation
             // is reactivated, instead of silently dropping the reaction.
             logInfo(`Reaction for message ${messageId} not in memory — updating in cache`)
-            void messageCache.updateMessageReactions(messageId, reactorJid, emojis)
+            void messageCache.updateMessageReactions(conversationId, messageId, reactorJid, emojis)
             return state
           }
 
@@ -2375,7 +2379,7 @@ export const chatStore = createStore<ChatState>()(
             // sliding window evicted it). Update the durable cache so the
             // reaction survives instead of being silently dropped.
             logInfo(`Reaction for message ${messageId} not in resident window — updating in cache`)
-            void messageCache.updateMessageReactions(messageId, reactorJid, emojis)
+            void messageCache.updateMessageReactions(conversationId, messageId, reactorJid, emojis)
             return state
           }
 
@@ -2416,7 +2420,7 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
-      updateMessage: (conversationId, messageId, updates) => {
+      updateMessage: (conversationId, messageId, updates, retractionReference) => {
         let recountNeeded = false
         set((state) => {
           const convMessages = state.messages.get(conversationId)
@@ -2424,7 +2428,14 @@ export const chatStore = createStore<ChatState>()(
 
           // Resolve by id/stanzaId first, origin-id only as fallback. XEP-0308
           // corrections reference the origin-id; retractions/MAM may use stanzaId.
-          const messageIndex = findMessageIndexById(convMessages, messageId)
+          let messageIndex: number
+          if (retractionReference) {
+            messageIndex = convMessages.findIndex((message) => message.id === messageId)
+          } else if (updates.isRetracted) {
+            messageIndex = resolveChatMessageReference(convMessages, messageId)?.candidates[0]?.index ?? -1
+          } else {
+            messageIndex = findMessageIndexById(convMessages, messageId)
+          }
           if (messageIndex === -1) return state
 
           const newMessages = new Map(state.messages)
@@ -2432,19 +2443,29 @@ export const chatStore = createStore<ChatState>()(
           const updatedMessage = {
             ...convMessages[messageIndex],
             ...updates,
+            ...(updates.isRetracted && convMessages[messageIndex].retractedAt
+              ? { retractedAt: convMessages[messageIndex].retractedAt }
+              : {}),
           }
           updatedConvMessages[messageIndex] = updatedMessage
           newMessages.set(conversationId, updatedConvMessages)
 
           // Update in IndexedDB asynchronously (non-blocking)
           // Use the actual message id (not the lookup id which could be stanzaId)
-          void messageCache.updateMessage(convMessages[messageIndex].id, updates)
-
-          // Update search index: re-index if body changed, remove if retracted
           if (updates.isRetracted) {
-            void searchIndex.removeMessage(updatedMessage)
-          } else if (updates.body) {
-            void searchIndex.updateMessage(updatedMessage)
+            // The whole durable side of a retraction — cache row and search
+            // document — is the storage sink's, so the resident path and the
+            // not-resident path cannot drift.
+            void retractChatMessageInStorage(
+              conversationId,
+              updatedMessage,
+              updates,
+              getStorageScopeJid(),
+              retractionReference ?? messageId
+            )
+          } else {
+            void messageCache.updateMessage(convMessages[messageIndex].id, updates)
+            if (updates.body) void searchIndex.updateMessage(updatedMessage)
           }
 
           // A retraction may target a `noLocalStore` message noted in
@@ -2516,24 +2537,62 @@ export const chatStore = createStore<ChatState>()(
       },
 
       recordPendingRetraction: (conversationId, targetId, actorJid) => {
+        const storageScopeAtStart = getStorageScopeJid()
+        const record: PendingRetraction = { targetId, actorJid, retractedAt: Date.now() }
         const resident = get().messages.get(conversationId)
-        const target = resident ? findMessageById(resident, targetId) : undefined
+        const resolution = resident
+          ? resolveChatMessageReference(resident, targetId)
+          : undefined
+        const target = resolution?.candidates.find(({ message }) =>
+          chatRetractionAuthor(message, record)
+        )?.message
         if (target) {
           // Resolved on the spot — updateMessage carries the write-through to
           // IndexedDB and the search-index removal.
-          if (!target.isRetracted && target.from === actorJid) {
-            get().updateMessage(conversationId, target.id, { isRetracted: true, retractedAt: new Date() })
-          }
+          get().updateMessage(
+            conversationId,
+            target.id,
+            {
+              isRetracted: true,
+              retractedAt: target.retractedAt ?? new Date(record.retractedAt),
+            },
+            targetId
+          )
           return
         }
+        if (resolution?.authoritative) return
 
         set((state) => {
           const existing = state.pendingRetractions.get(conversationId) ?? []
-          const next = addPendingRetraction(existing, { targetId, actorJid, retractedAt: Date.now() })
+          const next = addPendingRetraction(existing, record)
           if (next === existing) return state
           const nextPending = new Map(state.pendingRetractions)
           nextPending.set(conversationId, next)
           return { pendingRetractions: nextPending }
+        })
+
+        // The target is not resident, but it may well be CACHED — and the cache
+        // is where its identity is still canonical. Resolve and tombstone it
+        // there now, instead of leaving the body readable until something
+        // happens to reload the message.
+        void retractUnresidentChatTarget(conversationId, record, storageScopeAtStart).then((outcome) => {
+          // Switching accounts during this probe leaves a consumed authoritative
+          // record persisted for the old account. After switching back, if the
+          // authoritative row is not resident, an unrelated lower-tier match can
+          // consume the stale record. This window is bounded to the in-flight
+          // account switch; closing it requires account-scoped durable mutation
+          // after the active scope changes.
+          if (outcome === 'pending' || getStorageScopeJid() !== storageScopeAtStart) return
+          set((state) => {
+            const existing = state.pendingRetractions.get(conversationId) ?? []
+            const remaining = removePendingRetraction(existing, record)
+            if (remaining === existing) return state
+            const nextPending = new Map(state.pendingRetractions)
+            if (remaining.length === 0) nextPending.delete(conversationId)
+            else nextPending.set(conversationId, remaining)
+            return { pendingRetractions: nextPending }
+          })
+          flushKey(getScopedStorageKey(storageScopeAtStart))
         })
 
         // A pending retraction is a durable EVENT, not a lagging mirror: it
@@ -2546,7 +2605,7 @@ export const chatStore = createStore<ChatState>()(
         // `set`), so the blob is either already on disk via the leading edge
         // or sitting in the pending thunk. This lands the second case and
         // costs nothing in the first.
-        flushKey(getScopedStorageKey())
+        flushKey(getScopedStorageKey(storageScopeAtStart))
       },
 
       getMessage: (conversationId, messageId) => {

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -1,0 +1,1322 @@
+/**
+ * XEP-0424 retraction at the SOURCE: the retracted body must leave the durable
+ * cache and the search index, not merely stop being rendered.
+ *
+ * These tests run the real `messageCache` and `searchIndex` against fake
+ * IndexedDB and assert on the STORED bytes — `expectNoTraceOf` reads every row of
+ * both databases back and fails if the retracted text survives anywhere. A test
+ * that only inspected the in-memory store would pass with the body still on disk,
+ * which is the defect this file covers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { openDB } from 'idb'
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+import {
+  retractChatMessageInStorage,
+  retractRoomMessageInStorage,
+} from './shared/retractionStorage'
+import * as messageCache from '../utils/messageCache'
+import * as searchIndex from '../utils/searchIndex'
+import {
+  _clearRetractedIdentitiesForTesting,
+  chatRetractionAliases,
+  noteRetractedIdentity,
+  roomRetractionAliases,
+} from '../utils/retractedIdentities'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
+import { localStorageMock } from '../core/sideEffects.testHelpers'
+import type { Message, Room, RoomMessage } from '../core/types'
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+const SCOPE = 'romeo@montague.example'
+const OTHER_SCOPE = 'mercutio@verona.example'
+const CHAT = 'juliet@capulet.example'
+const OTHER_CHAT = 'benvolio@montague.example'
+const ROOM = 'balcony@conference.montague.example'
+const OTHER_ROOM = 'square@conference.verona.example'
+
+/** The word every test hides in a body and then demands the storage forget. */
+const SECRET = 'plutonium'
+
+function chatMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    type: 'chat',
+    id: 'chat-1',
+    conversationId: CHAT,
+    from: CHAT,
+    body: `the ${SECRET} shipment`,
+    timestamp: new Date(1_700_000_000_000),
+    isOutgoing: false,
+    ...overrides,
+  }
+}
+
+function roomMessage(overrides: Partial<RoomMessage> = {}): RoomMessage {
+  return {
+    type: 'groupchat',
+    id: 'room-1',
+    roomJid: ROOM,
+    from: `${ROOM}/alice`,
+    nick: 'alice',
+    body: `the ${SECRET} shipment`,
+    timestamp: new Date(1_700_000_000_000),
+    isOutgoing: false,
+    ...overrides,
+  }
+}
+
+function room(): Room {
+  return {
+    jid: ROOM,
+    name: 'balcony',
+    joined: true,
+    occupants: [],
+    unreadCount: 0,
+  } as unknown as Room
+}
+
+function switchScopeWhileIterating(scope: string): string[] {
+  return new Proxy(['👍'], {
+    get(target, property, receiver) {
+      if (property !== Symbol.iterator) return Reflect.get(target, property, receiver)
+      return function* () {
+        setStorageScopeJid(scope)
+        yield* target
+      }
+    },
+  })
+}
+
+/** Every value stored in both scoped databases, serialized. */
+async function dumpStorage(scope = SCOPE): Promise<string> {
+  const parts: string[] = []
+  const cache = await openDB(`fluux-message-cache:${scope}`)
+  for (const store of [...cache.objectStoreNames]) {
+    parts.push(JSON.stringify(await cache.getAll(store)))
+  }
+  cache.close()
+  const index = await openDB(`fluux-search-index:${scope}`)
+  for (const store of [...index.objectStoreNames]) {
+    parts.push(JSON.stringify(await index.getAll(store)))
+  }
+  index.close()
+  return parts.join('\n')
+}
+
+/** The criterion: no retracted content anywhere on disk, index postings included. */
+async function expectNoTraceOf(text: string): Promise<void> {
+  expect(await dumpStorage()).not.toContain(text)
+  expect(await searchIndex.search(text)).toEqual([])
+}
+
+async function searchInScope(scope: string, text: string): Promise<searchIndex.SearchIndexResult[]> {
+  setStorageScopeJid(scope)
+  await searchIndex.initSearchIndex(scope)
+  return searchIndex.search(text)
+}
+
+/**
+ * Let the stores' fire-and-forget durable writes settle. A retraction resolves
+ * through several sequential IndexedDB round trips, and fake-indexeddb completes
+ * each on a macrotask, so this drains macrotasks rather than microtasks.
+ */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 50; i++) await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('retraction propagates to the cache and the search index', () => {
+  beforeEach(async () => {
+    globalThis.indexedDB = new IDBFactory()
+    _resetStorageScopeForTesting()
+    messageCache._resetDBForTesting()
+    searchIndex._resetDBForTesting()
+    _clearRetractedIdentitiesForTesting()
+    localStorage.clear()
+    setStorageScopeJid(SCOPE)
+    await searchIndex.initSearchIndex(SCOPE)
+    chatStore.setState({ messages: new Map(), pendingRetractions: new Map() })
+    roomStore.setState({ messages: new Map(), rooms: new Map(), pendingRetractions: new Map() })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await searchIndex.closeSearchIndex()
+  })
+
+  // ===========================================================================
+  // Case 1 — the target is no longer resident when the retraction arrives
+  // ===========================================================================
+
+  describe('target not resident', () => {
+    it('erases a cached 1:1 message the resident window no longer holds', async () => {
+      const message = chatMessage()
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+
+      // The conversation was deactivated: nothing resident to patch.
+      expect(chatStore.getState().messages.get(CHAT)).toBeUndefined()
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, CHAT)
+      await settle()
+
+      const stored = await messageCache.getMessage(message.id)
+      expect(stored?.isRetracted).toBe(true)
+      expect(stored?.body).toBe('')
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('erases every chat row sharing the authorized stanza identity', async () => {
+      const first = chatMessage({ id: 'copy-a', stanzaId: 'shared-archive', body: 'holmium copy' })
+      const second = chatMessage({ id: 'copy-b', stanzaId: 'shared-archive', body: 'thulium copy' })
+      await messageCache.saveMessages([first, second])
+      await searchIndex.indexMessages([first, second])
+
+      chatStore.getState().recordPendingRetraction(CHAT, 'shared-archive', CHAT)
+      await settle()
+
+      expect((await messageCache.getMessage(first.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(second.id))?.isRetracted).toBe(true)
+      expect(await searchIndex.search('holmium')).toEqual([])
+      expect(await searchIndex.search('thulium')).toEqual([])
+    })
+
+    it('erases every cached chat copy from the resident storage sink', async () => {
+      const first = chatMessage({
+        id: 'resident-a',
+        stanzaId: 'resident-archive-a',
+        originId: 'resident-origin',
+        body: 'holmium resident',
+      })
+      const second = chatMessage({
+        id: 'resident-b',
+        stanzaId: 'resident-archive-b',
+        originId: 'resident-origin',
+        body: 'thulium resident',
+      })
+      await messageCache.saveMessages([first, second])
+      await searchIndex.indexMessages([first, second])
+      chatStore.setState({ messages: new Map([[CHAT, [first]]]) })
+
+      chatStore.getState().recordPendingRetraction(CHAT, first.originId!, first.from)
+      await settle()
+
+      expect((await messageCache.getMessage(first.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(second.id))?.isRetracted).toBe(true)
+      expect(await searchIndex.search('holmium')).toEqual([])
+      expect(await searchIndex.search('thulium')).toEqual([])
+    })
+
+    it('erases every indexed room copy in the cached identity closure', async () => {
+      const first = roomMessage({
+        id: 'room-closure-first',
+        stanzaId: 'room-closure-stanza-1',
+        originId: 'room-closure-origin',
+        occupantId: 'room-closure-occupant',
+        body: 'curium room closure',
+      })
+      const second = roomMessage({
+        id: 'room-closure-second',
+        stanzaId: 'room-closure-stanza-2',
+        originId: first.originId,
+        occupantId: first.occupantId,
+        body: 'fermium room closure',
+      })
+      await searchIndex.indexMessages([first, second])
+      await messageCache.saveRoomMessages([first, second])
+
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        second.stanzaId!,
+        second.from,
+        second.occupantId
+      )
+      await settle()
+
+      expect((await messageCache.getRoomMessage(ROOM, first.id, first.from))?.body).toBe('')
+      expect(await searchIndex.search('curium')).toEqual([])
+      expect(await searchIndex.search('fermium')).toEqual([])
+    })
+
+    it('does not mutate a globally keyed chat row outside the resolved owner', async () => {
+      const target = chatMessage({ id: 'shared-client-id', from: 'romeo@montague.example' })
+      const otherConversation = chatMessage({
+        id: target.id,
+        conversationId: OTHER_CHAT,
+        from: target.from,
+        body: 'other-conversation terbium',
+      })
+      await messageCache.saveMessage(otherConversation)
+      await searchIndex.indexMessage(otherConversation)
+
+      await retractChatMessageInStorage(CHAT, target, { retractedAt: new Date() })
+
+      expect(await messageCache.getMessage(target.id)).toMatchObject({
+        conversationId: OTHER_CHAT,
+        from: target.from,
+        body: 'other-conversation terbium',
+      })
+      expect((await messageCache.getMessage(target.id))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search('terbium')).toHaveLength(1)
+
+      const otherSender = chatMessage({
+        id: 'shared-sender-id',
+        from: 'mallory@montague.example',
+        body: 'other-sender ytterbium',
+      })
+      await messageCache.saveMessage(otherSender)
+      await searchIndex.indexMessage(otherSender)
+
+      await retractChatMessageInStorage(
+        CHAT,
+        { ...target, id: otherSender.id },
+        { retractedAt: new Date() }
+      )
+
+      expect(await messageCache.getMessage(otherSender.id)).toMatchObject({
+        conversationId: CHAT,
+        from: otherSender.from,
+        body: 'other-sender ytterbium',
+      })
+      expect((await messageCache.getMessage(otherSender.id))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search('ytterbium')).toHaveLength(1)
+    })
+
+    it('erases a cached room message the resident window no longer holds', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+
+      expect(roomStore.getState().messages.get(ROOM)).toBeUndefined()
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-1', message.from, 'occ-alice')
+      await settle()
+
+      const stored = await messageCache.getRoomMessage(ROOM, message.id)
+      expect(stored?.isRetracted).toBe(true)
+      expect(stored?.body).toBe('')
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('removes the pending record once the cached tombstone protects reload', async () => {
+      const message = chatMessage()
+      await messageCache.saveMessage(message)
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, CHAT)
+      await settle()
+
+      expect(chatStore.getState().pendingRetractions.get(CHAT) ?? []).toEqual([])
+    })
+
+    it('leaves a cached message alone when the retraction is not from its author', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-1', `${ROOM}/mallory`, 'occ-mallory')
+      await settle()
+
+      const stored = await messageCache.getRoomMessage(ROOM, message.id)
+      expect(stored?.isRetracted).toBeFalsy()
+      expect(stored?.body).toContain(SECRET)
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+    })
+
+    it('does not let an unauthorized unresolved room retraction scrub a later write', async () => {
+      const message = roomMessage({ stanzaId: 'archive-late', occupantId: 'occ-alice' })
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-late', message.from, 'occ-mallory')
+      await settle()
+
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+    })
+
+    it('does not let an unauthorized unresolved chat retraction scrub a later write', async () => {
+      const message = chatMessage()
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, 'mallory@montague.example')
+      await settle()
+
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getMessage(message.id))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+    })
+
+    it('removes the search document for an already-tombstoned chat target', async () => {
+      const message = chatMessage()
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt: new Date() })
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, message.from)
+      await settle()
+
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+
+    it('removes the search document for an already-tombstoned room target', async () => {
+      const message = roomMessage({ stanzaId: 'already-tombstoned', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateRoomMessage(
+        ROOM,
+        message.id,
+        { isRetracted: true, retractedAt: new Date() },
+        message.from
+      )
+
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        message.stanzaId!,
+        message.from,
+        message.occupantId
+      )
+      await settle()
+
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+
+    it('preserves a resident chat tombstone timestamp during duplicate cleanup', async () => {
+      const message = chatMessage()
+      const retractedAt = new Date('2026-07-22T03:53:00Z')
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt })
+      chatStore.setState({
+        messages: new Map([[CHAT, [{ ...message, isRetracted: true, retractedAt }]]]),
+      })
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, message.from)
+      await settle()
+
+      expect((await messageCache.getMessage(message.id))?.retractedAt).toEqual(retractedAt)
+      expect(chatStore.getState().messages.get(CHAT)?.[0].retractedAt).toEqual(retractedAt)
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+
+    it('preserves a resident room tombstone timestamp during duplicate cleanup', async () => {
+      const message = roomMessage({ stanzaId: 'duplicate-room', occupantId: 'occ-alice' })
+      const retractedAt = new Date('2026-07-22T03:53:00Z')
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateRoomMessage(
+        ROOM,
+        message.id,
+        { isRetracted: true, retractedAt },
+        message.from
+      )
+      roomStore.getState().addRoom(room(), [{ ...message, isRetracted: true, retractedAt }])
+
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        message.stanzaId!,
+        message.from,
+        message.occupantId
+      )
+      await settle()
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.retractedAt).toEqual(retractedAt)
+      expect(roomStore.getState().messages.get(ROOM)?.[0].retractedAt).toEqual(retractedAt)
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+
+    it('finishes chat index cleanup when restored replay finds a tombstone', async () => {
+      const message = chatMessage()
+      const retractedAt = new Date()
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt })
+      _clearRetractedIdentitiesForTesting()
+      chatStore.setState({
+        messages: new Map(),
+        pendingRetractions: new Map([[
+          CHAT,
+          [{ targetId: message.id, actorJid: message.from, retractedAt: retractedAt.getTime() }],
+        ]]),
+      })
+
+      await chatStore.getState().loadMessagesFromCache(CHAT)
+      await settle()
+
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+
+    it('finishes room index cleanup when restored replay finds a tombstone', async () => {
+      const message = roomMessage({ stanzaId: 'restored-room', occupantId: 'occ-alice' })
+      const retractedAt = new Date()
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+      await messageCache.updateRoomMessage(
+        ROOM,
+        message.id,
+        { isRetracted: true, retractedAt },
+        message.from
+      )
+      _clearRetractedIdentitiesForTesting()
+      roomStore.getState().addRoom(room(), [])
+      roomStore.setState({
+        pendingRetractions: new Map([[
+          ROOM,
+          [{
+            targetId: message.stanzaId!,
+            actorJid: message.from,
+            actorOccupantId: message.occupantId,
+            retractedAt: retractedAt.getTime(),
+          }],
+        ]]),
+      })
+
+      await roomStore.getState().loadMessagesFromCache(ROOM)
+      await settle()
+
+      expect(await searchIndex.search(SECRET)).toEqual([])
+    })
+  })
+
+  // ===========================================================================
+  // Case 2 — the retraction names an archive id assigned AFTER the index row
+  // ===========================================================================
+
+  describe('archive id assigned after the index row was written', () => {
+    it('erases a room document indexed under the composite id before the stanza id arrived', async () => {
+      // Indexed while the message had no archive id: its document lives under
+      // `room:<roomJid>:<from>:<id>` and can never be found under the stanza form.
+      const early = roomMessage({ occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(early)
+      await searchIndex.indexMessage(early)
+
+      // The MAM copy arrives and merges the archive id onto the same row.
+      await messageCache.saveRoomMessage({ ...early, stanzaId: 'archive-late' })
+      expect((await messageCache.getRoomMessage(ROOM, early.id))?.stanzaId).toBe('archive-late')
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-late', early.from, 'occ-alice')
+      await settle()
+
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('erases a 1:1 message whose archive id reached the cache after indexing', async () => {
+      const early = chatMessage()
+      await messageCache.saveMessage(early)
+      await searchIndex.indexMessage(early)
+
+      await messageCache.updateMessage(early.id, { stanzaId: 'archive-late' })
+      expect((await messageCache.getMessage(early.id))?.stanzaId).toBe('archive-late')
+
+      chatStore.getState().recordPendingRetraction(CHAT, 'archive-late', CHAT)
+      await settle()
+
+      await expectNoTraceOf(SECRET)
+    })
+  })
+
+  // ===========================================================================
+  // Case 3 — MUC nick reassignment: same room, nick and client id
+  // ===========================================================================
+
+  describe('room after a nick reassignment', () => {
+    const OTHER_SECRET = 'polonium'
+
+    it('does not delete the neighbour document that shares the composite index id', async () => {
+      // The departed occupant's message was indexed before its archive id
+      // arrived, so it owns the composite id `room:<roomJid>:<from>:<id>`.
+      const departed = roomMessage({
+        id: 'shared-id',
+        occupantId: 'occ-alice-1',
+        body: `the ${OTHER_SECRET} shipment`,
+        timestamp: new Date(1_700_000_000_000),
+      })
+      await searchIndex.indexMessage(departed)
+
+      // The nick was reassigned. Same room, same nick, same client id — only the
+      // archive and occupant ids differ.
+      const reassigned = roomMessage({
+        id: 'shared-id',
+        occupantId: 'occ-alice-2',
+        stanzaId: 'archive-recent',
+        timestamp: new Date(1_700_000_500_000),
+      })
+      await messageCache.saveRoomMessage(reassigned)
+      await searchIndex.indexMessage(reassigned)
+
+      await retractRoomMessageInStorage(ROOM, reassigned, { retractedAt: new Date() })
+
+      await expectNoTraceOf(SECRET)
+      // The departed occupant's message is a different message and keeps its own
+      // document: the retraction did not reach across the shared composite id.
+      expect(await searchIndex.search(OTHER_SECRET)).toHaveLength(1)
+    })
+
+    it('does not mutate the departed occupant cache row from the resident sink', async () => {
+      const departed = roomMessage({
+        id: 'shared-cache-id',
+        occupantId: 'occ-alice-1',
+        body: `the ${OTHER_SECRET} cache shipment`,
+      })
+      await messageCache.saveRoomMessage(departed)
+      await searchIndex.indexMessage(departed)
+
+      const reassigned = roomMessage({
+        id: departed.id,
+        occupantId: 'occ-alice-2',
+        stanzaId: 'archive-recent-cache',
+      })
+      await retractRoomMessageInStorage(ROOM, reassigned, { retractedAt: new Date() })
+
+      expect(await messageCache.getRoomMessage(ROOM, departed.id, departed.from)).toMatchObject({
+        occupantId: departed.occupantId,
+        body: departed.body,
+      })
+      expect((await messageCache.getRoomMessage(ROOM, departed.id, departed.from))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search(OTHER_SECRET)).toHaveLength(1)
+    })
+
+    it('does not apply a verified lower-tier alias after occupant reassignment', async () => {
+      const departed = roomMessage({
+        id: 'reused-id',
+        stanzaId: 'departed-archive',
+        occupantId: 'occ-alice-1',
+      })
+      await retractRoomMessageInStorage(ROOM, departed, { retractedAt: new Date() })
+
+      const reassigned = roomMessage({
+        id: departed.id,
+        stanzaId: 'reassigned-archive',
+        occupantId: 'occ-alice-2',
+        body: 'innocent ytterbium',
+      })
+      await messageCache.saveRoomMessage(reassigned)
+      await searchIndex.indexMessage(reassigned)
+
+      expect((await messageCache.getRoomMessage(ROOM, reassigned.id))?.body).toBe('innocent ytterbium')
+      expect((await messageCache.getRoomMessage(ROOM, reassigned.id))?.isRetracted).toBeFalsy()
+      expect(await searchIndex.search('ytterbium')).toHaveLength(1)
+    })
+
+    it('does not use equal body and timestamp as composite document ownership', async () => {
+      const departed = roomMessage({
+        id: 'shared-id',
+        occupantId: 'occ-alice-1',
+        body: 'OK',
+      })
+      await searchIndex.indexMessage(departed)
+
+      const reassigned = roomMessage({
+        id: 'shared-id',
+        occupantId: 'occ-alice-2',
+        stanzaId: 'archive-recent',
+        body: 'OK',
+      })
+      await messageCache.saveRoomMessage(reassigned)
+      await searchIndex.indexMessage(reassigned)
+
+      await retractRoomMessageInStorage(ROOM, reassigned, { retractedAt: new Date() })
+
+      expect(await searchIndex.search('OK')).toEqual([
+        expect.objectContaining({ indexId: `room:${ROOM}:${departed.from}:shared-id` }),
+      ])
+    })
+
+    it('does not fall through from an unauthorized room stanza tier to a client-id tier', async () => {
+      const authoritative = roomMessage({
+        id: 'authoritative-row',
+        stanzaId: 'shared-reference',
+        occupantId: 'occ-alice-1',
+        body: 'authoritative body',
+      })
+      const lowerTier = roomMessage({
+        id: 'shared-reference',
+        stanzaId: 'other-archive',
+        occupantId: 'occ-alice-2',
+        body: 'lower tier body',
+      })
+      await messageCache.saveRoomMessages([authoritative, lowerTier])
+      await searchIndex.indexMessages([authoritative, lowerTier])
+
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        'shared-reference',
+        lowerTier.from,
+        'occ-alice-2'
+      )
+      await settle()
+
+      await messageCache.saveRoomMessage(lowerTier)
+
+      expect(roomStore.getState().pendingRetractions.get(ROOM)).toBeUndefined()
+      expect((await messageCache.getRoomMessage(ROOM, authoritative.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getRoomMessage(ROOM, lowerTier.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getRoomMessage(ROOM, lowerTier.id))?.body).toBe('lower tier body')
+      expect(await searchIndex.search('lower tier')).toHaveLength(1)
+    })
+
+    it('does not fall through from an unauthorized chat stanza tier to a client-id tier', async () => {
+      const authoritative = chatMessage({
+        id: 'authoritative-row',
+        stanzaId: 'shared-reference',
+        body: 'authoritative body',
+      })
+      const lowerTier = chatMessage({
+        id: 'shared-reference',
+        stanzaId: 'other-archive',
+        from: 'mallory@montague.example',
+        body: 'lower tier body',
+      })
+      await messageCache.saveMessages([authoritative, lowerTier])
+      await searchIndex.indexMessages([authoritative, lowerTier])
+
+      chatStore.getState().recordPendingRetraction(
+        CHAT,
+        'shared-reference',
+        lowerTier.from
+      )
+      await settle()
+
+      await messageCache.saveMessage(lowerTier)
+
+      expect(chatStore.getState().pendingRetractions.get(CHAT)).toBeUndefined()
+      expect((await messageCache.getMessage(authoritative.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(lowerTier.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(lowerTier.id))?.body).toBe('lower tier body')
+      expect(await searchIndex.search('lower tier')).toHaveLength(1)
+    })
+
+    it('keeps a canonical stanza document owned by another room', async () => {
+      const otherRoomMessage = roomMessage({
+        roomJid: OTHER_ROOM,
+        from: `${OTHER_ROOM}/alice`,
+        stanzaId: 'shared-archive-id',
+        body: `the ${OTHER_SECRET} shipment`,
+      })
+      await searchIndex.indexMessage(otherRoomMessage)
+
+      const target = roomMessage({
+        stanzaId: 'shared-archive-id',
+        occupantId: 'occ-alice',
+      })
+      await messageCache.saveRoomMessage(target)
+      await retractRoomMessageInStorage(ROOM, target, { retractedAt: new Date() })
+
+      expect(await searchIndex.search(OTHER_SECRET)).toHaveLength(1)
+    })
+
+    it('refuses a retraction whose occupant id does not match the cached row', async () => {
+      const departed = roomMessage({
+        id: 'shared-id',
+        stanzaId: 'archive-old',
+        occupantId: 'occ-alice-1',
+      })
+      await messageCache.saveRoomMessage(departed)
+      await searchIndex.indexMessage(departed)
+
+      // The nick's new owner cannot retract what the previous owner wrote, even
+      // though room, nick and client id all match.
+      roomStore.getState().recordPendingRetraction(ROOM, 'shared-id', departed.from, 'occ-alice-2')
+      await settle()
+
+      expect((await messageCache.getRoomMessage(ROOM, 'shared-id'))?.body).toContain(SECRET)
+      expect(await searchIndex.search(SECRET)).toHaveLength(1)
+    })
+
+    it('accepts the same retraction from the occupant that wrote it', async () => {
+      const departed = roomMessage({
+        id: 'shared-id',
+        stanzaId: 'archive-old',
+        occupantId: 'occ-alice-1',
+      })
+      await messageCache.saveRoomMessage(departed)
+      await searchIndex.indexMessage(departed)
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'shared-id', departed.from, 'occ-alice-1')
+      await settle()
+
+      await expectNoTraceOf(SECRET)
+    })
+  })
+
+  // ===========================================================================
+  // Case 4 — a resident retraction racing the target's own durable write
+  // ===========================================================================
+
+  describe('retraction racing the cache write', () => {
+    it('does not let a 1:1 save that lands after the retraction store the body', async () => {
+      const message = chatMessage()
+      // The retraction reaches the cache first and finds nothing to tombstone;
+      // the target's own write is still queued behind it.
+      const retraction = retractChatMessageInStorage(CHAT, message, { retractedAt: new Date() })
+      const save = messageCache.saveMessage(message)
+      const index = searchIndex.indexMessage(message)
+
+      await Promise.all([retraction, save, index])
+      await settle()
+
+      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('does not let a room save that lands after the retraction store the body', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      const retraction = retractRoomMessageInStorage(ROOM, message, { retractedAt: new Date() })
+      const save = messageCache.saveRoomMessage(message)
+      const index = searchIndex.indexMessage(message)
+
+      await Promise.all([retraction, save, index])
+      await settle()
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('does not let a background catch-up write the body of an already-retracted 1:1 message', async () => {
+      // Nothing cached and nothing resident: the retraction can only be recorded.
+      const message = chatMessage()
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, CHAT)
+      await settle()
+
+      // MAM then fetches the range for a conversation the user never opens, so
+      // the pending record is never replayed against a resident window.
+      await messageCache.saveMessages([message])
+      await searchIndex.indexMessages([message])
+
+      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('does not let a background catch-up write the body of an already-retracted room message', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-1', message.from, 'occ-alice')
+      await settle()
+
+      await messageCache.saveRoomMessages([message])
+      await searchIndex.indexMessages([message])
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('retains an unresolved actor after an unauthorized lower-tier write', async () => {
+      const target = roomMessage({
+        id: 'author-copy',
+        stanzaId: 'ambiguous-reference',
+        occupantId: 'occ-alice',
+      })
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        target.stanzaId!,
+        target.from,
+        target.occupantId
+      )
+      await settle()
+
+      const unrelated = roomMessage({
+        id: target.stanzaId!,
+        stanzaId: undefined,
+        from: `${ROOM}/bob`,
+        nick: 'bob',
+        occupantId: 'occ-bob',
+        body: 'innocent zirconium',
+      })
+      await messageCache.saveRoomMessage(unrelated)
+      await searchIndex.indexMessage(unrelated)
+      await messageCache.saveRoomMessage(target)
+      await searchIndex.indexMessage(target)
+
+      expect((await messageCache.getRoomMessage(ROOM, unrelated.id))?.body).toBe('innocent zirconium')
+      expect((await messageCache.getRoomMessage(ROOM, target.id))?.isRetracted).toBe(true)
+      expect(await searchIndex.search('zirconium')).toHaveLength(1)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('retains the durable pending record after an unauthorized resident match', async () => {
+      const target = roomMessage({
+        id: 'resident-author-copy',
+        stanzaId: 'resident-ambiguous-reference',
+        occupantId: 'occ-alice',
+      })
+      const unrelated = roomMessage({
+        id: target.stanzaId!,
+        stanzaId: undefined,
+        from: `${ROOM}/bob`,
+        nick: 'bob',
+        occupantId: 'occ-bob',
+        body: 'innocent tantalum',
+      })
+      roomStore.getState().addRoom(room(), [])
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        target.stanzaId!,
+        target.from,
+        target.occupantId
+      )
+      await settle()
+
+      roomStore.getState().addMessage(ROOM, unrelated)
+      expect(roomStore.getState().pendingRetractions.get(ROOM)).toHaveLength(1)
+
+      roomStore.getState().addMessage(ROOM, target)
+      const residentTarget = roomStore.getState().messages.get(ROOM)?.find(
+        (message) => message.id === target.id
+      )
+      expect(residentTarget?.isRetracted).toBe(true)
+      expect(roomStore.getState().pendingRetractions.get(ROOM) ?? []).toHaveLength(0)
+    })
+
+    it('retains an unresolved actor after an unauthorized cache probe', async () => {
+      const target = chatMessage({ id: 'author-copy', stanzaId: 'ambiguous-chat-reference' })
+      const unrelated = chatMessage({
+        id: target.stanzaId!,
+        stanzaId: undefined,
+        from: 'mallory@montague.example',
+        body: 'innocent niobium',
+      })
+      await messageCache.saveMessage(unrelated)
+      await searchIndex.indexMessage(unrelated)
+
+      chatStore.getState().recordPendingRetraction(CHAT, target.stanzaId!, target.from)
+      await settle()
+      await messageCache.saveMessage(target)
+      await searchIndex.indexMessage(target)
+
+      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('innocent niobium')
+      expect((await messageCache.getMessage(target.id))?.isRetracted).toBe(true)
+      expect(await searchIndex.search('niobium')).toHaveLength(1)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('does not let a later MAM re-delivery resurrect a retracted body', async () => {
+      const message = chatMessage()
+      await messageCache.saveMessage(message)
+      await retractChatMessageInStorage(CHAT, message, { retractedAt: new Date() })
+
+      // A later run has no ledger: the tombstoned row is the only evidence left.
+      _clearRetractedIdentitiesForTesting()
+
+      // The archive hands the message back, body and all.
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('does not let a later MAM re-delivery resurrect a retracted room body', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(message)
+      await retractRoomMessageInStorage(ROOM, message, { retractedAt: new Date() })
+
+      _clearRetractedIdentitiesForTesting()
+
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('finds an earlier room tombstone through a lower identity tier', async () => {
+      const early = roomMessage({ occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(early)
+      await retractRoomMessageInStorage(ROOM, early, { retractedAt: new Date() })
+      _clearRetractedIdentitiesForTesting()
+
+      const redelivered = { ...early, stanzaId: 'archive-late' }
+      await searchIndex.indexMessage(redelivered)
+      await messageCache.saveRoomMessage(redelivered)
+
+      expect((await messageCache.getRoomMessage(ROOM, early.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('rechecks the ledger immediately before single and batched index writes', async () => {
+      const single = chatMessage({ id: 'single-race', body: 'single promethium' })
+      const batch = Array.from({ length: 51 }, (_, index) =>
+        chatMessage({
+          id: `batch-race-${index}`,
+          body: index === 50 ? 'last technetium' : `ordinary batch ${index}`,
+        })
+      )
+      const cacheCheck = vi.spyOn(messageCache, 'areRetractedInCache')
+      cacheCheck.mockImplementationOnce(async (messages) => {
+        noteRetractedIdentity(
+          { kind: 'chat', entityId: CHAT, accountScope: SCOPE },
+          chatRetractionAliases(messages[0] as Message),
+          messages[0] as Message,
+          Date.now()
+        )
+        return messages.map(() => false)
+      })
+
+      await searchIndex.indexMessage(single)
+
+      cacheCheck.mockImplementationOnce(async (messages) => {
+        const last = messages[messages.length - 1] as Message
+        noteRetractedIdentity(
+          { kind: 'chat', entityId: CHAT, accountScope: SCOPE },
+          chatRetractionAliases(last),
+          last,
+          Date.now()
+        )
+        return messages.map(() => false)
+      })
+      await searchIndex.indexMessages(batch)
+
+      expect(await searchIndex.search('promethium')).toEqual([])
+      expect(await searchIndex.search('technetium')).toEqual([])
+    })
+
+    it('does not apply a verified stanza alias to an unrelated chat client id', async () => {
+      const retracted = chatMessage({ id: 'original-id', stanzaId: 'shared-raw-id' })
+      await retractChatMessageInStorage(CHAT, retracted, { retractedAt: new Date() })
+
+      const unrelated = chatMessage({
+        id: 'shared-raw-id',
+        stanzaId: undefined,
+        body: 'unrelated hafnium',
+      })
+      await messageCache.saveMessage(unrelated)
+
+      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('unrelated hafnium')
+      expect((await messageCache.getMessage(unrelated.id))?.isRetracted).toBeFalsy()
+    })
+
+    it('does not apply a verified stanza alias to an unrelated room client id', async () => {
+      const retracted = roomMessage({
+        id: 'original-room-id',
+        stanzaId: 'shared-room-raw-id',
+        occupantId: 'occ-alice',
+      })
+      await retractRoomMessageInStorage(ROOM, retracted, { retractedAt: new Date() })
+
+      const unrelated = roomMessage({
+        id: 'shared-room-raw-id',
+        stanzaId: undefined,
+        occupantId: 'occ-bob',
+        from: `${ROOM}/bob`,
+        nick: 'bob',
+        body: 'unrelated lutetium',
+      })
+      await messageCache.saveRoomMessage(unrelated)
+
+      expect((await messageCache.getRoomMessage(ROOM, unrelated.id))?.body).toBe('unrelated lutetium')
+      expect((await messageCache.getRoomMessage(ROOM, unrelated.id))?.isRetracted).toBeFalsy()
+    })
+
+    it('keeps competing pending actors until an authorized chat actor matches', async () => {
+      const message = chatMessage({ id: 'competing-chat-actors' })
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, 'mallory@example.com')
+      await settle()
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, message.from)
+      await settle()
+
+      await messageCache.saveMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('keeps competing pending actors until an authorized room occupant matches', async () => {
+      const message = roomMessage({ id: 'competing-room-actors', occupantId: 'occ-alice' })
+      roomStore.getState().recordPendingRetraction(ROOM, message.id, message.from, 'occ-mallory')
+      await settle()
+      roomStore.getState().recordPendingRetraction(ROOM, message.id, message.from, message.occupantId)
+      await settle()
+
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+
+      expect((await messageCache.getRoomMessage(ROOM, message.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('finds a chat tombstone through stanza and origin identity tiers', async () => {
+      const stanzaTarget = chatMessage({ id: 'stanza-old', stanzaId: 'shared-stanza' })
+      const originTarget = chatMessage({ id: 'origin-old', originId: 'shared-origin' })
+      await messageCache.saveMessages([stanzaTarget, originTarget])
+      await retractChatMessageInStorage(CHAT, stanzaTarget, { retractedAt: new Date() })
+      await retractChatMessageInStorage(CHAT, originTarget, { retractedAt: new Date() })
+      _clearRetractedIdentitiesForTesting()
+
+      const stanzaCopy = { ...stanzaTarget, id: 'stanza-new', body: 'stanza dysprosium' }
+      const originCopy = { ...originTarget, id: 'origin-new', body: 'origin erbium' }
+      await messageCache.saveMessages([stanzaCopy, originCopy])
+      await searchIndex.indexMessages([stanzaCopy, originCopy])
+
+      expect((await messageCache.getMessage(stanzaCopy.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(originCopy.id))?.isRetracted).toBe(true)
+      expect(await searchIndex.search('dysprosium')).toEqual([])
+      expect(await searchIndex.search('erbium')).toEqual([])
+    })
+
+    it('cleans the transitive chat identity closure after resolving one stanza', async () => {
+      const first = chatMessage({
+        id: 'closure-first',
+        stanzaId: 'closure-stanza-1',
+        originId: 'closure-origin-1',
+      })
+      const bridge = chatMessage({
+        id: 'closure-bridge',
+        stanzaId: 'closure-stanza-2',
+        originId: first.originId,
+      })
+      const last = chatMessage({
+        id: 'closure-last',
+        stanzaId: bridge.stanzaId,
+        originId: 'closure-origin-2',
+      })
+      await messageCache.saveMessages([first, bridge, last])
+      await searchIndex.indexMessages([first, bridge, last])
+
+      await retractChatMessageInStorage(
+        CHAT,
+        first,
+        { retractedAt: new Date() },
+        SCOPE,
+        first.stanzaId
+      )
+
+      for (const message of [first, bridge, last]) {
+        expect((await messageCache.getMessage(message.id))?.body).toBe('')
+        expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      }
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('removes resolved chat pending state before a lower-tier id can reuse it', async () => {
+      const target = chatMessage({ id: 'resolved-chat-target', stanzaId: 'reused-chat-reference' })
+      await messageCache.saveMessage(target)
+
+      chatStore.getState().recordPendingRetraction(CHAT, target.stanzaId!, target.from)
+      await settle()
+
+      expect(chatStore.getState().pendingRetractions.get(CHAT) ?? []).toEqual([])
+      const unrelated = chatMessage({
+        id: target.stanzaId!,
+        stanzaId: 'unrelated-chat-stanza',
+        body: 'unrelated rhenium',
+      })
+      await messageCache.saveMessage(unrelated)
+      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('unrelated rhenium')
+      expect((await messageCache.getMessage(unrelated.id))?.isRetracted).toBeFalsy()
+    })
+
+    it('removes resolved room pending state before a lower-tier id can reuse it', async () => {
+      const target = roomMessage({
+        id: 'resolved-room-target',
+        stanzaId: 'reused-room-reference',
+        occupantId: 'resolved-room-occupant',
+      })
+      await messageCache.saveRoomMessage(target)
+
+      roomStore.getState().recordPendingRetraction(
+        ROOM,
+        target.stanzaId!,
+        target.from,
+        target.occupantId
+      )
+      await settle()
+
+      expect(roomStore.getState().pendingRetractions.get(ROOM) ?? []).toEqual([])
+      const unrelated = roomMessage({
+        id: target.stanzaId!,
+        stanzaId: 'unrelated-room-stanza',
+        occupantId: target.occupantId,
+        body: 'unrelated osmium',
+      })
+      await messageCache.saveRoomMessage(unrelated)
+      expect((await messageCache.getRoomMessage(ROOM, unrelated.id, unrelated.from))?.body).toBe('unrelated osmium')
+      expect((await messageCache.getRoomMessage(ROOM, unrelated.id, unrelated.from))?.isRetracted).toBeFalsy()
+    })
+
+    it('retains competing room actors for separate messages sharing a client id', async () => {
+      const alice = roomMessage({
+        id: 'shared-pending-client-id',
+        stanzaId: undefined,
+        occupantId: 'shared-pending-alice',
+      })
+      const bob = roomMessage({
+        id: alice.id,
+        stanzaId: undefined,
+        from: `${ROOM}/bob`,
+        nick: 'bob',
+        occupantId: 'shared-pending-bob',
+      })
+      roomStore.getState().recordPendingRetraction(ROOM, alice.id, alice.from, alice.occupantId)
+      roomStore.getState().recordPendingRetraction(ROOM, bob.id, bob.from, bob.occupantId)
+      await settle()
+
+      await messageCache.saveRoomMessage(alice)
+      expect((await messageCache.getRoomMessage(ROOM, alice.id, alice.from))?.isRetracted).toBe(true)
+
+      await messageCache.saveRoomMessage(bob)
+      expect((await messageCache.getRoomMessage(ROOM, bob.id, bob.from))?.isRetracted).toBe(true)
+      expect((await messageCache.getRoomMessage(ROOM, alice.id, alice.from))?.body).toBe('')
+      expect((await messageCache.getRoomMessage(ROOM, bob.id, bob.from))?.body).toBe('')
+    })
+  })
+
+  describe('account scope continuity', () => {
+    it('keeps single and batched index writes in their starting account', async () => {
+      const single = chatMessage({ id: 'scope-single', body: 'single cobalt' })
+      const batch = chatMessage({ id: 'scope-batch', body: 'batch iridium' })
+      const cacheCheck = vi.spyOn(messageCache, 'areRetractedInCache')
+      cacheCheck.mockImplementationOnce(async (messages, scopeJid) => {
+        expect(scopeJid).toBe(SCOPE)
+        setStorageScopeJid(OTHER_SCOPE)
+        return messages.map(() => false)
+      })
+
+      await searchIndex.indexMessage(single)
+
+      setStorageScopeJid(SCOPE)
+      cacheCheck.mockImplementationOnce(async (messages, scopeJid) => {
+        expect(scopeJid).toBe(SCOPE)
+        setStorageScopeJid(OTHER_SCOPE)
+        return messages.map(() => false)
+      })
+      await searchIndex.indexMessages([batch])
+
+      expect(await searchInScope(SCOPE, 'cobalt')).toHaveLength(1)
+      expect(await searchInScope(SCOPE, 'iridium')).toHaveLength(1)
+      expect(await searchInScope(OTHER_SCOPE, 'cobalt')).toEqual([])
+      expect(await searchInScope(OTHER_SCOPE, 'iridium')).toEqual([])
+    })
+
+    it('removes from the account where the retraction started', async () => {
+      const target = chatMessage({ id: 'shared-account-id', body: 'alpha tungsten' })
+      await messageCache.saveMessage(target)
+      await searchIndex.indexMessage(target)
+
+      setStorageScopeJid(OTHER_SCOPE)
+      await searchIndex.initSearchIndex(OTHER_SCOPE)
+      const other = chatMessage({ id: target.id, body: 'beta vanadium' })
+      await messageCache.saveMessage(other)
+      await searchIndex.indexMessage(other)
+
+      setStorageScopeJid(SCOPE)
+      const updateMessage = messageCache.updateMessage
+      vi.spyOn(messageCache, 'updateMessage').mockImplementationOnce(async (...args) => {
+        await updateMessage(...args)
+        setStorageScopeJid(OTHER_SCOPE)
+      })
+
+      await retractChatMessageInStorage(CHAT, target, { retractedAt: new Date() })
+
+      expect(await searchInScope(SCOPE, 'tungsten')).toEqual([])
+      expect(await searchInScope(OTHER_SCOPE, 'vanadium')).toHaveLength(1)
+    })
+
+    it('keeps chat and room reaction writes in their starting account scope', async () => {
+      const chat = chatMessage({ id: 'reaction-chat' })
+      const roomTarget = roomMessage({ id: 'reaction-room', occupantId: 'occ-alice' })
+      await messageCache.saveMessage(chat)
+      await messageCache.saveRoomMessage(roomTarget)
+      noteRetractedIdentity(
+        { kind: 'chat', entityId: CHAT, accountScope: SCOPE },
+        chatRetractionAliases(chat),
+        chat,
+        Date.now()
+      )
+      noteRetractedIdentity(
+        { kind: 'room', entityId: ROOM, accountScope: SCOPE },
+        roomRetractionAliases(roomTarget),
+        roomTarget,
+        Date.now()
+      )
+
+      setStorageScopeJid(SCOPE)
+      await messageCache.updateMessageReactions(
+        CHAT,
+        chat.id,
+        'benvolio@example.com',
+        switchScopeWhileIterating(OTHER_SCOPE)
+      )
+      setStorageScopeJid(SCOPE)
+      await messageCache.updateRoomMessageReactions(
+        ROOM,
+        roomTarget.id,
+        `${ROOM}/benvolio`,
+        switchScopeWhileIterating(OTHER_SCOPE)
+      )
+      setStorageScopeJid(SCOPE)
+
+      expect((await messageCache.getMessage(chat.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getRoomMessage(ROOM, roomTarget.id))?.isRetracted).toBe(true)
+      await expectNoTraceOf(SECRET)
+    })
+  })
+
+  // ===========================================================================
+  // No regression on history reload or on search
+  // ===========================================================================
+
+  describe('history reload and search are unaffected', () => {
+    it('reloads the tombstone from the cache into the resident window', async () => {
+      const kept = chatMessage({ id: 'chat-kept', body: 'an ordinary line', timestamp: new Date(1_699_999_000_000) })
+      const message = chatMessage()
+      await messageCache.saveMessages([kept, message])
+      await searchIndex.indexMessages([kept, message])
+
+      chatStore.getState().recordPendingRetraction(CHAT, message.id, CHAT)
+      await settle()
+
+      await chatStore.getState().loadMessagesFromCache(CHAT)
+      const resident = chatStore.getState().messages.get(CHAT) ?? []
+      expect(resident.map((m) => m.id)).toEqual(['chat-kept', 'chat-1'])
+      expect(resident[1].isRetracted).toBe(true)
+      expect(resident[0].body).toBe('an ordinary line')
+      expect(await searchIndex.search('ordinary')).toHaveLength(1)
+    })
+
+    it('keeps the XEP-0425 moderator fields the same update carries', async () => {
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessage(message)
+      await searchIndex.indexMessage(message)
+      roomStore.getState().addRoom(room(), [message])
+
+      roomStore.getState().updateMessage(ROOM, 'archive-1', {
+        isRetracted: true,
+        retractedAt: new Date(),
+        isModerated: true,
+        moderatedBy: 'friar',
+        moderationReason: 'off topic',
+      })
+      await settle()
+
+      const stored = await messageCache.getRoomMessage(ROOM, message.id)
+      expect(stored?.isModerated).toBe(true)
+      expect(stored?.moderatedBy).toBe('friar')
+      expect(stored?.moderationReason).toBe('off topic')
+      await expectNoTraceOf(SECRET)
+    })
+
+    it('leaves other room messages searchable and intact', async () => {
+      const kept = roomMessage({ id: 'room-kept', stanzaId: 'archive-kept', body: 'an ordinary line', occupantId: 'occ-bob', from: `${ROOM}/bob`, nick: 'bob' })
+      const message = roomMessage({ stanzaId: 'archive-1', occupantId: 'occ-alice' })
+      await messageCache.saveRoomMessages([kept, message])
+      await searchIndex.indexMessages([kept, message])
+      roomStore.getState().addRoom(room(), [])
+
+      roomStore.getState().recordPendingRetraction(ROOM, 'archive-1', message.from, 'occ-alice')
+      await settle()
+
+      expect((await messageCache.getRoomMessage(ROOM, 'room-kept'))?.body).toBe('an ordinary line')
+      expect(await searchIndex.search('ordinary')).toHaveLength(1)
+      await expectNoTraceOf(SECRET)
+    })
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -64,6 +64,14 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
 import * as messageCache from '../utils/messageCache'
 
 /**
+ * The durable half of a retraction resolves the identity ladder before it writes,
+ * so its cache calls land a few microtasks after the synchronous store update.
+ */
+async function flushRetractionStorage(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
+/**
  * Simulate the view reporting "genuinely at the live edge" for the
  * CURRENT activation generation — mirrors what `RoomView`'s `reportLiveEdge`
  * callback does in the real app after `setActiveRoom` runs. Requires the REAL
@@ -5930,7 +5938,7 @@ describe('roomStore', () => {
       expect(updated?.isRetracted).toBe(true)
     })
 
-    it('should update message found by stanzaId when messageId is a stanza-id', () => {
+    it('should update message found by stanzaId when messageId is a stanza-id', async () => {
       const roomJid = 'room@conference.example.com'
       const msg: RoomMessage = {
         ...createMessage('client-id-1', roomJid, 'alice', 'Hello'),
@@ -5944,8 +5952,19 @@ describe('roomStore', () => {
 
       const updated = roomWindow(roomJid)[0]
       expect(updated?.isRetracted).toBe(true)
+      // The durable write resolves the identity ladder first, so it lands a few
+      // microtasks after the synchronous store update.
+      await flushRetractionStorage()
       // Verify IndexedDB update uses actual message id, not the stanza-id
-      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(roomJid, 'client-id-1', { isRetracted: true }, `${roomJid}/alice`)
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+        roomJid,
+        'client-id-1',
+        { isRetracted: true, retractedAt: expect.any(Date) },
+        `${roomJid}/alice`,
+        // The account scope captured before the first await; none is set here.
+        null,
+        expect.objectContaining({ id: 'client-id-1' })
+      )
     })
 
     it('should update message found by originId when a correction references the origin-id', () => {
@@ -6535,11 +6554,15 @@ describe('roomStore pending retractions', () => {
 
     expect(roomWindow(roomJid)[0]).toMatchObject({ isRetracted: true })
     expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
+    await flushRetractionStorage()
     expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
       roomJid,
       'm1',
       expect.objectContaining({ isRetracted: true }),
-      expect.any(String)
+      expect.any(String),
+      // The account scope captured before the first await; none is set here.
+      null,
+      expect.objectContaining({ id: 'm1' })
     )
   })
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -15,7 +15,7 @@ import type {
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
-import { roomIdentityKeys } from '../utils/roomMessageIdentity'
+import { resolveRoomMessageReference, roomIdentityKeys } from '../utils/roomMessageIdentity'
 import { getBareJid } from '../core/jid'
 import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
@@ -66,7 +66,8 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
-import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
+import { addPendingRetraction, applyPendingRetractions, removePendingRetraction, roomRetractionAuthor, type PendingRetraction } from './shared/pendingRetractions'
+import { retractRoomMessageInStorage, retractUnresidentRoomTarget } from './shared/retractionStorage'
 import { createRemoteDividerAdvanceTracker } from './shared/dividerAdvance'
 import { locallyPublishedDisplayed } from '../core/localMdsPublishes'
 import { isAhead } from './shared/readPointer'
@@ -684,15 +685,7 @@ function commitRoomUpdate(
  * dedupe, merge/sort/trim, and refresh the sidebar preview. The only difference between the two
  * callers is WHICH cache slice they fetch (latest-N vs the slice around an anchor).
  */
-/**
- * XEP-0424 authorship gate, room flavour. XEP-0421 occupant-id is the stable,
- * unforgeable author identity and wins whenever BOTH sides carry one — a nick
- * can be reassigned once its owner leaves. Mirrors Chat.isSameMucAuthor.
- */
-export const roomRetractionAuthor = (message: StoredRoomMessage, record: PendingRetraction): boolean =>
-  message.occupantId && record.actorOccupantId
-    ? message.occupantId === record.actorOccupantId
-    : message.from === record.actorJid
+export { roomRetractionAuthor }
 
 /**
  * Room twin of chatStore's resolvePendingRetractions: replay a room's pending
@@ -709,14 +702,17 @@ function resolveRoomPendingRetractions(
   const pending = state.pendingRetractions.get(roomJid)
   if (!pending || pending.length === 0) return { messages: slice }
 
-  const { messages, applied, remaining } = applyPendingRetractions(slice, pending, roomRetractionAuthor)
+  const { messages, resolved, remaining } = applyPendingRetractions(
+    slice,
+    pending,
+    roomRetractionAuthor,
+    resolveRoomMessageReference
+  )
   if (remaining.length === pending.length) return { messages }
 
   if (options.persist !== false) {
-    for (const { messageId, retractedAt } of applied) {
-      const retracted = findMessageById(messages, messageId)
-      void messageCache.updateRoomMessage(roomJid, messageId, { isRetracted: true, retractedAt }, retracted?.from)
-      if (retracted) void searchIndex.removeMessage(retracted)
+    for (const { message, retractedAt } of resolved) {
+      void retractRoomMessageInStorage(roomJid, message, { retractedAt })
     }
   }
 
@@ -958,7 +954,12 @@ export interface RoomState {
     incrementMentions?: boolean
   }) => void
   updateReactions: (roomJid: string, messageId: string, reactorNick: string, emojis: string[]) => void
-  updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
+  updateMessage: (
+    roomJid: string,
+    messageId: string,
+    updates: Partial<RoomMessage>,
+    retractionReference?: string
+  ) => void
   clearMessageStanzaId: (roomJid: string, stanzaId: string) => void
   getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
   /**
@@ -2328,7 +2329,7 @@ export const roomStore = createStore<RoomState>()(
     })
   },
 
-  updateMessage: (roomJid, messageId, updates) => {
+  updateMessage: (roomJid, messageId, updates, retractionReference) => {
     let recountNeeded = false
     set((state) => {
       const newRooms = new Map(state.rooms)
@@ -2339,23 +2340,35 @@ export const roomStore = createStore<RoomState>()(
       // Retractions (XEP-0424) reference the MUC stanza-id; corrections (XEP-0308)
       // reference the sender-assigned origin-id (a MUC may rewrite the message id).
       const resident = state.messages.get(roomJid) ?? []
-      const targetIdx = findMessageIndexById(resident, messageId)
+      let targetIdx: number
+      if (retractionReference) {
+        targetIdx = resident.findIndex((message) => message.id === messageId)
+      } else if (updates.isRetracted) {
+        targetIdx = resolveRoomMessageReference(resident, messageId)?.candidates[0]?.index ?? -1
+      } else {
+        targetIdx = findMessageIndexById(resident, messageId)
+      }
       let updatedMessage: RoomMessage | undefined
       const newMessages = targetIdx === -1 ? resident : resident.map((msg, i) => {
         if (i !== targetIdx) return msg
-        updatedMessage = { ...msg, ...updates }
+        updatedMessage = {
+          ...msg,
+          ...updates,
+          ...(updates.isRetracted && msg.retractedAt ? { retractedAt: msg.retractedAt } : {}),
+        }
         return updatedMessage
       })
 
       // Update IndexedDB (non-blocking) — use actual message id, not the lookup key
       if (updatedMessage) {
-        void messageCache.updateRoomMessage(roomJid, updatedMessage.id, updates, updatedMessage.from)
-
-        // Update search index: re-index if body changed, remove if retracted
         if (updates.isRetracted) {
-          void searchIndex.removeMessage(updatedMessage)
-        } else if (updates.body) {
-          void searchIndex.updateMessage(updatedMessage)
+          // The whole durable side of a retraction — cache row and search
+          // document — is the storage sink's, so the resident path and the
+          // not-resident path cannot drift.
+          void retractRoomMessageInStorage(roomJid, updatedMessage, updates)
+        } else {
+          void messageCache.updateRoomMessage(roomJid, updatedMessage.id, updates, updatedMessage.from)
+          if (updates.body) void searchIndex.updateMessage(updatedMessage)
         }
 
         // A retraction may target a `noLocalStore` message noted in
@@ -2432,6 +2445,7 @@ export const roomStore = createStore<RoomState>()(
   },
 
   recordPendingRetraction: (roomJid, targetId, actorJid, actorOccupantId) => {
+    const storageScopeAtStart = getStorageScopeJid()
     const record: PendingRetraction = {
       targetId,
       actorJid,
@@ -2439,15 +2453,25 @@ export const roomStore = createStore<RoomState>()(
       retractedAt: Date.now(),
     }
     const resident = get().messages.get(roomJid) ?? []
-    const target = findMessageById(resident, targetId)
+    const resolution = resolveRoomMessageReference(resident, targetId)
+    const target = resolution?.candidates.find(({ message }) =>
+      roomRetractionAuthor(message, record)
+    )?.message
     if (target) {
       // Resolved on the spot — updateMessage carries the write-through to
       // IndexedDB and the search-index removal.
-      if (!target.isRetracted && roomRetractionAuthor(target, record)) {
-        get().updateMessage(roomJid, target.id, { isRetracted: true, retractedAt: new Date() })
-      }
+      get().updateMessage(
+        roomJid,
+        target.id,
+        {
+          isRetracted: true,
+          retractedAt: target.retractedAt ?? new Date(record.retractedAt),
+        },
+        targetId
+      )
       return
     }
+    if (resolution?.authoritative) return
 
     set((state) => {
       const existing = state.pendingRetractions.get(roomJid) ?? []
@@ -2457,6 +2481,29 @@ export const roomStore = createStore<RoomState>()(
       nextPending.set(roomJid, next)
       savePendingRetractionsToStorage(nextPending)
       return { pendingRetractions: nextPending }
+    })
+
+    // The target is not resident, but it may well be CACHED — and the cache is
+    // where its identity is still canonical. Resolve and tombstone it there now,
+    // instead of leaving the body readable until something reloads the message.
+    void retractUnresidentRoomTarget(roomJid, record, storageScopeAtStart).then((outcome) => {
+      // Switching accounts during this probe leaves a consumed authoritative
+      // record persisted for the old account. After switching back, if the
+      // authoritative row is not resident, an unrelated lower-tier match can
+      // consume the stale record. This window is bounded to the in-flight
+      // account switch; closing it requires account-scoped durable mutation
+      // after the active scope changes.
+      if (outcome === 'pending' || getStorageScopeJid() !== storageScopeAtStart) return
+      set((state) => {
+        const existing = state.pendingRetractions.get(roomJid) ?? []
+        const remaining = removePendingRetraction(existing, record)
+        if (remaining === existing) return state
+        const nextPending = new Map(state.pendingRetractions)
+        if (remaining.length === 0) nextPending.delete(roomJid)
+        else nextPending.set(roomJid, remaining)
+        savePendingRetractionsToStorage(nextPending)
+        return { pendingRetractions: nextPending }
+      })
     })
   },
 

--- a/packages/fluux-sdk/src/stores/searchStore.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.ts
@@ -24,6 +24,8 @@ import type { XMPPClient } from '../core/XMPPClient'
 import type { Message, RoomMessage } from '../core/types'
 import { applyPendingRetractions } from './shared/pendingRetractions'
 import { getCorrectionStanzaIds } from '../core/types/message-internal'
+import { resolveChatMessageReference } from '../utils/chatMessageIdentity'
+import { resolveRoomMessageReference } from '../utils/roomMessageIdentity'
 
 /**
  * Filter type for narrowing search results by conversation type.
@@ -199,7 +201,12 @@ function isChatRetracted(msg: Message): boolean {
   const current = state.getMessage(msg.conversationId, msg.id) ?? msg
   if (current.isRetracted) return true
   const pending = state.pendingRetractions.get(msg.conversationId) ?? []
-  return applyPendingRetractions([current], pending, chatRetractionAuthor).applied.length > 0
+  return applyPendingRetractions(
+    [current],
+    pending,
+    chatRetractionAuthor,
+    resolveChatMessageReference
+  ).applied.length > 0
 }
 
 function findResidentRoomMessage(msg: RoomMessage, roomJid: string): RoomMessage | undefined {
@@ -219,7 +226,12 @@ function isRoomRetracted(msg: RoomMessage, roomJid: string): boolean {
   const current = findResidentRoomMessage(msg, roomJid) ?? msg
   if (current.isRetracted) return true
   const pending = state.pendingRetractions.get(roomJid) ?? []
-  return applyPendingRetractions([current], pending, roomRetractionAuthor).applied.length > 0
+  return applyPendingRetractions(
+    [current],
+    pending,
+    roomRetractionAuthor,
+    resolveRoomMessageReference
+  ).applied.length > 0
 }
 
 type SearchMessageCandidate =
@@ -697,7 +709,16 @@ async function indexMAMResults(results: SearchResult[]): Promise<void> {
       }
     }
 
-    // Index using the same search index used for local messages
+    // Index using the same search index used for local messages.
+    //
+    // A remote search result is projected without its archive, origin and
+    // occupant ids, so a room result is indexed as an ownerless composite
+    // document: a later retraction verified through the archive id cannot prove
+    // ownership of it, and that document's body survives. The window is bounded
+    // to room results indexed from a remote search that were never also indexed
+    // locally; closing it means carrying the optional identity fields through
+    // this projection, which belongs with the identity-boundary work rather than
+    // here.
     if (chatMessages.length > 0) {
       await searchIndex.indexMessages(chatMessages as any)
     }

--- a/packages/fluux-sdk/src/stores/shared/pendingRetractions.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingRetractions.test.ts
@@ -3,8 +3,11 @@ import {
   addPendingRetraction,
   applyPendingRetractions,
   PENDING_RETRACTION_CAP,
+  roomRetractionAuthor,
   type PendingRetraction,
 } from './pendingRetractions'
+import { resolveChatMessageReference } from '../../utils/chatMessageIdentity'
+import { resolveRoomMessageReference } from '../../utils/roomMessageIdentity'
 
 const AT = new Date('2026-07-22T03:53:00Z').getTime()
 
@@ -28,6 +31,20 @@ describe('addPendingRetraction', () => {
     expect(addPendingRetraction(existing, entry('a'))).toBe(existing)
   })
 
+  it('retains competing actors for the same unresolved target', () => {
+    const attacker = entry('a', 'mallory@example.com')
+    const author = entry('a', 'contact@example.com')
+
+    expect(addPendingRetraction([attacker], author)).toEqual([attacker, author])
+  })
+
+  it('keeps the earliest delivery for the same target and actor', () => {
+    const later = entry('a', 'contact@example.com', AT + 1000)
+    const earlier = entry('a', 'contact@example.com', AT)
+
+    expect(addPendingRetraction([later], earlier)).toEqual([earlier])
+  })
+
   it('caps the list, dropping the oldest record', () => {
     let list: PendingRetraction[] = []
     for (let i = 0; i < PENDING_RETRACTION_CAP + 5; i++) {
@@ -42,18 +59,29 @@ describe('applyPendingRetractions', () => {
   it('tombstones a target that is now present and reports it applied', () => {
     const messages = [message('m1'), message('m2')]
 
-    const result = applyPendingRetractions(messages, [entry('m2')], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [entry('m2')],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages[1]).toMatchObject({ id: 'm2', isRetracted: true, retractedAt: new Date(AT) })
     expect(result.messages[0]).toBe(messages[0])
     expect(result.applied).toEqual([{ messageId: 'm2', retractedAt: new Date(AT) }])
+    expect(result.resolved).toEqual([{ message: result.messages[1], retractedAt: new Date(AT) }])
     expect(result.remaining).toEqual([])
   })
 
   it('resolves the target through any id tier (stanza-id, origin-id)', () => {
     const messages = [message('m1', { stanzaId: 'srv-1' }), message('m2', { originId: 'org-2' })]
 
-    const result = applyPendingRetractions(messages, [entry('srv-1'), entry('org-2')], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [entry('srv-1'), entry('org-2')],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages[0]).toMatchObject({ isRetracted: true })
     expect(result.messages[1]).toMatchObject({ isRetracted: true })
@@ -63,37 +91,167 @@ describe('applyPendingRetractions', () => {
   it('keeps a record pending when its target is not present', () => {
     const messages = [message('m1')]
 
-    const result = applyPendingRetractions(messages, [entry('absent')], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [entry('absent')],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages).toBe(messages)
     expect(result.applied).toEqual([])
+    expect(result.resolved).toEqual([])
     expect(result.remaining).toEqual([entry('absent')])
   })
 
-  it('drops a record whose author does not match the target — never tombstones', () => {
+  it('retains a record whose first matching candidate has another author', () => {
     const messages = [message('m1', { from: 'someone-else@example.com' })]
 
-    const result = applyPendingRetractions(messages, [entry('m1')], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [entry('m1')],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages).toBe(messages)
     expect(result.applied).toEqual([])
+    expect(result.resolved).toEqual([])
+    expect(result.remaining).toEqual([entry('m1')])
+  })
+
+  it('prefers an authorized stanza target over an unauthorized client-id collision', () => {
+    const messages = [
+      message('shared', { from: 'someone-else@example.com' }),
+      message('author-copy', { stanzaId: 'shared' }),
+    ]
+
+    const result = applyPendingRetractions(
+      messages,
+      [entry('shared')],
+      isAuthor,
+      resolveChatMessageReference
+    )
+
+    expect(result.messages[0]).not.toHaveProperty('isRetracted')
+    expect(result.messages[1]).toMatchObject({ isRetracted: true })
+    expect(result.resolved[0].message).toBe(result.messages[1])
     expect(result.remaining).toEqual([])
+  })
+
+  it('consumes an unauthorized authoritative match', () => {
+    const messages = [message('author-copy', {
+      stanzaId: 'shared',
+      from: 'someone-else@example.com',
+    })]
+
+    const result = applyPendingRetractions(
+      messages,
+      [entry('shared')],
+      isAuthor,
+      resolveChatMessageReference
+    )
+
+    expect(result.messages).toBe(messages)
+    expect(result.remaining).toEqual([])
+  })
+
+  it('retains unmatched competing actors after a fallback target resolves', () => {
+    const attacker = entry('m1', 'mallory@example.com')
+    const author = entry('m1')
+
+    const result = applyPendingRetractions(
+      [message('m1')],
+      [attacker, author],
+      isAuthor,
+      resolveChatMessageReference
+    )
+
+    expect(result.messages[0]).toMatchObject({ isRetracted: true })
+    expect(result.remaining).toEqual([attacker])
+  })
+
+  it('consumes every competitor after an authoritative target resolves', () => {
+    const attacker = entry('shared-stanza', 'mallory@example.com')
+    const author = entry('shared-stanza')
+
+    const result = applyPendingRetractions(
+      [message('m1', { stanzaId: 'shared-stanza' })],
+      [attacker, author],
+      isAuthor,
+      resolveChatMessageReference
+    )
+
+    expect(result.messages[0]).toMatchObject({ isRetracted: true })
+    expect(result.remaining).toEqual([])
+  })
+
+  it('replays two legitimate room retractions sharing a client id', () => {
+    const alice = {
+      targetId: 'shared-id',
+      actorJid: 'room@example.com/alice',
+      actorOccupantId: 'occupant-alice',
+      retractedAt: AT,
+    }
+    const bob = {
+      targetId: 'shared-id',
+      actorJid: 'room@example.com/bob',
+      actorOccupantId: 'occupant-bob',
+      retractedAt: AT + 1,
+    }
+    const aliceMessage = message('shared-id', {
+      from: alice.actorJid,
+      occupantId: alice.actorOccupantId,
+    })
+    const bobMessage = message('shared-id', {
+      from: bob.actorJid,
+      occupantId: bob.actorOccupantId,
+    })
+
+    const first = applyPendingRetractions(
+      [aliceMessage],
+      [alice, bob],
+      roomRetractionAuthor,
+      resolveRoomMessageReference
+    )
+    expect(first.messages[0]).toMatchObject({ isRetracted: true })
+    expect(first.remaining).toEqual([bob])
+
+    const second = applyPendingRetractions(
+      [bobMessage],
+      first.remaining,
+      roomRetractionAuthor,
+      resolveRoomMessageReference
+    )
+    expect(second.messages[0]).toMatchObject({ isRetracted: true })
+    expect(second.remaining).toEqual([])
   })
 
   it('resolves an already-retracted target without rewriting the array', () => {
     const messages = [message('m1', { isRetracted: true })]
 
-    const result = applyPendingRetractions(messages, [entry('m1')], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [entry('m1')],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages).toBe(messages)
     expect(result.applied).toEqual([])
+    expect(result.resolved).toEqual([{ message: messages[0], retractedAt: new Date(AT) }])
     expect(result.remaining).toEqual([])
   })
 
   it('returns the input array untouched when there is nothing pending', () => {
     const messages = [message('m1')]
 
-    const result = applyPendingRetractions(messages, [], isAuthor)
+    const result = applyPendingRetractions(
+      messages,
+      [],
+      isAuthor,
+      resolveChatMessageReference
+    )
 
     expect(result.messages).toBe(messages)
     expect(result.remaining).toEqual([])

--- a/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
@@ -12,12 +12,13 @@
  * @module
  */
 
-import { findMessageIndexById } from '../../utils/messageLookup'
-
-/** A retraction whose target was not resident when it arrived. */
-export interface PendingRetraction {
-  /** The `<retract id="…">` reference — any id tier of the target. */
-  targetId: string
+/**
+ * The author fields the XEP-0424 gate reads, and nothing else. A full
+ * {@link PendingRetraction} satisfies it, and so does the actor kept alongside a
+ * retraction reference whose target has not been resolved yet
+ * (`utils/retractedIdentities.ts`), which carries no `targetId`.
+ */
+export interface RetractionActor {
   /**
    * Author the retraction claims to come from. XEP-0424 only lets a message be
    * retracted by its own author, so this is re-checked when the target shows up.
@@ -25,10 +26,16 @@ export interface PendingRetraction {
   actorJid: string
   /**
    * XEP-0421 occupant-id of the retracting author (MUC only). Preferred over
-   * {@link actorJid} when the target carries one too — a nick can be reassigned
-   * once its owner leaves, an occupant-id cannot.
+   * {@link RetractionActor.actorJid} when the target carries one too — a nick can
+   * be reassigned once its owner leaves, an occupant-id cannot.
    */
   actorOccupantId?: string
+}
+
+/** A retraction whose target was not resident when it arrived. */
+export interface PendingRetraction extends RetractionActor {
+  /** The `<retract id="…">` reference — any id tier of the target. */
+  targetId: string
   /** Epoch ms the retraction was received; becomes the target's `retractedAt`. */
   retractedAt: number
 }
@@ -49,66 +56,157 @@ export interface RetractableMessage {
   retractedAt?: Date
 }
 
+export interface PendingReferenceResolution<T> {
+  authoritative: boolean
+  candidates: Array<{ message: T; index: number }>
+}
+
 /** Outcome of replaying a conversation's pending retractions against a slice. */
 export interface PendingRetractionResult<T> {
   /** The patched array, or the input array itself when nothing changed. */
   messages: T[]
   /** Targets tombstoned by this pass — the caller writes these through to the cache. */
   applied: Array<{ messageId: string; retractedAt: Date }>
+  /** Author-resolved targets that need durable cache/index cleanup. */
+  resolved: Array<{ message: T; retractedAt: Date }>
   /** Records whose target is still unknown; keep them for the next pass. */
   remaining: PendingRetraction[]
 }
 
 /**
- * Add a record, newest last. Idempotent per target, and capped so a retraction
- * targeting a message we never load cannot grow the list without bound.
+ * Add a record, newest last. Idempotent per target and actor, and capped so
+ * retractions targeting messages we never load cannot grow the list without
+ * bound.
  */
 export function addPendingRetraction(
   list: PendingRetraction[],
   entry: PendingRetraction
 ): PendingRetraction[] {
-  // Same array back when the target is already recorded, so callers can skip the
-  // state write (a retraction re-delivered by carbons/MAM must not churn state).
-  if (list.some((r) => r.targetId === entry.targetId)) return list
+  const duplicateIndex = list.findIndex(
+    (record) =>
+      record.targetId === entry.targetId &&
+      record.actorJid === entry.actorJid &&
+      record.actorOccupantId === entry.actorOccupantId
+  )
+  if (duplicateIndex !== -1) {
+    if (list[duplicateIndex].retractedAt <= entry.retractedAt) return list
+    const next = [...list]
+    next[duplicateIndex] = entry
+    return next
+  }
   return [...list, entry].slice(-PENDING_RETRACTION_CAP)
+}
+
+export function removePendingRetraction(
+  list: PendingRetraction[],
+  entry: PendingRetraction
+): PendingRetraction[] {
+  const remaining = list.filter((record) =>
+    record.targetId !== entry.targetId ||
+    record.actorJid !== entry.actorJid ||
+    record.actorOccupantId !== entry.actorOccupantId
+  )
+  return remaining.length === list.length ? list : remaining
 }
 
 /**
  * Replay pending retractions against a message slice.
  *
- * A record resolves as soon as its target is present — applied when the author
- * matches, dropped otherwise (an unauthorized retraction must never tombstone,
- * and re-checking it on every load would be pure churn).
+ * A record resolves only when an author-matching target is present. A lower-tier
+ * identity collision can surface an unrelated message first, so an unauthorized
+ * candidate remains pending for a later authoritative match.
  */
 export function applyPendingRetractions<T extends RetractableMessage>(
   messages: T[],
   pending: readonly PendingRetraction[],
-  isAuthor: (message: T, record: PendingRetraction) => boolean
+  isAuthor: (message: T, record: PendingRetraction) => boolean,
+  resolveReference: (
+    messages: readonly T[],
+    reference: string
+  ) => PendingReferenceResolution<T> | undefined
 ): PendingRetractionResult<T> {
-  if (pending.length === 0) return { messages, applied: [], remaining: [] }
+  if (pending.length === 0) return { messages, applied: [], resolved: [], remaining: [] }
 
-  const applied: PendingRetractionResult<T>['applied'] = []
+  const applied = new Map<number, Date>()
+  const resolved = new Map<number, Date>()
   const remaining: PendingRetraction[] = []
   let patched: T[] | null = null
 
+  const byReference = new Map<string, PendingRetraction[]>()
   for (const record of pending) {
+    const records = byReference.get(record.targetId)
+    if (records) records.push(record)
+    else byReference.set(record.targetId, [record])
+  }
+
+  for (const [reference, records] of byReference) {
     const source: T[] = patched ?? messages
-    const index = findMessageIndexById(source, record.targetId)
-    if (index === -1) {
-      remaining.push(record)
+    const resolution = resolveReference(source, reference)
+    if (!resolution) {
+      remaining.push(...records)
       continue
     }
 
-    const target = source[index]
-    // Resolved either way from here: an unauthorized retraction is dropped, not
-    // retried, and an already-tombstoned target needs no second write.
-    if (target.isRetracted || !isAuthor(target, record)) continue
+    const consumed = new Set<PendingRetraction>()
+    for (const candidate of resolution.candidates) {
+      const index = candidate.index
+      const target = (patched ?? messages)[index]
+      const authorized = records.filter((record) => isAuthor(target, record))
+      if (authorized.length === 0) continue
+      for (const record of authorized) consumed.add(record)
 
-    const retractedAt = new Date(record.retractedAt)
-    patched = [...source]
-    patched[index] = { ...target, isRetracted: true, retractedAt }
-    applied.push({ messageId: target.id, retractedAt })
+      const receivedAt = Math.min(...authorized.map((record) => record.retractedAt))
+      const retractedAt = target.retractedAt && target.retractedAt.getTime() <= receivedAt
+        ? target.retractedAt
+        : new Date(receivedAt)
+      const knownResolved = resolved.get(index)
+      if (!knownResolved || retractedAt < knownResolved) resolved.set(index, retractedAt)
+      if (target.isRetracted && !applied.has(index)) continue
+      if (target.isRetracted && target.retractedAt?.getTime() === retractedAt.getTime()) continue
+
+      const next: T[] = [...(patched ?? messages)]
+      next[index] = { ...target, isRetracted: true, retractedAt }
+      patched = next
+      const knownApplied = applied.get(index)
+      if (!knownApplied || retractedAt < knownApplied) applied.set(index, retractedAt)
+    }
+    if (!resolution.authoritative) {
+      remaining.push(...records.filter((record) => !consumed.has(record)))
+    }
   }
 
-  return { messages: patched ?? messages, applied, remaining }
+  return {
+    messages: patched ?? messages,
+    applied: [...applied].map(([index, retractedAt]) => ({
+      messageId: (patched ?? messages)[index].id,
+      retractedAt,
+    })),
+    resolved: [...resolved].map(([index, retractedAt]) => ({
+      message: (patched ?? messages)[index],
+      retractedAt,
+    })),
+    remaining,
+  }
 }
+
+/**
+ * XEP-0424 authorship gate for a 1:1 message: only a message's own author may
+ * retract it.
+ */
+export const chatRetractionAuthor = (
+  message: { from: string },
+  record: RetractionActor
+): boolean => message.from === record.actorJid
+
+/**
+ * XEP-0424 authorship gate, room flavour. XEP-0421 occupant-id is the stable,
+ * unforgeable author identity and wins whenever BOTH sides carry one — a nick
+ * can be reassigned once its owner leaves. Mirrors Chat.isSameMucAuthor.
+ */
+export const roomRetractionAuthor = (
+  message: { from: string; occupantId?: string },
+  record: RetractionActor
+): boolean =>
+  message.occupantId && record.actorOccupantId
+    ? message.occupantId === record.actorOccupantId
+    : message.from === record.actorJid

--- a/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
+++ b/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
@@ -1,0 +1,243 @@
+/**
+ * The durable half of a retraction (XEP-0424) — shared by the chat and room stores.
+ *
+ * A tombstone in the resident window is a rendering decision. This module is the
+ * one that makes the retraction TRUE of the data: the cached row loses its
+ * content and the search document goes away. Both stores route every retraction
+ * through here — the resident path, the pending-record replay, and the case this
+ * module exists for, a retraction whose target is not resident at all.
+ *
+ * An evicted or never-loaded target leaves no resident object to patch, so the
+ * durable cache resolves its tiered identity ladder of stanzaId → originId →
+ * from+id. Search documents carry optional identity fields to prove ownership,
+ * but the cache remains the canonical boundary for resolving and expanding
+ * logical copies before their content is scrubbed and their index entries are
+ * removed.
+ *
+ * @module Stores/Shared/RetractionStorage
+ */
+
+import type { Message } from '../../core/types/chat'
+import type { RoomMessage } from '../../core/types/room'
+import * as messageCache from '../../utils/messageCache'
+import * as searchIndex from '../../utils/searchIndex'
+import {
+  chatRetractionAliases,
+  clearPendingRetractionIdentity,
+  consumePendingRetractionIdentity,
+  noteRetractedIdentity,
+  notePendingRetractionIdentity,
+  roomRetractionAliases,
+  type RetractionScope,
+} from '../../utils/retractedIdentities'
+import { getStorageScopeJid } from '../../utils/storageScope'
+import {
+  chatRetractionAuthor,
+  roomRetractionAuthor,
+  type PendingRetraction,
+} from './pendingRetractions'
+
+export type PendingRetractionOutcome = 'pending' | 'consumed' | 'resolved'
+
+/**
+ * Apply a retraction to the durable copies of a KNOWN chat message.
+ *
+ * The ledger note comes first and is not conditional on the cache write finding
+ * a row: when the message's own save is still in flight there is nothing to
+ * update yet, and the note is what stops that save from landing the body (see
+ * `retractedIdentities.ts`).
+ */
+export async function retractChatMessageInStorage(
+  conversationId: string,
+  message: Message,
+  updates: Partial<Message> = {},
+  storageScope: string | null = getStorageScopeJid(),
+  targetReference: string = message.stanzaId ?? message.originId ?? message.id
+): Promise<void> {
+  // `updates` carries whatever else the same event set — XEP-0425 moderation
+  // arrives as a retraction plus its moderator fields, and dropping them here
+  // would leave the cached row saying only "deleted".
+  const retractedAt = message.retractedAt ?? updates.retractedAt ?? new Date()
+  const scope: RetractionScope = { kind: 'chat', entityId: conversationId, accountScope: storageScope }
+  noteRetractedIdentity(scope, chatRetractionAliases(message), message, retractedAt.getTime())
+  const resolution = await messageCache.findChatRetractionTargets(
+    conversationId,
+    targetReference,
+    storageScope
+  )
+  const actor = { actorJid: message.from }
+  const targets = new Map<string, Message>([[message.id, message]])
+  for (const candidate of resolution?.candidates ?? []) {
+    if (chatRetractionAuthor(candidate, actor)) targets.set(candidate.id, candidate)
+  }
+  const queue = [...targets.values()]
+  for (let index = 0; index < queue.length; index++) {
+    const target = queue[index]
+    const copies = await messageCache.findChatMessageCopies(
+      conversationId,
+      target,
+      storageScope
+    )
+    for (const candidate of copies) {
+      if (targets.has(candidate.id) || !chatRetractionAuthor(candidate, actor)) continue
+      targets.set(candidate.id, candidate)
+      queue.push(candidate)
+    }
+  }
+  for (const target of targets.values()) {
+    const targetRetractedAt = target.retractedAt ?? retractedAt
+    noteRetractedIdentity(
+      scope,
+      chatRetractionAliases(target),
+      target,
+      targetRetractedAt.getTime()
+    )
+    await messageCache.updateMessage(
+      target.id,
+      { ...updates, isRetracted: true, retractedAt: targetRetractedAt },
+      storageScope,
+      { conversationId: target.conversationId, from: target.from }
+    )
+    await searchIndex.removeMessage(target, storageScope)
+  }
+}
+
+/** Room twin of {@link retractChatMessageInStorage}. */
+export async function retractRoomMessageInStorage(
+  roomJid: string,
+  message: RoomMessage,
+  updates: Partial<RoomMessage> = {},
+  storageScope: string | null = getStorageScopeJid()
+): Promise<void> {
+  // See the chat twin: `updates` may carry XEP-0425 moderator fields.
+  const retractedAt = message.retractedAt ?? updates.retractedAt ?? new Date()
+  const scope: RetractionScope = { kind: 'room', entityId: roomJid, accountScope: storageScope }
+  noteRetractedIdentity(scope, roomRetractionAliases(message), message, retractedAt.getTime())
+  const actor = { actorJid: message.from, actorOccupantId: message.occupantId }
+  const copies = (await messageCache.findRoomMessageCopies(
+    roomJid,
+    message,
+    storageScope
+  )).filter((copy) => roomRetractionAuthor(copy.message, actor))
+  const targets: messageCache.RoomMessageCopy[] = copies.length > 0
+    ? copies
+    : [{
+        cacheKey: '',
+        identityKeys: roomRetractionAliases(message),
+        ids: [message.id],
+        message,
+      }]
+  for (const target of targets) {
+    const targetRetractedAt = target.message.retractedAt ?? retractedAt
+    noteRetractedIdentity(
+      scope,
+      roomRetractionAliases(target.message),
+      target.message,
+      targetRetractedAt.getTime()
+    )
+    await messageCache.updateRoomMessage(
+      roomJid,
+      target.message.id,
+      { ...updates, isRetracted: true, retractedAt: targetRetractedAt },
+      target.message.from,
+      storageScope,
+      target.message
+    )
+    await searchIndex.removeMessage(
+      target.message,
+      storageScope,
+      { identityKeys: target.identityKeys, ids: target.ids }
+    )
+  }
+}
+
+/**
+ * Apply a retraction whose target is NOT in the resident window, by resolving it
+ * against the durable cache.
+ *
+ * An unresolved reference retains its actor until a cache row arrives, so the
+ * write boundary can verify authorship before adopting the retraction.
+ */
+export async function retractUnresidentChatTarget(
+  conversationId: string,
+  record: PendingRetraction,
+  storageScope: string | null = getStorageScopeJid()
+): Promise<PendingRetractionOutcome> {
+  const scope: RetractionScope = { kind: 'chat', entityId: conversationId, accountScope: storageScope }
+  notePendingRetractionIdentity(scope, record.targetId, record)
+
+  const resolution = await messageCache.findChatRetractionTargets(
+    conversationId,
+    record.targetId,
+    storageScope
+  )
+  const targets = resolution?.candidates.filter((message) =>
+    chatRetractionAuthor(message, record)
+  ) ?? []
+  if (targets.length === 0 && resolution?.authoritative) {
+    clearPendingRetractionIdentity(scope, record.targetId)
+    return 'consumed'
+  }
+  if (targets.length === 0) return 'pending'
+
+  await retractChatMessageInStorage(
+    conversationId,
+    targets[0],
+    { retractedAt: new Date(record.retractedAt) },
+    storageScope,
+    record.targetId
+  )
+  consumePendingRetractionIdentity(
+    scope,
+    record.targetId,
+    record,
+    resolution?.authoritative ?? false
+  )
+  return 'resolved'
+}
+
+/**
+ * Room twin of {@link retractUnresidentChatTarget}.
+ *
+ * The candidate list can hold more than one row — after a nick reassignment an
+ * old archive copy and a recent message share room, nick and client id. The
+ * XEP-0424 authorship gate picks between them on the occupant-id, exactly as it
+ * does for a resident window. Cache resolution returns only the highest matching
+ * identity tier.
+ */
+export async function retractUnresidentRoomTarget(
+  roomJid: string,
+  record: PendingRetraction,
+  storageScope: string | null = getStorageScopeJid()
+): Promise<PendingRetractionOutcome> {
+  const scope: RetractionScope = { kind: 'room', entityId: roomJid, accountScope: storageScope }
+  notePendingRetractionIdentity(scope, record.targetId, record)
+
+  const resolution = await messageCache.findRoomRetractionTargets(
+    roomJid,
+    record.targetId,
+    storageScope
+  )
+  const target = resolution?.candidates.find((message) =>
+    roomRetractionAuthor(message, record)
+  )
+  if (!target && resolution?.authoritative) {
+    clearPendingRetractionIdentity(scope, record.targetId)
+    return 'consumed'
+  }
+  if (!target) return 'pending'
+
+  await retractRoomMessageInStorage(
+    roomJid,
+    target,
+    { retractedAt: new Date(record.retractedAt) },
+    storageScope
+  )
+  consumePendingRetractionIdentity(
+    scope,
+    record.targetId,
+    record,
+    resolution?.authoritative ?? false
+  )
+  return 'resolved'
+}

--- a/packages/fluux-sdk/src/utils/chatMessageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/chatMessageIdentity.ts
@@ -1,0 +1,95 @@
+/**
+ * The one definition of a 1:1 chat message's identity (XEP-0359), shared by the
+ * resident-window dedup (`chatStore`'s timeline config) and the durable
+ * retraction boundary. The 1:1 twin of {@link module:Utils/RoomMessageIdentity}:
+ * the same tiered ladder — stanzaId, then originId, then from+id — with two
+ * copies being the same logical message iff they share ANY key.
+ *
+ * Unlike the room ladder these keys are NOT scoped by conversation. A 1:1
+ * message traverses one archive (the account's own), and `from` already pins the
+ * lowest tier to a sender, so the keys are usable across conversations.
+ *
+ * @module Utils/ChatMessageIdentity
+ */
+
+/** The fields the chat ladder reads. `Message` satisfies it. */
+export interface ChatIdentityFields {
+  from: string
+  id: string
+  stanzaId?: string
+  originId?: string
+}
+
+export type ChatIdentityTier = 'stanzaId' | 'originId' | 'fallback'
+
+export interface ChatReferenceProbe<T> {
+  tier: ChatIdentityTier
+  authoritative: boolean
+  matches: (message: T) => boolean
+}
+
+export interface ChatReferenceResolution<T> {
+  tier: ChatIdentityTier
+  authoritative: boolean
+  candidates: Array<{ message: T; index: number }>
+}
+
+export interface ChatIdentityProbe<T> extends ChatReferenceProbe<T> {
+  reference: string
+}
+
+/** Every identity key the message carries, most-specific first. For matching. */
+export function chatIdentityKeys(m: ChatIdentityFields): string[] {
+  const keys: string[] = []
+  if (m.stanzaId) keys.push(`stanzaId:${m.stanzaId}`)
+  if (m.originId) keys.push(`originId:${m.originId}`)
+  keys.push(`from:${m.from}:id:${m.id}`)
+  return keys
+}
+
+/** The single canonical key — the highest tier present. */
+export function chatCanonicalKey(m: ChatIdentityFields): string {
+  return chatIdentityKeys(m)[0]
+}
+
+export function chatReferenceProbes<T extends Pick<ChatIdentityFields, 'id' | 'stanzaId' | 'originId'>>(
+  reference: string
+): ChatReferenceProbe<T>[] {
+  return [
+    { tier: 'stanzaId', authoritative: true, matches: (message) => message.stanzaId === reference },
+    { tier: 'originId', authoritative: true, matches: (message) => message.originId === reference },
+    { tier: 'fallback', authoritative: false, matches: (message) => message.id === reference },
+  ]
+}
+
+export function chatIdentityProbes<T extends Pick<ChatIdentityFields, 'id' | 'stanzaId' | 'originId'>>(
+  message: Pick<ChatIdentityFields, 'id' | 'stanzaId' | 'originId'>
+): ChatIdentityProbe<T>[] {
+  const references: Record<ChatIdentityTier, string | undefined> = {
+    stanzaId: message.stanzaId,
+    originId: message.originId,
+    fallback: message.id,
+  }
+  return chatReferenceProbes<T>('').flatMap((tierProbe) => {
+    const reference = references[tierProbe.tier]
+    if (!reference) return []
+    const probe = chatReferenceProbes<T>(reference).find(({ tier }) => tier === tierProbe.tier)!
+    return [{ ...probe, reference }]
+  })
+}
+
+export function resolveChatMessageReference<T extends Pick<ChatIdentityFields, 'id' | 'stanzaId' | 'originId'>>(
+  messages: readonly T[],
+  reference: string
+): ChatReferenceResolution<T> | undefined {
+  for (const probe of chatReferenceProbes<T>(reference)) {
+    const candidates: ChatReferenceResolution<T>['candidates'] = []
+    messages.forEach((message, index) => {
+      if (probe.matches(message)) candidates.push({ message, index })
+    })
+    if (candidates.length > 0) {
+      return { tier: probe.tier, authoritative: probe.authoritative, candidates }
+    }
+  }
+  return undefined
+}

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -6,6 +6,9 @@ import type { Message, RoomMessage } from '../core/types'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
 import { selectCatchUpQuery } from './mamCatchUpUtils'
 import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
+import {
+  _clearRetractedIdentitiesForTesting,
+} from './retractedIdentities'
 
 // Must import after fake-indexeddb/auto
 import * as messageCache from './messageCache'
@@ -54,6 +57,7 @@ describe('messageCache', () => {
 
   beforeEach(async () => {
     _resetStorageScopeForTesting()
+    _clearRetractedIdentitiesForTesting()
     // Reset IndexedDB completely before each test
     // This ensures test isolation with fake-indexeddb
     globalThis.indexedDB = new IDBFactory()
@@ -373,7 +377,7 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'react-1' })
         await messageCache.saveMessage(message)
 
-        const found = await messageCache.updateMessageReactions('react-1', 'bob@example.com', ['👍'])
+        const found = await messageCache.updateMessageReactions(conversationId, 'react-1', 'bob@example.com', ['👍'])
 
         expect(found).toBe(true)
         const retrieved = await messageCache.getMessage('react-1')
@@ -384,10 +388,21 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'react-2', stanzaId: 'server-stanza-id-1' })
         await messageCache.saveMessage(message)
 
-        const found = await messageCache.updateMessageReactions('server-stanza-id-1', 'bob@example.com', ['👍'])
+        const found = await messageCache.updateMessageReactions(conversationId, 'server-stanza-id-1', 'bob@example.com', ['👍'])
 
         expect(found).toBe(true)
         const retrieved = await messageCache.getMessage('react-2')
+        expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
+      })
+
+      it('should find the message by originId', async () => {
+        const message = createMockMessage(conversationId, { id: 'react-origin', originId: 'origin-reaction-id' })
+        await messageCache.saveMessage(message)
+
+        const found = await messageCache.updateMessageReactions(conversationId, 'origin-reaction-id', 'bob@example.com', ['👍'])
+
+        expect(found).toBe(true)
+        const retrieved = await messageCache.getMessage(message.id)
         expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
       })
 
@@ -395,7 +410,7 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'react-3', reactions: { '👍': ['bob@example.com'] } })
         await messageCache.saveMessage(message)
 
-        await messageCache.updateMessageReactions('react-3', 'bob@example.com', ['❤️'])
+        await messageCache.updateMessageReactions(conversationId, 'react-3', 'bob@example.com', ['❤️'])
 
         const retrieved = await messageCache.getMessage('react-3')
         expect(retrieved?.reactions).toEqual({ '❤️': ['bob@example.com'] })
@@ -408,14 +423,14 @@ describe('messageCache', () => {
         })
         await messageCache.saveMessage(message)
 
-        await messageCache.updateMessageReactions('react-4', 'bob@example.com', [])
+        await messageCache.updateMessageReactions(conversationId, 'react-4', 'bob@example.com', [])
 
         const retrieved = await messageCache.getMessage('react-4')
         expect(retrieved?.reactions).toEqual({ '👍': ['carol@example.com'] })
       })
 
       it('should return false when the message is not found', async () => {
-        const found = await messageCache.updateMessageReactions('nonexistent', 'bob@example.com', ['👍'])
+        const found = await messageCache.updateMessageReactions(conversationId, 'nonexistent', 'bob@example.com', ['👍'])
         expect(found).toBe(false)
       })
     })
@@ -571,6 +586,7 @@ describe('messageCache', () => {
         expect(byStanzaId).not.toBeNull()
         expect(byStanzaId?.id).toBe('room-stanza')
       })
+
     })
 
     describe('saveRoomMessages', () => {
@@ -1347,6 +1363,12 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     expect((await messageCache.getRoomMessage(ROOM, 'server-9'))!.reactions?.['👍']).toContain('r@c/bob')
     await messageCache.updateRoomMessageReactions(ROOM, 'client-1', 'r@c/bob', []) // removal
     expect((await messageCache.getRoomMessage(ROOM, 'server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
+  })
+  it('updateRoomMessageReactions resolves an origin id', async () => {
+    await messageCache.saveRoomMessage(mk({ id: 'origin-reaction-target', originId: 'reaction-origin' }))
+    const found = await messageCache.updateRoomMessageReactions(ROOM, 'reaction-origin', 'r@c/bob', ['👍'])
+    expect(found).toBe(true)
+    expect((await messageCache.getRoomMessage(ROOM, 'origin-reaction-target'))!.reactions?.['👍']).toContain('r@c/bob')
   })
   it('getRoomMessagesAround returns each logical message once', async () => {
     await messageCache.saveRoomMessage(mk({ stanzaId: 'S' }))

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -15,7 +15,31 @@ import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message } from '../core/types/chat'
 import type { RoomMessage } from '../core/types/room'
 import { getStorageScopeJid } from './storageScope'
-import { roomCanonicalKey, roomIdentityKeys, roomStanzaKey, roomOriginKey } from './roomMessageIdentity'
+import {
+  roomCanonicalKey,
+  roomIdentityKeys,
+  roomOriginKey,
+  roomReferenceProbes,
+  roomStanzaKey,
+  type RoomIdentityTier,
+} from './roomMessageIdentity'
+import {
+  chatIdentityProbes,
+  chatReferenceProbes,
+  type ChatIdentityTier,
+  type ChatReferenceProbe,
+} from './chatMessageIdentity'
+import {
+  adoptPendingRetraction,
+  chatPendingRetractionAliases,
+  chatRetractionAliases,
+  noteRetractedIdentity,
+  roomPendingRetractionAliases,
+  roomRetractionAliases,
+  retractedAtForIdentity,
+  type RetractionScope,
+} from './retractedIdentities'
+import { chatRetractionAuthor, roomRetractionAuthor } from '../stores/shared/pendingRetractions'
 import {
   makeCacheOrderKey,
   isAfterBoundary,
@@ -194,7 +218,7 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
           // alive meanwhile via the migration's chained requests, and openDB resolves
           // only after it commits. Do not deleteObjectStore here (illegal from the
           // async continuation) — the migration clear()s the legacy store instead.
-          migrateRoomStoreToCanonical(transaction).catch((err) => {
+          migrateRoomStoreToCanonical(transaction, scopeJid).catch((err) => {
             // Log before aborting: this streaming rewrite of the whole room archive
             // is the riskiest path in the upgrade, and the abort otherwise swallows
             // the cause silently. Then: aborting rejects openDB (getDB's caller
@@ -267,6 +291,100 @@ function deserializeRoomMessage(stored: StoredRoomMessage): RoomMessage {
 }
 
 // =============================================================================
+// Retraction enforcement (XEP-0424)
+// =============================================================================
+
+/**
+ * A retracted row keeps its position and its tombstone flag and NOTHING a reader
+ * could render as content. `isRenderableStoredMessage` keeps a tombstone
+ * renderable on `isRetracted` alone, so stripping these does not move an unread
+ * boundary or a catch-up cursor.
+ *
+ * `body` is required on `BaseMessage`, so it is emptied rather than deleted.
+ * `replyTo` is left alone: it quotes ANOTHER message, which this retraction does
+ * not cover.
+ */
+function scrubRetractedContent<T extends StoredMessage | StoredRoomMessage>(row: T): T {
+  return {
+    ...row,
+    body: '',
+    originalBody: undefined,
+    attachment: undefined,
+    linkPreview: undefined,
+    poll: undefined,
+    pollClosed: undefined,
+    encryptedPayload: undefined,
+    unsupportedEncryption: undefined,
+  }
+}
+
+/**
+ * The single retraction gate every cache write passes through.
+ *
+ * Two jobs, in order:
+ * 1. Adopt a retraction this session recorded but the row could not carry — the
+ *    retraction arrived while this very write was still in flight, so there was
+ *    no row to tombstone (see `retractedIdentities.ts`).
+ * 2. Strip the content of any retracted row, whatever marked it: a fresh
+ *    tombstone, a re-delivered MAM copy merged onto one, or the ledger above.
+ *
+ * Applying it at write time rather than at the tombstoning call site is what
+ * makes "no retracted body survives in the cache" hold for EVERY writer,
+ * including a re-save that would otherwise resurrect the body.
+ */
+function enforceRetraction(
+  row: StoredMessage,
+  scope: RetractionScope
+): StoredMessage
+function enforceRetraction(
+  row: StoredRoomMessage,
+  scope: RetractionScope
+): StoredRoomMessage
+function enforceRetraction(
+  row: StoredMessage | StoredRoomMessage,
+  scope: RetractionScope
+): StoredMessage | StoredRoomMessage {
+  let next = row
+  if (!next.isRetracted) {
+    const verifiedAliases =
+      scope.kind === 'room'
+        ? roomRetractionAliases(next as StoredRoomMessage)
+        : chatRetractionAliases(next)
+    const retractedAt =
+      retractedAtForIdentity(scope, verifiedAliases, (record) =>
+        scope.kind === 'room'
+          ? roomRetractionAuthor(next as StoredRoomMessage, record)
+          : chatRetractionAuthor(next, record)
+      ) ??
+      adoptPendingRetraction(
+        scope,
+        scope.kind === 'room'
+          ? roomPendingRetractionAliases(next as StoredRoomMessage)
+          : chatPendingRetractionAliases(next),
+        (record) =>
+          scope.kind === 'room'
+            ? roomRetractionAuthor(next as StoredRoomMessage, record)
+            : chatRetractionAuthor(next, record)
+      )
+    if (retractedAt !== undefined) {
+      noteRetractedIdentity(scope, verifiedAliases, next, retractedAt)
+      next = { ...next, isRetracted: true, retractedAt }
+    }
+  }
+  return next.isRetracted ? scrubRetractedContent(next) : next
+}
+
+/** The retraction scope a stored chat row belongs to. */
+function chatScopeOf(row: { conversationId: string }, accountScope?: string | null): RetractionScope {
+  return { kind: 'chat', entityId: row.conversationId, accountScope }
+}
+
+/** The retraction scope a stored room row belongs to. */
+function roomScopeOf(row: { roomJid: string }, accountScope?: string | null): RetractionScope {
+  return { kind: 'room', entityId: row.roomJid, accountScope }
+}
+
+// =============================================================================
 // v4 room-store canonicalization (identity-resolving upsert + streaming migration)
 // =============================================================================
 
@@ -276,11 +394,15 @@ export function _setMigrationFaultForTesting(on: boolean): void {
   migrationFaultForTesting = on
 }
 
+type RoomIdentityStore = {
+  index(name: 'identityKeys'): { getAll(key: string): Promise<StoredRoomMessage[]> }
+  index(name: 'ids'): { getAll(key: string): Promise<StoredRoomMessage[]> }
+}
+
 /** The minimal room-store surface the identity-resolving upsert needs. */
-type RoomStoreLike = {
+type RoomStoreLike = RoomIdentityStore & {
   put(v: StoredRoomMessage): Promise<unknown>
   delete(key: string): Promise<void>
-  index(name: 'identityKeys'): { getAll(key: string): Promise<StoredRoomMessage[]> }
 }
 
 /**
@@ -290,7 +412,7 @@ type RoomStoreLike = {
  * message under several rows, and only a scan of all tiers finds them all.
  */
 async function findRoomRowsByIdentity(
-  store: RoomStoreLike,
+  store: RoomIdentityStore,
   m: StoredRoomMessage
 ): Promise<StoredRoomMessage[]> {
   const found = new Map<string, StoredRoomMessage>()
@@ -319,6 +441,33 @@ async function findRoomRowById(
   return matches.find((r) => r.roomJid === roomJid && (from === undefined || r.from === from))
 }
 
+function roomRowBelongsToMessage(row: StoredRoomMessage, message: RoomMessage): boolean {
+  const messageKeys = new Set(roomIdentityKeys(message))
+  if (!row.identityKeys.some((key) => messageKeys.has(key))) return false
+  return !row.occupantId || !message.occupantId || row.occupantId === message.occupantId
+}
+
+async function findRoomRowsByReference(
+  store: RoomIdentityStore,
+  roomJid: string,
+  reference: string
+): Promise<{ tier: RoomIdentityTier; authoritative: boolean; candidates: StoredRoomMessage[] } | undefined> {
+  for (const probe of roomReferenceProbes<StoredRoomMessage>(reference)) {
+    const matches = probe.tier === 'fallback'
+      ? await store.index('ids').getAll(reference)
+      : await store.index('identityKeys').getAll(
+          probe.tier === 'stanzaId'
+            ? roomStanzaKey(roomJid, reference)
+            : roomOriginKey(roomJid, reference)
+        )
+    const candidates = matches.filter((row) => row.roomJid === roomJid)
+    if (candidates.length > 0) {
+      return { tier: probe.tier, authoritative: probe.authoritative, candidates }
+    }
+  }
+  return undefined
+}
+
 /**
  * Core: resolve every existing row sharing any tier with `incoming` (echo,
  * live/MAM, bridge), merge them and `incoming` into one, delete the losers, put
@@ -331,7 +480,8 @@ async function findRoomRowById(
 async function upsertStoredRoomRow(
   store: RoomStoreLike,
   incoming: StoredRoomMessage,
-  excludeKey?: string
+  excludeKey?: string,
+  scopeJid?: string | null
 ): Promise<void> {
   const matches = (await findRoomRowsByIdentity(store, incoming)).filter((r) => r.cacheKey !== excludeKey)
   let merged = incoming
@@ -339,12 +489,22 @@ async function upsertStoredRoomRow(
   const survivorKey = merged.cacheKey
   if (excludeKey && excludeKey !== survivorKey) await store.delete(excludeKey)
   for (const row of matches) if (row.cacheKey !== survivorKey) await store.delete(row.cacheKey)
-  await store.put(merged)
+  // The documented room-cache identity treats a shared room, nick, and client
+  // id as one message. After nick reassignment, a colliding new message therefore
+  // inherits an old occupant's tombstone and its content is scrubbed. This window
+  // is bounded to a reused nick with a colliding client id; closing
+  // fluux-room-nick-reuse-false-deletion belongs at
+  // fluux-identity-resolution-boundary rather than in the scrub.
+  await store.put(enforceRetraction(merged, roomScopeOf(merged, scopeJid)))
 }
 
 /** Insert or merge a live-arriving message by identity (migration + archive write path). */
-async function upsertRoomRowByIdentity(store: RoomStoreLike, message: RoomMessage): Promise<void> {
-  await upsertStoredRoomRow(store, serializeRoomMessage(message))
+async function upsertRoomRowByIdentity(
+  store: RoomStoreLike,
+  message: RoomMessage,
+  scopeJid?: string | null
+): Promise<void> {
+  await upsertStoredRoomRow(store, serializeRoomMessage(message), undefined, scopeJid)
 }
 
 /** Minimal cursor view over the legacy room store during migration. */
@@ -361,13 +521,16 @@ type MigrationTransaction = { objectStore(name: string): unknown }
  * transaction; any throw is caught by the caller, which aborts that transaction
  * atomically — so a partial rewrite can never be observed.
  */
-async function migrateRoomStoreToCanonical(transaction: MigrationTransaction): Promise<void> {
+async function migrateRoomStoreToCanonical(
+  transaction: MigrationTransaction,
+  scopeJid: string | null
+): Promise<void> {
   const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE) as LegacyRoomStore
   const dest = transaction.objectStore(ROOM_MESSAGES_STORE) as RoomStoreLike
   let cursor = await legacy.openCursor()
   while (cursor) {
     if (migrationFaultForTesting) throw new Error('migration fault (test)')
-    await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value))
+    await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value), scopeJid)
     cursor = await cursor.continue()
   }
   await legacy.clear() // legacy store now empty; a future version bump can drop it synchronously
@@ -377,10 +540,81 @@ async function migrateRoomStoreToCanonical(transaction: MigrationTransaction): P
 // Chat Message Operations
 // =============================================================================
 
-/** Minimal structural view of the idb chat-message object store. */
-type ChatMessageStore = {
+type StoredMessageCursor = {
+  value: StoredMessage
+  continue(): Promise<StoredMessageCursor | null>
+}
+
+type ChatMessageReader = {
   get(key: string): Promise<StoredMessage | undefined>
+  index(name: 'stanzaId'): { getAll(key: string): Promise<StoredMessage[]> }
+  index(name: 'conv_timestamp'): {
+    openCursor(range: IDBKeyRange): Promise<StoredMessageCursor | null>
+  }
+}
+
+/** Minimal structural view of the idb chat-message object store. */
+type ChatMessageStore = ChatMessageReader & {
   put(value: StoredMessage): Promise<unknown>
+}
+
+async function findChatRowsByReference(
+  store: ChatMessageReader,
+  conversationId: string,
+  reference: string
+): Promise<{ tier: ChatIdentityTier; authoritative: boolean; candidates: StoredMessage[] } | undefined> {
+  for (const probe of chatReferenceProbes<StoredMessage>(reference)) {
+    const candidates = await findChatRowsForProbe(store, conversationId, reference, probe)
+    if (candidates.length > 0) {
+      return { tier: probe.tier, authoritative: probe.authoritative, candidates }
+    }
+  }
+  return undefined
+}
+
+async function findChatRowsForProbe(
+  store: ChatMessageReader,
+  conversationId: string,
+  reference: string,
+  probe: ChatReferenceProbe<StoredMessage>
+): Promise<StoredMessage[]> {
+  let matches: StoredMessage[] = []
+  if (probe.tier === 'stanzaId') {
+    matches = await store.index('stanzaId').getAll(reference)
+  } else if (probe.tier === 'originId') {
+    let cursor = await store.index('conv_timestamp').openCursor(
+      entityTimestampRange(conversationId)
+    )
+    while (cursor) {
+      if (probe.matches(cursor.value)) matches.push(cursor.value)
+      cursor = await cursor.continue()
+    }
+  } else {
+    const clientMatch = await store.get(reference)
+    if (clientMatch) matches = [clientMatch]
+  }
+  return matches.filter(
+    (row) => row.conversationId === conversationId && probe.matches(row)
+  )
+}
+
+async function findChatRowsByIdentity(
+  store: ChatMessageReader,
+  message: Message
+): Promise<StoredMessage[]> {
+  for (const probe of chatIdentityProbes<StoredMessage>(message)) {
+    const matches = await findChatRowsForProbe(
+      store,
+      message.conversationId,
+      probe.reference,
+      probe
+    )
+    const candidates = probe.tier === 'fallback'
+      ? matches.filter((row) => row.from === message.from)
+      : matches
+    if (candidates.length > 0) return candidates
+  }
+  return []
 }
 
 /**
@@ -527,17 +761,23 @@ export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): Store
  */
 async function putChatMessageGuarded(
   store: ChatMessageStore,
-  message: Message
+  message: Message,
+  scopeJid: string | null
 ): Promise<void> {
+  const existing = (await findChatRowsByIdentity(store, message))[0]
   const incomingRank = decryptionRank(message)
-  if (incomingRank < 2) {
-    const existing = await store.get(message.id)
-    if (existing && decryptionRank(existing) > incomingRank) {
-      // Existing entry is more recoverable — don't degrade it.
-      return
-    }
+  if (existing && incomingRank < 2 && decryptionRank(existing) > incomingRank) {
+    // Existing entry is more recoverable — don't degrade it.
+    return
   }
-  await store.put(serializeMessage(message))
+  // XEP-0424 is monotonic: a re-delivered copy of a retracted message (MAM
+  // re-ingestion, a carbon) carries its original body and would otherwise
+  // resurrect it. The chat twin of mergeRoomRows' retraction OR.
+  const incoming =
+    existing?.isRetracted
+      ? { ...serializeMessage(message), isRetracted: true, retractedAt: existing.retractedAt }
+      : serializeMessage(message)
+  await store.put(enforceRetraction(incoming, chatScopeOf(incoming, scopeJid)))
 }
 
 /**
@@ -546,10 +786,11 @@ async function putChatMessageGuarded(
  * degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  */
 export async function saveMessageWithResult(message: Message): Promise<boolean> {
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
-    await putChatMessageGuarded(tx.store, message)
+    await putChatMessageGuarded(tx.store, message, scopeJid)
     await tx.done
     return true
   } catch (error) {
@@ -576,13 +817,14 @@ export async function saveMessage(message: Message): Promise<void> {
 export async function saveMessages(messages: Message[]): Promise<boolean> {
   if (messages.length === 0) return true
 
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(MESSAGES_STORE)
 
     for (const msg of messages) {
-      await putChatMessageGuarded(store, msg)
+      await putChatMessageGuarded(store, msg, scopeJid)
     }
     await tx.done
     return true
@@ -1027,12 +1269,18 @@ export async function getTotalRoomMessageCount(): Promise<number> {
  */
 export async function updateMessage(
   id: string,
-  updates: Partial<Message>
+  updates: Partial<Message>,
+  scopeJid: string | null = getStorageScopeJid(),
+  expectedOwner?: Pick<Message, 'conversationId' | 'from'>
 ): Promise<void> {
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const existing = await db.get(MESSAGES_STORE, id)
     if (!existing) return
+    if (expectedOwner && (
+      existing.conversationId !== expectedOwner.conversationId ||
+      existing.from !== expectedOwner.from
+    )) return
 
     const updated = {
       ...existing,
@@ -1048,7 +1296,7 @@ export async function updateMessage(
           : updates.retractedAt ?? existing.retractedAt,
     }
 
-    await db.put(MESSAGES_STORE, updated)
+    await db.put(MESSAGES_STORE, enforceRetraction(updated, chatScopeOf(updated, scopeJid)))
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to update message:', error)
@@ -1065,18 +1313,20 @@ export async function updateMessage(
  * @returns true if the message was found and updated, false otherwise.
  */
 export async function updateMessageReactions(
+  conversationId: string,
   messageId: string,
   reactorJid: string,
   emojis: string[],
 ): Promise<boolean> {
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB(getStorageScopeJid())
-
-    let existing = await db.get(MESSAGES_STORE, messageId)
+    const db = await getDB(scopeJid)
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+    const existing = (await findChatRowsByReference(tx.store, conversationId, messageId))?.candidates[0]
     if (!existing) {
-      existing = await db.getFromIndex(MESSAGES_STORE, 'stanzaId', messageId)
+      await tx.done
+      return false
     }
-    if (!existing) return false
 
     // Build new reactions map: remove reactor from all, then add to new emojis
     const newReactions: Record<string, string[]> = {}
@@ -1100,7 +1350,8 @@ export async function updateMessageReactions(
       reactions: Object.keys(newReactions).length > 0 ? newReactions : undefined,
     }
 
-    await db.put(MESSAGES_STORE, updated)
+    await tx.store.put(enforceRetraction(updated, chatScopeOf(updated, scopeJid)))
+    await tx.done
     return true
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -1108,6 +1359,203 @@ export async function updateMessageReactions(
     }
     return false
   }
+}
+
+export interface RetractionTargetResolution<T> {
+  tier: ChatIdentityTier | RoomIdentityTier
+  authoritative: boolean
+  candidates: T[]
+}
+
+/**
+ * Every cached chat message a `<retract id="…">` reference could name, most
+ * specific tier first.
+ *
+ * A retraction names ONE tier of its target (`Chat.getMessageReferenceId`), and
+ * which tier it is depends on what the retracting client knew — so the reference
+ * has to be tried against the whole ladder, not just the store's primary key.
+ * Resolution stops at the highest tier with a match: indexed `stanzaId`, then
+ * `originId` through a conversation-bounded cursor walk, then the primary-key
+ * client id. Adding an origin-id index would be a schema change.
+ *
+ * Confined to `conversationId`: a client id is a name in one stream and repeats
+ * across conversations.
+ */
+export async function findChatRetractionTargets(
+  conversationId: string,
+  targetId: string,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<RetractionTargetResolution<Message> | undefined> {
+  try {
+    const db = await getDB(scopeJid)
+    const store = db.transaction(MESSAGES_STORE).store
+    const resolution = await findChatRowsByReference(store, conversationId, targetId)
+    return resolution
+      ? { ...resolution, candidates: resolution.candidates.map(deserializeMessage) }
+      : undefined
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to resolve chat retraction target:', error)
+    }
+    return undefined
+  }
+}
+
+/**
+ * Every cached chat row sharing any identity tier with `message`.
+ *
+ * Unlike reference resolution, this probes the complete ladder because a
+ * resolved target can bridge several archive copies through different aliases.
+ * The caller repeats this expansion for newly discovered authorized copies.
+ */
+export async function findChatMessageCopies(
+  conversationId: string,
+  message: Message,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<Message[]> {
+  try {
+    const db = await getDB(scopeJid)
+    const store = db.transaction(MESSAGES_STORE).store
+    const found = new Map<string, StoredMessage>()
+    for (const probe of chatIdentityProbes<StoredMessage>(message)) {
+      const matches = await findChatRowsForProbe(
+        store,
+        conversationId,
+        probe.reference,
+        probe
+      )
+      const candidates = probe.tier === 'fallback'
+        ? matches.filter((row) => row.from === message.from)
+        : matches
+      for (const candidate of candidates) found.set(candidate.id, candidate)
+    }
+    return [...found.values()].map(deserializeMessage)
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to expand chat message copies:', error)
+    }
+    return []
+  }
+}
+
+/**
+ * Every cached room message a `<retract id="…">` reference could name, most
+ * specific tier first.
+ *
+ * Room twin of {@link findChatRetractionTargets}, resolved entirely through the
+ * room-scoped `identityKeys` aliases plus the `ids` index. Every lookup is
+ * confined to `roomJid`: stanza ids and origin ids are assigned per archive and
+ * repeat across rooms, and client ids repeat everywhere.
+ *
+ * Resolution stops at the first tier with a match. MORE THAN ONE row can come
+ * back from the `ids` tier alone — after a nick
+ * reassignment an old archive copy and a recent message can share room, nick and
+ * client id. The caller's XEP-0424 authorship gate (occupant-id first) decides
+ * among rows within that tier, exactly as it does for a resident window.
+ */
+export async function findRoomRetractionTargets(
+  roomJid: string,
+  targetId: string,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<RetractionTargetResolution<RoomMessage> | undefined> {
+  try {
+    const db = await getDB(scopeJid)
+    const store = db.transaction(ROOM_MESSAGES_STORE).store
+    const resolution = await findRoomRowsByReference(store, roomJid, targetId)
+    return resolution
+      ? { ...resolution, candidates: resolution.candidates.map(deserializeRoomMessage) }
+      : undefined
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to resolve room retraction target:', error)
+    }
+    return undefined
+  }
+}
+
+export interface RoomMessageCopy {
+  cacheKey: string
+  identityKeys: string[]
+  ids: string[]
+  message: RoomMessage
+}
+
+export async function findRoomMessageCopies(
+  roomJid: string,
+  message: RoomMessage,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<RoomMessageCopy[]> {
+  try {
+    const db = await getDB(scopeJid)
+    const store = db.transaction(ROOM_MESSAGES_STORE).store
+    const found = new Map<string, StoredRoomMessage>()
+    const queue = [serializeRoomMessage(message)]
+    for (let index = 0; index < queue.length; index++) {
+      for (const row of await findRoomRowsByIdentity(store, queue[index])) {
+        if (row.roomJid !== roomJid || found.has(row.cacheKey)) continue
+        found.set(row.cacheKey, row)
+        queue.push(row)
+      }
+    }
+    return [...found.values()].map((row) => ({
+      cacheKey: row.cacheKey,
+      identityKeys: row.identityKeys,
+      ids: row.ids,
+      message: deserializeRoomMessage(row),
+    }))
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to expand room message copies:', error)
+    }
+    return []
+  }
+}
+
+/**
+ * Which of these messages the durable archive already holds as a tombstone,
+ * positionally aligned with the input.
+ *
+ * The search index has no retraction state of its own and an incoming copy
+ * carries none either: an archive re-delivery of a message retracted in an
+ * EARLIER session arrives with its original body, and nothing but the cache row
+ * remembers otherwise. One readonly transaction probes every identity tier the
+ * incoming room copy carries; a merged row keeps every absorbed tier in
+ * `identityKeys`.
+ */
+export async function areRetractedInCache(
+  messages: readonly (Message | RoomMessage)[],
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<boolean[]> {
+  const verdicts = new Array<boolean>(messages.length).fill(false)
+  if (messages.length === 0) return verdicts
+
+  try {
+    const db = await getDB(scopeJid)
+    const tx = db.transaction([MESSAGES_STORE, ROOM_MESSAGES_STORE], 'readonly')
+    const chatRows = tx.objectStore(MESSAGES_STORE)
+    const roomRows = tx.objectStore(ROOM_MESSAGES_STORE).index('identityKeys')
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i]
+      if (message.type === 'groupchat') {
+        for (const key of roomIdentityKeys(message)) {
+          const rows = await roomRows.getAll(key)
+          if (rows.some((row) => row.roomJid === message.roomJid && row.isRetracted === true)) {
+            verdicts[i] = true
+            break
+          }
+        }
+      } else {
+        const rows = await findChatRowsByIdentity(chatRows, message)
+        verdicts[i] = rows.some((row) => row.isRetracted === true)
+      }
+    }
+    await tx.done
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to read retraction state from cache:', error)
+    }
+  }
+  return verdicts
 }
 
 /**
@@ -1179,8 +1627,9 @@ export async function saveRoomMessage(message: RoomMessage): Promise<void> {
 export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean> {
   if (messages.length === 0) return true
 
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(ROOM_MESSAGES_STORE)
 
@@ -1188,7 +1637,7 @@ export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean
     // and merges, so a same-batch optimistic+reflection pair must collapse into one
     // row — the second upsert has to observe the first's write. Concurrent puts would
     // each see an empty store and leave two rows.
-    for (const msg of messages) await upsertRoomRowByIdentity(store as never, msg)
+    for (const msg of messages) await upsertRoomRowByIdentity(store as never, msg, scopeJid)
     await tx.done
     return true
   } catch (error) {
@@ -1468,14 +1917,20 @@ export async function updateRoomMessage(
   roomJid: string,
   id: string,
   updates: Partial<RoomMessage>,
-  from?: string
+  from?: string,
+  scopeJid: string | null = getStorageScopeJid(),
+  expectedOwner?: RoomMessage
 ): Promise<void> {
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(ROOM_MESSAGES_STORE)
     const existing = await findRoomRowById(store.index('ids'), roomJid, id, from)
     if (!existing) { await tx.done; return }
+    if (expectedOwner && !roomRowBelongsToMessage(existing, expectedOwner)) {
+      await tx.done
+      return
+    }
     const updated = { ...deserializeRoomMessage(existing), ...updates } as RoomMessage
     // Compare identity FIELDS, not just the canonical key: adding an originId to a
     // row that already has a stanzaId (or changing the id) leaves the canonical key
@@ -1491,7 +1946,7 @@ export async function updateRoomMessage(
       const row = serializeRoomMessage(updated)
       row.identityKeys = existing.identityKeys // unchanged
       row.ids = existing.ids
-      await store.put(row)
+      await store.put(enforceRetraction(row, roomScopeOf(row, scopeJid)))
     } else {
       // An identity field changed. Union the existing row's accumulated aliases in
       // (do NOT delete-then-upsert — a deleted row cannot be rediscovered, and
@@ -1508,7 +1963,7 @@ export async function updateRoomMessage(
       // re-keys + deletes the stale row when it changed; either way the pre-update
       // copy is not merged back in. The finder uses row.identityKeys (revoked tier
       // absent), so a row legitimately still carrying that stanzaId is NOT pulled in.
-      await upsertStoredRoomRow(store as never, row, existing.cacheKey)
+      await upsertStoredRoomRow(store as never, row, existing.cacheKey, scopeJid)
     }
     await tx.done
   } catch (error) {
@@ -1532,8 +1987,11 @@ export async function updateRoomMessageReactions(
   reactorNick: string,
   emojis: string[],
 ): Promise<boolean> {
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
+    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+    const store = tx.store
 
     // Both resolution paths must be confined to THIS room, or a collision in
     // another room wins. A MUC reaction references the server stanza-id, which
@@ -1543,12 +2001,11 @@ export async function updateRoomMessageReactions(
     // by room JID, so getFromIndex('ids', …) could return a DIFFERENT room's
     // message when a client id collides; take every id match and keep the one in
     // this room. (Mirrors getRoomMessageByStanzaId's room-scoping.)
-    let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, messageId))
+    const existing = (await findRoomRowsByReference(store, roomJid, messageId))?.candidates[0]
     if (!existing) {
-      const idMatches = await db.getAllFromIndex(ROOM_MESSAGES_STORE, 'ids', messageId)
-      existing = idMatches.find((row) => row.roomJid === roomJid)
+      await tx.done
+      return false
     }
-    if (!existing) return false
 
     // Build new reactions map: remove reactor from all, then add to new emojis
     const newReactions: Record<string, string[]> = {}
@@ -1575,7 +2032,8 @@ export async function updateRoomMessageReactions(
       reactions: Object.keys(newReactions).length > 0 ? newReactions : undefined,
     }
 
-    await db.put(ROOM_MESSAGES_STORE, updated)
+    await store.put(enforceRetraction(updated, roomScopeOf(updated, scopeJid)))
+    await tx.done
     return true
   } catch (error) {
     if (isIndexedDBAvailable()) {

--- a/packages/fluux-sdk/src/utils/retractedIdentities.ts
+++ b/packages/fluux-sdk/src/utils/retractedIdentities.ts
@@ -1,0 +1,288 @@
+/**
+ * Identities retracted during this session, so a durable write that RACES the
+ * retraction cannot resurrect the retracted body.
+ *
+ * A retraction (XEP-0424) and its target's own cache write are independent
+ * fire-and-forget promises. When the retraction wins the race the cache row does
+ * not exist yet: `updateMessage` finds nothing and returns, then the pending save
+ * lands and stores the body, and the pending `indexMessage` writes the document
+ * the retraction had just tried to remove. A cache row cannot record a retraction
+ * that has no row, so the record lives here instead — consulted by every cache put
+ * and by every index write.
+ *
+ * Identity is NOT reimplemented here. It delegates to the tiered ladders
+ * (`roomMessageIdentity.ts`, `chatMessageIdentity.ts`): stanzaId → originId →
+ * from+id. A `from+id`-only key would fail a retraction that references the
+ * stanza id only — the same lesson `stores/shared/transientUnread.ts` records for
+ * unread counting, applied here to the cache and index boundary.
+ *
+ * An unresolved reference stays separate from the verified identity ledger and
+ * carries its actor until a cache write can apply the authorship gate.
+ *
+ * Scoped by `{storageScope, kind, entityId}` (never a bare `entityId` — that
+ * would leak retractions across accounts sharing the same room/chat id).
+ * Session-lived: once the write it guards has landed, the tombstone is in the
+ * cache row itself and outlives this map.
+ *
+ * @module Utils/RetractedIdentities
+ */
+
+import { getStorageScopeJid } from './storageScope'
+import { roomIdentityKeys, type RoomIdentityFields } from './roomMessageIdentity'
+import { chatIdentityKeys, type ChatIdentityFields } from './chatMessageIdentity'
+
+/** Which entity a retraction belongs to. Mirrors `transientUnread.ScopeKey`. */
+export interface RetractionScope {
+  kind: 'chat' | 'room'
+  /** `conversationId` for chat, `roomJid` for room. */
+  entityId: string
+  accountScope?: string | null
+}
+
+export interface PendingRetractionIdentity {
+  actorJid: string
+  actorOccupantId?: string
+  retractedAt: number
+}
+
+export interface VerifiedRetractionActor {
+  from: string
+  occupantId?: string
+}
+
+// U+0000 separator: scopes/kinds/entity ids/ids cannot contain it, so joins never collide.
+const SEP = String.fromCharCode(0)
+
+/**
+ * Alias cap across every scope. The cap keeps unresolved references and
+ * race-protection entries bounded during a long session. More than 2,000
+ * concurrent verified actor-alias entries — about 667 messages carrying three
+ * identity tiers — can evict a retraction before its cache and index writes
+ * land, allowing a later save to retain the original body. Closing that bounded
+ * window requires an authorized lifecycle or durable state.
+ */
+const ALIAS_CAP = 2000
+
+/** alias -> verified actors. Insertion-ordered, so the oldest evicts first. */
+const retracted = new Map<string, PendingRetractionIdentity[]>()
+const pending = new Map<string, PendingRetractionIdentity[]>()
+let retractedCount = 0
+let pendingCount = 0
+
+function sameActor(
+  left: PendingRetractionIdentity,
+  right: Pick<PendingRetractionIdentity, 'actorJid' | 'actorOccupantId'>
+): boolean {
+  return left.actorJid === right.actorJid && left.actorOccupantId === right.actorOccupantId
+}
+
+function scopePrefix(scope: RetractionScope): string {
+  const accountScope = scope.accountScope === undefined ? getStorageScopeJid() : scope.accountScope
+  return `${accountScope ?? ''}${SEP}${scope.kind}${SEP}${scope.entityId}${SEP}`
+}
+
+/**
+ * The alias a bare `<retract id="…">` reference contributes. Every message
+ * contributes one per id tier it carries, so a note made from the reference alone
+ * still resolves once the message itself shows up.
+ */
+function rawAlias(reference: string): string {
+  return `ref${SEP}${reference}`
+}
+
+export interface PendingRetractionAlias {
+  alias: string
+  authoritative: boolean
+}
+
+function rawAliasesOf(
+  m: { id: string; stanzaId?: string; originId?: string }
+): PendingRetractionAlias[] {
+  const aliases = new Map<string, boolean>()
+  for (const [reference, authoritative] of [
+    [m.id, false],
+    [m.stanzaId, true],
+    [m.originId, true],
+  ] as const) {
+    if (!reference) continue
+    const alias = rawAlias(reference)
+    aliases.set(alias, (aliases.get(alias) ?? false) || authoritative)
+  }
+  return [...aliases].map(([alias, authoritative]) => ({ alias, authoritative }))
+}
+
+/** Every verified alias a chat message is known under. */
+export function chatRetractionAliases(m: ChatIdentityFields & { id: string }): string[] {
+  return chatIdentityKeys(m)
+}
+
+/** Every verified alias a room message is known under. */
+export function roomRetractionAliases(m: RoomIdentityFields): string[] {
+  return roomIdentityKeys(m)
+}
+
+export function chatPendingRetractionAliases(
+  m: ChatIdentityFields & { id: string }
+): PendingRetractionAlias[] {
+  return rawAliasesOf(m)
+}
+
+export function roomPendingRetractionAliases(m: RoomIdentityFields): PendingRetractionAlias[] {
+  return rawAliasesOf(m)
+}
+
+export function notePendingRetractionIdentity(
+  scope: RetractionScope,
+  targetId: string,
+  record: PendingRetractionIdentity
+): void {
+  const key = `${scopePrefix(scope)}${rawAlias(targetId)}`
+  const known = pending.get(key) ?? []
+  const actorIndex = known.findIndex((candidate) => sameActor(candidate, record))
+  if (actorIndex === -1) {
+    pending.set(key, [...known, record])
+    pendingCount++
+  } else if (record.retractedAt < known[actorIndex].retractedAt) {
+    const next = [...known]
+    next[actorIndex] = record
+    pending.set(key, next)
+  }
+  while (pendingCount > ALIAS_CAP) {
+    const oldest = pending.keys().next()
+    if (oldest.done) break
+    const records = pending.get(oldest.value)!
+    if (records.length === 1) pending.delete(oldest.value)
+    else pending.set(oldest.value, records.slice(1))
+    pendingCount--
+  }
+}
+
+export function clearPendingRetractionIdentity(
+  scope: RetractionScope,
+  targetId: string
+): void {
+  const key = `${scopePrefix(scope)}${rawAlias(targetId)}`
+  const records = pending.get(key)
+  if (records) pendingCount -= records.length
+  pending.delete(key)
+}
+
+export function consumePendingRetractionIdentity(
+  scope: RetractionScope,
+  targetId: string,
+  record: PendingRetractionIdentity,
+  authoritative: boolean
+): void {
+  if (authoritative) {
+    clearPendingRetractionIdentity(scope, targetId)
+    return
+  }
+  const key = `${scopePrefix(scope)}${rawAlias(targetId)}`
+  const records = pending.get(key)
+  if (!records) return
+  const remaining = records.filter((candidate) => !sameActor(candidate, record))
+  pendingCount -= records.length - remaining.length
+  if (remaining.length === 0) pending.delete(key)
+  else pending.set(key, remaining)
+}
+
+export function adoptPendingRetraction(
+  scope: RetractionScope,
+  aliases: readonly PendingRetractionAlias[],
+  isAuthor: (record: PendingRetractionIdentity) => boolean
+): number | undefined {
+  const prefix = scopePrefix(scope)
+  let earliest: number | undefined
+  for (const { alias, authoritative } of aliases) {
+    const key = `${prefix}${alias}`
+    const records = pending.get(key)
+    if (!records) continue
+    const authorized = records.filter(isAuthor)
+    if (authoritative) {
+      pending.delete(key)
+      pendingCount -= records.length
+    } else if (authorized.length > 0) {
+      const remaining = records.filter((record) => !isAuthor(record))
+      pendingCount -= authorized.length
+      if (remaining.length === 0) pending.delete(key)
+      else pending.set(key, remaining)
+    }
+    for (const record of authorized) {
+      if (earliest === undefined || record.retractedAt < earliest) {
+        earliest = record.retractedAt
+      }
+    }
+  }
+  return earliest
+}
+
+/**
+ * Record that everything reachable through these aliases is retracted. Idempotent;
+ * the earliest `retractedAt` wins so a re-delivered retraction cannot move the
+ * tombstone forward.
+ */
+export function noteRetractedIdentity(
+  scope: RetractionScope,
+  aliases: readonly string[],
+  actor: VerifiedRetractionActor,
+  retractedAt: number
+): void {
+  const prefix = scopePrefix(scope)
+  const record: PendingRetractionIdentity = {
+    actorJid: actor.from,
+    ...(actor.occupantId ? { actorOccupantId: actor.occupantId } : {}),
+    retractedAt,
+  }
+  for (const alias of aliases) {
+    const key = `${prefix}${alias}`
+    const known = retracted.get(key) ?? []
+    const actorIndex = known.findIndex((candidate) => sameActor(candidate, record))
+    if (actorIndex === -1) {
+      retracted.set(key, [...known, record])
+      retractedCount++
+    } else if (retractedAt < known[actorIndex].retractedAt) {
+      const next = [...known]
+      next[actorIndex] = record
+      retracted.set(key, next)
+    }
+  }
+  while (retractedCount > ALIAS_CAP) {
+    const oldest = retracted.keys().next()
+    if (oldest.done) break
+    const records = retracted.get(oldest.value)!
+    if (records.length === 1) retracted.delete(oldest.value)
+    else retracted.set(oldest.value, records.slice(1))
+    retractedCount--
+  }
+}
+
+/**
+ * The retraction time recorded for any of these aliases, or undefined when none
+ * is known. Resolves through ANY tier — a note made from the stanza id still
+ * answers a lookup carrying only `from`+`id`.
+ */
+export function retractedAtForIdentity(
+  scope: RetractionScope,
+  aliases: readonly string[],
+  isAuthor: (record: PendingRetractionIdentity) => boolean
+): number | undefined {
+  const prefix = scopePrefix(scope)
+  let earliest: number | undefined
+  for (const alias of aliases) {
+    const records = retracted.get(`${prefix}${alias}`) ?? []
+    for (const record of records) {
+      if (isAuthor(record) && (earliest === undefined || record.retractedAt < earliest)) {
+        earliest = record.retractedAt
+      }
+    }
+  }
+  return earliest
+}
+
+/** Test-only: this module's state is a plain top-level Map, untouched by store resets. */
+export function _clearRetractedIdentitiesForTesting(): void {
+  retracted.clear()
+  pending.clear()
+  retractedCount = 0
+  pendingCount = 0
+}

--- a/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
@@ -14,6 +14,20 @@ export interface RoomIdentityFields {
   originId?: string
 }
 
+export type RoomIdentityTier = 'stanzaId' | 'originId' | 'fallback'
+
+export interface RoomReferenceProbe<T> {
+  tier: RoomIdentityTier
+  authoritative: boolean
+  matches: (message: T) => boolean
+}
+
+export interface RoomReferenceResolution<T> {
+  tier: RoomIdentityTier
+  authoritative: boolean
+  candidates: Array<{ message: T; index: number }>
+}
+
 // U+0000 separator: JIDs/ids/stanzaIds cannot contain it, so joins never collide.
 const S = '\u0000'
 
@@ -53,4 +67,30 @@ export function roomStanzaKey(roomJid: string, stanzaId: string): string {
 /** The room-scoped originId identity key (for revocation). Mirrors {@link roomStanzaKey}. */
 export function roomOriginKey(roomJid: string, originId: string): string {
   return scoped(roomJid, `originId${S}${originId}`)
+}
+
+export function roomReferenceProbes<T extends Pick<RoomIdentityFields, 'id' | 'stanzaId' | 'originId'>>(
+  reference: string
+): RoomReferenceProbe<T>[] {
+  return [
+    { tier: 'stanzaId', authoritative: true, matches: (message) => message.stanzaId === reference },
+    { tier: 'originId', authoritative: true, matches: (message) => message.originId === reference },
+    { tier: 'fallback', authoritative: false, matches: (message) => message.id === reference },
+  ]
+}
+
+export function resolveRoomMessageReference<T extends Pick<RoomIdentityFields, 'id' | 'stanzaId' | 'originId'>>(
+  messages: readonly T[],
+  reference: string
+): RoomReferenceResolution<T> | undefined {
+  for (const probe of roomReferenceProbes<T>(reference)) {
+    const candidates: RoomReferenceResolution<T>['candidates'] = []
+    messages.forEach((message, index) => {
+      if (probe.matches(message)) candidates.push({ message, index })
+    })
+    if (candidates.length > 0) {
+      return { tier: probe.tier, authoritative: probe.authoritative, candidates }
+    }
+  }
+  return undefined
 }

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
+import { openDB } from 'idb'
 import type { RoomMessage } from '../core/types'
 import type { StoredMessage } from '../core/types/message-internal'
 import { setStorageScopeJid, _resetStorageScopeForTesting } from './storageScope'
@@ -136,6 +137,35 @@ describe('searchIndex', () => {
       expect(results[0].conversationId).toBe('room@conference.example.com')
       expect(results[0].isRoom).toBe(true)
       expect(results[0].messageId).toBe('room-msg-77')
+    })
+
+    it('should read a legacy document without optional identity fields', async () => {
+      await initSearchIndex('test@example.com')
+      const db = await openDB('fluux-search-index:test@example.com')
+      const tx = db.transaction(['search-tokens', 'search-docs'], 'readwrite')
+      await tx.objectStore('search-docs').put({
+        indexId: 'room:legacy-archive',
+        messageId: 'legacy-message',
+        tokens: ['legacy'],
+        conversationId: 'legacy@conference.example.com',
+        from: 'legacy@conference.example.com/alice',
+        timestamp: 1_700_000_000_000,
+        isRoom: true,
+        body: 'legacy searchable body',
+      })
+      await tx.objectStore('search-tokens').put({
+        token: 'legacy',
+        postings: ['room:legacy-archive'],
+      })
+      await tx.done
+      db.close()
+
+      expect(await search('legacy')).toEqual([
+        expect.objectContaining({
+          messageId: 'legacy-message',
+          body: 'legacy searchable body',
+        }),
+      ])
     })
 
     it('should include nick in room message search results', async () => {
@@ -421,6 +451,58 @@ describe('searchIndex', () => {
 
       // Should not throw
       await removeMessage(msg)
+    })
+
+    it('should keep a chat document owned by another conversation', async () => {
+      const indexed = createChatMessage('alice@example.com', {
+        id: 'shared-chat-id',
+        from: 'alice@example.com',
+        body: 'ownership marker',
+      })
+      const colliding = createChatMessage('bob@example.com', {
+        id: indexed.id,
+        from: 'bob@example.com',
+        body: 'other body',
+      })
+      await indexMessage(indexed)
+
+      await removeMessage(colliding)
+
+      expect(await search('ownership')).toHaveLength(1)
+    })
+
+    it('should keep a composite room document owned by another occupant', async () => {
+      const indexed = createRoomMessage('room@conference.example.com', {
+        id: 'shared-room-id',
+        occupantId: 'occupant-one',
+        body: 'occupant ownership marker',
+      })
+      const colliding = createRoomMessage(indexed.roomJid, {
+        id: indexed.id,
+        from: indexed.from,
+        occupantId: 'occupant-two',
+        body: 'other body',
+      })
+      await indexMessage(indexed)
+
+      await removeMessage(colliding)
+
+      expect(await search('ownership')).toHaveLength(1)
+    })
+
+    it('should remove a composite room document after an index restart', async () => {
+      const indexed = createRoomMessage('room@conference.example.com', {
+        id: 'late-archive-id',
+        occupantId: 'stable-occupant',
+        body: 'durable ownership marker',
+      })
+      await indexMessage(indexed)
+      await closeSearchIndex()
+      _resetDBForTesting()
+
+      await removeMessage({ ...indexed, stanzaId: 'archive-assigned-later' })
+
+      expect(await search('durable')).toEqual([])
     })
   })
 

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -17,7 +17,15 @@ import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { getStorageScopeJid } from './storageScope'
+import {
+  chatRetractionAliases,
+  roomRetractionAliases,
+  retractedAtForIdentity,
+  type RetractionScope,
+} from './retractedIdentities'
 import * as messageCache from './messageCache'
+import { chatRetractionAuthor, roomRetractionAuthor } from '../stores/shared/pendingRetractions'
+import { roomIdentityKeys } from './roomMessageIdentity'
 
 const DB_NAME = 'fluux-search-index'
 const DB_VERSION = 2
@@ -50,6 +58,9 @@ interface DocEntry {
   timestamp: number
   isRoom: boolean
   body: string
+  stanzaId?: string
+  originId?: string
+  occupantId?: string
 }
 
 interface MetaEntry {
@@ -258,6 +269,235 @@ function getIndexId(message: Message | RoomMessage): string {
   return `chat:${message.id}`
 }
 
+/**
+ * The index ids a message may ALSO be stored under, besides {@link getIndexId}.
+ *
+ * The two room forms are mutually exclusive at write time, so a room message
+ * indexed before its archive id arrived lives under the composite form for good —
+ * its document is invisible to a removal that only knows the stanza form. This is
+ * the read-side complement, not a second write key: nothing is ever indexed here.
+ */
+function getFallbackIndexIds(message: Message | RoomMessage): string[] {
+  if (message.type !== 'groupchat' || !message.stanzaId) return []
+  return [`room:${message.roomJid}:${message.from}:${message.id}`]
+}
+
+interface RoomDocumentOwner {
+  roomJid: string
+  from: string
+  id: string
+  originId?: string
+  occupantId?: string
+}
+
+export interface RoomIdentityClosure {
+  identityKeys: readonly string[]
+  ids: readonly string[]
+}
+
+const ROOM_OWNER_CAP = 2000
+const roomDocumentOwners = new Map<string, RoomDocumentOwner>()
+
+function roomOwnerKey(indexId: string, scopeJid: string | null): string {
+  return `${scopeJid ?? ''}\u0000${indexId}`
+}
+
+function clearRoomDocumentOwners(scopeJid: string | null): void {
+  const prefix = `${scopeJid ?? ''}\u0000`
+  for (const key of roomDocumentOwners.keys()) {
+    if (key.startsWith(prefix)) roomDocumentOwners.delete(key)
+  }
+}
+
+function recordRoomDocumentOwner(
+  indexId: string,
+  message: Message | RoomMessage,
+  scopeJid: string | null
+): void {
+  if (message.type !== 'groupchat' || message.stanzaId) return
+  roomDocumentOwners.set(roomOwnerKey(indexId, scopeJid), {
+    roomJid: message.roomJid,
+    from: message.from,
+    id: message.id,
+    originId: message.originId,
+    occupantId: message.occupantId,
+  })
+  while (roomDocumentOwners.size > ROOM_OWNER_CAP) {
+    const oldest = roomDocumentOwners.keys().next()
+    if (oldest.done) break
+    roomDocumentOwners.delete(oldest.value)
+  }
+}
+
+/**
+ * Whether a document found under a FALLBACK id genuinely names this message.
+ *
+ * The composite form is `roomJid:from:id` — none of which is unique after a nick
+ * reassignment, where an old archive copy and a recent message share all three
+ * and differ only in their archive and occupant ids. Only one of them owns that
+ * document (indexing is idempotent per id), so the other must not delete it.
+ */
+function docBelongsToRoom(doc: DocEntry, message: RoomMessage): boolean {
+  return doc.isRoom && doc.conversationId === message.roomJid
+}
+
+function fallbackDocNamesMessage(
+  doc: DocEntry,
+  message: Message | RoomMessage,
+  indexId: string,
+  scopeJid: string | null
+): boolean {
+  if (message.type !== 'groupchat' || !docBelongsToRoom(doc, message)) return false
+  if (doc.messageId !== message.id || doc.from !== message.from) return false
+  // A room message carrying neither occupant-id nor origin-id cannot prove
+  // ownership of its composite document after nick reassignment, so only its
+  // canonical document is removed. This window is bounded to messages indexed
+  // in that identifier-less form; closing it requires additional durable
+  // ownership data.
+  const durableOwner: RoomDocumentOwner = {
+    roomJid: doc.conversationId,
+    from: doc.from,
+    id: doc.messageId,
+    originId: doc.originId,
+    occupantId: doc.occupantId,
+  }
+  if (roomOwnerNamesMessage(durableOwner, message)) return true
+  const owner = roomDocumentOwners.get(roomOwnerKey(indexId, scopeJid))
+  return owner ? roomOwnerNamesMessage(owner, message) : false
+}
+
+function docBelongsToRoomIdentityClosure(
+  doc: DocEntry,
+  message: RoomMessage,
+  indexId: string,
+  closureKeys: ReadonlySet<string>,
+  closureIds: ReadonlySet<string>,
+  scopeJid: string | null
+): boolean {
+  if (!docBelongsToRoom(doc, message)) return false
+  const docKeys = roomIdentityKeys({
+    roomJid: doc.conversationId,
+    from: doc.from,
+    id: doc.messageId,
+    stanzaId: doc.stanzaId,
+    originId: doc.originId,
+  })
+  if (docKeys.slice(0, -1).some((key) => closureKeys.has(key))) return true
+  if (!closureKeys.has(docKeys[docKeys.length - 1]) || !closureIds.has(doc.messageId)) {
+    return false
+  }
+  return fallbackDocNamesMessage(
+    doc,
+    { ...message, id: doc.messageId },
+    indexId,
+    scopeJid
+  )
+}
+
+function roomOwnerNamesMessage(owner: RoomDocumentOwner, message: RoomMessage): boolean {
+  if (owner.roomJid !== message.roomJid || owner.from !== message.from || owner.id !== message.id) {
+    return false
+  }
+  if (owner.occupantId && message.occupantId) return owner.occupantId === message.occupantId
+  if (owner.originId && message.originId) return owner.originId === message.originId
+  return false
+}
+
+function docBelongsToChat(doc: DocEntry, message: Message): boolean {
+  return !doc.isRoom &&
+    doc.messageId === message.id &&
+    doc.conversationId === message.conversationId &&
+    doc.from === message.from
+}
+
+function createDocEntry(
+  message: Message | RoomMessage,
+  indexId: string,
+  tokens: string[]
+): DocEntry {
+  const doc: DocEntry = {
+    indexId,
+    messageId: message.id,
+    tokens,
+    conversationId: message.type === 'groupchat' ? message.roomJid : message.conversationId,
+    from: message.from,
+    timestamp: message.timestamp.getTime(),
+    isRoom: message.type === 'groupchat',
+    body: message.body!,
+  }
+  if (message.stanzaId) doc.stanzaId = message.stanzaId
+  if (message.originId) doc.originId = message.originId
+  if (message.type === 'groupchat') {
+    doc.nick = message.nick
+    if (message.occupantId) doc.occupantId = message.occupantId
+  }
+  return doc
+}
+
+/** The retraction scope a message belongs to. */
+function retractionScopeOf(
+  message: Message | RoomMessage,
+  accountScope: string | null
+): RetractionScope {
+  return message.type === 'groupchat'
+    ? { kind: 'room', entityId: message.roomJid, accountScope }
+    : { kind: 'chat', entityId: message.conversationId, accountScope }
+}
+
+/**
+ * Whether the message has been retracted even though the copy in hand does not
+ * say so. Two blind spots, one per timescale:
+ *
+ * - This session: a retraction and its target's own indexing are independent
+ *   fire-and-forget promises, so `removeMessage` can find no document and the
+ *   indexing that follows would put the retracted body back
+ *   (`retractedIdentities.ts`).
+ * - An earlier session: an archive re-delivery carries the original body, and
+ *   only the cached tombstone still remembers the retraction.
+ *
+ * The in-memory check answers first and costs nothing; the cache read is the
+ * fallback.
+ */
+function isKnownRetracted(message: Message | RoomMessage, scopeJid: string | null): boolean {
+  const aliases =
+    message.type === 'groupchat'
+      ? roomRetractionAliases(message)
+      : chatRetractionAliases(message)
+  return retractedAtForIdentity(
+    retractionScopeOf(message, scopeJid),
+    aliases,
+    (record) =>
+      message.type === 'groupchat'
+        ? roomRetractionAuthor(message, record)
+        : chatRetractionAuthor(message, record)
+  ) !== undefined
+}
+
+async function isRetractedElsewhere(
+  message: Message | RoomMessage,
+  scopeJid: string | null
+): Promise<boolean> {
+  if (isKnownRetracted(message, scopeJid)) return true
+  return (await messageCache.areRetractedInCache([message], scopeJid))[0]
+}
+
+/**
+ * Batch twin of {@link isRetractedElsewhere}: one cache transaction, not one per
+ * message. `fromCache` skips that transaction for callers whose messages ARE the
+ * cache rows — a backfill would otherwise read the whole archive back a second
+ * time to learn what each row already says.
+ */
+async function rejectRetracted(
+  messages: (Message | RoomMessage)[],
+  fromCache: boolean,
+  scopeJid: string | null
+): Promise<(Message | RoomMessage)[]> {
+  const unknown = messages.filter((m) => !isKnownRetracted(m, scopeJid))
+  if (fromCache || unknown.length === 0) return unknown
+  const retracted = await messageCache.areRetractedInCache(unknown, scopeJid)
+  return unknown.filter((_, i) => !retracted[i])
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -275,17 +515,19 @@ export async function initSearchIndex(scopeJid: string): Promise<void> {
  * Skips messages with no body, retracted messages, and noLocalStore messages.
  * Silently returns if IndexedDB is not available.
  */
-export async function indexMessage(message: Message | RoomMessage): Promise<void> {
+export async function indexMessage(
+  message: Message | RoomMessage,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<void> {
   if (!isIndexedDBAvailable()) return
   if (!message.body || message.isRetracted || isNoLocalStore(message)) return
+  if (await isRetractedElsewhere(message, scopeJid)) return
 
   const indexId = getIndexId(message)
   const tokens = uniqueTokens(message.body)
   if (tokens.length === 0) return
 
-  const conversationId = message.type === 'groupchat' ? message.roomJid : message.conversationId
-
-  const db = await getDB()
+  const db = await getDB(scopeJid)
   const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
   const tokensStore = tx.objectStore(TOKENS_STORE)
   const docsStore = tx.objectStore(DOCS_STORE)
@@ -297,18 +539,11 @@ export async function indexMessage(message: Message | RoomMessage): Promise<void
     return
   }
 
-  // Write document entry
-  const doc: DocEntry = {
-    indexId,
-    messageId: message.id,
-    tokens,
-    conversationId,
-    from: message.from,
-    timestamp: message.timestamp.getTime(),
-    isRoom: message.type === 'groupchat',
-    body: message.body,
+  const doc = createDocEntry(message, indexId, tokens)
+  if (isKnownRetracted(message, scopeJid)) {
+    await tx.done
+    return
   }
-  if (message.type === 'groupchat') doc.nick = message.nick
   await docsStore.put(doc)
 
   // Update posting lists for each token
@@ -325,6 +560,7 @@ export async function indexMessage(message: Message | RoomMessage): Promise<void
   }
 
   await tx.done
+  recordRoomDocumentOwner(indexId, message, scopeJid)
 }
 
 /**
@@ -334,20 +570,37 @@ export async function indexMessage(message: Message | RoomMessage): Promise<void
  */
 const INDEX_BATCH_SIZE = 50
 
+/** Options for {@link indexMessages}. */
+export interface IndexMessagesOptions {
+  /**
+   * The messages were read straight from the message cache, so their
+   * `isRetracted` flag is already the durable truth and needs no second look.
+   * Set by the backfill and the rebuild; never by a live ingestion path, whose
+   * messages come off the wire and may name something the archive has since
+   * tombstoned.
+   */
+  fromCache?: boolean
+}
+
 /**
  * Index multiple messages, splitting into small transactions to avoid
  * IDB transaction lifetime issues.
  * Silently returns if IndexedDB is not available.
  */
-export async function indexMessages(messages: (Message | RoomMessage)[]): Promise<void> {
+export async function indexMessages(
+  messages: (Message | RoomMessage)[],
+  options: IndexMessagesOptions = {},
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const indexable = messages.filter((m) => m.body && !m.isRetracted && !isNoLocalStore(m))
+  const candidates = messages.filter((m) => m.body && !m.isRetracted && !isNoLocalStore(m))
+  const indexable = await rejectRetracted(candidates, options.fromCache === true, scopeJid)
   if (indexable.length === 0) return
 
   // Process in small batches to keep each IDB transaction short-lived
   for (let i = 0; i < indexable.length; i += INDEX_BATCH_SIZE) {
     const batch = indexable.slice(i, i + INDEX_BATCH_SIZE)
-    await indexBatch(batch)
+    await indexBatch(batch, scopeJid)
   }
 }
 
@@ -355,38 +608,31 @@ export async function indexMessages(messages: (Message | RoomMessage)[]): Promis
  * Index a small batch of messages in a single transaction.
  * Kept small enough that the IDB transaction won't auto-commit.
  */
-async function indexBatch(messages: (Message | RoomMessage)[]): Promise<void> {
-  const db = await getDB()
+async function indexBatch(
+  messages: (Message | RoomMessage)[],
+  scopeJid: string | null
+): Promise<void> {
+  const db = await getDB(scopeJid)
   const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
   const tokensStore = tx.objectStore(TOKENS_STORE)
   const docsStore = tx.objectStore(DOCS_STORE)
 
   const tokenCache = new Map<string, TokenEntry>()
+  const indexedMessages: Array<{ indexId: string; message: Message | RoomMessage }> = []
 
   for (const message of messages) {
     const indexId = getIndexId(message)
     const tokens = uniqueTokens(message.body!)
     if (tokens.length === 0) continue
 
-    const conversationId =
-      message.type === 'groupchat' ? message.roomJid : message.conversationId
-
     // Skip if already indexed
     const existing = await docsStore.get(indexId)
     if (existing) continue
 
-    const doc: DocEntry = {
-      indexId,
-      messageId: message.id,
-      tokens,
-      conversationId,
-      from: message.from,
-      timestamp: message.timestamp.getTime(),
-      isRoom: message.type === 'groupchat',
-      body: message.body!,
-    }
-    if (message.type === 'groupchat') doc.nick = message.nick
+    const doc = createDocEntry(message, indexId, tokens)
+    if (isKnownRetracted(message, scopeJid)) continue
     await docsStore.put(doc)
+    indexedMessages.push({ indexId, message })
 
     for (const token of tokens) {
       let entry = tokenCache.get(token)
@@ -406,42 +652,86 @@ async function indexBatch(messages: (Message | RoomMessage)[]): Promise<void> {
   }
 
   await tx.done
+  for (const indexed of indexedMessages) {
+    recordRoomDocumentOwner(indexed.indexId, indexed.message, scopeJid)
+  }
 }
 
 /**
  * Remove a message from the search index.
  * Reads the document's token list and removes it from all posting lists.
  */
-export async function removeMessage(message: Message | RoomMessage): Promise<void> {
+export async function removeMessage(
+  message: Message | RoomMessage,
+  scopeJid: string | null = getStorageScopeJid(),
+  roomIdentityClosure?: RoomIdentityClosure
+): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const indexId = getIndexId(message)
 
-  const db = await getDB()
+  const db = await getDB(scopeJid)
   const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
   const tokensStore = tx.objectStore(TOKENS_STORE)
   const docsStore = tx.objectStore(DOCS_STORE)
+  const closureKeys = new Set(roomIdentityClosure?.identityKeys ?? [])
+  const closureIds = new Set(roomIdentityClosure?.ids ?? [])
 
-  const doc = await docsStore.get(indexId)
-  if (!doc) {
-    await tx.done
-    return
-  }
+  const drop = async (
+    indexId: string,
+    verification: 'chat' | 'room' | 'room-identity' | 'room-closure'
+  ): Promise<void> => {
+    const doc = await docsStore.get(indexId)
+    if (!doc) return
+    if (verification === 'chat' && (message.type === 'groupchat' || !docBelongsToChat(doc, message))) return
+    if (verification === 'room' && (message.type !== 'groupchat' || !docBelongsToRoom(doc, message))) return
+    if (verification === 'room-identity' && !fallbackDocNamesMessage(doc, message, indexId, scopeJid)) return
+    if (
+      verification === 'room-closure' &&
+      (message.type !== 'groupchat' || !docBelongsToRoomIdentityClosure(
+        doc,
+        message,
+        indexId,
+        closureKeys,
+        closureIds,
+        scopeJid
+      ))
+    ) return
 
-  // Remove from all posting lists
-  for (const token of doc.tokens) {
-    const entry = await tokensStore.get(token)
-    if (entry) {
-      entry.postings = entry.postings.filter((id) => id !== indexId)
-      if (entry.postings.length === 0) {
-        await tokensStore.delete(token)
-      } else {
-        await tokensStore.put(entry)
+    // Remove from all posting lists
+    for (const token of doc.tokens) {
+      const entry = await tokensStore.get(token)
+      if (entry) {
+        entry.postings = entry.postings.filter((id) => id !== indexId)
+        if (entry.postings.length === 0) {
+          await tokensStore.delete(token)
+        } else {
+          await tokensStore.put(entry)
+        }
       }
     }
+
+    // Remove the document
+    await docsStore.delete(indexId)
+    roomDocumentOwners.delete(roomOwnerKey(indexId, scopeJid))
   }
 
-  // Remove the document
-  await docsStore.delete(indexId)
+  await drop(
+    getIndexId(message),
+    message.type !== 'groupchat' ? 'chat' : message.stanzaId ? 'room' : 'room-identity'
+  )
+  for (const fallbackId of getFallbackIndexIds(message)) {
+    await drop(fallbackId, 'room-identity')
+  }
+  if (message.type === 'groupchat' && roomIdentityClosure) {
+    // Reads every document in the account to find the ones the closure owns, so
+    // a single room retraction costs one pass over the whole archive rather than
+    // a bounded set of lookups. Only ownership-verified documents are dropped
+    // (see `drop`), so the cost is in the scan, not in what it deletes. Bounding
+    // it means deriving the candidate index ids from the identity keys and
+    // absorbed client ids instead of scanning.
+    const docs = await docsStore.getAll()
+    for (const doc of docs) await drop(doc.indexId, 'room-closure')
+  }
+
   await tx.done
 }
 
@@ -449,10 +739,13 @@ export async function removeMessage(message: Message | RoomMessage): Promise<voi
  * Update a message in the search index (e.g., after XEP-0308 correction).
  * Removes the old entry and re-indexes with the new body.
  */
-export async function updateMessage(message: Message | RoomMessage): Promise<void> {
+export async function updateMessage(
+  message: Message | RoomMessage,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  await removeMessage(message)
-  await indexMessage(message)
+  await removeMessage(message, scopeJid)
+  await indexMessage(message, scopeJid)
 }
 
 /**
@@ -624,12 +917,12 @@ export async function backfillFromMessageCache(): Promise<void> {
   let roomCount = 0
 
   await messageCache.iterateAllMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch)
+    await indexMessages(batch, { fromCache: true })
     chatCount += batch.length
   })
 
   await messageCache.iterateAllRoomMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch)
+    await indexMessages(batch, { fromCache: true })
     roomCount += batch.length
   })
 
@@ -664,8 +957,10 @@ export async function rebuildSearchIndex(
 ): Promise<number> {
   if (!isIndexedDBAvailable()) return 0
 
+  const scopeJid = getStorageScopeJid()
+  clearRoomDocumentOwners(scopeJid)
   // Clear existing index data
-  const db = await getDB()
+  const db = await getDB(scopeJid)
   const tx = db.transaction([TOKENS_STORE, DOCS_STORE, META_STORE], 'readwrite')
   await tx.objectStore(TOKENS_STORE).clear()
   await tx.objectStore(DOCS_STORE).clear()
@@ -680,13 +975,13 @@ export async function rebuildSearchIndex(
   let indexed = 0
 
   await messageCache.iterateAllMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch)
+    await indexMessages(batch, { fromCache: true })
     indexed += batch.length
     onProgress?.({ indexed, total: totalMessages })
   })
 
   await messageCache.iterateAllRoomMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch)
+    await indexMessages(batch, { fromCache: true })
     indexed += batch.length
     onProgress?.({ indexed, total: totalMessages })
   })
@@ -705,13 +1000,15 @@ export async function rebuildSearchIndex(
  */
 export async function clearSearchIndex(): Promise<void> {
   if (!isIndexedDBAvailable()) return
+  const scopeJid = getStorageScopeJid()
   try {
-    const db = await getDB()
+    const db = await getDB(scopeJid)
     const tx = db.transaction([TOKENS_STORE, DOCS_STORE, META_STORE], 'readwrite')
     await tx.objectStore(TOKENS_STORE).clear()
     await tx.objectStore(DOCS_STORE).clear()
     await tx.objectStore(META_STORE).clear()
     await tx.done
+    clearRoomDocumentOwners(scopeJid)
   } catch {
     // Ignore errors (DB may not exist yet)
   }
@@ -741,4 +1038,5 @@ export async function closeSearchIndex(): Promise<void> {
 export function _resetDBForTesting(): void {
   dbPromise = null
   dbNameForPromise = null
+  roomDocumentOwners.clear()
 }


### PR DESCRIPTION
A retraction (XEP-0424) whose target was no longer in the resident window only recorded a pending marker, so the message body stayed in the IndexedDB cache and in the search index until something happened to reload it. Even a resident retraction only flagged the cached row, leaving the body readable, and a later archive copy could put it back.

A retraction now resolves against the durable cache, where the tiered identity (stanzaId → originId → from+id) is still canonical, and every cache write strips the content of a retracted row — so no writer, including an archive re-delivery, can resurrect it. Rooms and one-to-one chats both.

## What changed

- `shared/retractionStorage.ts` is the one durable-side applier for both stores, used by the resident path, the pending replay and the not-resident path, so chat and room cannot drift.
- Authorship is decided against a **resolved** target: resolution stops at the highest matching tier, and an unauthorized match there fails rather than falling through to an ambiguous lower one.
- Deletion proves ownership before removing anything, so a reused nick cannot destroy the previous occupant's message or its search document.
- MAM emits the existing actor-carrying retraction event on the unresolved path, so an archived retraction is gated on its author instead of applying unchecked.
- The search document carries optional identity fields (additive; no schema version bump, no migration — documents written earlier simply lack them and behave as before), and the account scope is captured once and carried across each durable operation.

Identity is reused, not reimplemented: the chat ladder is extracted verbatim into `utils/chatMessageIdentity.ts` alongside the existing room one, following the precedent of `shared/transientUnread.ts`.

## Accepted limits

Four windows are accepted rather than closed, each documented in the code beside the mechanism that bounds it:

- a room document carrying neither occupant-id nor origin-id cannot prove ownership of its composite entry
- an account switch during a cache probe leaves a stale pending record
- the session ledger's alias cap can evict a retraction before its writes land
- an in-page archive retraction is matched by nick alone

Two more are noted where they live: a remote search result is projected without its identity fields, and the room closure cleanup scans the document store rather than a bounded candidate set.

Messages retracted **before** this change keep their body until a separate migration removes it; that is deliberate and scheduled on its own branch.

## Read path

The existing search read-side hardening is untouched. It is now largely redundant for exclusion — a known retraction no longer has a document — but still carries the neighbouring-context "Message deleted" lines and the window between recording a retraction and its asynchronous cache write.
