### PR TITLE
feat(anomaly): observe protocol and read-state invariants from the SDK

### DIFF
--- a/apps/fluux/src/anomaly/AnomalyInstaller.test.tsx
+++ b/apps/fluux/src/anomaly/AnomalyInstaller.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { useEffect } from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AnomalyInstaller from './AnomalyInstaller'
+
+const runtime = vi.hoisted(() => {
+  const client = { id: 'client' }
+  return {
+    client,
+    events: [] as string[],
+    install: vi.fn(),
+  }
+})
+
+vi.mock('@fluux/sdk', () => ({
+  useXMPPContext: () => ({ client: runtime.client }),
+}))
+
+vi.mock('./install', () => ({
+  install: (client: unknown) => runtime.install(client),
+}))
+
+function ConnectionOwner(): null {
+  useEffect(() => {
+    runtime.events.push('child-mounted')
+  }, [])
+  return null
+}
+
+beforeEach(() => {
+  runtime.events.length = 0
+  runtime.install.mockReset()
+  runtime.install.mockImplementation(() => {
+    runtime.events.push('installed')
+    return () => runtime.events.push('detached')
+  })
+})
+
+afterEach(cleanup)
+
+describe('AnomalyInstaller', () => {
+  it('attaches before mounting a connection-owning child', async () => {
+    const view = render(
+      <AnomalyInstaller>
+        <ConnectionOwner />
+      </AnomalyInstaller>,
+    )
+
+    await waitFor(() => expect(runtime.events).toEqual(['installed', 'child-mounted']))
+    expect(runtime.install).toHaveBeenCalledWith(runtime.client)
+
+    view.unmount()
+    expect(runtime.events).toEqual(['installed', 'child-mounted', 'detached'])
+  })
+})

--- a/apps/fluux/src/anomaly/AnomalyInstaller.tsx
+++ b/apps/fluux/src/anomaly/AnomalyInstaller.tsx
@@ -1,16 +1,29 @@
 /**
- * Mounts the anomaly runtime inside `XMPPProvider`, so the detectors added in
- * later stages can read the client from context. Renders nothing.
+ * Mounts the anomaly runtime inside `XMPPProvider`, so the detectors that read
+ * protocol traffic can reach the client. Children mount only after attachment.
  *
  * It lives inside the provider rather than in `main.tsx` because at that level
  * there is no client — `XMPPProvider` constructs it internally.
  *
  * @module Anomaly/Installer
  */
-import { useEffect } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { useXMPPContext } from '@fluux/sdk'
 import { install } from './install'
 
-export default function AnomalyInstaller(): null {
-  useEffect(() => install(), [])
-  return null
+export interface AnomalyInstallerProps {
+  children: ReactNode
+}
+
+export default function AnomalyInstaller({ children }: AnomalyInstallerProps): ReactNode {
+  const { client } = useXMPPContext()
+  const [attachedClient, setAttachedClient] = useState<typeof client | null>(null)
+
+  useEffect(() => {
+    const cleanup = install(client)
+    setAttachedClient(client)
+    return cleanup
+  }, [client])
+
+  return attachedClient === client ? children : null
 }

--- a/apps/fluux/src/anomaly/detectors/archiveMerge.test.ts
+++ b/apps/fluux/src/anomaly/detectors/archiveMerge.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { createArchiveMergeDetector } from './archiveMerge'
+import { CTX, ID, METRIC, TAG } from '../values'
+import type { RecordInput } from '../recorder'
+import type { Opaque } from '../values'
+import type { ArchiveMergeReport } from '@fluux/sdk'
+
+const TOKEN = TAG.focus
+
+function report(overrides: Partial<ArchiveMergeReport> = {}): ArchiveMergeReport {
+  return {
+    entityKind: 'chat',
+    entityId: 'alice@example.com',
+    direction: 'backward',
+    complete: true,
+    outcome: 'durable',
+    returned: 10,
+    retained: 7,
+    deduplicated: 3,
+    patched: 0,
+    intentionallyUnstored: 0,
+    persistenceFailed: 0,
+    ...overrides,
+  }
+}
+
+function setup() {
+  const records: RecordInput[] = []
+  const counts: Array<[Opaque, number]> = []
+  const detector = createArchiveMergeDetector({
+    record: (input) => records.push(input),
+    count: (key, by) => counts.push([key, by]),
+    token: () => TOKEN,
+  })
+  return { detector, records, counts }
+}
+
+describe('archive merge counting', () => {
+  it('counts the rows a durable page returned and retained', () => {
+    const { detector, records, counts } = setup()
+
+    detector.observe(report())
+
+    expect(counts).toEqual([
+      [METRIC.mamRowsReturned, 10],
+      [METRIC.mamRowsRetained, 7],
+    ])
+    expect(records).toEqual([])
+  })
+
+  it('counts a page that retained nothing without dropping its denominator', () => {
+    const { detector, counts } = setup()
+
+    // Every row deduped. The yield rate needs the denominator anyway: a page that
+    // returned ten rows and kept none is exactly what the rate exists to show.
+    detector.observe(report({ returned: 10, retained: 0, deduplicated: 10 }))
+
+    expect(counts).toEqual([[METRIC.mamRowsReturned, 10]])
+  })
+
+  it('counts patched duplicate rows as durable yield', () => {
+    const { detector, counts } = setup()
+
+    detector.observe(report({ returned: 1, retained: 0, deduplicated: 0, patched: 1 }))
+
+    expect(counts).toEqual([
+      [METRIC.mamRowsReturned, 1],
+      [METRIC.mamRowsRetained, 1],
+    ])
+  })
+
+  it('says nothing at all about an empty page', () => {
+    const { detector, records, counts } = setup()
+
+    detector.observe(
+      report({ returned: 0, retained: 0, deduplicated: 0 }),
+    )
+
+    expect(counts).toEqual([])
+    expect(records).toEqual([])
+  })
+})
+
+describe('mam-write-failed', () => {
+  it('records a failed durable write', () => {
+    const { detector, records } = setup()
+
+    detector.observe(
+      report({ outcome: 'failed', returned: 4, retained: 0, deduplicated: 1, persistenceFailed: 3 }),
+    )
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.mamWriteFailed)
+    expect(records[0].sev).toBe('bug')
+    expect(records[0].expected).toBe(0)
+    expect(records[0].observed).toBe(3)
+    expect(records[0].ctx).toEqual(
+      expect.arrayContaining([
+        [CTX.target, TOKEN],
+        [CTX.returned, 4],
+      ]),
+    )
+  })
+
+  it('stays silent on a partial page', () => {
+    const { detector, records } = setup()
+
+    // `partial` means an EARLIER merge for this entity failed — and that merge
+    // already recorded it. Recording again would report one fault twice.
+    detector.observe(report({ outcome: 'partial', retained: 7, persistenceFailed: 0 }))
+
+    expect(records).toEqual([])
+  })
+
+  it('still counts the rows of a failed page', () => {
+    const { detector, counts } = setup()
+
+    detector.observe(
+      report({ outcome: 'failed', returned: 4, retained: 0, persistenceFailed: 4, deduplicated: 0 }),
+    )
+
+    // Returned rows are a fact about the query, not about the write.
+    expect(counts).toEqual([[METRIC.mamRowsReturned, 4]])
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/archiveMerge.ts
+++ b/apps/fluux/src/anomaly/detectors/archiveMerge.ts
@@ -1,0 +1,52 @@
+/**
+ * What an archive merge cost and what it kept.
+ *
+ * The SDK reports one outcome per archive merge (`onArchiveMerge`). Two things are
+ * derived here: the merge-yield rate's two counters, and one invariant — a durable
+ * write that did not commit, which freezes that entity's catch-up cursor for the
+ * rest of the session and is invisible everywhere else.
+ *
+ * @module Anomaly/Detectors/ArchiveMerge
+ */
+import type { ArchiveMergeReport } from '@fluux/sdk'
+import type { RecordInput } from '../recorder'
+import { CTX, ID, METRIC, type Opaque } from '../values'
+
+export interface ArchiveMergeDetector {
+  observe(report: ArchiveMergeReport): void
+}
+
+export interface ArchiveMergeOptions {
+  record: (input: RecordInput) => void
+  count: (key: Opaque, by: number) => void
+  /** Tokenizes an entity id at the recorder boundary. Never the raw value. */
+  token: (report: ArchiveMergeReport) => Opaque
+}
+
+export function createArchiveMergeDetector(opts: ArchiveMergeOptions): ArchiveMergeDetector {
+  return {
+    observe(report) {
+      // Zero is not a measurement: an empty page would add a denominator sample
+      // that says nothing about yield.
+      if (report.returned > 0) opts.count(METRIC.mamRowsReturned, report.returned)
+      const durablyWritten = report.retained + report.patched
+      if (durablyWritten > 0) opts.count(METRIC.mamRowsRetained, durablyWritten)
+
+      // `partial` means an EARLIER merge for this entity failed, and that merge
+      // recorded it already. Reporting here would count one fault twice and make
+      // a single lost page look like a run of them.
+      if (report.outcome !== 'failed') return
+
+      opts.record({
+        id: ID.mamWriteFailed,
+        sev: 'bug',
+        expected: 0,
+        observed: report.persistenceFailed,
+        ctx: [
+          [CTX.target, opts.token(report)],
+          [CTX.returned, report.returned],
+        ],
+      })
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/pointerRegression.test.ts
+++ b/apps/fluux/src/anomaly/detectors/pointerRegression.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import { createPointerRegressionDetector, type PointerObservation } from './pointerRegression'
+import { CTX, ID, TAG } from '../values'
+import type { RecordInput } from '../recorder'
+import type { ReadPointer, ReadStateGeneration } from '@fluux/sdk'
+
+const TOKEN = TAG.focus
+
+/** A pointer whose only comparable property is its timestamp. */
+function pointer(ms: number, messageId = `m-${ms}`): ReadPointer {
+  return {
+    order: { role: 'floor', timestamp: ms },
+    identity: { kind: 'local', messageId },
+  } as unknown as ReadPointer
+}
+
+/** The ordering rule under test, stated here rather than imported. */
+function isAhead(candidate: ReadPointer, current: ReadPointer | undefined): boolean {
+  if (!current) return true
+  return candidate.order.timestamp > current.order.timestamp
+}
+
+const GEN: ReadStateGeneration = { store: 1, entity: 3 }
+
+function observation(
+  ptr: ReadPointer | undefined,
+  generation: ReadStateGeneration = GEN,
+  id = 'alice@example.com',
+): PointerObservation {
+  return { kind: 'chat', id, pointer: ptr, generation }
+}
+
+function setup() {
+  const records: RecordInput[] = []
+  const detector = createPointerRegressionDetector({
+    record: (input) => records.push(input),
+    token: () => TOKEN,
+    isAhead,
+  })
+  return { detector, records }
+}
+
+describe('pointer-regression fires', () => {
+  it('when a pointer is replaced by one strictly behind it', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(5_000)))
+    detector.observe(observation(pointer(3_000)))
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.pointerRegression)
+    expect(records[0].sev).toBe('bug')
+    expect(records[0].ctx).toEqual(
+      expect.arrayContaining([
+        [CTX.conv, TOKEN],
+        // How far back it went: a one-millisecond slip and a week of lost read
+        // state are the same invariant break but not the same investigation.
+        [CTX.behindMs, 2_000],
+      ]),
+    )
+  })
+
+  it('again on a second regression for the same entity', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(9_000)))
+    detector.observe(observation(pointer(5_000)))
+    detector.observe(observation(pointer(1_000)))
+
+    // The state follows the pointer rather than latching: a detector that reported
+    // once and went quiet would hide a cursor walking backwards.
+    expect(records).toHaveLength(2)
+  })
+
+  it('for a room as well as a conversation', () => {
+    const { detector, records } = setup()
+    const room = { kind: 'room' as const, id: 'g@conf.example.com', generation: GEN }
+    detector.observe({ ...room, pointer: pointer(5_000) })
+    detector.observe({ ...room, pointer: pointer(4_000) })
+
+    expect(records).toHaveLength(1)
+    expect(records[0].ctx).toEqual(expect.arrayContaining([[CTX.room, TOKEN]]))
+  })
+})
+
+describe('pointer-regression stays silent', () => {
+  it('on an advance', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(1_000)))
+    detector.observe(observation(pointer(2_000)))
+
+    expect(records).toEqual([])
+  })
+
+  it('on an identical rewrite', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(1_000)))
+    detector.observe(observation(pointer(1_000)))
+
+    // Writing the same pointer twice is idempotence, not regression.
+    expect(records).toEqual([])
+  })
+
+  it('on the first pointer an entity ever has', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(1_000)))
+
+    expect(records).toEqual([])
+  })
+
+  it('when the store generation moved', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(9_000), { store: 1, entity: 3 }))
+    // An account switch or a logout: every pointer is new, and the first
+    // observation of a generation has no predecessor to be behind.
+    detector.observe(observation(pointer(1_000), { store: 2, entity: 0 }))
+
+    expect(records).toEqual([])
+  })
+
+  it('when the entity generation moved', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(9_000), { store: 1, entity: 3 }))
+    // The conversation was deleted and re-created; its read state starts over.
+    detector.observe(observation(pointer(1_000), { store: 1, entity: 4 }))
+
+    expect(records).toEqual([])
+  })
+
+  it('on the first observation AFTER a generation change, then watches again', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(9_000), { store: 1, entity: 3 }))
+    detector.observe(observation(pointer(5_000), { store: 1, entity: 4 }))
+    detector.observe(observation(pointer(4_000), { store: 1, entity: 4 }))
+
+    // Silent across the boundary, armed again inside the new generation.
+    expect(records).toHaveLength(1)
+  })
+
+  it('when the pointer is cleared', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(5_000)))
+    detector.observe(observation(undefined))
+
+    // A cleared pointer is a different event with a different cause, and the
+    // ordering rule has no answer for "behind nothing".
+    expect(records).toEqual([])
+  })
+
+  it('for an entity whose pointer never moves', () => {
+    const { detector, records } = setup()
+    const other = 'bob@example.com'
+    detector.observe(observation(pointer(5_000)))
+    detector.observe(observation(pointer(1_000), GEN, other))
+    detector.observe(observation(pointer(6_000)))
+
+    // Two entities, two independent histories: `other`'s lower timestamp is not a
+    // regression of `alice`'s pointer.
+    expect(records).toEqual([])
+  })
+
+  it('after a reset', () => {
+    const { detector, records } = setup()
+    detector.observe(observation(pointer(5_000)))
+    detector.reset()
+    detector.observe(observation(pointer(1_000)))
+
+    expect(records).toEqual([])
+  })
+})
+
+describe('bounds', () => {
+  it('tracks a bounded number of entities', () => {
+    const records: RecordInput[] = []
+    const detectorWithBound = createPointerRegressionDetector({
+      record: (input) => records.push(input),
+      token: () => TOKEN,
+      isAhead,
+      maxTracked: 2,
+    })
+
+    detectorWithBound.observe(observation(pointer(5_000), GEN, 'a@example.com'))
+    detectorWithBound.observe(observation(pointer(5_000), GEN, 'b@example.com'))
+    detectorWithBound.observe(observation(pointer(5_000), GEN, 'c@example.com'))
+    // 'a' was evicted, so its regression cannot be seen — a bounded detector
+    // misses rather than leaks.
+    detectorWithBound.observe(observation(pointer(1_000), GEN, 'a@example.com'))
+    detectorWithBound.observe(observation(pointer(1_000), GEN, 'c@example.com'))
+
+    expect(records).toHaveLength(1)
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/pointerRegression.ts
+++ b/apps/fluux/src/anomaly/detectors/pointerRegression.ts
@@ -1,0 +1,109 @@
+/**
+ * A read pointer that moved backwards.
+ *
+ * The pointer is forward-only, and the direction it must never take is the
+ * unrecoverable one: a position that slips back re-marks read messages as unread,
+ * and nothing downstream can tell that from genuine new mail (#1076).
+ *
+ * "Forward-only" holds WITHIN one generation. An account switch, a logout, and
+ * deleting a conversation all replace a pointer wholesale, so this detector resets
+ * on the SDK's `ReadStateGeneration` rather than trying to recognise those
+ * transitions from the pointer alone — reporting them would be the false positive
+ * that costs a detector its life (design §6.1).
+ *
+ * @module Anomaly/Detectors/PointerRegression
+ */
+import type { ReadPointer, ReadStateGeneration } from '@fluux/sdk'
+import type { RecordInput } from '../recorder'
+import { CTX, ID, type Opaque } from '../values'
+
+/** Bounded like every other detector: a diagnostic must not become the leak. */
+const MAX_TRACKED = 300
+
+export interface PointerObservation {
+  kind: 'chat' | 'room'
+  id: string
+  pointer: ReadPointer | undefined
+  generation: ReadStateGeneration
+}
+
+export interface PointerRegressionDetector {
+  observe(observation: PointerObservation): void
+  reset(): void
+}
+
+export interface PointerRegressionOptions {
+  record: (input: RecordInput) => void
+  token: (kind: 'chat' | 'room', id: string) => Opaque
+  /**
+   * The SDK's own ordering rule.
+   *
+   * Injected rather than imported so a caller cannot quietly substitute a
+   * different comparison: a detector that re-derives the ordering would eventually
+   * disagree with the store and report the disagreement as a bug in the store.
+   */
+  isAhead: (candidate: ReadPointer, current: ReadPointer | undefined) => boolean
+  maxTracked?: number
+}
+
+interface Tracked {
+  pointer: ReadPointer
+  generation: ReadStateGeneration
+}
+
+function sameGeneration(a: ReadStateGeneration, b: ReadStateGeneration): boolean {
+  return a.store === b.store && a.entity === b.entity
+}
+
+export function createPointerRegressionDetector(
+  opts: PointerRegressionOptions
+): PointerRegressionDetector {
+  const maxTracked = opts.maxTracked ?? MAX_TRACKED
+  const seen = new Map<string, Tracked>()
+
+  return {
+    observe({ kind, id, pointer, generation }) {
+      const key = `${kind} ${id}`
+      // A cleared pointer is a different event with a different cause, and the
+      // ordering rule has no answer for "behind nothing". Forget the entity so the
+      // next pointer it gets is a first observation rather than a comparison
+      // against a position that no longer exists.
+      if (!pointer) {
+        seen.delete(key)
+        return
+      }
+
+      const previous = seen.get(key)
+      seen.set(key, { pointer, generation })
+      while (seen.size > maxTracked) {
+        const oldest = seen.keys().next()
+        if (oldest.done) break
+        seen.delete(oldest.value)
+      }
+
+      // No predecessor, or a predecessor from another generation: nothing this
+      // pointer could legitimately be compared against.
+      if (!previous || !sameGeneration(previous.generation, generation)) return
+
+      // The question is whether what was ALREADY there is strictly ahead of what
+      // was just written. Asking it in this direction is what makes an identical
+      // rewrite silent: a tie is not an advance either way.
+      if (!opts.isAhead(previous.pointer, pointer)) return
+
+      opts.record({
+        id: ID.pointerRegression,
+        sev: 'bug',
+        expected: 0,
+        observed: 1,
+        ctx: [
+          [kind === 'room' ? CTX.room : CTX.conv, opts.token(kind, id)],
+          [CTX.behindMs, previous.pointer.order.timestamp - pointer.order.timestamp],
+        ],
+      })
+    },
+
+    reset() {
+      seen.clear()
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/stanzaFacts.test.ts
+++ b/apps/fluux/src/anomaly/detectors/stanzaFacts.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { outboundFacts, inboundReplyFacts, type ElementLike } from './stanzaFacts'
+
+function el(
+  name: string,
+  attrs: Record<string, unknown> = {},
+  children: ElementLike[] = [],
+): ElementLike {
+  return {
+    name,
+    attrs,
+    children,
+    getChild(childName: string, ns?: string) {
+      return children.find((c) => c.name === childName && (ns === undefined || c.attrs.xmlns === ns))
+    },
+  }
+}
+
+function textEl(name: string, value: string): ElementLike {
+  return {
+    name,
+    attrs: {},
+    children: [value],
+    getChild: () => undefined,
+  }
+}
+
+describe('outboundFacts', () => {
+  it('classifies a disco#info query and makes it dedupable', () => {
+    const iq = el('iq', { type: 'get', to: 'example.com', id: 'q1' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info' }),
+    ])
+    expect(outboundFacts(iq)).toEqual({
+      id: 'q1',
+      kind: 'disco-info',
+      to: 'example.com',
+      dedupe: 'disco-info|example.com|',
+    })
+  })
+
+  it('separates two disco#info queries for different nodes', () => {
+    const withNode = el('iq', { type: 'get', to: 'example.com', id: 'q2' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info', node: 'urn:x:caps#v1' }),
+    ])
+    expect(outboundFacts(withNode)?.dedupe).toBe('disco-info|example.com|urn:x:caps#v1')
+  })
+
+  it('separates successive disco#items RSM pages', () => {
+    const page = (id: string, after?: string) =>
+      el('iq', { type: 'get', to: 'conference.example.com', id }, [
+        el('query', { xmlns: 'http://jabber.org/protocol/disco#items' }, [
+          el('set', { xmlns: 'http://jabber.org/protocol/rsm' }, [
+            textEl('max', '20'),
+            ...(after === undefined ? [] : [textEl('after', after)]),
+          ]),
+        ]),
+      ])
+
+    expect(outboundFacts(page('q3'))?.dedupe)
+      .not.toBe(outboundFacts(page('q4', 'room-20'))?.dedupe)
+  })
+
+  it('normalizes every disco#items RSM selector field', () => {
+    const query = (children: ElementLike[]) =>
+      el('iq', { type: 'get', to: 'conference.example.com', id: 'q3' }, [
+        el('query', { xmlns: 'http://jabber.org/protocol/disco#items' }, [
+          el('set', { xmlns: 'http://jabber.org/protocol/rsm' }, children),
+        ]),
+      ])
+    const forward = query([
+      textEl('max', '20'),
+      textEl('after', 'room-20'),
+      textEl('before', ''),
+      textEl('index', '20'),
+    ])
+    const reversed = query([
+      textEl('index', '20'),
+      textEl('before', ''),
+      textEl('after', 'room-20'),
+      textEl('max', '20'),
+    ])
+
+    expect(outboundFacts(forward)?.dedupe).toBe(
+      'disco-items|conference.example.com||{"max":"20","after":"room-20","before":"","index":"20"}',
+    )
+    expect(outboundFacts(reversed)?.dedupe).toBe(outboundFacts(forward)?.dedupe)
+  })
+
+  it('classifies an avatar fetch by its pubsub node', () => {
+    const iq = el('iq', { type: 'get', to: 'a@example.com', id: 'q5' }, [
+      el('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' }, [
+        el('items', { node: 'urn:xmpp:avatar:data' }),
+      ]),
+    ])
+    const facts = outboundFacts(iq)
+    expect(facts?.kind).toBe('avatar')
+    expect(facts?.dedupe).toBe(
+      'avatar|a@example.com|urn:xmpp:avatar:data|{"itemIds":[],"maxItems":"","subid":""}',
+    )
+  })
+
+  it('separates avatar fetches for different item hashes', () => {
+    const avatar = (id: string, hash: string) => el('iq', { type: 'get', to: 'a@example.com', id }, [
+      el('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' }, [
+        el('items', { node: 'urn:xmpp:avatar:data' }, [el('item', { id: hash })]),
+      ]),
+    ])
+
+    expect(outboundFacts(avatar('q5', 'hash-a'))?.dedupe)
+      .not.toBe(outboundFacts(avatar('q6', 'hash-b'))?.dedupe)
+  })
+
+  it('refuses to call a MAM page redundant', () => {
+    const iq = el('iq', { type: 'set', to: 'a@example.com', id: 'q3' }, [
+      el('query', { xmlns: 'urn:xmpp:mam:2' }),
+    ])
+    const facts = outboundFacts(iq)
+    // Paging queries the same archive on purpose; a shared dedupe key would report
+    // every second page as a redundant query.
+    expect(facts?.kind).toBe('mam')
+    expect(facts?.dedupe).toBeNull()
+  })
+
+  it('tracks an IQ set for replies without deduplicating its payload', () => {
+    const iq = el('iq', { type: 'set', to: 'a@example.com', id: 'q7' }, [
+      el('vCard', { xmlns: 'vcard-temp' }, [el('FN', {}, [])]),
+    ])
+
+    expect(outboundFacts(iq)).toEqual({
+      id: 'q7',
+      kind: 'vcard',
+      to: 'a@example.com',
+      dedupe: null,
+    })
+  })
+
+  it('ignores messages, presence and IQ replies', () => {
+    expect(outboundFacts(el('message', { to: 'a@example.com', id: 'm1' }))).toBeNull()
+    expect(outboundFacts(el('presence', { id: 'p1' }))).toBeNull()
+    expect(outboundFacts(el('iq', { type: 'result', id: 'r1', to: 'a@example.com' }))).toBeNull()
+  })
+
+  it('ignores an IQ with no id, which could never be paired', () => {
+    const iq = el('iq', { type: 'get', to: 'example.com' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info' }),
+    ])
+    expect(outboundFacts(iq)).toBeNull()
+  })
+
+  it('keys a query with no target on the empty string, which is the account server', () => {
+    const iq = el('iq', { type: 'get', id: 'q4' }, [el('query', { xmlns: 'jabber:iq:roster' })])
+    expect(outboundFacts(iq)).toEqual({ id: 'q4', kind: 'roster', to: '', dedupe: null })
+  })
+})
+
+describe('inboundReplyFacts', () => {
+  it('reports a result and an error alike', () => {
+    expect(inboundReplyFacts(el('iq', { type: 'result', id: 'q1' }))).toEqual({
+      id: 'q1',
+      type: 'result',
+    })
+    expect(inboundReplyFacts(el('iq', { type: 'error', id: 'q1' }))).toEqual({
+      id: 'q1',
+      type: 'error',
+    })
+  })
+
+  it('ignores an inbound request, which answers nothing', () => {
+    expect(inboundReplyFacts(el('iq', { type: 'get', id: 'srv-1' }))).toBeNull()
+    expect(inboundReplyFacts(el('message', { id: 'm1' }))).toBeNull()
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/stanzaFacts.ts
+++ b/apps/fluux/src/anomaly/detectors/stanzaFacts.ts
@@ -1,0 +1,185 @@
+/**
+ * What an anomaly detector may know about a stanza.
+ *
+ * Structural rather than ltx-typed: the classifier is pure, the tests build
+ * literals, and a real `Element` satisfies this shape. Nothing here reaches a
+ * record — the app tokenizes `to` at the recorder boundary, and `kind` becomes a
+ * closed TAG constant.
+ *
+ * @module Anomaly/Detectors/StanzaFacts
+ */
+
+export type QueryKind =
+  | 'disco-info'
+  | 'disco-items'
+  | 'vcard'
+  | 'avatar'
+  | 'mam'
+  | 'roster'
+  | 'other'
+
+export interface ElementLike {
+  name: string
+  attrs: Record<string, unknown>
+  children?: unknown[]
+  getChild(name: string, ns?: string): ElementLike | undefined
+}
+
+export interface OutFacts {
+  id: string
+  kind: QueryKind
+  /** The JID as addressed. Empty means the account's own server. */
+  to: string
+  /**
+   * Identity for the redundancy check, or `null` when a repeat is legitimate.
+   */
+  dedupe: string | null
+}
+
+export interface InFacts {
+  id: string
+  type: string
+}
+
+const NS_DISCO_INFO = 'http://jabber.org/protocol/disco#info'
+const NS_DISCO_ITEMS = 'http://jabber.org/protocol/disco#items'
+const NS_VCARD = 'vcard-temp'
+const NS_MAM = 'urn:xmpp:mam:2'
+const NS_ROSTER = 'jabber:iq:roster'
+const NS_PUBSUB = 'http://jabber.org/protocol/pubsub'
+const NS_RSM = 'http://jabber.org/protocol/rsm'
+const AVATAR_NODES = new Set(['urn:xmpp:avatar:data', 'urn:xmpp:avatar:metadata'])
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function elements(parent: ElementLike): ElementLike[] {
+  const out: ElementLike[] = []
+  for (const raw of parent.children ?? []) {
+    const child = raw as ElementLike | undefined
+    if (child && typeof child === 'object' && typeof child.name === 'string') out.push(child)
+  }
+  return out
+}
+
+function text(element: ElementLike): string {
+  return (element.children ?? [])
+    .filter((child): child is string => typeof child === 'string')
+    .join('')
+}
+
+function rsmSelector(query: ElementLike): string {
+  const set = elements(query).find(
+    (element) => element.name === 'set' && str(element.attrs?.xmlns) === NS_RSM,
+  )
+  const value = (name: string): string | null => {
+    const element = set && elements(set).find((child) => child.name === name)
+    return element ? text(element) : null
+  }
+  return JSON.stringify({
+    max: value('max'),
+    after: value('after'),
+    before: value('before'),
+    index: value('index'),
+  })
+}
+
+/**
+ * The payload namespace and the node it addresses.
+ *
+ * The node lives one level down for PubSub — `<pubsub><items node="…"/></pubsub>` —
+ * and on the payload itself for disco. Both are read, because for an avatar fetch
+ * the node IS the identity: metadata and data are two different queries to the same
+ * JID.
+ */
+function payload(stanza: ElementLike): { ns: string; node: string; selector: string } {
+  for (const child of elements(stanza)) {
+    const ns = str(child.attrs?.xmlns)
+    if (!ns) continue
+    const rsm = ns === NS_DISCO_ITEMS ? rsmSelector(child) : ''
+    const own = str(child.attrs?.node)
+    if (own) return { ns, node: own, selector: rsm }
+    for (const grandchild of elements(child)) {
+      const node = str(grandchild.attrs?.node)
+      if (node) {
+        const itemIds = elements(grandchild)
+          .filter((element) => element.name === 'item')
+          .map((element) => str(element.attrs?.id))
+          .filter(Boolean)
+          .sort()
+        const selector = JSON.stringify({
+          itemIds,
+          maxItems: str(grandchild.attrs?.max_items),
+          subid: str(grandchild.attrs?.subid),
+        })
+        return { ns, node, selector }
+      }
+    }
+    return { ns, node: '', selector: rsm }
+  }
+  return { ns: '', node: '', selector: '' }
+}
+
+function classify(ns: string, node: string): QueryKind {
+  switch (ns) {
+    case NS_DISCO_INFO:
+      return 'disco-info'
+    case NS_DISCO_ITEMS:
+      return 'disco-items'
+    case NS_VCARD:
+      return 'vcard'
+    case NS_MAM:
+      return 'mam'
+    case NS_ROSTER:
+      return 'roster'
+    case NS_PUBSUB:
+      return AVATAR_NODES.has(node) ? 'avatar' : 'other'
+    default:
+      return 'other'
+  }
+}
+
+/**
+ * Which kinds are judged for redundancy.
+ *
+ * A MAM query pages through one archive with a different window each time, and a
+ * roster or generic IQ has no stable identity a repeat could be measured against.
+ * Giving either a dedupe key would report ordinary traffic as an anomaly — the one
+ * outcome that costs this log its credibility.
+ */
+const DEDUPABLE: ReadonlySet<QueryKind> = new Set<QueryKind>([
+  'disco-info',
+  'disco-items',
+  'vcard',
+  'avatar',
+])
+
+export function outboundFacts(stanza: ElementLike): OutFacts | null {
+  if (stanza.name !== 'iq') return null
+  const type = str(stanza.attrs.type)
+  if (type !== 'get' && type !== 'set') return null
+  const id = str(stanza.attrs.id)
+  if (!id) return null
+
+  const { ns, node, selector } = payload(stanza)
+  const kind = classify(ns, node)
+  const to = str(stanza.attrs.to)
+  return {
+    id,
+    kind,
+    to,
+    dedupe: type === 'get' && DEDUPABLE.has(kind)
+      ? `${kind}|${to}|${node}${kind === 'avatar' || kind === 'disco-items' ? `|${selector}` : ''}`
+      : null,
+  }
+}
+
+export function inboundReplyFacts(stanza: ElementLike): InFacts | null {
+  if (stanza.name !== 'iq') return null
+  const type = str(stanza.attrs.type)
+  if (type !== 'result' && type !== 'error') return null
+  const id = str(stanza.attrs.id)
+  if (!id) return null
+  return { id, type }
+}

--- a/apps/fluux/src/anomaly/detectors/xmppTraffic.test.ts
+++ b/apps/fluux/src/anomaly/detectors/xmppTraffic.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest'
+import { createTrafficDetector, type TrafficOptions } from './xmppTraffic'
+import type { OutFacts } from './stanzaFacts'
+import { CTX, ID, TAG } from '../values'
+import type { RecordInput } from '../recorder'
+
+/** Any minted constant: the detector only needs token identity, never its value. */
+const TOKEN = TAG.focus
+
+function discoTo(jid: string, id: string): OutFacts {
+  return { id, kind: 'disco-info', to: jid, dedupe: `disco-info|${jid}|` }
+}
+
+function setup(overrides: Partial<TrafficOptions> = {}) {
+  const records: RecordInput[] = []
+  const detector = createTrafficDetector({
+    record: (input) => records.push(input),
+    token: () => TOKEN,
+    ...overrides,
+  })
+  return { detector, records }
+}
+
+function sampleUntil(detector: ReturnType<typeof createTrafficDetector>, end: number): void {
+  for (let now = 1_000; now <= end; now += 1_000) detector.sweep(now)
+}
+
+describe('redundant-query', () => {
+  it('fires when an answered query is repeated inside the window', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 5_000)
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.redundantQuery)
+    expect(records[0].sev).toBe('suspect')
+    expect(records[0].expected).toBe(1)
+    expect(records[0].observed).toBe(2)
+    expect(records[0].ctx).toEqual(
+      expect.arrayContaining([
+        [CTX.query, TAG.qDiscoInfo],
+        [CTX.target, TOKEN],
+        [CTX.elapsedMs, 4_900],
+      ]),
+    )
+  })
+
+  it('counts a third query in the same window as three', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+    detector.observeIn({ id: 'q2', type: 'result' }, 1_100)
+    detector.observeOut(discoTo('example.com', 'q3'), 2_000)
+
+    expect(records.map((r) => r.observed)).toEqual([2, 3])
+    expect(records[1].ctx).toEqual(expect.arrayContaining([[CTX.elapsedMs, 1_900]]))
+  })
+
+  it('stays silent once the window has passed', () => {
+    const { detector, records } = setup({ redundantWindowMs: 60_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 61_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('treats a re-query after an error as a retry, not a redundancy', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'error' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('closes an answered episode when a repeated query errors', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+    detector.observeIn({ id: 'q2', type: 'error' }, 1_100)
+    detector.observeOut(discoTo('example.com', 'q3'), 2_000)
+
+    expect(records.filter((record) => record.id === ID.redundantQuery)).toHaveLength(1)
+  })
+
+  it('closes an answered episode when a repeated query times out', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+    sampleUntil(detector, 31_000)
+    detector.observeOut(discoTo('example.com', 'q3'), 32_000)
+
+    expect(records.filter((record) => record.id === ID.redundantQuery)).toHaveLength(1)
+    expect(records.filter((record) => record.id === ID.iqUnanswered)).toHaveLength(1)
+  })
+
+  it('closes an answered episode when its repeated query is evicted', () => {
+    const { detector, records } = setup({ maxTracked: 2 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+    detector.observeOut(discoTo('other.example.com', 'q3'), 1_100)
+    detector.observeOut(discoTo('third.example.com', 'q4'), 1_200)
+    detector.observeIn({ id: 'q2', type: 'error' }, 1_300)
+    detector.observeOut(discoTo('example.com', 'q5'), 2_000)
+
+    expect(records.filter((record) => record.id === ID.redundantQuery)).toHaveLength(1)
+  })
+
+  it('says nothing about a query that has not been answered yet', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('separates two targets', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('a.example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 10)
+    detector.observeOut(discoTo('b.example.com', 'q2'), 20)
+
+    expect(records).toEqual([])
+  })
+
+  it('never judges a query with no dedupe key', () => {
+    const { detector, records } = setup()
+    const mam: OutFacts = { id: 'm1', kind: 'mam', to: 'a@example.com', dedupe: null }
+    detector.observeOut(mam, 0)
+    detector.observeIn({ id: 'm1', type: 'result' }, 10)
+    detector.observeOut({ ...mam, id: 'm2' }, 20)
+
+    expect(records).toEqual([])
+  })
+
+  it('forgets what was answered when the connection resets', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 10)
+    detector.reset()
+    // Re-querying disco after a reconnect is correct: the server may not be the
+    // same one, and its features may have changed.
+    detector.observeOut(discoTo('example.com', 'q2'), 20)
+
+    expect(records).toEqual([])
+  })
+})
+
+describe('iq-unanswered', () => {
+  it('fires once the threshold is reached with no reply', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+
+    sampleUntil(detector, 29_000)
+    expect(records).toEqual([])
+
+    detector.sweep(30_000)
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.iqUnanswered)
+    expect(records[0].sev).toBe('bug')
+    expect(records[0].expected).toBe(30_000)
+    expect(records[0].observed).toBe(30_000)
+    expect(records[0].ctx).toEqual(
+      expect.arrayContaining([
+        [CTX.query, TAG.qDiscoInfo],
+        [CTX.target, TOKEN],
+      ]),
+    )
+  })
+
+  it('reports one pending IQ once, not on every sweep', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    sampleUntil(detector, 31_000)
+    detector.sweep(45_000)
+
+    expect(records).toHaveLength(1)
+  })
+
+  it('stays silent when the reply arrives in time', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 500)
+    detector.sweep(60_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('reports a reply that reaches the threshold before the next sweep', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000, maxSweepStepMs: 1_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    sampleUntil(detector, 29_000)
+
+    detector.observeIn({ id: 'q1', type: 'result' }, 30_500)
+    detector.observeOut(discoTo('example.com', 'q2'), 30_501)
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.iqUnanswered)
+    expect(records[0].observed).toBe(30_000)
+  })
+
+  it('accepts an error reply as an answer', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'error' }, 500)
+    detector.sweep(60_000)
+
+    // A `service-unavailable` is a reply. Only silence is the invariant break.
+    expect(records).toEqual([])
+  })
+
+  it('forgets everything in flight when the connection resets', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.reset()
+    detector.sweep(60_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('bounds what it tracks', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000, maxTracked: 2 })
+    detector.observeOut(discoTo('a.example.com', 'q1'), 0)
+    detector.observeOut(discoTo('b.example.com', 'q2'), 1)
+    detector.observeOut(discoTo('c.example.com', 'q3'), 2)
+    sampleUntil(detector, 33_000)
+
+    // The oldest was evicted rather than retained: a leak inside a detector is
+    // worse than a missed record.
+    expect(records).toHaveLength(2)
+  })
+
+  it('ignores a reply to something it never saw sent', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeIn({ id: 'unknown-1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q1'), 200)
+    detector.observeIn({ id: 'q1', type: 'result' }, 300)
+    detector.sweep(60_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('does not count a suspended interval as observed waiting time', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000, maxSweepStepMs: 1_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+
+    detector.sweep(3_600_000)
+
+    expect(records).toEqual([])
+    detector.observeIn({ id: 'q1', type: 'result' }, 3_600_001)
+    detector.sweep(3_601_000)
+    expect(records).toEqual([])
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/xmppTraffic.ts
+++ b/apps/fluux/src/anomaly/detectors/xmppTraffic.ts
@@ -1,0 +1,171 @@
+/**
+ * The two invariants observable from the outbound application stanza seam.
+ *
+ * `redundant-query` says a query already answered was asked again inside a window;
+ * `iq-unanswered` says a request was never answered at all. Both are pure and
+ * clock-injected: `install.ts` supplies the stanzas, the clock and the sink.
+ *
+ * @module Anomaly/Detectors/XmppTraffic
+ */
+import type { RecordInput } from '../recorder'
+import { CTX, ID, queryKindTag, type Opaque } from '../values'
+import type { InFacts, OutFacts } from './stanzaFacts'
+
+const REDUNDANT_WINDOW_MS = 60_000
+const UNANSWERED_MS = 30_000
+const MAX_SWEEP_STEP_MS = 1_000
+/**
+ * How many requests and answered keys are remembered.
+ *
+ * A detector that grows without bound is a leak shipped as a diagnostic. Evicting
+ * the oldest entry loses a record; keeping everything loses the session.
+ */
+const MAX_TRACKED = 200
+
+export interface TrafficDetector {
+  observeOut(facts: OutFacts, now: number): void
+  observeIn(facts: InFacts, now: number): void
+  /** Report requests that have now been pending too long. */
+  sweep(now: number): void
+  /** Forget everything: a connection boundary makes every pending request moot. */
+  reset(): void
+}
+
+export interface TrafficOptions {
+  record: (input: RecordInput) => void
+  /** Tokenizes a JID at the recorder boundary. Never the raw value. */
+  token: (jid: string) => Opaque
+  redundantWindowMs?: number
+  unansweredMs?: number
+  maxSweepStepMs?: number
+  maxTracked?: number
+}
+
+interface Pending {
+  facts: OutFacts
+  at: number
+  observedAge: number
+}
+
+function evictOldest<K, V>(
+  map: Map<K, V>,
+  limit: number,
+  onEvict?: (value: V) => void
+): void {
+  while (map.size > limit) {
+    const oldest = map.keys().next()
+    if (oldest.done) return
+    const value = map.get(oldest.value)
+    map.delete(oldest.value)
+    if (value !== undefined) onEvict?.(value)
+  }
+}
+
+export function createTrafficDetector(opts: TrafficOptions): TrafficDetector {
+  const redundantWindowMs = opts.redundantWindowMs ?? REDUNDANT_WINDOW_MS
+  const unansweredMs = opts.unansweredMs ?? UNANSWERED_MS
+  const maxSweepStepMs = opts.maxSweepStepMs ?? MAX_SWEEP_STEP_MS
+  const maxTracked = opts.maxTracked ?? MAX_TRACKED
+
+  /** Requests still waiting for a reply, keyed by stanza id. */
+  const pending = new Map<string, Pending>()
+  /** When each dedupable query episode was first answered, and how many were sent. */
+  const answered = new Map<string, { at: number; sent: number }>()
+  let lastObservedAt: number | null = null
+
+  const advanceObservedAges = (now: number): void => {
+    const sinceObservation = lastObservedAt === null ? 0 : now - lastObservedAt
+    lastObservedAt = now
+    const observedStep = Number.isFinite(sinceObservation)
+      ? Math.max(0, Math.min(sinceObservation, maxSweepStepMs))
+      : 0
+    for (const request of pending.values()) {
+      const sinceRequest = Math.max(0, now - request.at)
+      request.observedAge += Math.min(observedStep, sinceRequest)
+    }
+  }
+
+  const recordUnanswered = (id: string, request: Pending): void => {
+    pending.delete(id)
+    if (request.facts.dedupe) answered.delete(request.facts.dedupe)
+    opts.record({
+      id: ID.iqUnanswered,
+      sev: 'bug',
+      expected: unansweredMs,
+      observed: request.observedAge,
+      ctx: [
+        [CTX.query, queryKindTag(request.facts.kind)],
+        [CTX.target, opts.token(request.facts.to)],
+      ],
+    })
+  }
+
+  return {
+    observeOut(facts, now) {
+      if (pending.size === 0) lastObservedAt = now
+      pending.set(facts.id, { facts, at: now, observedAge: 0 })
+      evictOldest(pending, maxTracked, (request) => {
+        if (request.facts.dedupe) answered.delete(request.facts.dedupe)
+      })
+
+      if (!facts.dedupe) return
+      const previous = answered.get(facts.dedupe)
+      if (!previous) return
+      const elapsed = now - previous.at
+      if (elapsed > redundantWindowMs) {
+        // Out of the window: this query starts a new episode rather than extending
+        // one, and it will re-arm when its own reply arrives.
+        answered.delete(facts.dedupe)
+        return
+      }
+      previous.sent++
+      opts.record({
+        id: ID.redundantQuery,
+        sev: 'suspect',
+        expected: 1,
+        observed: previous.sent,
+        ctx: [
+          [CTX.query, queryKindTag(facts.kind)],
+          [CTX.target, opts.token(facts.to)],
+          [CTX.elapsedMs, elapsed],
+        ],
+      })
+    },
+
+    observeIn(facts, now) {
+      const request = pending.get(facts.id)
+      if (!request) return
+      advanceObservedAges(now)
+      if (request.observedAge >= unansweredMs) {
+        recordUnanswered(facts.id, request)
+        return
+      }
+      pending.delete(facts.id)
+      // Only a RESULT establishes that the answer is now known. An error leaves the
+      // caller with nothing cached, so its retry is not a redundancy.
+      if (facts.type !== 'result') {
+        if (request.facts.dedupe) answered.delete(request.facts.dedupe)
+        return
+      }
+      if (!request.facts.dedupe) return
+      if (!answered.has(request.facts.dedupe)) {
+        answered.set(request.facts.dedupe, { at: now, sent: 1 })
+      }
+      evictOldest(answered, maxTracked)
+    },
+
+    sweep(now) {
+      advanceObservedAges(now)
+      for (const [id, request] of pending) {
+        if (request.observedAge < unansweredMs) continue
+        recordUnanswered(id, request)
+      }
+    },
+
+    reset() {
+      pending.clear()
+      answered.clear()
+      lastObservedAt = null
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { chatStore, roomStore } from '@fluux/sdk'
+import { chatStore, connectionStore, roomStore } from '@fluux/sdk'
 import {
   getRecorder,
   install,
@@ -11,10 +11,16 @@ import {
 } from './install'
 import { CTX, METRIC, resetValuesForTesting } from './values'
 import { hasAnomalySignalHandler, signalAnomaly } from '../utils/anomalySignal'
+import type { ElementLike } from './detectors/stanzaFacts'
+import type { TrafficClient } from './install'
 import {
   recordRecountDeferral,
   resetRecountDeferralsForTesting,
 } from '../../../../packages/fluux-sdk/src/stores/shared/recountDiagnostics'
+import {
+  reportArchiveMerge,
+  type ArchiveMergeReport,
+} from '../../../../packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics'
 import { measured } from '../../../../packages/fluux-sdk/src/utils/measure'
 
 type WindowWithSink = Record<string, unknown> & { __fluuxAnomalies?: string[] }
@@ -645,5 +651,250 @@ describe('readiness', () => {
     getRecorder()!.flushDigest(1000)
     const digest = records().filter((r) => r.kind === 'digest').pop()
     expect(digest.counters['recorder/dropped-not-ready']).toBeGreaterThan(0)
+  })
+})
+
+describe('traffic detector wiring', () => {
+  /** A client that hands back the handlers it was given. */
+  function stubClient() {
+    const out: Array<(s: ElementLike) => void> = []
+    const inbound: Array<(s: ElementLike) => void> = []
+    const released: string[] = []
+    const client: TrafficClient = {
+      onApplicationStanzaOut: (h) => {
+        out.push(h)
+        return () => released.push('out')
+      },
+      onStanza: (h) => {
+        inbound.push(h)
+        return () => released.push('in')
+      },
+    }
+    return { client, out, inbound, released }
+  }
+
+  function iq(attrs: Record<string, unknown>, ns?: string): ElementLike {
+    const children: ElementLike[] = ns
+      ? [{ name: 'query', attrs: { xmlns: ns }, children: [], getChild: () => undefined }]
+      : []
+    return {
+      name: 'iq',
+      attrs,
+      children,
+      getChild: (name: string) => children.find((c) => c.name === name),
+    }
+  }
+
+  it('records a redundant query seen through the client seams', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, out, inbound } = stubClient()
+      const cleanup = install(client)
+      await whenReady()
+
+      const disco = 'http://jabber.org/protocol/disco#info'
+      out[0](iq({ type: 'get', to: 'example.com', id: 'q1' }, disco))
+      inbound[0](iq({ type: 'result', id: 'q1' }))
+      out[0](iq({ type: 'get', to: 'example.com', id: 'q2' }, disco))
+
+      expect(records().map((r) => r.id)).toContain('xmpp-traffic/redundant-query')
+      cleanup()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('forgets pending requests when the connection drops', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, out } = stubClient()
+      const cleanup = install(client)
+      await whenReady()
+
+      out[0](iq({ type: 'get', to: 'example.com', id: 'q1' }, 'http://jabber.org/protocol/disco#info'))
+      // Any connection status change resets: everything in flight when the
+      // connection moved is unanswerable through no fault of the app.
+      const onConnection = vi.mocked(connectionStore.subscribe).mock.calls.at(-1)?.[0] as
+        unknown as (next: { status: string }, prev: { status: string }) => void
+      onConnection({ status: 'reconnecting' }, { status: 'online' })
+      vi.advanceTimersByTime(60_000)
+
+      expect(records().map((r) => r.id)).not.toContain('xmpp-traffic/iq-unanswered')
+      cleanup()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('releases the client subscriptions with the last hold', () => {
+    const { client, released } = stubClient()
+
+    install(client)()
+
+    expect(released).toEqual(expect.arrayContaining(['out', 'in']))
+  })
+
+  it('installs without a client', () => {
+    expect(() => install()()).not.toThrow()
+  })
+})
+
+describe('archive merge wiring', () => {
+  function merge(overrides: Partial<ArchiveMergeReport> = {}): ArchiveMergeReport {
+    return {
+      entityKind: 'chat',
+      entityId: 'alice@example.com',
+      direction: 'forward',
+      complete: true,
+      outcome: 'durable',
+      returned: 10,
+      retained: 7,
+      deduplicated: 3,
+      patched: 0,
+      intentionallyUnstored: 0,
+      persistenceFailed: 0,
+      ...overrides,
+    }
+  }
+
+  it('records a failed archive write reported by a store', async () => {
+    const cleanup = install()
+    await whenReady()
+
+    reportArchiveMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
+
+    expect(records().map((r) => r.id)).toContain('xmpp-traffic/mam-write-failed')
+    cleanup()
+  })
+
+  it('leaves a healthy merge to the counters', async () => {
+    const cleanup = install()
+    await whenReady()
+
+    reportArchiveMerge(merge())
+
+    expect(records().map((r) => r.id)).not.toContain('xmpp-traffic/mam-write-failed')
+    cleanup()
+  })
+
+  it('stops observing merges once the last hold is released', async () => {
+    const cleanup = install()
+    await whenReady()
+    cleanup()
+
+    reportArchiveMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
+
+    expect(records().map((r) => r.id)).not.toContain('xmpp-traffic/mam-write-failed')
+  })
+})
+
+describe('pointer regression wiring', () => {
+  type MetaLike = { readPointer?: { order: { role: 'floor'; timestamp: number } } }
+
+  function pointerMeta(timestamp: number): MetaLike {
+    return { readPointer: { order: { role: 'floor', timestamp } } }
+  }
+
+  /** Drive the chat store subscription the way the store would. */
+  function pushChatMeta(next: Map<string, MetaLike>, prev: Map<string, MetaLike>): void {
+    const subscription = vi.mocked(chatStore.subscribe).mock.calls.at(-1)?.[0] as unknown as (
+      next: ChatSubscriptionState & { conversationMeta: Map<string, MetaLike> },
+      prev: ChatSubscriptionState & { conversationMeta: Map<string, MetaLike> },
+    ) => void
+    const base = {
+      lastArrivedMessage: new Map<string, ArrivedMessage>(),
+      activeConversationId: null,
+      activationPending: false,
+    }
+    subscription({ ...base, conversationMeta: next }, { ...base, conversationMeta: prev })
+  }
+
+  function pushRoomMeta(next: Map<string, MetaLike>, prev: Map<string, MetaLike>): void {
+    const subscription = vi.mocked(roomStore.subscribe).mock.calls.at(-1)?.[0] as unknown as (
+      next: RoomSubscriptionState & { roomMeta: Map<string, MetaLike> },
+      prev: RoomSubscriptionState & { roomMeta: Map<string, MetaLike> },
+    ) => void
+    const base = {
+      lastArrivedMessage: new Map<string, ArrivedMessage>(),
+      activeRoomJid: null,
+      activationPending: false,
+    }
+    subscription({ ...base, roomMeta: next }, { ...base, roomMeta: prev })
+  }
+
+  it('records a pointer that moved backwards', async () => {
+    const cleanup = install()
+    await whenReady()
+
+    const first = new Map([['alice@example.com', pointerMeta(5_000)]])
+    const second = new Map([['alice@example.com', pointerMeta(3_000)]])
+    pushChatMeta(first, new Map())
+    pushChatMeta(second, first)
+
+    expect(records().map((r) => r.id)).toContain('read-state/pointer-regression')
+    cleanup()
+  })
+
+  it('compares the first update with the pointer present at installation', async () => {
+    const base = chatStore.getState()
+    const first = new Map([['alice@example.com', pointerMeta(5_000)]])
+    const state = vi.spyOn(chatStore, 'getState').mockReturnValue({
+      ...base,
+      conversationMeta: first,
+    } as never)
+    const cleanup = install()
+    await whenReady()
+
+    const second = new Map([['alice@example.com', pointerMeta(3_000)]])
+    pushChatMeta(second, first)
+
+    expect(records().map((r) => r.id)).toContain('read-state/pointer-regression')
+    cleanup()
+    state.mockRestore()
+  })
+
+  it('seeds existing room pointers as well as conversation pointers', async () => {
+    const base = roomStore.getState()
+    const first = new Map([['team@conference.example.com', pointerMeta(5_000)]])
+    const state = vi.spyOn(roomStore, 'getState').mockReturnValue({
+      ...base,
+      roomMeta: first,
+    } as never)
+    const cleanup = install()
+    await whenReady()
+
+    const second = new Map([['team@conference.example.com', pointerMeta(3_000)]])
+    pushRoomMeta(second, first)
+
+    expect(records().map((r) => r.id)).toContain('read-state/pointer-regression')
+    cleanup()
+    state.mockRestore()
+  })
+
+  it('says nothing when the pointer advances', async () => {
+    const cleanup = install()
+    await whenReady()
+
+    const first = new Map([['alice@example.com', pointerMeta(3_000)]])
+    const second = new Map([['alice@example.com', pointerMeta(5_000)]])
+    pushChatMeta(first, new Map())
+    pushChatMeta(second, first)
+
+    expect(records().map((r) => r.id)).not.toContain('read-state/pointer-regression')
+    cleanup()
+  })
+
+  it('ignores a store event that did not touch the metadata map', async () => {
+    const cleanup = install()
+    await whenReady()
+
+    const meta = new Map([['alice@example.com', pointerMeta(5_000)]])
+    pushChatMeta(meta, new Map())
+    // Same map reference on both sides: the scan must not even look, which is what
+    // keeps message traffic from paying for this detector.
+    pushChatMeta(meta, meta)
+
+    expect(records().map((r) => r.id)).not.toContain('read-state/pointer-regression')
+    cleanup()
   })
 })

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -15,7 +15,7 @@
  *
  * @module Anomaly/Install
  */
-import { chatStore, getStorageScopeJid, readRecountDeferrals, roomStore, setMeasurementEnabled } from '@fluux/sdk'
+import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, onArchiveMerge, readRecountDeferrals, roomReadStateGeneration, roomStore, setMeasurementEnabled } from '@fluux/sdk'
 import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
 import { createDenominatorTracker, type DenominatorName } from './denominators'
 import { warmConversation, warmRoom } from './identity'
@@ -30,12 +30,16 @@ import {
 import type { ViewportKind } from '../utils/viewportAtBottom'
 import { detectOS, platform } from '@/platform'
 import { recordForSignal } from './detectors/signalRecords'
+import { inboundReplyFacts, outboundFacts, type ElementLike } from './detectors/stanzaFacts'
+import { createTrafficDetector, type TrafficDetector } from './detectors/xmppTraffic'
+import { createArchiveMergeDetector } from './detectors/archiveMerge'
+import { createPointerRegressionDetector } from './detectors/pointerRegression'
 import { browserWorld, startDetectorTick, type DetectorTick } from './detectors/tick'
 import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
 import { createPluginFsWriter, createTauriSink } from './sinks/tauri'
-import { ID, METRIC, RECOUNT_METRIC, TAG, initTokenizer, isTokenizerReady, type Opaque } from './values'
+import { ID, METRIC, RECOUNT_METRIC, TAG, initTokenizer, isTokenizerReady, tokenSync, type Opaque } from './values'
 
 const DIGEST_INTERVAL_MS = 5 * 60 * 1000
 /**
@@ -86,7 +90,21 @@ let digestTimer: ReturnType<typeof setInterval> | null = null
 let detachListener: (() => void) | null = null
 let detectorTick: DetectorTick | null = null
 let storeUnsubscribes: (() => void) | null = null
+let clientUnsubscribes: (() => void) | null = null
+let archiveMergeUnsubscribe: (() => void) | null = null
+let trafficDetector: TrafficDetector | null = null
 let perfWatch: PerfMeasureWatch | null = null
+
+/**
+ * What the traffic detector needs from the client.
+ *
+ * Structural rather than `XMPPClient`: this module is unit-tested without a client,
+ * and a type naming the class would drag the SDK barrel into those tests.
+ */
+export interface TrafficClient {
+  onApplicationStanzaOut(handler: (stanza: ElementLike) => void): () => void
+  onStanza(handler: (stanza: ElementLike) => void): () => void
+}
 
 type ProbeWindow = Window & {
   __fluuxAnomalies?: string[]
@@ -278,7 +296,7 @@ function attemptSessionRecord(rec: Recorder): void {
  * @returns a release for THIS hold. The subscriptions come down when the last hold
  * is released; the runtime itself is never destroyed.
  */
-export function install(): () => void {
+export function install(client?: TrafficClient): () => void {
   const rec = runtime()
   markAnomalyBuild()
   announceSessionOnce(rec)
@@ -359,11 +377,66 @@ export function install(): () => void {
       })
     }
 
+    // Every read-pointer write, watched for the one direction it must never take.
+    // The pointer and its generation are read in the SAME callback: a generation
+    // learned later than the pointer it explains would turn an account switch into
+    // a phantom regression.
+    const pointerRegression = createPointerRegressionDetector({
+      record: (input) => rec.record(input),
+      token: (kind, id) => (kind === 'room' ? tokenSync('room', id) : tokenSync('jid', id)),
+      isAhead,
+    })
+
+    /**
+     * Scan the metadata map that just changed.
+     *
+     * Guarded on the map's identity by the caller: it is recreated only when
+     * metadata actually changes, so message traffic — by far the most frequent
+     * store event — costs one reference comparison.
+     */
+    const scanPointers = <T extends { readPointer?: Parameters<typeof isAhead>[0] }>(
+      kind: 'chat' | 'room',
+      nextMeta: ReadonlyMap<string, T>,
+      prevMeta: ReadonlyMap<string, T>,
+      generation: (id: string) => { store: number; entity: number },
+    ): void => {
+      for (const [id, meta] of nextMeta) {
+        if (prevMeta.get(id) === meta) continue
+        pointerRegression.observe({
+          kind,
+          id,
+          pointer: meta.readPointer,
+          generation: generation(id),
+        })
+      }
+    }
+
+    const seedPointers = <T extends { readPointer?: Parameters<typeof isAhead>[0] }>(
+      kind: 'chat' | 'room',
+      meta: ReadonlyMap<string, T>,
+      generation: (id: string) => { store: number; entity: number },
+    ): void => {
+      for (const [id, value] of meta) {
+        pointerRegression.observe({
+          kind,
+          id,
+          pointer: value.readPointer,
+          generation: generation(id),
+        })
+      }
+    }
+
+    seedPointers('chat', chatStore.getState().conversationMeta, chatReadStateGeneration)
+    seedPointers('room', roomStore.getState().roomMeta, roomReadStateGeneration)
+
     const unsubChat = chatStore.subscribe((next, prev) => {
       denominators.observeArrivals(
         { lastArrivedMessage: next.lastArrivedMessage, isRoom: false },
         { lastArrivedMessage: prev.lastArrivedMessage, isRoom: false },
       )
+      if (next.conversationMeta !== prev.conversationMeta) {
+        scanPointers('chat', next.conversationMeta, prev.conversationMeta, chatReadStateGeneration)
+      }
       observeActiveEntity()
     })
     const unsubRooms = roomStore.subscribe((next, prev) => {
@@ -371,12 +444,57 @@ export function install(): () => void {
         { lastArrivedMessage: next.lastArrivedMessage, isRoom: true },
         { lastArrivedMessage: prev.lastArrivedMessage, isRoom: true },
       )
+      if (next.roomMeta !== prev.roomMeta) {
+        scanPointers('room', next.roomMeta, prev.roomMeta, roomReadStateGeneration)
+      }
       observeActiveEntity()
     })
     storeUnsubscribes = () => {
       storeObserversAttached = false
       unsubChat()
       unsubRooms()
+    }
+
+    // The archive merge seam. Store-side, so it attaches with or without a client:
+    // a merge can be driven by a cache rehydrate as well as by a live walk.
+    const archiveMerge = createArchiveMergeDetector({
+      record: (input) => rec.record(input),
+      count: (key, by) => rec.count(key, by),
+      token: (report) =>
+        report.entityKind === 'room' ? tokenSync('room', report.entityId) : tokenSync('jid', report.entityId),
+    })
+    archiveMergeUnsubscribe = onArchiveMerge((report) => archiveMerge.observe(report))
+
+    // The application IQ traffic detectors. Absent a client — a unit test, or a
+    // harness that mounts the runtime on its own — nothing attaches and nothing is
+    // reported, rather than a detector observing a half-wired session.
+    if (client) {
+      const traffic = createTrafficDetector({
+        record: (input) => rec.record(input),
+        token: (jid) => tokenSync('jid', jid),
+      })
+      trafficDetector = traffic
+
+      const offOut = client.onApplicationStanzaOut((stanza) => {
+        const facts = outboundFacts(stanza)
+        if (facts) traffic.observeOut(facts, Date.now())
+      })
+      const offIn = client.onStanza((stanza) => {
+        const facts = inboundReplyFacts(stanza)
+        if (facts) traffic.observeIn(facts, Date.now())
+      })
+      // A connection boundary makes every pending request unanswerable through no
+      // fault of the app, and re-querying disco after a reconnect is correct — the
+      // server may not even be the same one. The connection store carries this;
+      // the client's own lifecycle bus is internal to the SDK.
+      const offConnection = connectionStore.subscribe((next, prev) => {
+        if (next.status !== prev.status) traffic.reset()
+      })
+      clientUnsubscribes = () => {
+        offOut()
+        offIn()
+        offConnection()
+      }
     }
 
     // Ask the SDK to time its heaviest synchronous operations, and watch for the
@@ -398,7 +516,13 @@ export function install(): () => void {
       // The sampler is the only thing that can say the app was alive at a given
       // instant. Wall clock cannot: the WebView freezes timers while hidden, so a
       // suspended hour and an hour of use are indistinguishable afterwards.
-      onSample: (now) => foregroundShare.sample(now),
+      onSample: (now) => {
+        foregroundShare.sample(now)
+        // The sampler is the only thing that knows the app was alive at this
+        // instant. Sweeping on a timer of its own would report every request in
+        // flight when the WebView froze as unanswered.
+        trafficDetector?.sweep(Date.now())
+      },
     })
 
     digestTimer = setInterval(() => {
@@ -455,6 +579,11 @@ export function install(): () => void {
     clearAnomalyMetricHandler()
     storeUnsubscribes?.()
     storeUnsubscribes = null
+    clientUnsubscribes?.()
+    clientUnsubscribes = null
+    archiveMergeUnsubscribe?.()
+    archiveMergeUnsubscribe = null
+    trafficDetector = null
     perfWatch?.stop()
     perfWatch = null
     setMeasurementEnabled(false)
@@ -479,6 +608,11 @@ export function resetInstallForTesting(): void {
   clearAnomalyMetricHandler()
   storeUnsubscribes?.()
   storeUnsubscribes = null
+  clientUnsubscribes?.()
+  clientUnsubscribes = null
+  archiveMergeUnsubscribe?.()
+  archiveMergeUnsubscribe = null
+  trafficDetector = null
   perfWatch?.stop()
   perfWatch = null
   setMeasurementEnabled(false)

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -12,6 +12,7 @@
  *
  * @module Anomaly/Values
  */
+import type { QueryKind } from './detectors/stanzaFacts'
 
 // ---------------------------------------------------------------------------
 // Opaque values
@@ -124,7 +125,42 @@ export const TAG = Object.freeze({
   // performance entry, and this is where it becomes a constant.
   perfPersist: mint('perf:persist', 'tag'),
   perfMergeArchive: mint('perf:merge-archive', 'tag'),
+  // Outbound query kinds. A payload namespace is free text of exactly the sort the
+  // registries keep out of a record, so it becomes a constant here.
+  qDiscoInfo: mint('q:disco-info', 'tag'),
+  qDiscoItems: mint('q:disco-items', 'tag'),
+  qVcard: mint('q:vcard', 'tag'),
+  qAvatar: mint('q:avatar', 'tag'),
+  qMam: mint('q:mam', 'tag'),
+  qRoster: mint('q:roster', 'tag'),
+  qOther: mint('q:other', 'tag'),
 })
+
+/**
+ * The TAG for a query kind.
+ *
+ * Total over the union rather than a lookup that can miss: an unmapped kind would
+ * reach a record as `undefined`, and the serializer would drop the whole record
+ * rather than the one field.
+ */
+export function queryKindTag(kind: QueryKind): Opaque {
+  switch (kind) {
+    case 'disco-info':
+      return TAG.qDiscoInfo
+    case 'disco-items':
+      return TAG.qDiscoItems
+    case 'vcard':
+      return TAG.qVcard
+    case 'avatar':
+      return TAG.qAvatar
+    case 'mam':
+      return TAG.qMam
+    case 'roster':
+      return TAG.qRoster
+    case 'other':
+      return TAG.qOther
+  }
+}
 
 /** Invariant ids. One entry per row in docs/ANOMALY_INVARIANTS.md. */
 export const ID = Object.freeze({
@@ -141,6 +177,10 @@ export const ID = Object.freeze({
   unreadFocusCleared: mint('read-state/unread-focus-cleared', 'id'),
   fabAtLiveEdge: mint('scroll/fab-at-live-edge', 'id'),
   jumpTargetMiss: mint('scroll/jump-target-miss', 'id'),
+  redundantQuery: mint('xmpp-traffic/redundant-query', 'id'),
+  iqUnanswered: mint('xmpp-traffic/iq-unanswered', 'id'),
+  mamWriteFailed: mint('xmpp-traffic/mam-write-failed', 'id'),
+  pointerRegression: mint('read-state/pointer-regression', 'id'),
 })
 
 /** Permitted `ctx` keys. */
@@ -164,6 +204,12 @@ export const CTX = Object.freeze({
   peak: mint('peak', 'ctx'),
   /** Signed px by which a jump target sat outside the viewport. */
   offBy: mint('offBy', 'ctx'),
+  /** The queried entity, as an entity token — never the JID. */
+  target: mint('target', 'ctx'),
+  /** Rows delivered to this archive merge. */
+  returned: mint('returned', 'ctx'),
+  /** How far back a read pointer moved, in milliseconds. */
+  behindMs: mint('behindMs', 'ctx'),
 })
 
 /**
@@ -208,6 +254,7 @@ export const COUNTER = Object.freeze({
 export const METRIC = Object.freeze({
   mamQueries: mint('mam.queries', 'counter'),
   mamRowsRetained: mint('mam.rowsRetained', 'counter'),
+  mamRowsReturned: mint('mam.rowsReturned', 'counter'),
   roomJoins: mint('room.joins', 'counter'),
   scrollWrites: mint('scroll.writes', 'counter'),
   probe: mint('probe.metric', 'counter'),
@@ -241,11 +288,9 @@ export interface RateSpec {
  * own meaning. A skill holding the pairings would have to be kept in step with this
  * file by hand, and a mismatch would silently compare the wrong two numbers.
  *
- * `mam.rowsRetained`, `idb.writes` and `mam.queries` are deliberately absent. Rows
- * retained is not observable from either end of the MAM path — retention is decided
- * downstream of the typed event — and nothing MAM-related is exported at all, so
- * both the numerator and the denominator would have to be invented. They arrive in
- * stage 5 with the seams they need.
+ * The archive-merge seam now supplies `mam.rowsRetained/rowsReturned` from one
+ * report. The pairing remains informational until the build-stamp question below
+ * is settled. `idb.writes` and `mam.queries` still have no sound normalized pairing.
  *
  * MessageList renders have several causes: arrivals, typing, presence, read-state,
  * scroll and resize. Conversation and room arrival signals now exist, while renders
@@ -259,7 +304,7 @@ export interface RateSpec {
  * signals. The counters remain useful raw evidence and inputs for that later rate.
  *
  * Build stamps contain the app version and short HEAD, so dirty rebuilds from the
- * same HEAD share a review series. Before stage 5 makes any rate judgeable, choose
+ * same HEAD share a review series. Before making any rate judgeable, choose
  * either a content-derived fingerprint or a clean-tree requirement. Current
  * informational rates issue no per-build verdicts, so the shared series cannot
  * dilute a verdict today.
@@ -275,6 +320,24 @@ export const RATE: Readonly<Record<string, RateSpec>> = Object.freeze({
     id: mint('scroll.writes/positioning', 'rate'),
     numerator: METRIC.scrollWrites,
     denominator: METRIC.scrollPositioningOps,
+    informational: true,
+  }),
+  // The archive merge seam's yield: of the rows this merge received, how many the
+  // store wrote durably. Both halves come from ONE report, so the pairing
+  // cannot mix a numerator and a denominator measured at different moments.
+  //
+  // Informational for now, and NOT because the quantity is doubtful: seeding it
+  // requires settling the build-stamp question in docs/anomaly-baseline.json, since
+  // dirty rebuilds from one short HEAD currently share a review series.
+  //
+  // Read it with the registry's warning: `retained` means WRITTEN, not new to the
+  // archive. A backgrounded entity keeps no resident array, so its pages dedupe
+  // against nothing and are rewritten in full — a yield near 1 there says the
+  // catch-up wrote, not that it learned anything.
+  mamPageYield: Object.freeze({
+    id: mint('mam.rowsRetained/rowsReturned', 'rate'),
+    numerator: METRIC.mamRowsRetained,
+    denominator: METRIC.mamRowsReturned,
     informational: true,
   }),
 })

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -270,22 +270,25 @@ const AnomalyInstaller = __FLUUX_ANOMALY__
   ? React.lazy(() => import('./anomaly/AnomalyInstaller'))
   : null
 
+const application = (
+  <ThemeProvider>
+    <DemoTutorialProvider enabled={tutorialEnabled} client={demoClient} animation={demoAnimation}>
+      <HashRouter useTransitions={ROUTER_USE_TRANSITIONS}>
+        <App />
+      </HashRouter>
+    </DemoTutorialProvider>
+  </ThemeProvider>
+)
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RenderLoopBoundary>
       <XMPPProvider client={demoClient}>
-        {AnomalyInstaller && (
+        {AnomalyInstaller ? (
           <React.Suspense fallback={null}>
-            <AnomalyInstaller />
+            <AnomalyInstaller>{application}</AnomalyInstaller>
           </React.Suspense>
-        )}
-        <ThemeProvider>
-          <DemoTutorialProvider enabled={tutorialEnabled} client={demoClient} animation={demoAnimation}>
-            <HashRouter useTransitions={ROUTER_USE_TRANSITIONS}>
-              <App />
-            </HashRouter>
-          </DemoTutorialProvider>
-        </ThemeProvider>
+        ) : application}
       </XMPPProvider>
       {import.meta.env.DEV && <RenderLoopWarningBanner />}
     </RenderLoopBoundary>

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -146,6 +146,14 @@ const AnomalyInstaller = __FLUUX_ANOMALY__
   ? React.lazy(() => import('./anomaly/AnomalyInstaller'))
   : null
 
+const application = (
+  <ThemeProvider>
+    <HashRouter useTransitions={ROUTER_USE_TRANSITIONS}>
+      <App />
+    </HashRouter>
+  </ThemeProvider>
+)
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RenderLoopBoundary>
@@ -154,16 +162,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         proxyAdapter={proxyAdapter}
         shouldAutoReconnect={() => getReconnectIntent() === 'active'}
       >
-        {AnomalyInstaller && (
+        {AnomalyInstaller ? (
           <React.Suspense fallback={null}>
-            <AnomalyInstaller />
+            <AnomalyInstaller>{application}</AnomalyInstaller>
           </React.Suspense>
-        )}
-        <ThemeProvider>
-          <HashRouter useTransitions={ROUTER_USE_TRANSITIONS}>
-            <App />
-          </HashRouter>
-        </ThemeProvider>
+        ) : application}
       </XMPPProvider>
       {import.meta.env.DEV && <RenderLoopWarningBanner />}
     </RenderLoopBoundary>

--- a/apps/fluux/src/test-setup.ts
+++ b/apps/fluux/src/test-setup.ts
@@ -260,6 +260,7 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
     chatStore: {
       getState: () => ({
         conversations: new Map(),
+        conversationMeta: new Map(),
         messages: new Map(),
         activeConversationId: null,
         activationPending: false,
@@ -276,6 +277,7 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
     roomStore: {
       getState: () => ({
         rooms: new Map(),
+        roomMeta: new Map(),
         roomRuntime: new Map(),
         activeRoomJid: null,
         activationPending: false,

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -180,12 +180,64 @@ can be at the bottom of a resident slice with newer unread messages beyond it. A
 sampling window ends the episode silently, so suspended timers cannot turn an
 unobserved interval into persistence evidence.
 
-_(stage 5 adds `badge-vs-pointer` and `pointer-regression`, both of which need SDK
-seams that do not exist yet.)_
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `read-state/pointer-regression` | bug | The read pointer for `ctx.conv` or `ctx.room` was replaced by one `ctx.behindMs` ms behind it, inside a single read-state generation | The forward-only invariant broke, in its unrecoverable direction: read messages are marked unread again and nothing downstream can tell that from new mail (#1076). Find the writer — the viewport observer, XEP-0490, or mark-read |
+
+**Named non-cases:**
+
+- A generation change is never a regression. `chatReadStateGeneration` /
+  `roomReadStateGeneration` report a `store` scope (logout, account switch) and an
+  `entity` scope (that conversation or room deleted); a move in **either** resets the
+  comparison, and the first pointer of a new generation has no predecessor.
+- Writing the same pointer twice is idempotence. Only a pointer strictly behind its
+  predecessor counts, decided by the SDK's own `isAhead` rather than by a comparison
+  this detector invents.
+- A pointer being CLEARED is a different event with a different cause, and is not
+  reported here.
+- The detector observes at most 300 entities. Past that the oldest is dropped, so a
+  very large account can miss a regression — it never leaks to keep one.
 
 ### `xmpp-traffic/`
 
-_(stage 5: `mam-page-yield`, `redundant-query`, `iq-unanswered`)_
+Both read the outbound application stanza seam (`client.onApplicationStanzaOut`) and
+pair it with the inbound stanzas `onStanza` already carries.
+
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `xmpp-traffic/redundant-query` | suspect | The same disco, vCard or avatar query went to `ctx.target` again `ctx.elapsedMs` after the previous one had already been answered. `observed` is how many were sent inside the window, `expected` is 1 | A cache that is not being consulted, or a caller re-querying on every presence. `ctx.query` names the kind |
+| `xmpp-traffic/iq-unanswered` | bug | An outbound application IQ went `observed` ms with no reply (`expected` is the threshold). `ctx.query` names the kind, `ctx.target` the entity | The peer or server never answered. Read it with the connection crumbs: a reply lost across a reconnect is cleared, not reported |
+| `xmpp-traffic/mam-write-failed` | bug | An archive merge for `ctx.target` failed to write `observed` of the `ctx.returned` rows it was given | The IndexedDB transaction did not commit. That entity's durable catch-up cursor is now frozen for the session (`archiveSaveChain.ts`), so the next session refetches from the stale cursor rather than skipping the page. Look for storage pressure or a closed database |
+
+**Named non-cases**, so a later reader does not think they were forgotten:
+
+- Neither id sees connection-level traffic. The keepalive ping and the Stream
+  Management `<r/>` bypass the application layer, so a stalled ping or an
+  unacknowledged SM request is invisible here by construction.
+- `redundant-query` never judges MAM or roster traffic. MAM pages the same archive
+  with a different window on purpose, and a roster fetch after a reconnect is
+  expected. Only disco, vCard and avatar queries carry a dedupe identity.
+- `redundant-query` requires the previous query to have been **answered**. A
+  re-query after an error or a timeout is a retry, not a redundancy.
+- An avatar `data` and `metadata` fetch to one JID are two different queries: the
+  PubSub node is part of the identity, as is a disco `node`.
+- `iq-unanswered` clears everything in flight on disconnect and on reconnect. A
+  request outstanding when the connection drops is unanswerable through no fault of
+  the app.
+- An IQ whose transport write failed is still reported as outbound. The seam reports
+  the hand-off to the transport, not the socket write; the connection reset that
+  follows clears the pending entry.
+
+More named non-cases, for the archive merge:
+
+- A `partial` merge is **not** recorded. It means an earlier page for the same entity
+  failed — and that page recorded it. One fault, one record.
+- Only a merge is observed, never a protocol query. Chat walks reach the store as one
+  accumulated set, while forward room walks can arrive per page; neither store event
+  retains the collector's per-query id.
+
+The merge yield itself is a RATE, not an id: severity `drift` is judged only on rates
+(design §5.4). See `mam.rowsRetained/rowsReturned` under `resource/`.
 
 ### `scroll/`
 
@@ -243,8 +295,15 @@ but they never produce `ok` or `drift` and must not be added to the baseline yet
 |---|---|---|
 | `render.MessageList/roomSwitch` | Message-list renders / conversation or room switches | Conversation and room arrivals are now counted separately, but this rate still divides by switches while renders also scale with arrivals, typing, presence, read-state, scroll, and resize |
 | `scroll.writes/positioning` | Re-assert-loop scroll writes / positioning operations | The frame-loop signal does not yet distinguish a scroll call being issued from geometry actually moving |
+| `mam.rowsRetained/rowsReturned` | Rows an archive merge wrote durably / rows that merge received | The quantity is sound — both halves come from one report — but seeding a baseline needs the build-stamp question settled first (see `docs/anomaly-baseline.json`) |
+
+**`retained` means written, not new.** Only the conversation or room on screen keeps a
+resident array; a backgrounded entity dedupes against nothing, so its pages are
+rewritten in full and its yield sits near 1. That is a fact about where the merge
+dedupes, not about how much the catch-up learned. Compare yields within one entity
+state, never across them.
 
 `apps/fluux/src/anomaly/values.ts` owns these pairings and their judgeability. Before
-stage 5 makes either rate judgeable, also resolve the build-stamp limitation documented
+making any informational rate judgeable, also resolve the build-stamp limitation documented
 in `docs/anomaly-baseline.json`: dirty rebuilds from one short HEAD currently share a
 series.

--- a/docs/anomaly-baseline.json
+++ b/docs/anomaly-baseline.json
@@ -11,7 +11,7 @@
     "or 'ok'. An all-informational window is not a clean judged week.",
     "See docs/ANOMALY_INVARIANTS.md for why the current rates are informational.",
     "Build stamps contain the app version and short HEAD, so dirty rebuilds from one",
-    "HEAD share a series. Before Stage 5 makes any rate judgeable, choose either a",
+    "HEAD share a series. Before making any rate judgeable, choose either a",
     "content-derived fingerprint or a clean-tree requirement.",
     "",
     "When a judgeable rate exists, seed it from a week you are willing to call normal",

--- a/docs/superpowers/plans/2026-07-29-anomaly-log-stages-0-1.md
+++ b/docs/superpowers/plans/2026-07-29-anomaly-log-stages-0-1.md
@@ -3268,11 +3268,12 @@ introduces it.
 
 ### `read-state/`
 
-_(stage 3: `unread-survives-focus`; stage 5: `badge-vs-pointer`, `pointer-regression`)_
+_(stage 3: `unread-survives-focus`; stage 5: `pointer-regression`. The
+`badge-vs-pointer` objective was withdrawn; see the design's §5.1.)_
 
 ### `xmpp-traffic/`
 
-_(stage 5: `mam-page-yield`, `redundant-query`, `iq-unanswered`)_
+_(stage 5: `redundant-query`, `iq-unanswered`, plus MAM merge yield as a rate.)_
 
 ### `scroll/`
 

--- a/docs/superpowers/plans/2026-08-31-anomaly-log-stage-5a-outbound-stanza-seam.md
+++ b/docs/superpowers/plans/2026-08-31-anomaly-log-stage-5a-outbound-stanza-seam.md
@@ -1,0 +1,1403 @@
+# Anomaly log stage 5a — outbound application stanza seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first of the four stage-5 SDK seams — `onApplicationStanzaOut` — and the two
+detectors it unblocks, `xmpp-traffic/redundant-query` and `xmpp-traffic/iq-unanswered`.
+
+**Architecture:** The SDK gains one public subscription over the two application-layer send paths
+that already exist (`XMPPClient.sendStanza` and `XMPPClient.sendIQ`), emitting the `Element` the
+caller already built — no payload construction, no new type. The app subscribes to that seam and to
+the existing inbound `onStanza`, classifies each outbound IQ into a closed set of query kinds, and
+runs a pure state machine that pairs requests with replies. All anomaly-system code stays in
+`apps/fluux/src/anomaly/`.
+
+**Tech Stack:** TypeScript, vitest, `@xmpp/client` (ltx `Element`), Zustand (untouched here).
+
+**Spec:** `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` §5.2, §5.5, §8.
+
+> **Status:** Implemented. Later review moved observation to the shared real/demo send boundary,
+> assigned IQ ids before that boundary, and isolated every subscriber's snapshot. The public SDK
+> doc comments, benchmark README, and anomaly invariant registry own the current contracts; code
+> excerpts below preserve the implementation plan rather than restating those owners.
+
+## Stage 5 is four plans, not one
+
+The spec's stage 5 covers four independent seams. Each is independently useful and independently
+revertable, and each unblocks a different detector family, so each gets its own plan:
+
+| Plan | Seam | Unblocks |
+|---|---|---|
+| **5a — this plan** | `onApplicationStanzaOut` | `xmpp-traffic/redundant-query`, `xmpp-traffic/iq-unanswered` |
+| 5b | Archive-merge outcome seam | MAM merge yield as an informational rate, plus `xmpp-traffic/mam-write-failed` |
+| 5c | scoped `readStateGeneration` | `read-state/pointer-regression` |
+| 5d | unread diagnostic returning both counts from one guarded snapshot | Exported diagnostic seam; detector objective withdrawn (design §5.1) |
+
+The 5b–5d follow-up plans record those outcomes. MAM merge yield is deliberately **not** in this
+plan: it cannot be built from an outbound hook, because retention is decided downstream of the
+typed MAM event.
+
+## Global Constraints
+
+- **No anomaly-system code enters `dist`.** The seam emits an ltx `Element`; `Token`, `LocalRef` and
+  the HMAC key stay in `apps/fluux/src/anomaly/`. The app tokenizes at the recorder boundary.
+- **Hot-path budget.** Each seam is a null check plus at most one dispatch. No payload object may be
+  constructed when no handler is registered, and the per-stanza cost with no subscriber must stay
+  within noise of the unsubscribed baseline. A measurable regression means the seam gets redesigned,
+  not accepted with a note.
+- **A diagnostic seam must never break a send.** A throwing subscriber is contained and reported;
+  the stanza still goes out.
+- **Named coverage gap, carried into the registry:** connection-level sends bypass the application
+  layer (the keepalive ping at `core/modules/Connection.ts:1238` and the SM `<r/>` nonza at `:1336`
+  go straight to the transport). `iq-unanswered` therefore cannot see a stalled ping or an
+  unacknowledged SM request. Instrumenting the transport is out of scope for this slice.
+- **Registries are closed.** Every new id, ctx key and tag is minted in
+  `apps/fluux/src/anomaly/values.ts`; `Scalar` is `Opaque | number | boolean | null`, so no raw
+  string — no JID, no stanza id, no namespace — may reach a record.
+- **Parity is asserted, not assumed.** Every new `ID` entry needs a matching row in
+  `docs/ANOMALY_INVARIANTS.md`; `values.test.ts` checks both directions.
+
+## Facts established by reading the code (2026-08-31)
+
+These are verified, not inherited from the spec. Later tasks depend on them.
+
+1. **The application layer has exactly two send paths.** `XMPPClient.sendStanza`
+   (`core/XMPPClient.ts:1824`) and `XMPPClient.sendIQ` (`:1834`). `moduleDeps.sendStanza` / `sendIQ`
+   (`:683-684`) funnel every module through them, and `buildE2EEPrimitives().sendStanza` (`:1801`)
+   goes through `sendStanza` too. The `getXmpp()` calls in `MAM.ts` are the **collector fallback for
+   tests**, not sends — every real MAM query calls `this.deps.sendIQ`.
+2. **`iqCaller.request()` assigns the stanza id.** `node_modules/@xmpp/iq/caller.js:42-44` sets
+   `stanza.attrs.id` synchronously at the top of `request()`, before its first `await`. So the id is
+   present immediately after the call returns its promise, and **not before**. Emitting before the
+   call would publish an id-less IQ that can never be paired with a reply.
+3. **IQ replies do reach `onStanza`.** `@xmpp/connection/index.js:96-97` emits `element` (which
+   feeds the middleware chain, and so `iqCaller._route`) **and** `stanza`, unconditionally.
+   `Connection.ts:2273` listens to `stanza`, and `XMPPClient` re-emits it at `:763`. The iqCaller
+   consuming a reply in middleware therefore does not hide it from the app.
+4. **The installer can reach the client.** `AnomalyInstaller` is mounted inside `XMPPProvider`
+   (`main.tsx:157`, `demo.tsx:277`); `useXMPPContext()` returns `{ client }`.
+5. **`install()` currently takes no arguments** and holds a refcount (`attachRefs`) with a single
+   attach/detach block. The client subscription joins that block.
+
+---
+
+### Task 1: The SDK seam
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/types/client.ts` (add the event to `XMPPClientEvents`)
+- Modify: `packages/fluux-sdk/src/core/XMPPClient.ts` (`onApplicationStanzaOut`, the private
+  dispatcher, and the two emit sites)
+- Test: `packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `client.onApplicationStanzaOut(handler: (stanza: Element) => void): () => void`, and the
+  bus event `applicationStanzaOut: (stanza: Element) => void` on `XMPPClientEvents`.
+
+The event goes on `XMPPClientEvents` rather than `InternalClientEvents` for one reason: `stanza` is
+already there and `onStanza` is its wrapper. Consistency with the inbound half is worth more than
+keeping `on()` one key narrower.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts`. The suite drives a client
+whose transport is a stub, so it asserts the seam and nothing else.
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import xml from '@xmpp/xml'
+import type { Element } from '@xmpp/client'
+import { XMPPClient } from './XMPPClient'
+
+/** Reach the protected send paths without a real connection. */
+class TestClient extends XMPPClient {
+  public sent: Element[] = []
+  public iqRequests: Element[] = []
+
+  constructor(private readonly failSend = false) {
+    super({ service: 'ws://localhost:5280/ws', domain: 'example.com' })
+    const self = this
+    // requireTransport() is what the send paths call to get the transport.
+    ;(this as unknown as { requireTransport: () => unknown }).requireTransport = () => ({
+      send: async (stanza: Element) => {
+        if (self.failSend) throw new Error('socket closed')
+        self.sent.push(stanza)
+      },
+      iqCaller: {
+        request: (iq: Element) => {
+          // Mirrors @xmpp/iq/caller.js: the id is assigned inside request().
+          if (!iq.attrs.id) iq.attrs.id = 'assigned-1'
+          self.iqRequests.push(iq)
+          return new Promise<Element>(() => {})
+        },
+      },
+    })
+  }
+
+  sendStanzaForTest(stanza: Element): Promise<void> {
+    return this.sendStanza(stanza)
+  }
+
+  sendIQForTest(iq: Element): Promise<Element> {
+    return this.sendIQ(iq)
+  }
+}
+
+describe('onApplicationStanzaOut', () => {
+  it('reports a stanza sent through sendStanza', async () => {
+    const client = new TestClient()
+    const seen: Element[] = []
+    client.onApplicationStanzaOut((s) => seen.push(s))
+
+    const message = xml('message', { to: 'a@example.com' }, xml('body', {}, 'hi'))
+    await client.sendStanzaForTest(message)
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].name).toBe('message')
+  })
+
+  it('reports an IQ only after its id has been assigned', async () => {
+    const client = new TestClient()
+    const ids: Array<string | undefined> = []
+    client.onApplicationStanzaOut((s) => ids.push(s.attrs.id as string | undefined))
+
+    void client.sendIQForTest(xml('iq', { type: 'get', to: 'example.com' }))
+
+    // An id-less outbound IQ can never be paired with its reply, so publishing one
+    // would be worse than publishing nothing.
+    expect(ids).toEqual(['assigned-1'])
+  })
+
+  it('stops reporting after unsubscribe', async () => {
+    const client = new TestClient()
+    const seen: Element[] = []
+    const off = client.onApplicationStanzaOut((s) => seen.push(s))
+    off()
+
+    await client.sendStanzaForTest(xml('presence'))
+
+    expect(seen).toEqual([])
+  })
+
+  it('sends the stanza even when a subscriber throws', async () => {
+    const client = new TestClient()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    client.onApplicationStanzaOut(() => {
+      throw new Error('detector bug')
+    })
+
+    await client.sendStanzaForTest(xml('message', { to: 'a@example.com' }))
+
+    expect(client.sent).toHaveLength(1)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/XMPPClient.outboundStanza.test.ts`
+Expected: FAIL — `client.onApplicationStanzaOut is not a function`.
+
+- [ ] **Step 3: Declare the event**
+
+In `packages/fluux-sdk/src/core/types/client.ts`, inside `XMPPClientEvents`, directly under the
+`stanza` entry:
+
+```typescript
+  /**
+   * An application-layer stanza was handed to the transport.
+   *
+   * Connection-level sends — the keepalive ping and the Stream Management `<r/>`
+   * nonza — bypass this layer and are therefore NOT reported. Subscribe through
+   * {@link XMPPClient.onApplicationStanzaOut}.
+   */
+  applicationStanzaOut: (stanza: Element) => void
+```
+
+- [ ] **Step 4: Implement the subscription and the dispatcher**
+
+In `packages/fluux-sdk/src/core/XMPPClient.ts`, next to `onStanza` (around `:977`):
+
+```typescript
+  /**
+   * Subscribe to application-layer stanzas on their way out.
+   *
+   * The counterpart to {@link onStanza}. Reports everything sent through the
+   * application layer — messages, presence and IQ requests, including the id
+   * `iqCaller` assigns — and nothing sent by the connection machine itself, so a
+   * keepalive ping and an SM `<r/>` are invisible here by construction.
+   *
+   * @param handler - Callback invoked for each outbound application stanza
+   * @returns A function to unsubscribe
+   */
+  onApplicationStanzaOut(handler: (stanza: Element) => void): () => void {
+    return this.subscribeToBus('applicationStanzaOut', handler)
+  }
+
+  /**
+   * Dispatch on the outbound hot path.
+   *
+   * Deliberately not `emit()`: that builds a rest-args array on every call, and this
+   * runs for every stanza the app sends. With no subscriber the cost is one Map
+   * lookup. A handler that throws is contained — a diagnostic subscriber must never
+   * stop a stanza from being sent.
+   */
+  private emitApplicationStanzaOut(stanza: Element): void {
+    const handlers = this.eventHandlers.get('applicationStanzaOut')
+    if (!handlers || handlers.size === 0) return
+    for (const handler of handlers) {
+      try {
+        ;(handler as (s: Element) => void)(stanza)
+      } catch (err) {
+        console.warn('[XMPPClient] applicationStanzaOut subscriber threw:', err)
+      }
+    }
+  }
+```
+
+- [ ] **Step 5: Emit from both send paths**
+
+In `sendStanza` (`:1824`), before the transport call:
+
+```typescript
+  protected async sendStanza(stanza: Element): Promise<void> {
+    const xmpp = this.requireTransport('', { checkSocket: true })
+    this.emitApplicationStanzaOut(stanza)
+    try {
+      await xmpp.send(stanza)
+    } catch (err) {
+      this.repairAndRethrowSendError(err)
+    }
+  }
+```
+
+In `sendIQ` (`:1834`), after `request()` — which is where the id gets assigned:
+
+```typescript
+  protected async sendIQ(iq: Element, timeoutMs?: number): Promise<Element> {
+    const xmpp = this.requireTransport('IQ', { checkSocket: true })
+    try {
+      const request = xmpp.iqCaller.request(iq)
+      // After request(), never before: iqCaller assigns the id inside it, and an
+      // id-less outbound IQ cannot be paired with its reply.
+      this.emitApplicationStanzaOut(iq)
+      if (timeoutMs != null) {
+        return await Promise.race([
+          request,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new RequestTimeoutError(timeoutMs)), timeoutMs)
+          ),
+        ])
+      }
+      return await request
+    } catch (err) {
+      this.repairAndRethrowSendError(err)
+    }
+  }
+```
+
+- [ ] **Step 6: Run the test and watch it pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/XMPPClient.outboundStanza.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 7: Run the SDK suite and typecheck**
+
+Run: `npx vitest run -w @fluux/sdk` (or `npm test`) and `npm run typecheck`
+Expected: no new failures. `XMPPClient.test.ts` must stay green — the seam adds a dispatch to paths
+it already exercises.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/types/client.ts packages/fluux-sdk/src/core/XMPPClient.ts \
+        packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts
+git commit -m "feat(sdk): report application stanzas on their way out"
+```
+
+---
+
+### Task 2: Measure the hot-path cost
+
+**Files:**
+- Create: `packages/fluux-sdk/bench/outboundSeam.bench.ts`
+- Modify: `packages/fluux-sdk/package.json` (add `bench:seam`)
+- Modify: `packages/fluux-sdk/bench/README.md` (one paragraph)
+
+**Interfaces:**
+- Consumes: `onApplicationStanzaOut` from Task 1.
+- Produces: a number to quote in the pull request. No runtime artefact.
+
+The spec makes this a merge gate, not a nicety: the seam ships in `dist` to every SDK consumer.
+
+- [ ] **Step 1: Write the benchmark**
+
+```typescript
+/**
+ * Per-stanza cost of the outbound seam, with and without a subscriber.
+ *
+ * The budget is "within noise of the unsubscribed baseline". A measurable
+ * regression means the seam gets redesigned, not accepted with a note
+ * (design §5.5).
+ */
+import { bench, describe } from 'vitest'
+import xml from '@xmpp/xml'
+import type { Element } from '@xmpp/client'
+
+type Handler = (stanza: Element) => void
+
+/** The dispatcher under measurement, isolated from the transport. */
+function makeDispatcher(): { emit: (s: Element) => void; add: (h: Handler) => void } {
+  const handlers = new Set<Handler>()
+  return {
+    add: (h) => handlers.add(h),
+    emit: (stanza) => {
+      if (handlers.size === 0) return
+      for (const handler of handlers) {
+        try {
+          handler(stanza)
+        } catch {
+          // measured path only
+        }
+      }
+    },
+  }
+}
+
+const stanza = xml('message', { to: 'a@example.com', id: 'x1' }, xml('body', {}, 'hello'))
+
+describe('outbound seam dispatch', () => {
+  bench('no subscriber', () => {
+    const d = makeDispatcher()
+    for (let i = 0; i < 10_000; i++) d.emit(stanza)
+  })
+
+  bench('one subscriber', () => {
+    const d = makeDispatcher()
+    let seen = 0
+    d.add(() => { seen++ })
+    for (let i = 0; i < 10_000; i++) d.emit(stanza)
+  })
+})
+```
+
+- [ ] **Step 2: Add the script**
+
+In `packages/fluux-sdk/package.json`, beside `bench:persist`:
+
+```json
+    "bench:seam": "vitest bench --config vitest.bench.config.ts --run bench/outboundSeam.bench.ts",
+```
+
+- [ ] **Step 3: Run it and record the numbers**
+
+Run: `npm run bench:seam -w @fluux/sdk`
+Expected: the two rows print. Record both in the pull request body. If "no subscriber" is
+distinguishable from an empty loop by more than measurement noise, stop and redesign the dispatcher
+before continuing.
+
+- [ ] **Step 4: Document it**
+
+Add to `packages/fluux-sdk/bench/README.md`:
+
+```markdown
+## Outbound seam dispatch
+
+```bash
+npm run bench:seam -w @fluux/sdk
+```
+
+The per-stanza cost of `onApplicationStanzaOut` with and without a subscriber. The seam ships in
+`dist` to every SDK consumer, so the unsubscribed path must stay a Map lookup.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/bench/outboundSeam.bench.ts packages/fluux-sdk/bench/README.md \
+        packages/fluux-sdk/package.json
+git commit -m "bench(sdk): measure the outbound seam dispatch cost"
+```
+
+---
+
+### Task 3: Classify an outbound stanza
+
+**Files:**
+- Create: `apps/fluux/src/anomaly/detectors/stanzaFacts.ts`
+- Test: `apps/fluux/src/anomaly/detectors/stanzaFacts.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```typescript
+  export type QueryKind = 'disco-info' | 'disco-items' | 'vcard' | 'avatar' | 'mam' | 'roster' | 'other'
+  export interface ElementLike {
+    name: string
+    attrs: Record<string, unknown>
+    children?: unknown[]
+    getChild(name: string, ns?: string): ElementLike | undefined
+  }
+  export interface OutFacts { id: string; kind: QueryKind; to: string; dedupe: string | null }
+  export interface InFacts { id: string; type: string }
+  export function outboundFacts(stanza: ElementLike): OutFacts | null
+  export function inboundReplyFacts(stanza: ElementLike): InFacts | null
+  ```
+
+`ElementLike` rather than ltx's `Element`: the classifier is pure, the app's tests construct
+literals, and a real `Element` satisfies it structurally.
+
+`dedupe` is the whole judgement of the redundancy detector, so it lives here where it can be tested
+in isolation. A `null` dedupe means "a repeat of this is legitimate" — MAM re-queries the same
+archive with a different window on purpose, and a roster fetch after a reconnect is not a bug.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { outboundFacts, inboundReplyFacts, type ElementLike } from './stanzaFacts'
+
+function el(
+  name: string,
+  attrs: Record<string, unknown> = {},
+  children: ElementLike[] = [],
+): ElementLike {
+  return {
+    name,
+    attrs,
+    children,
+    getChild(childName: string, ns?: string) {
+      return children.find(
+        (c) => c.name === childName && (ns === undefined || c.attrs.xmlns === ns),
+      )
+    },
+  }
+}
+
+describe('outboundFacts', () => {
+  it('classifies a disco#info query and makes it dedupable', () => {
+    const iq = el('iq', { type: 'get', to: 'example.com', id: 'q1' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info' }),
+    ])
+    expect(outboundFacts(iq)).toEqual({
+      id: 'q1',
+      kind: 'disco-info',
+      to: 'example.com',
+      dedupe: 'disco-info|example.com|',
+    })
+  })
+
+  it('separates two disco#info queries for different nodes', () => {
+    const withNode = el('iq', { type: 'get', to: 'example.com', id: 'q2' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info', node: 'urn:x:caps#v1' }),
+    ])
+    expect(outboundFacts(withNode)?.dedupe).toBe('disco-info|example.com|urn:x:caps#v1')
+  })
+
+  it('refuses to call a MAM page redundant', () => {
+    const iq = el('iq', { type: 'set', to: 'a@example.com', id: 'q3' }, [
+      el('query', { xmlns: 'urn:xmpp:mam:2' }),
+    ])
+    const facts = outboundFacts(iq)
+    // Paging queries the same archive on purpose; a shared dedupe key would report
+    // every second page as a redundant query.
+    expect(facts?.kind).toBe('mam')
+    expect(facts?.dedupe).toBeNull()
+  })
+
+  it('ignores messages, presence and IQ replies', () => {
+    expect(outboundFacts(el('message', { to: 'a@example.com', id: 'm1' }))).toBeNull()
+    expect(outboundFacts(el('presence', { id: 'p1' }))).toBeNull()
+    expect(outboundFacts(el('iq', { type: 'result', id: 'r1', to: 'a@example.com' }))).toBeNull()
+  })
+
+  it('ignores an IQ with no id, which could never be paired', () => {
+    const iq = el('iq', { type: 'get', to: 'example.com' }, [
+      el('query', { xmlns: 'http://jabber.org/protocol/disco#info' }),
+    ])
+    expect(outboundFacts(iq)).toBeNull()
+  })
+
+  it('keys a query with no target on the empty string, which is the server', () => {
+    const iq = el('iq', { type: 'get', id: 'q4' }, [
+      el('query', { xmlns: 'jabber:iq:roster' }),
+    ])
+    expect(outboundFacts(iq)).toEqual({ id: 'q4', kind: 'roster', to: '', dedupe: null })
+  })
+})
+
+describe('inboundReplyFacts', () => {
+  it('reports a result and an error alike', () => {
+    expect(inboundReplyFacts(el('iq', { type: 'result', id: 'q1' }))).toEqual({
+      id: 'q1',
+      type: 'result',
+    })
+    expect(inboundReplyFacts(el('iq', { type: 'error', id: 'q1' }))).toEqual({
+      id: 'q1',
+      type: 'error',
+    })
+  })
+
+  it('ignores an inbound request, which answers nothing', () => {
+    expect(inboundReplyFacts(el('iq', { type: 'get', id: 'srv-1' }))).toBeNull()
+    expect(inboundReplyFacts(el('message', { id: 'm1' }))).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/detectors/stanzaFacts.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the classifier**
+
+```typescript
+/**
+ * What an anomaly detector may know about a stanza.
+ *
+ * Structural rather than ltx-typed: the classifier is pure, and a real `Element`
+ * satisfies this shape. Nothing here reaches a record — the app tokenizes `to` at
+ * the recorder boundary, and `kind` becomes a closed TAG constant.
+ *
+ * @module Anomaly/Detectors/StanzaFacts
+ */
+
+export type QueryKind =
+  | 'disco-info'
+  | 'disco-items'
+  | 'vcard'
+  | 'avatar'
+  | 'mam'
+  | 'roster'
+  | 'other'
+
+export interface ElementLike {
+  name: string
+  attrs: Record<string, unknown>
+  children?: unknown[]
+  getChild(name: string, ns?: string): ElementLike | undefined
+}
+
+export interface OutFacts {
+  id: string
+  kind: QueryKind
+  /** Bare or full JID as addressed; empty string means the account's own server. */
+  to: string
+  /**
+   * Identity for the redundancy check, or `null` when a repeat is legitimate.
+   */
+  dedupe: string | null
+}
+
+export interface InFacts {
+  id: string
+  type: string
+}
+
+const NS_DISCO_INFO = 'http://jabber.org/protocol/disco#info'
+const NS_DISCO_ITEMS = 'http://jabber.org/protocol/disco#items'
+const NS_VCARD = 'vcard-temp'
+const NS_MAM = 'urn:xmpp:mam:2'
+const NS_ROSTER = 'jabber:iq:roster'
+const NS_PUBSUB = 'http://jabber.org/protocol/pubsub'
+const AVATAR_NODES = new Set(['urn:xmpp:avatar:data', 'urn:xmpp:avatar:metadata'])
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function childNamespace(stanza: ElementLike): { ns: string; node: string } {
+  for (const raw of stanza.children ?? []) {
+    const child = raw as ElementLike | undefined
+    if (!child || typeof child !== 'object' || typeof child.name !== 'string') continue
+    const ns = str(child.attrs?.xmlns)
+    if (ns) return { ns, node: str(child.attrs?.node) }
+  }
+  return { ns: '', node: '' }
+}
+
+function classify(ns: string, node: string): QueryKind {
+  switch (ns) {
+    case NS_DISCO_INFO:
+      return 'disco-info'
+    case NS_DISCO_ITEMS:
+      return 'disco-items'
+    case NS_VCARD:
+      return 'vcard'
+    case NS_MAM:
+      return 'mam'
+    case NS_ROSTER:
+      return 'roster'
+    case NS_PUBSUB:
+      return AVATAR_NODES.has(node) ? 'avatar' : 'other'
+    default:
+      return 'other'
+  }
+}
+
+/**
+ * Which kinds are judged for redundancy.
+ *
+ * A MAM query pages through one archive with a different window each time, and a
+ * roster or generic IQ has no stable identity a repeat could be measured against.
+ * Giving either a dedupe key would report ordinary traffic as an anomaly — the one
+ * outcome that costs this log its credibility.
+ */
+const DEDUPABLE: ReadonlySet<QueryKind> = new Set<QueryKind>([
+  'disco-info',
+  'disco-items',
+  'vcard',
+  'avatar',
+])
+
+export function outboundFacts(stanza: ElementLike): OutFacts | null {
+  if (stanza.name !== 'iq') return null
+  const type = str(stanza.attrs.type)
+  if (type !== 'get' && type !== 'set') return null
+  const id = str(stanza.attrs.id)
+  if (!id) return null
+
+  const { ns, node } = childNamespace(stanza)
+  const kind = classify(ns, node)
+  const to = str(stanza.attrs.to)
+  return {
+    id,
+    kind,
+    to,
+    dedupe: DEDUPABLE.has(kind) ? `${kind}|${to}|${node}` : null,
+  }
+}
+
+export function inboundReplyFacts(stanza: ElementLike): InFacts | null {
+  if (stanza.name !== 'iq') return null
+  const type = str(stanza.attrs.type)
+  if (type !== 'result' && type !== 'error') return null
+  const id = str(stanza.attrs.id)
+  if (!id) return null
+  return { id, type }
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/detectors/stanzaFacts.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/anomaly/detectors/stanzaFacts.ts apps/fluux/src/anomaly/detectors/stanzaFacts.test.ts
+git commit -m "feat(anomaly): classify an outbound IQ into a closed set of query kinds"
+```
+
+---
+
+### Task 4: Register the two ids
+
+**Files:**
+- Modify: `apps/fluux/src/anomaly/values.ts`
+- Modify: `docs/ANOMALY_INVARIANTS.md`
+- Test: `apps/fluux/src/anomaly/values.test.ts` (existing parity test must pass unchanged)
+
+**Interfaces:**
+- Produces: `ID.redundantQuery`, `ID.iqUnanswered`, `CTX.target`, and the `TAG.q*` query-kind
+  constants, plus `queryKindTag(kind: QueryKind): Opaque`.
+
+- [ ] **Step 1: Run the parity test first, to see it pass before the change**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/values.test.ts`
+Expected: PASS. This is the control: it must fail in Step 3 for the right reason.
+
+- [ ] **Step 2: Add the constants**
+
+In `values.ts`, extend `TAG` (query kinds), `ID`, and `CTX`:
+
+```typescript
+  // Outbound query kinds. A namespace is free text of exactly the sort the
+  // registries keep out of a record, so it becomes a constant here.
+  qDiscoInfo: mint('q:disco-info', 'tag'),
+  qDiscoItems: mint('q:disco-items', 'tag'),
+  qVcard: mint('q:vcard', 'tag'),
+  qAvatar: mint('q:avatar', 'tag'),
+  qMam: mint('q:mam', 'tag'),
+  qRoster: mint('q:roster', 'tag'),
+  qOther: mint('q:other', 'tag'),
+```
+
+```typescript
+  redundantQuery: mint('xmpp-traffic/redundant-query', 'id'),
+  iqUnanswered: mint('xmpp-traffic/iq-unanswered', 'id'),
+```
+
+```typescript
+  /** The queried entity, as an entity token — never the JID. */
+  target: mint('target', 'ctx'),
+```
+
+`CTX.query` already exists and carries the query-kind TAG; do not mint a second key for it.
+
+Then, below the `TAG` block, the mapping the detector needs:
+
+```typescript
+/**
+ * The TAG for a query kind.
+ *
+ * A total function over the union rather than a lookup that can miss: an unmapped
+ * kind would otherwise reach a record as `undefined` and be dropped by the
+ * serializer, losing the record rather than the field.
+ */
+export function queryKindTag(kind: QueryKind): Opaque {
+  switch (kind) {
+    case 'disco-info': return TAG.qDiscoInfo
+    case 'disco-items': return TAG.qDiscoItems
+    case 'vcard': return TAG.qVcard
+    case 'avatar': return TAG.qAvatar
+    case 'mam': return TAG.qMam
+    case 'roster': return TAG.qRoster
+    case 'other': return TAG.qOther
+  }
+}
+```
+
+Import `QueryKind` as a type from `./detectors/stanzaFacts`.
+
+- [ ] **Step 3: Run the parity test and watch it fail**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/values.test.ts`
+Expected: FAIL — `ID` has entries with no row in `docs/ANOMALY_INVARIANTS.md`.
+
+- [ ] **Step 4: Write the registry rows**
+
+In `docs/ANOMALY_INVARIANTS.md`, replace the `### \`xmpp-traffic/\`` placeholder line
+(`_(stage 5: ...)_`) with the shipped table, keeping `mam-page-yield` named as still to come:
+
+```markdown
+### `xmpp-traffic/`
+
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `xmpp-traffic/redundant-query` | suspect | The same disco, vCard or avatar query was sent to `ctx.target` again `ctx.elapsedMs` after the previous one had already been answered. `observed` is how many times it was sent inside the window, `expected` is 1 | A cache that is not being consulted, or a caller re-querying on every presence. `ctx.query` names the kind |
+| `xmpp-traffic/iq-unanswered` | bug | An outbound application IQ went `observed` ms with no reply (`expected` is the threshold). `ctx.query` names the kind, `ctx.target` the entity | The peer or server never answered. Correlate with the connection crumbs: a reply lost across a reconnect is cleared rather than reported |
+
+**Named non-cases:**
+
+- Neither id sees connection-level traffic. The keepalive ping and the Stream Management `<r/>`
+  bypass the application layer, so a stalled ping is invisible here by construction.
+- `redundant-query` never judges MAM or roster traffic. MAM pages the same archive with a different
+  window on purpose, and a roster fetch after a reconnect is expected.
+- `redundant-query` requires the previous query to have been **answered**. A re-query after an error
+  or a timeout is a retry, not a redundancy.
+- `iq-unanswered` is cleared on disconnect and on reconnect. Everything in flight when a connection
+  drops is unanswerable through no fault of the app.
+- An IQ whose transport write failed is still reported as outbound. The seam reports the hand-off,
+  not the socket; the connection reset that follows clears the pending entry.
+
+_(stage 5 continued with MAM merge yield, which needed the archive-merge outcome seam)_
+```
+
+- [ ] **Step 5: Run the parity test and watch it pass**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/values.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/anomaly/values.ts docs/ANOMALY_INVARIANTS.md
+git commit -m "feat(anomaly): register the two xmpp-traffic invariants"
+```
+
+---
+
+### Task 5: The traffic detector
+
+**Files:**
+- Create: `apps/fluux/src/anomaly/detectors/xmppTraffic.ts`
+- Test: `apps/fluux/src/anomaly/detectors/xmppTraffic.test.ts`
+
+**Interfaces:**
+- Consumes: `OutFacts`, `InFacts` (Task 3); `ID`, `CTX`, `queryKindTag`, `tokenSync` (Task 4).
+- Produces:
+  ```typescript
+  export interface TrafficDetector {
+    observeOut(facts: OutFacts, now: number): void
+    observeIn(facts: InFacts, now: number): void
+    sweep(now: number): void
+    reset(): void
+  }
+  export function createTrafficDetector(opts: {
+    record: (input: RecordInput) => void
+    token: (jid: string) => Opaque
+    redundantWindowMs?: number
+    unansweredMs?: number
+    maxTracked?: number
+  }): TrafficDetector
+  ```
+
+Pure and clock-injected, like the other detectors: it decides, and `install.ts` wires it.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { createTrafficDetector } from './xmppTraffic'
+import type { OutFacts } from './stanzaFacts'
+import { CTX, ID, TAG } from '../values'
+import type { RecordInput } from '../recorder'
+
+const TOKEN = TAG.focus // any minted Opaque; identity is all the detector needs
+
+function discoTo(jid: string, id: string): OutFacts {
+  return { id, kind: 'disco-info', to: jid, dedupe: `disco-info|${jid}|` }
+}
+
+function setup(overrides: Partial<Parameters<typeof createTrafficDetector>[0]> = {}) {
+  const records: RecordInput[] = []
+  const detector = createTrafficDetector({
+    record: (input) => records.push(input),
+    token: () => TOKEN,
+    ...overrides,
+  })
+  return { detector, records }
+}
+
+describe('redundant-query', () => {
+  it('fires when an answered query is repeated inside the window', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 5_000)
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.redundantQuery)
+    expect(records[0].sev).toBe('suspect')
+    expect(records[0].expected).toBe(1)
+    expect(records[0].observed).toBe(2)
+    expect(records[0].ctx).toEqual(
+      expect.arrayContaining([[CTX.elapsedMs, 4_900], [CTX.query, TAG.qDiscoInfo]]),
+    )
+  })
+
+  it('stays silent once the window has passed', () => {
+    const { detector, records } = setup({ redundantWindowMs: 60_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 61_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('treats a re-query after an error as a retry, not a redundancy', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'error' }, 100)
+    detector.observeOut(discoTo('example.com', 'q2'), 1_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('separates two targets', () => {
+    const { detector, records } = setup()
+    detector.observeOut(discoTo('a.example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 10)
+    detector.observeOut(discoTo('b.example.com', 'q2'), 20)
+
+    expect(records).toEqual([])
+  })
+
+  it('never judges a query with no dedupe key', () => {
+    const { detector, records } = setup()
+    const mam: OutFacts = { id: 'm1', kind: 'mam', to: 'a@example.com', dedupe: null }
+    detector.observeOut(mam, 0)
+    detector.observeIn({ id: 'm1', type: 'result' }, 10)
+    detector.observeOut({ ...mam, id: 'm2' }, 20)
+
+    expect(records).toEqual([])
+  })
+})
+
+describe('iq-unanswered', () => {
+  it('fires once the threshold passes with no reply', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+
+    detector.sweep(29_000)
+    expect(records).toEqual([])
+
+    detector.sweep(30_001)
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe(ID.iqUnanswered)
+    expect(records[0].sev).toBe('bug')
+    expect(records[0].expected).toBe(30_000)
+    expect(records[0].observed).toBe(30_001)
+  })
+
+  it('reports one pending IQ once, not on every sweep', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.sweep(31_000)
+    detector.sweep(45_000)
+
+    expect(records).toHaveLength(1)
+  })
+
+  it('stays silent when the reply arrives in time', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.observeIn({ id: 'q1', type: 'result' }, 500)
+    detector.sweep(60_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('forgets everything in flight when the connection resets', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000 })
+    detector.observeOut(discoTo('example.com', 'q1'), 0)
+    detector.reset()
+    detector.sweep(60_000)
+
+    expect(records).toEqual([])
+  })
+
+  it('bounds what it tracks', () => {
+    const { detector, records } = setup({ unansweredMs: 30_000, maxTracked: 2 })
+    detector.observeOut(discoTo('a.example.com', 'q1'), 0)
+    detector.observeOut(discoTo('b.example.com', 'q2'), 1)
+    detector.observeOut(discoTo('c.example.com', 'q3'), 2)
+    detector.sweep(40_000)
+
+    // The oldest was evicted rather than retained: a leak in a detector is worse
+    // than a missed record.
+    expect(records).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/detectors/xmppTraffic.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the detector**
+
+```typescript
+/**
+ * The two invariants observable from the outbound application stanza seam.
+ *
+ * `redundant-query` says a query already answered was asked again inside a window;
+ * `iq-unanswered` says a request was never answered at all. Both are pure and
+ * clock-injected: `install.ts` supplies the stanzas, the clock and the sink.
+ *
+ * @module Anomaly/Detectors/XmppTraffic
+ */
+import type { RecordInput } from '../recorder'
+import { CTX, ID, queryKindTag, type Opaque } from '../values'
+import type { InFacts, OutFacts } from './stanzaFacts'
+
+const REDUNDANT_WINDOW_MS = 60_000
+const UNANSWERED_MS = 30_000
+/**
+ * How many requests and answered keys are remembered.
+ *
+ * A detector that grows without bound is a leak reported as a diagnostic. Evicting
+ * the oldest entry loses a record; keeping everything loses the session.
+ */
+const MAX_TRACKED = 200
+
+export interface TrafficDetector {
+  observeOut(facts: OutFacts, now: number): void
+  observeIn(facts: InFacts, now: number): void
+  /** Report requests that have now been pending too long. */
+  sweep(now: number): void
+  /** Forget everything: a connection boundary makes every pending request moot. */
+  reset(): void
+}
+
+export interface TrafficOptions {
+  record: (input: RecordInput) => void
+  /** Tokenizes a JID at the recorder boundary. Never the raw value. */
+  token: (jid: string) => Opaque
+  redundantWindowMs?: number
+  unansweredMs?: number
+  maxTracked?: number
+}
+
+interface Pending {
+  facts: OutFacts
+  at: number
+}
+
+function evictOldest<K, V>(map: Map<K, V>, limit: number): void {
+  while (map.size > limit) {
+    const oldest = map.keys().next()
+    if (oldest.done) return
+    map.delete(oldest.value)
+  }
+}
+
+export function createTrafficDetector(opts: TrafficOptions): TrafficDetector {
+  const redundantWindowMs = opts.redundantWindowMs ?? REDUNDANT_WINDOW_MS
+  const unansweredMs = opts.unansweredMs ?? UNANSWERED_MS
+  const maxTracked = opts.maxTracked ?? MAX_TRACKED
+
+  /** Requests still waiting for a reply, keyed by stanza id. */
+  const pending = new Map<string, Pending>()
+  /** When each dedupable query was last ANSWERED, and how many were sent since. */
+  const answered = new Map<string, { at: number; sent: number }>()
+
+  return {
+    observeOut(facts, now) {
+      pending.set(facts.id, { facts, at: now })
+      evictOldest(pending, maxTracked)
+
+      if (!facts.dedupe) return
+      const previous = answered.get(facts.dedupe)
+      if (!previous) return
+      const elapsed = now - previous.at
+      if (elapsed > redundantWindowMs) {
+        answered.delete(facts.dedupe)
+        return
+      }
+      previous.sent++
+      opts.record({
+        id: ID.redundantQuery,
+        sev: 'suspect',
+        expected: 1,
+        observed: previous.sent,
+        ctx: [
+          [CTX.query, queryKindTag(facts.kind)],
+          [CTX.target, opts.token(facts.to)],
+          [CTX.elapsedMs, elapsed],
+        ],
+      })
+    },
+
+    observeIn(facts, now) {
+      const request = pending.get(facts.id)
+      if (!request) return
+      pending.delete(facts.id)
+      // Only a RESULT establishes that the answer is now known. An error leaves the
+      // caller with nothing cached, so its retry is not a redundancy.
+      if (facts.type !== 'result' || !request.facts.dedupe) return
+      answered.set(request.facts.dedupe, { at: now, sent: 1 })
+      evictOldest(answered, maxTracked)
+    },
+
+    sweep(now) {
+      for (const [id, request] of pending) {
+        const elapsed = now - request.at
+        if (elapsed <= unansweredMs) continue
+        // Deleted as it is reported: the record says it went unanswered, and a
+        // second report of the same request would say nothing new.
+        pending.delete(id)
+        opts.record({
+          id: ID.iqUnanswered,
+          sev: 'bug',
+          expected: unansweredMs,
+          observed: elapsed,
+          ctx: [
+            [CTX.query, queryKindTag(request.facts.kind)],
+            [CTX.target, opts.token(request.facts.to)],
+          ],
+        })
+      }
+    },
+
+    reset() {
+      pending.clear()
+      answered.clear()
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/detectors/xmppTraffic.test.ts`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/anomaly/detectors/xmppTraffic.ts apps/fluux/src/anomaly/detectors/xmppTraffic.test.ts
+git commit -m "feat(anomaly): detect redundant and unanswered application IQs"
+```
+
+---
+
+### Task 6: Wire the detector to the client
+
+**Files:**
+- Modify: `apps/fluux/src/anomaly/install.ts`
+- Modify: `apps/fluux/src/anomaly/AnomalyInstaller.tsx`
+- Test: `apps/fluux/src/anomaly/install.test.ts`
+
+**Interfaces:**
+- Consumes: `createTrafficDetector` (Task 5), `outboundFacts` / `inboundReplyFacts` (Task 3),
+  `client.onApplicationStanzaOut` (Task 1).
+- Produces: `install(client?: TrafficClient)` where
+  ```typescript
+  interface TrafficClient {
+    onApplicationStanzaOut(handler: (stanza: ElementLike) => void): () => void
+    onStanza(handler: (stanza: ElementLike) => void): () => void
+    on(event: 'offline' | 'reconnecting', handler: () => void): () => void
+  }
+  ```
+
+A structural parameter type, not `XMPPClient`: `install.ts` must stay testable without constructing
+a client, and the app's SDK mock does not carry one.
+
+The client is optional so the existing call sites and every current test keep working; when it is
+absent the traffic detector simply does not attach.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/fluux/src/anomaly/install.test.ts`:
+
+```typescript
+describe('traffic detector wiring', () => {
+  it('pairs an outbound IQ with its reply through the client seams', () => {
+    const out: Array<(s: ElementLike) => void> = []
+    const inbound: Array<(s: ElementLike) => void> = []
+    const client = {
+      onApplicationStanzaOut: (h: (s: ElementLike) => void) => { out.push(h); return () => {} },
+      onStanza: (h: (s: ElementLike) => void) => { inbound.push(h); return () => {} },
+      on: () => () => {},
+    }
+
+    const release = install(client)
+
+    expect(out).toHaveLength(1)
+    expect(inbound).toHaveLength(1)
+
+    release()
+  })
+
+  it('detaches the client subscriptions when the last hold is released', () => {
+    const offs: string[] = []
+    const client = {
+      onApplicationStanzaOut: () => () => offs.push('out'),
+      onStanza: () => () => offs.push('in'),
+      on: () => () => offs.push('conn'),
+    }
+
+    install(client)()
+
+    expect(offs).toEqual(expect.arrayContaining(['out', 'in', 'conn']))
+  })
+})
+```
+
+Import `type ElementLike` from `./detectors/stanzaFacts` at the top of the test file.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly/install.test.ts`
+Expected: FAIL — `install()` takes no arguments, so nothing subscribes.
+
+- [ ] **Step 3: Wire it in `install.ts`**
+
+Add the imports:
+
+```typescript
+import { createTrafficDetector, type TrafficDetector } from './detectors/xmppTraffic'
+import { inboundReplyFacts, outboundFacts, type ElementLike } from './detectors/stanzaFacts'
+import { tokenSync } from './values'
+```
+
+Declare the module-level handle beside the other attachment state:
+
+```typescript
+let trafficDetector: TrafficDetector | null = null
+let clientUnsubscribes: (() => void) | null = null
+```
+
+Add the structural client type near `ProbeWindow`:
+
+```typescript
+/**
+ * What the traffic detector needs from the client.
+ *
+ * Structural rather than `XMPPClient`: this module is unit-tested without a client,
+ * and the app's SDK mock does not construct one.
+ */
+export interface TrafficClient {
+  onApplicationStanzaOut(handler: (stanza: ElementLike) => void): () => void
+  onStanza(handler: (stanza: ElementLike) => void): () => void
+  on(event: 'offline' | 'reconnecting', handler: () => void): () => void
+}
+```
+
+Inside the `attachRefs === 1` block, after the store subscriptions:
+
+```typescript
+    if (client) {
+      const traffic = createTrafficDetector({
+        record: (input) => rec.record(input),
+        token: (jid) => tokenSync('jid', jid),
+      })
+      trafficDetector = traffic
+
+      const offOut = client.onApplicationStanzaOut((stanza) => {
+        const facts = outboundFacts(stanza)
+        if (facts) traffic.observeOut(facts, Date.now())
+      })
+      const offIn = client.onStanza((stanza) => {
+        const facts = inboundReplyFacts(stanza)
+        if (facts) traffic.observeIn(facts, Date.now())
+      })
+      // A connection boundary makes every pending request unanswerable through no
+      // fault of the app, and re-querying disco after a reconnect is correct.
+      const offOffline = client.on('offline', () => traffic.reset())
+      const offReconnecting = client.on('reconnecting', () => traffic.reset())
+      clientUnsubscribes = () => {
+        offOut()
+        offIn()
+        offOffline()
+        offReconnecting()
+      }
+    }
+```
+
+Sweep from the existing sampler — `startDetectorTick`'s `onSample` already runs once a second and is
+the only signal that says the app was alive at that instant:
+
+```typescript
+      onSample: (now) => {
+        foregroundShare.sample(now)
+        trafficDetector?.sweep(Date.now())
+      },
+```
+
+Change the signature and release both in the release path and in `resetInstallForTesting`:
+
+```typescript
+export function install(client?: TrafficClient): () => void {
+```
+
+```typescript
+    clientUnsubscribes?.()
+    clientUnsubscribes = null
+    trafficDetector = null
+```
+
+- [ ] **Step 4: Pass the client from the installer**
+
+`apps/fluux/src/anomaly/AnomalyInstaller.tsx`:
+
+```typescript
+import { useEffect } from 'react'
+import { useXMPPContext } from '@fluux/sdk'
+import { install } from './install'
+
+export default function AnomalyInstaller(): null {
+  const { client } = useXMPPContext()
+  useEffect(() => install(client), [client])
+  return null
+}
+```
+
+- [ ] **Step 5: Run the anomaly suite**
+
+Run: `cd apps/fluux && npx vitest run src/anomaly`
+Expected: PASS, including the two new wiring tests.
+
+If `useXMPPContext` is not on the app's `@fluux/sdk` mock, add it there — a new SDK export used by
+the app has to be present in the mock (project testing note).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/anomaly/install.ts apps/fluux/src/anomaly/AnomalyInstaller.tsx \
+        apps/fluux/src/anomaly/install.test.ts
+git commit -m "feat(anomaly): observe application IQ traffic from the client seam"
+```
+
+---
+
+### Task 7: Prove a healthy session stays quiet
+
+**Files:**
+- Modify: `scripts/anomaly-smoke.ts`
+
+**Interfaces:**
+- Consumes: the ids from Task 4.
+
+The smoke test already asserts that a healthy demo session fires **no** detector. Both new ids join
+that set: a detector that fires on ordinary traffic is deleted rather than tuned, and this is where
+that is caught before it reaches the log.
+
+- [ ] **Step 1: Add the ids to the healthy-session assertion**
+
+In `scripts/anomaly-smoke.ts`, in the `ids` set (around `:272`):
+
+```typescript
+        'xmpp-traffic/redundant-query',
+        'xmpp-traffic/iq-unanswered',
+```
+
+- [ ] **Step 2: Run the smoke test**
+
+Run: `npm run test:scroll -- anomaly-smoke` (or the project's Playwright entry point for
+`scripts/anomaly-smoke.ts`; check `package.json` for the script that drives it)
+Expected: PASS — the healthy demo session produces neither id.
+
+If either fires, do not tune the threshold. Find out which ordinary path produced it and fix the
+classification; a detector that fires during normal use is the one failure this design deletes a
+detector for.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/anomaly-smoke.ts
+git commit -m "test(anomaly): hold the new traffic detectors to a silent healthy session"
+```
+
+---
+
+### Task 8: Close the slice
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` (§5.2 status)
+
+- [ ] **Step 1: Mark the two ids shipped in the spec's catalogue**
+
+In §5.2, mark `redundant-query` and `iq-unanswered` as shipped in stage 5a. The follow-up 5b plan
+ships MAM merge yield as a rate. The registry owns the live contract; the spec's table only needs to
+stop claiming the traffic detectors are unbuilt.
+
+- [ ] **Step 2: Run the full verification**
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run bench:seam -w @fluux/sdk
+```
+
+Expected: all green; the bench numbers go in the pull request body.
+
+- [ ] **Step 3: Commit and open the pull request**
+
+Use `$preflight-change` for the readiness verdict, then `$publish-change`. The pull request states
+the measured per-stanza cost and names the coverage gap (connection-level sends are invisible).
+
+---
+
+## Self-review
+
+**Spec coverage.** §5.5 seam 1 → Task 1. Hot-path budget and measurement → Tasks 1 and 2. §5.2
+`redundant-query` and `iq-unanswered` → Tasks 3–6. §5.2 `mam-page-yield` → explicitly out of this
+plan, deferred to 5b with the reason. §6.1 (a false-positive detector is deleted) → Task 7's control.
+Privacy by construction (§4.4) → Task 4's `CTX.target` token and closed query-kind tags; no raw JID
+or namespace can reach a record because `Scalar` admits no string.
+
+**Placeholders.** None: every step carries the code or the exact command.
+
+**Type consistency.** `OutFacts`/`InFacts`/`ElementLike`/`QueryKind` are defined in Task 3 and used
+under those names in Tasks 4, 5 and 6. `createTrafficDetector` options match its call in Task 6.
+`queryKindTag` is defined in Task 4 and consumed in Task 5. `CTX.query` is reused rather than
+duplicated; `CTX.target` is new.

--- a/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5b-archive-merge-seam.md
+++ b/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5b-archive-merge-seam.md
@@ -1,0 +1,381 @@
+# Anomaly log stage 5b — archive merge outcome seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every archive merge a single reported outcome — how many rows it
+returned and what durably happened to each of them — and turn that into the MAM page-yield rate and
+a detector for a failed durable write.
+
+**Architecture:** A shared store-side diagnostic module owns the subscription and the arithmetic.
+`chatStore.mergeMAMMessages` and `roomStore.mergeMAMMessages` already compute every input the
+dispositions need and already hold the two promises that say whether the write landed; they report
+once both settle. The app subscribes, counts rows, and records one invariant.
+
+**Tech Stack:** TypeScript, Zustand vanilla stores, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` §5.2, §5.4, §5.5
+seam 2. Predecessor: `docs/superpowers/plans/2026-08-31-anomaly-log-stage-5a-outbound-stanza-seam.md`.
+
+## Two facts that change the spec's plan
+
+Both were verified against the current code on 2026-09-01. The spec is a month old and its §5.5 is
+wrong on each.
+
+**1. Archive patches are not fire-and-forget.** §5.5 says the seam "requires tracking them rather
+than discarding the promise — a small change to product code". That was true of the `void
+messageCache.updateMessage(...)` calls on the live paths (reactions, retractions, live stanza-id
+backfill), but **not** of the archive merge. `chatStore.ts:3005-3007` builds
+`archiveWriteMessages = [...persistableMessages, ...persistablePatches]` and writes both in **one**
+`messageCache.saveMessages` transaction (`:3105`), gated through `conversationArchiveSaves.chain`.
+`roomStore.ts:4029-4031` and `:4120-4122` are identical. **No product-code change is needed** — the
+promise this seam must await already exists and is already awaited for the gap/coverage commit.
+
+**2. There is no query id at merge time.** §5.5 types the payload with `queryId: string`.
+`MAM.ts` emits `chat:history-messages` once per walk, with `allMessages` accumulated across every
+page, while forward room history is emitted per page. Neither store event retains the collector's
+protocol-query id, so such a field could only carry an invented value. The payload instead carries
+what actually exists and is useful: the entity (raw JID, tokenized by the app at the recorder
+boundary, per the §5.5 boundary rule), its kind, the direction, and whether the walk reported
+complete.
+
+A third, smaller consequence: the two booleans the stores hold give `partial` a truer meaning than
+the spec guessed. `saveMessages` is one IndexedDB transaction and so is all-or-nothing per merge;
+`chain()` ANDs it with every earlier in-flight page for the same entity
+(`stores/shared/archiveSaveChain.ts`). So `partial` is observable, and it means: **this** merge's
+write landed while an **earlier** one for the same entity did not — the rows are on disk but the
+durable cursor is frozen. That is exactly §5.5's "at least one attempted write succeeded and at
+least one failed", distributed across the pages of a catch-up rather than within one page.
+
+## Global Constraints
+
+- **No payload is built when nobody is subscribed.** The stores guard every computation behind
+  `hasArchiveMergeSubscribers()`; with the seam unused the cost is one predicate call per merge.
+- **The SDK never emits anomaly types.** The payload is plain data with a raw JID; `Token` and the
+  HMAC key stay in `apps/fluux/src/anomaly/`.
+- **Every returned row gets exactly one disposition**, and they balance:
+  `returned === retained + deduplicated + patched + intentionallyUnstored + persistenceFailed`.
+- **The store is not made to do more work than it already does.** No new write, no new await on a
+  path that did not already have one, no change to when gap or coverage transitions commit.
+- **Registry parity.** Any new `ID` needs a row in `docs/ANOMALY_INVARIANTS.md`; `values.test.ts`
+  checks both directions, and its regex treats any `` `a-b/c-d` `` in the doc as a declared id.
+- **The yield is a rate, not an invariant id.** §5.2 gives `mam-page-yield` severity `drift`, and
+  §5.4 says drift verdicts are computed **only** on rates. Minting an id for it would be a category
+  error; it ships as `mam.rowsRetained/rowsReturned`.
+- **The rate ships informational.** `docs/anomaly-baseline.json` requires the build-stamp question
+  (dirty rebuilds from one short HEAD share a series) to be settled before *any* rate becomes
+  judgeable. That is a maintainer decision, not a side effect of this plan.
+
+## What each disposition means here
+
+Read against `timeline.mergeArchive` (`stores/shared/messageTimeline.ts:139`), whose `newMessages`
+are rows new to the **resident window** and whose `patched` are **resident** messages that gained a
+server stanza-id from an archived copy — the archived copy itself then dedupes away.
+
+| disposition | source |
+|---|---|
+| `retained` | new to the window, persistable, and the write committed |
+| `patched` | a duplicate row that carried a durable stanza-id backfill, and the write committed |
+| `deduplicated` | `returned - newMessages - patched`: a duplicate that wrote nothing |
+| `intentionallyUnstored` | `noLocalStore` rows, whether new or patching (`isNoLocalStore` filters them out of `persistableMessages` / `persistablePatches` on purpose) |
+| `persistenceFailed` | every row whose attempted write did not commit — on failure, `retained` and `patched` are 0 and their rows move here |
+
+---
+
+### Task 1: The diagnostics module
+
+**Files:**
+- Create: `packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts`
+- Test: `packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  export type ArchiveMergeOutcome = 'durable' | 'partial' | 'failed'
+  export interface ArchiveMergeInputs {
+    returned: number; newMessages: number; persistableNew: number
+    patched: number; persistablePatched: number
+  }
+  export interface ArchiveMergeReport {
+    entityKind: 'chat' | 'room'
+    /** Raw JID. The consumer tokenizes it; the SDK never sees a token. */
+    entityId: string
+    direction: 'backward' | 'forward'
+    complete: boolean
+    outcome: ArchiveMergeOutcome
+    returned: number; retained: number; deduplicated: number
+    patched: number; intentionallyUnstored: number; persistenceFailed: number
+  }
+  export function onArchiveMerge(handler: (report: ArchiveMergeReport) => void): () => void
+  export function hasArchiveMergeSubscribers(): boolean
+  export function describeArchiveMerge(inputs: ArchiveMergeInputs, ownWriteCommitted: boolean,
+    chainCommitted: boolean, attempted: boolean): Pick<ArchiveMergeReport, 'outcome' | 'returned' |
+    'retained' | 'deduplicated' | 'patched' | 'intentionallyUnstored' | 'persistenceFailed'>
+  export function reportArchiveMerge(report: ArchiveMergeReport): void
+  export function resetArchiveMergeDiagnosticsForTesting(): void
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Cover the balance on every path, the outcome table, and the subscriber guard.
+
+```typescript
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  describeArchiveMerge, hasArchiveMergeSubscribers, onArchiveMerge, reportArchiveMerge,
+  resetArchiveMergeDiagnosticsForTesting, type ArchiveMergeReport,
+} from './archiveMergeDiagnostics'
+
+afterEach(() => resetArchiveMergeDiagnosticsForTesting())
+
+const page = { returned: 10, newMessages: 6, persistableNew: 5, patched: 2, persistablePatched: 1 }
+
+function balances(r: Pick<ArchiveMergeReport, 'returned' | 'retained' | 'deduplicated' | 'patched' |
+  'intentionallyUnstored' | 'persistenceFailed'>): boolean {
+  return r.returned === r.retained + r.deduplicated + r.patched + r.intentionallyUnstored +
+    r.persistenceFailed
+}
+
+describe('describeArchiveMerge', () => {
+  it('accounts for every returned row when the write commits', () => {
+    const r = describeArchiveMerge(page, true, true, true)
+    expect(r).toMatchObject({
+      outcome: 'durable', returned: 10, retained: 5, patched: 1,
+      // 1 new + 1 patching row were noLocalStore; 10 - 6 new - 2 patched = 2 plain duplicates.
+      intentionallyUnstored: 2, deduplicated: 2, persistenceFailed: 0,
+    })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('moves both written kinds to persistenceFailed when the write fails', () => {
+    const r = describeArchiveMerge(page, false, false, true)
+    expect(r).toMatchObject({ outcome: 'failed', retained: 0, patched: 0, persistenceFailed: 6 })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('calls a merge partial when its own write landed behind a failed earlier page', () => {
+    const r = describeArchiveMerge(page, true, false, true)
+    expect(r.outcome).toBe('partial')
+    // The rows ARE on disk. Only the durable cursor is frozen, so they are retained.
+    expect(r.retained).toBe(5)
+    expect(balances(r)).toBe(true)
+  })
+
+  it('is durable when nothing was attempted', () => {
+    const nothing = { returned: 4, newMessages: 0, persistableNew: 0, patched: 0, persistablePatched: 0 }
+    const r = describeArchiveMerge(nothing, true, true, false)
+    expect(r).toMatchObject({ outcome: 'durable', deduplicated: 4, retained: 0 })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('never reports a negative duplicate count', () => {
+    // Defensive: patched rows are duplicates by construction, so this cannot
+    // happen — but a clamp here beats a nonsense record if the timeline changes.
+    const odd = { returned: 1, newMessages: 1, persistableNew: 1, patched: 1, persistablePatched: 1 }
+    expect(describeArchiveMerge(odd, true, true, true).deduplicated).toBe(0)
+  })
+})
+
+describe('subscription', () => {
+  it('reports nothing and claims no subscribers when nobody listens', () => {
+    expect(hasArchiveMergeSubscribers()).toBe(false)
+  })
+
+  it('delivers a report to every subscriber and stops on unsubscribe', () => {
+    const seen: ArchiveMergeReport[] = []
+    const off = onArchiveMerge((r) => seen.push(r))
+    expect(hasArchiveMergeSubscribers()).toBe(true)
+
+    const report: ArchiveMergeReport = {
+      entityKind: 'chat', entityId: 'a@example.com', direction: 'forward', complete: true,
+      outcome: 'durable', returned: 1, retained: 1, deduplicated: 0, patched: 0,
+      intentionallyUnstored: 0, persistenceFailed: 0,
+    }
+    reportArchiveMerge(report)
+    off()
+    reportArchiveMerge(report)
+
+    expect(seen).toEqual([report])
+    expect(hasArchiveMergeSubscribers()).toBe(false)
+  })
+
+  it('contains a throwing subscriber', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seen: string[] = []
+    onArchiveMerge(() => { throw new Error('detector bug') })
+    onArchiveMerge((r) => seen.push(r.entityId))
+
+    reportArchiveMerge({
+      entityKind: 'room', entityId: 'room@conf.example.com', direction: 'backward', complete: false,
+      outcome: 'failed', returned: 0, retained: 0, deduplicated: 0, patched: 0,
+      intentionallyUnstored: 0, persistenceFailed: 0,
+    })
+
+    // A diagnostic subscriber must not take the merge down with it.
+    expect(seen).toEqual(['room@conf.example.com'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail** — `cd packages/fluux-sdk && npx vitest run
+  src/stores/shared/archiveMergeDiagnostics.test.ts`. Expected: module not found.
+
+- [ ] **Step 3: Implement the module** with the disposition arithmetic in one place, the subscriber
+  Set, and a `try/catch` per handler.
+
+- [ ] **Step 4: Run it and watch it pass.**
+
+- [ ] **Step 5: Export it** from `packages/fluux-sdk/src/stores/index.ts` and
+  `packages/fluux-sdk/src/index.ts` (public compatibility surface — the export is
+  `onArchiveMerge` plus the two types; `reportArchiveMerge`, `describeArchiveMerge` and the reset
+  stay internal to the SDK, exported from the module for the stores and its own test only).
+
+- [ ] **Step 6: Commit** — `feat(sdk): report what an archive merge did with every row`
+
+---
+
+### Task 2: Report from the chat store
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts` (`mergeMAMMessages`, `:2881-3245`)
+- Test: `packages/fluux-sdk/src/stores/chatStore.archiveMerge.test.ts` (new)
+
+**Interfaces:**
+- Consumes: Task 1.
+
+The counts are computed inside `set()`, where `newMessages`, `patched`, `persistableMessages` and
+`persistablePatches` live; the report is emitted after both promises settle, next to the existing
+`archiveCommitGate.then(...)` at `:3200`. Two new outer `let`s carry the state across, in the style
+of the existing `durableMessages` and `archiveCommitGate`.
+
+- [ ] **Step 1: Write the failing test** — drive `mergeMAMMessages` with a mocked `messageCache`,
+  and assert: a durable page reports the right dispositions; a failed `saveMessages` reports
+  `failed` with `persistenceFailed` carrying both kinds; a page where every row dedupes reports
+  `durable` with `returned === deduplicated`; nothing is reported when no one subscribed.
+
+- [ ] **Step 2: Run it and watch it fail.**
+
+- [ ] **Step 3: Implement.** Inside `set()`, right after `archiveWriteMessages` is built:
+
+```typescript
+          // Diagnostics only: nothing is computed unless something is listening
+          // (design §3.3 rule 2 applied inside the SDK).
+          if (hasArchiveMergeSubscribers()) {
+            mergeInputs = {
+              returned: mamMessages.length,
+              newMessages: newMessages.length,
+              persistableNew: persistableMessages.length,
+              patched: patched.length,
+              persistablePatched: persistablePatches.length,
+            }
+          }
+```
+
+capture `ownWrite = savePromise` where the save is issued, and after `set()` returns:
+
+```typescript
+        if (mergeInputs) {
+          const inputs = mergeInputs
+          const attempted = inputs.persistableNew + inputs.persistablePatched > 0
+          void Promise.all([ownWrite ?? Promise.resolve(true), archiveCommitGate ?? Promise.resolve(true)])
+            .then(([own, chained]) => {
+              reportArchiveMerge({
+                entityKind: 'chat',
+                entityId: conversationId,
+                direction,
+                complete,
+                ...describeArchiveMerge(inputs, own, chained, attempted),
+              })
+            })
+        }
+```
+
+- [ ] **Step 4: Run it and watch it pass**, then run the chat store suite:
+  `npx vitest run src/stores/chatStore` — the merge is heavily tested and must be unchanged.
+
+- [ ] **Step 5: Commit** — `feat(sdk): report the outcome of a chat archive merge`
+
+---
+
+### Task 3: Report from the room store
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/roomStore.ts` (`:3939-4265`)
+- Test: `packages/fluux-sdk/src/stores/roomStore.archiveMerge.test.ts` (new)
+
+Identical shape to Task 2 — `newFromMAM` is the room's name for `newMessages`,
+`messageCache.saveRoomMessages` the write, `roomArchiveSaves` the chain — with `entityKind: 'room'`
+and `entityId: roomJid`.
+
+- [ ] **Step 1: Write the failing test** (durable page, failed write, all-duplicates page).
+- [ ] **Step 2: Run it and watch it fail.**
+- [ ] **Step 3: Implement**, mirroring Task 2.
+- [ ] **Step 4: Run it and watch it pass**, then `npx vitest run src/stores/roomStore`.
+- [ ] **Step 5: Commit** — `feat(sdk): report the outcome of a room archive merge`
+
+---
+
+### Task 4: Count the rows and record a failed write
+
+**Files:**
+- Modify: `apps/fluux/src/anomaly/values.ts` (`METRIC.mamRowsReturned`, `RATE.mamYield`,
+  `ID.mamWriteFailed`)
+- Create: `apps/fluux/src/anomaly/detectors/archiveMerge.ts`
+- Test: `apps/fluux/src/anomaly/detectors/archiveMerge.test.ts`
+- Modify: `apps/fluux/src/anomaly/install.ts` (subscribe)
+- Modify: `apps/fluux/src/anomaly/install.test.ts`
+- Modify: `docs/ANOMALY_INVARIANTS.md`
+
+**Interfaces:**
+- Produces: `createArchiveMergeDetector({ record, count, token })` with `observe(report)`.
+
+`METRIC.mamRowsRetained` already exists and is currently never counted; this is what it was reserved
+for. The new numerator/denominator pair is `mam.rowsRetained / mam.rowsReturned`, registered in
+`RATE` as **informational** with the build-stamp reason stated in the comment.
+
+`ID.mamWriteFailed` = `xmpp-traffic/mam-write-failed`, severity `bug`: a merge whose durable write
+did not commit. Its `ctx` carries the entity token, `returned`, and `persistenceFailed`. `partial`
+is deliberately **not** recorded: it means an *earlier* merge failed, and that merge already fired
+this id — recording both would double-count one fault.
+
+- [ ] **Step 1: Write the failing detector test** — counts on a durable page; counts plus one record
+  on a failed page; no record on a `partial` page; no record and no counts on an empty page.
+- [ ] **Step 2: Run it and watch it fail.**
+- [ ] **Step 3: Implement the detector** and add the constants.
+- [ ] **Step 4: Add the registry rows** for `xmpp-traffic/mam-write-failed`, replace the
+  `_(stage 5 continues with mam-page-yield…)_` line with the rate's entry in the `resource/`
+  section, and state the two named non-cases: `partial` is not recorded, and `deduplicated` counts
+  rows already in the **resident window**, which is not proof they are in IndexedDB.
+- [ ] **Step 5: Wire it in `install.ts`** — `onArchiveMerge` beside the traffic detector, released
+  with the same hold; extend the install test with a control that a failed merge reaches the log.
+- [ ] **Step 6: Run** `cd apps/fluux && npx vitest run src/anomaly` and the parity test.
+- [ ] **Step 7: Commit** — `feat(anomaly): measure archive page yield and catch a failed archive write`
+
+---
+
+### Task 5: Close the slice
+
+- [ ] **Step 1:** Add the two new ids to the healthy-session control in `scripts/anomaly-smoke.ts`.
+- [ ] **Step 2:** Update §5.2 and §5.5 of the spec: mark `mam-page-yield` shipped as a rate, record
+  that patches already ride the archive write (no product change was needed), and that the payload
+  carries the entity rather than a `queryId`, with the reason.
+- [ ] **Step 3:** Full verification — `npm test`, `npm run typecheck`, `npm run lint`,
+  `npx playwright test --config playwright.e2e.config.ts --project=anomaly-chromium`,
+  `npm run check:anomaly:prod`.
+- [ ] **Step 4:** `$preflight-change`, then `$publish-change`.
+
+## Self-review
+
+**Spec coverage.** §5.5 seam 2 → Tasks 1–3, with the two documented deviations. §5.2
+`mam-page-yield` → Task 4, as a rate because §5.4 forbids judging drift on anything else. §5.4's
+"MAM pairing waits for the stage-5 seam" → Task 4's `RATE.mamYield`. The balance invariant → Task 1's
+tests, asserted on every path rather than on the happy one.
+
+**Placeholders.** Tasks 1 and 2 carry full code and test bodies; Tasks 3–5 are stated as deltas
+against Task 2 with the exact symbols named, because repeating 200 lines of an identical store body
+would be transcription rather than instruction.
+
+**Type consistency.** `ArchiveMergeInputs` / `ArchiveMergeReport` / `describeArchiveMerge` /
+`reportArchiveMerge` / `hasArchiveMergeSubscribers` are defined in Task 1 and used under those names
+in Tasks 2–4. `entityKind` is `'chat' | 'room'` throughout, matching the stores' own vocabulary.

--- a/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5c-read-state-generation.md
+++ b/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5c-read-state-generation.md
@@ -1,0 +1,177 @@
+# Anomaly log stage 5c — read-state generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the read pointer's forward-only invariant checkable from outside the SDK, by exposing
+the generation a pointer belongs to, and ship `read-state/pointer-regression` on top of it.
+
+**Architecture:** Both stores already keep the two counters the detector needs — a store-scope epoch
+bumped by logout and account switch, and a per-entity epoch bumped when a conversation or room is
+deleted. They are module-private. This slice exposes them read-only, and the app samples a pointer
+and its generation in the same store-subscription callback, so the two cannot disagree.
+
+**Tech Stack:** TypeScript, Zustand vanilla stores, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` §5.1, §5.5
+seam 4. Predecessors: stage 5a and 5b plans in this directory.
+
+## What the code already provides
+
+Verified 2026-09-01.
+
+- `chatCacheEpoch` (`chatStore.ts:602`) is bumped by `switchAccount` (`:3540`), `reset` (`:3562`)
+  and the archive-save test reset (`:623`). `roomCacheEpoch` (`roomStore.ts:405`) mirrors it.
+- `chatEntityEpoch` is bumped **only** by `invalidateChatEntity` (`:697`), whose sole production
+  caller is `deleteConversation` (`:1639`). `roomEntityEpoch` / `invalidateRoomEntity` /
+  `removeRoom` (`:1332`) mirror it.
+- **The spec's premise is out of date in the app's favour.** §5.5 argues a single global counter
+  would be wrong "because the underlying `chatCacheEpoch` is bumped by conversation *deletion* as
+  well as by logout and account switch". It is not: deletion bumps the **entity** epoch. The two
+  scopes the seam is asked to expose already exist, correctly separated. Nothing needs restructuring
+  — only exporting.
+- `isAhead(candidate, current)` is **already public** (`index.ts:245`). The detector must use it
+  rather than compare timestamps itself: a detector with its own ordering rule would eventually
+  disagree with the store and report the disagreement as a bug in the store.
+- `switchAccount` and `reset` also `chatEntityEpoch.clear()`, so an entity epoch can go **down**
+  across a store-generation change. The detector therefore compares the pair, and any difference in
+  either scope is a reset — never an ordering.
+
+## Global Constraints
+
+- **Read-only.** No counter changes meaning, no bump moves, no new bump. This slice adds two
+  exported readers and nothing else to the SDK.
+- **A reader, not a signal — a deliberate deviation from §5.5.** The spec proposes a
+  `{ scope, gen }` event. A detector has to sample the pointer and the generation *together*: with
+  an event, a generation change delivered after the pointer write it explains produces exactly the
+  false positive §6.1 deletes a detector for. A reader called inside the same subscription callback
+  as the pointer read cannot race. The scoping the spec asked for is preserved — the reader returns
+  both scopes.
+- **Registry parity** and the closed value registries, as in 5a/5b.
+- The detector must **ignore the first observation** in a generation, **accept an identical
+  rewrite**, and record only a strictly-behind pointer within one generation (§5.1).
+
+---
+
+### Task 1: Expose the generation
+
+**Files:**
+- Create: `packages/fluux-sdk/src/core/types/readStateGeneration.ts` (the type)
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts`, `packages/fluux-sdk/src/stores/roomStore.ts`
+- Modify: `packages/fluux-sdk/src/index.ts`
+- Test: `packages/fluux-sdk/src/stores/readStateGeneration.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  export interface ReadStateGeneration {
+    /** Bumped by logout and account switch: every entity's read state is new. */
+    store: number
+    /** Bumped when THIS entity is deleted and later recreated. */
+    entity: number
+  }
+  export function chatReadStateGeneration(conversationId: string): ReadStateGeneration
+  export function roomReadStateGeneration(roomJid: string): ReadStateGeneration
+  ```
+
+Two functions rather than one facade: a `stores/shared/` module reading both stores would invert the
+layering it belongs to (shared is imported *by* the stores), and a registry to dodge that would add
+indirection for one call.
+
+- [ ] **Step 1: Write the failing test** — a generation is stable across ordinary pointer writes;
+  `deleteConversation` bumps only `entity`; `reset` bumps `store`; the room twin behaves the same;
+  an unknown entity reads `entity: 0` rather than throwing.
+- [ ] **Step 2: Run it and watch it fail.**
+- [ ] **Step 3: Implement** the two readers next to the existing epoch helpers, and export them.
+- [ ] **Step 4: Run it and watch it pass**, plus both store suites.
+- [ ] **Step 5: Commit** — `feat(sdk): expose the generation a read pointer belongs to`
+
+---
+
+### Task 2: The pointer-regression detector
+
+**Files:**
+- Create: `apps/fluux/src/anomaly/detectors/pointerRegression.ts`
+- Test: `apps/fluux/src/anomaly/detectors/pointerRegression.test.ts`
+- Modify: `apps/fluux/src/anomaly/values.ts` (`ID.pointerRegression`)
+- Modify: `docs/ANOMALY_INVARIANTS.md`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  export interface PointerObservation {
+    kind: 'chat' | 'room'
+    id: string
+    pointer: ReadPointer | undefined
+    generation: ReadStateGeneration
+  }
+  export function createPointerRegressionDetector(opts: {
+    record: (input: RecordInput) => void
+    token: (kind: 'chat' | 'room', id: string) => Opaque
+    isAhead: (candidate: ReadPointer, current: ReadPointer | undefined) => boolean
+    maxTracked?: number
+  }): { observe(o: PointerObservation): void; reset(): void }
+  ```
+
+`isAhead` is injected rather than imported so the detector's test states the ordering rule it is
+testing against instead of inheriting it silently; `install.ts` passes the SDK's own.
+
+The rule, in one line: record when `isAhead(previous, next)` — the pointer that was already there is
+strictly ahead of the one just written — and the generation is unchanged.
+
+- [ ] **Step 1: Write the failing test.** Cases, each named for the behaviour it protects:
+  a strictly-behind write inside one generation records `bug`; an identical rewrite is silent; an
+  advance is silent; the first pointer for an entity is silent; a pointer replaced after a `store`
+  bump is silent; after an `entity` bump is silent; a second regression for the same entity is
+  recorded again (the state follows the pointer, it does not latch); two entities are independent;
+  a pointer going from defined to `undefined` is silent (a cleared pointer is a different event and
+  `isAhead` has no answer for it); tracking is bounded.
+- [ ] **Step 2: Run it and watch it fail.**
+- [ ] **Step 3: Implement**, then add `ID.pointerRegression = 'read-state/pointer-regression'`.
+- [ ] **Step 4: Add the registry row** — severity `bug`, meaning, and the named non-cases (generation
+  change, identical rewrite, first observation, cleared pointer).
+- [ ] **Step 5: Run it and watch it pass**, plus the parity test.
+- [ ] **Step 6: Commit** — `feat(anomaly): detect a read pointer moving backwards`
+
+---
+
+### Task 3: Sample pointers from the stores
+
+**Files:**
+- Modify: `apps/fluux/src/anomaly/install.ts`
+- Modify: `apps/fluux/src/anomaly/install.test.ts`
+
+The chat and room subscriptions already exist. The pointer scan hangs off them, guarded on the meta
+map's identity: `next.conversationMeta !== prev.conversationMeta` skips almost every store event,
+since the map is only recreated when metadata actually changes.
+
+- [ ] **Step 1: Write the failing test** — a regression driven through the mocked store
+  subscription reaches the log; an advance does not.
+- [ ] **Step 2: Run it and watch it fail.**
+- [ ] **Step 3: Implement** the scan: for each entity whose meta reference changed, observe
+  `{ kind, id, pointer, generation }`.
+- [ ] **Step 4: Run it and watch it pass**, then `npx vitest run src/anomaly`.
+- [ ] **Step 5: Commit** — `feat(anomaly): watch every read pointer write for a regression`
+
+---
+
+### Task 4: Close the slice
+
+- [ ] **Step 1:** Add the new id to the healthy-session control in `scripts/anomaly-smoke.ts`.
+- [ ] **Step 2:** Update §5.1 and §5.5 of the spec: `pointer-regression` shipped, the deletion-bump
+  premise corrected, and the reader-versus-signal deviation with its reason.
+- [ ] **Step 3:** Full verification — `npm test`, `npm run typecheck`, `npm run lint`, the anomaly
+  Playwright project, `npm run check:anomaly:prod`.
+
+## Self-review
+
+**Spec coverage.** §5.5 seam 4 → Task 1, with the scoping preserved and the deviation argued.
+§5.1 `pointer-regression`'s three stated rules (reset on generation, ignore the first observation,
+accept an identical rewrite) → Task 2's named test cases. §6.1 (a false-positive detector is
+deleted) → the generation reset and the smoke control in Task 4.
+
+**Placeholders.** Task 1 and 2 name every case to test and the exact rule; no step says "add
+appropriate handling".
+
+**Type consistency.** `ReadStateGeneration` is defined in Task 1 and consumed under that name in
+Tasks 2 and 3. `PointerObservation.pointer` is `ReadPointer | undefined`, matching
+`conversationMeta.readPointer`'s optionality.

--- a/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5d-unread-diagnostic.md
+++ b/docs/superpowers/plans/2026-09-01-anomaly-log-stage-5d-unread-diagnostic.md
@@ -1,0 +1,116 @@
+# Anomaly log stage 5d — unread diagnostic Implementation Plan
+
+> **Status:** The diagnostic task is complete. The detector task was withdrawn by the design
+> decision referenced below.
+
+**Goal:** Expose an archive-derived unread count and the displayed badge **from one validated
+snapshot** through a read-only SDK diagnostic.
+
+**Architecture:** A read-only function per store walks the same coverage gates the real recount
+walks, calls the same archive counter, and returns `exact` only when nothing moved underneath it.
+It writes nothing: no recount version bump, no transient prune, no coverage invalidation.
+
+**Tech Stack:** TypeScript, Zustand vanilla stores, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` §5.1, §5.5
+seam 3. Predecessors: the 5a, 5b and 5c plans in this directory.
+
+> **Outcome:** The diagnostic shipped and remains exported. The proposed detector and its wiring
+> were withdrawn by the decision recorded in the design's §5.1; that section is the single source
+> for the reason, and this plan does not override it.
+
+## Why this is not a thin wrapper over the recount
+
+`recomputeUnreadForConversation` (`chatStore.ts:2690-2855`) and `recomputeUnreadForRoom`
+(`roomStore.ts:2541-2700`) cannot be reused as-is, and not for style reasons. Their prelude has
+three side effects a diagnostic must not have:
+
+1. `bumpChatRecountVersion` / `bumpRoomRecountVersion` — the latest-wins token. A diagnostic that
+   bumped it would **cancel a real recount already in flight**, turning an observer into a cause.
+2. `pruneTransient` — it edits the transient unread overlay.
+3. `clearConversationCoverage` on an unresolvable bottom — it invalidates a persisted record.
+
+So the diagnostic is a **second traversal of the same gates**, side-effect free, calling the same
+helpers (`computeFloor`, `isCaughtUpForCounting`, `resolveCoverageBottom`, `isAfterBoundary`,
+`countUnreadInArchive` / `countRoomUnreadInArchive`, `transientCounts`). Two traversals can drift
+apart, and the mitigation is not a comment: **an agreement test** provokes each reachable gate and
+asserts the recount's own deferral tally and the diagnostic name the same reason.
+
+What it must NOT do is what §5.1 already rules out: counting from the resident or bounded-cache
+slice. That would recreate the under-count class the diagnostic exists to expose, making its result
+unreliable exactly when the discrepancy needs investigation.
+
+## Global Constraints
+
+- **Read-only.** No store write, no version bump, no prune, no coverage change, on any path.
+- **One snapshot.** `archiveCount` and `badgeCount` are validated against the same unmoved context:
+  the badge is read last, and the context check runs after it.
+- **Only `exact` may be compared.** `deferred` means the coverage gate declined — the real recount
+  would have declined too. `stale` means the inputs moved mid-computation. Neither is evidence of a
+  bug, and treating either as a mismatch would make the detector fire during ordinary catch-up.
+- **Exported seam.** `chatUnreadDiagnostic` and `roomUnreadDiagnostic` remain public SDK diagnostics.
+
+---
+
+### Task 1: The diagnostic
+
+**Files:**
+- Create: `packages/fluux-sdk/src/stores/shared/unreadDiagnostic.ts`
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts`, `packages/fluux-sdk/src/stores/roomStore.ts`,
+  `packages/fluux-sdk/src/index.ts`
+- Test: `packages/fluux-sdk/src/stores/unreadDiagnostic.test.ts`
+
+**Interfaces:**
+```typescript
+export interface UnreadDiagnostic {
+  status: 'exact' | 'deferred' | 'stale'
+  /** Archive-derived, including the transient overlay. Only on `exact`. */
+  archiveCount?: number
+  /** What the badge displays. Only on `exact`. */
+  badgeCount?: number
+  /** Which gate stood down. Only on `deferred`. */
+  reason?: RecountDeferralReason
+}
+export function chatUnreadDiagnostic(conversationId: string): Promise<UnreadDiagnostic>
+export function roomUnreadDiagnostic(roomJid: string): Promise<UnreadDiagnostic>
+```
+
+`reason` goes beyond the spec's shape on purpose: the app already folds recount deferral tallies
+(#1211), and a `deferred` with no reason would be the one diagnostic in this system that says
+something is unknown without saying why.
+
+- [x] **Step 1: Write the failing test** — `exact` returns both counts and they agree on a healthy
+  conversation; a conversation with no coverage record defers with `coverage-missing`; a history
+  that is not caught up defers with `history-not-caught-up`; a pointerless entity defers; a
+  mismatched badge still reports `exact` with the two different numbers (the diagnostic reports, it
+  does not judge); the room twin behaves the same.
+- [x] **Step 2: Run it and watch it fail.**
+- [x] **Step 3: Implement** both functions beside their recounts, each carrying a comment binding it
+  to its twin.
+- [x] **Step 4: Write the agreement test** — for each reachable gate, drive the real recount and the
+  diagnostic against the same state and assert they name the same reason. Reachable here means
+  observable through the store: `no-meta`, `pointerless-defer`, `no-floor`,
+  `history-not-caught-up`, `coverage-missing`, `coverage-short-of-floor`, `cache-unavailable`, and
+  the `exact` path. The race reasons (`recount-superseded`, `input-version-changed`,
+  `context-changed`) map to `stale` by design and are stated as such rather than asserted equal.
+- [x] **Step 5: Run both, plus the two store suites** — the recount is the most guarded function in
+  the read-state system and must be untouched.
+- [x] **Step 6: Commit** — `feat(sdk): expose the archive-derived unread count beside the badge`
+
+---
+
+### Task 2: The detector — withdrawn
+
+This task and its wiring are not implemented. The reason is maintained in the
+[design decision in §5.1](../specs/2026-07-29-client-anomaly-detection-log-design.md#51-read-state).
+No detector id, invariant-registry row, installer wiring, or healthy-session control ships.
+
+## Self-review
+
+**Spec coverage.** §5.5 seam 3 → Task 1, including the "both counts from one guarded snapshot"
+requirement that removes the need for a public revalidation operation. The withdrawn detector is
+owned by the §5.1 decision linked from Task 2.
+
+**Placeholders.** Every task names its cases and its exact symbols.
+
+**Type consistency.** `UnreadDiagnostic` and `RecountDeferralReason` are the SDK's exported types.

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -459,11 +459,16 @@ record contract, severity, context fields, and named non-cases.
 
 | id | check | sev | stage |
 |---|---|---|---|
-| `pointer-regression` | every pointer write must satisfy `isAhead` (`stores/shared/readPointer.ts:89`) | bug | **5 — blocked** |
+| `pointer-regression` | every pointer write must satisfy `isAhead` (`stores/shared/readPointer.ts`) | bug | shipped (5c) |
 | `unread-survives-focus` | See the runtime invariant registry | registry | 3 |
-| `badge-vs-pointer` | archive-derived recount vs displayed count | bug | **5 — blocked** |
+| `badge-vs-pointer` | archive-derived recount vs displayed count | — | objective withdrawn (§5.1) |
 
-**`pointer-regression` moves to stage 5, because generations are not observable.** "Forward-only"
+**Shipped in 5c, and the premise below was half wrong.** Deletion does NOT bump `chatCacheEpoch`:
+it bumps a per-entity epoch through `invalidateChatEntity`, and the two scopes the seam was asked
+to invent already existed, correctly separated. Only exporting them was missing. The rest of the
+argument stands and is why the detector resets on the PAIR.
+
+**`pointer-regression` shipped in stage 5 because generations were not observable beforehand.** "Forward-only"
 holds *within* one store generation. Several normal transitions legitimately replace a pointer
 wholesale, so the detector needs a **generation identity** to reset on — and the previous revision
 claimed that identity was reachable from the signals `recountContextIsCurrent` guards on. It is not:
@@ -475,8 +480,8 @@ be invisible, and every one of them would surface as a false `pointer-regression
 outcome §6.1 deletes a detector for. Shipping it in stage 3 on partial signals would spend the
 system's credibility on its first detector.
 
-It therefore moves to stage 5 behind a `readStateGeneration` seam (§5.5). Its contract, once the
-seam exists:
+The stage 5 `readStateGeneration` seam (§5.5) made that generation observable. Its shipped
+contract:
 
 - **resets** whenever the generation changes (account switch, rehydration, store reset);
 - **ignores the first observation** in each generation, having no predecessor to compare against;
@@ -487,40 +492,33 @@ seam exists:
 invariant registry owns its current continuity and reset contract, including how the publicly
 observable account/storage scope bounds an episode.
 
-**Why `badge-vs-pointer` is deferred.** The original design proposed
-`recomputeCountsFromPointer` (`stores/shared/notificationState.ts:637`) as an oracle. That is not
-implementable:
+**Outcome — objective withdrawn, detector not shipped.** The proposed trigger treats every metadata
+replacement as evidence worth comparing. For an active conversation above the live edge, the
+supported count-only `markAsRead` preserves the read pointer while clearing the badge; the archive
+still contains the unread rows, so the exact diagnostic returns the ordinary state `(2, 0)` and the
+detector records it as a bug. The design rule in §6.1 deletes a detector that fires during ordinary
+use rather than tuning it until the control passes, so this objective was withdrawn during stage 5,
+not forgotten.
 
-- it is **not exported** from `index.ts`, `stores/index.ts`, or `core/index.ts`;
-- it operates on a **supplied message slice**, not the durable archive;
-- its counts are **explicitly not trusted** — `chatStore.ts:2484` discards them as "provisional".
-
-The real recount checks MAM coverage (`isCaughtUpForCounting`, `chatStore.ts:2569`), resolves the
-coverage bottom, incorporates the transient overlay, compares order positions, and only then calls
-`messageCache.countUnreadInArchive`. A detector running against the resident or bounded-cache slice
-would **recreate the exact under-count class it exists to catch** — the worst possible failure for a
-detector, because it would be silent precisely when the bug is present.
-
-This detector therefore requires a **read-only SDK diagnostic seam** exposing an archive-derived
-count with the same coverage gating, and lands in stage 5 (§5.5). Only `unread-survives-focus`
-remains in stage 3 — it is the one read-state invariant fully observable from public surfaces.
-
-**Evaluation trigger for stage 5.** When it does land, `badge-vs-pointer` must not free-run — during
-a normal recompute the displayed count and the pointer legitimately disagree for a window. It must
-be debounced 500ms on `conversationMeta` / `roomMeta` change and suppressed while a recount is in
-flight. A detector that fires during normal settling is indistinguishable from one that found a bug,
-and by §6.1 it would be deleted.
+The read-only diagnostic seam the detector required **did ship** and is exported as
+`chatUnreadDiagnostic(id)` / `roomUnreadDiagnostic(jid)`. It derives the archive count through the
+recount's coverage gates while keeping private validation and race guards inside the SDK. A future
+badge detector therefore needs a sound trigger model, not new SDK visibility.
 
 ### 5.2 `xmpp-traffic/`
 
-`onStanza` is **inbound only**. All three detectors land in **stage 5**, but they do not all need
+`onStanza` is **inbound only**. All three checks shipped in **stage 5**, but they do not all use
 the same seam — and an outbound hook alone is not sufficient for any of them:
 
-| id | check | sev | seam required |
-|---|---|---|---|
-| `redundant-query` | same disco/vCard/MAM target re-queried within a window | suspect | `onApplicationStanzaOut` |
-| `iq-unanswered` | outbound application IQ with no result within 30s | bug | `onApplicationStanzaOut` |
-| `mam-page-yield` | rows returned vs rows **retained** per query | drift | MAM outcome seam (§5.5) |
+| id | check | sev | seam required | status |
+|---|---|---|---|---|
+| `redundant-query` | same disco/vCard/avatar target re-queried within a window | suspect | `onApplicationStanzaOut` | shipped (5a) |
+| `iq-unanswered` | outbound application IQ with no result within 30s | bug | `onApplicationStanzaOut` | shipped (5a) |
+| `mam-page-yield` | rows returned vs rows **retained** per merge | drift | archive merge seam (§5.5) | shipped (5b), as a RATE — §5.4 judges drift only on rates, so an id would have been a category error |
+
+As shipped, `redundant-query` judges only disco, vCard and avatar queries. MAM pages the same
+archive with a different window by design, and a roster fetch after a reconnect is expected, so
+neither carries a redundancy identity — the registry records this as a named non-case.
 
 **`mam-page-yield` cannot be built from an outbound hook.** The outbound seam sees the query and the
 typed MAM event sees the messages *returned*, but retention is decided later — durable
@@ -560,8 +558,8 @@ observe two pairings, both informational until their remaining measurement ambig
 | `render.MessageList/roomSwitch` | conversation or room switch | Informational: renders also scale with traffic, and room arrivals are not observable separately from MAM merges |
 | `scroll.writes/positioning` | positioning operation (live-edge stick, anchor restore, jump) | Informational: the frame-loop signal does not distinguish an issued write from actual movement |
 
-The message-arrival, MAM, and IndexedDB pairings wait for the stage 5 seams that can measure their
-denominators without substituting a nearby but different quantity.
+Stage 5 added the MAM retained/returned pairing through the archive-merge seam. Message-arrival and
+IndexedDB pairings still need sound denominators rather than nearby but different quantities.
 
 Raw counters are still emitted — they are the rate inputs and remain useful for spotting an
 absolute explosion — but **drift verdicts are computed only on rates**.
@@ -587,13 +585,20 @@ boundary §4.4 already requires for JIDs.
 
 1. **`onApplicationStanzaOut(handler)`** — outbound application stanzas only.
 
-2. **A MAM outcome seam** emitting, once a page has been merged into the cache:
+2. **An archive merge outcome seam** emitting once a MAM delivery has been merged into the cache:
 
    ```ts
-   { queryId: string, outcome: 'durable' | 'partial' | 'failed', returned: number,
+   { entityKind: 'chat' | 'room', entityId: string, direction, complete: boolean,
+     outcome: 'durable' | 'partial' | 'failed', returned: number,
      retained: number, deduplicated: number, patched: number,
      intentionallyUnstored: number, persistenceFailed: number }
    ```
+
+   **Shipped in 5b with no `queryId`, and the design was wrong to ask for one.**
+   `MAM.ts` emits `chat:history-messages` once per walk, with every page accumulated
+   into one array, while forward room history is emitted per page. Neither store event
+   carries the collector's per-query id, so the payload carries the entity — raw,
+   tokenized by the app at the recorder boundary — instead of an invented id.
 
    **Every returned row gets exactly one disposition**, and they balance:
 
@@ -610,13 +615,22 @@ boundary §4.4 already requires for JIDs.
      (`chatStore.ts:2758–2760`). It is neither a plain duplicate nor a plain insert, and folding it
      into `deduplicated` would make a page look inert while it was in fact writing.
 
-   **Emission waits for inserts *and* patches to resolve.** Today those patches are fire-and-forget
-   (`void messageCache.updateMessage(...)`), so this seam requires tracking them rather than
-   discarding the promise — a small change to product code, not only a new event, and one to plan
-   for in stage 5.
+   **Emission waits for inserts *and* patches to resolve** — and that needed no product change.
+   The fire-and-forget `void messageCache.updateMessage(...)` calls are on the LIVE paths
+   (reactions, retractions, live stanza-id backfill). The archive merge already writes new rows and
+   stanza-id patches in ONE `saveMessages` transaction, gated through `archiveSaveChain`, because
+   the gap and coverage cursors already had to defer on it. The seam reuses that promise.
 
-   `outcome` is then derived mechanically from `persistenceFailed` and the number of writes
-   attempted, so it can never disagree with the counts:
+   `outcome` is then derived mechanically from the two booleans the store already holds — this
+   merge's own transaction, and the chain that ANDs it with every earlier in-flight page for the
+   same entity — so it can never disagree with the counts. `partial` is therefore observable and
+   means something sharper than the design assumed: THIS page's rows are on disk while an EARLIER
+   page's failure has frozen the durable cursor.
+
+   One more thing the code says and the design did not: `retained` means **written**, not new to
+   the archive. Dedupe happens against the RESIDENT window, and only the entity on screen has one,
+   so a backgrounded catch-up rewrites its pages in full. `docs/ANOMALY_INVARIANTS.md` carries this
+   warning next to the rate.
 
    | `outcome` | Condition |
    |---|---|
@@ -626,7 +640,13 @@ boundary §4.4 already requires for JIDs.
 
    Unblocks §5.2.
 
-3. **A read-only unread diagnostic** returning **both counts from one validated snapshot**:
+3. **A read-only unread diagnostic** returning **both counts from one validated snapshot**
+   — shipped in 5d as `chatUnreadDiagnostic(id)` / `roomUnreadDiagnostic(jid)`, with a `reason` on
+   `deferred` (the app already folds recount deferral tallies, and an unexplained "unknown" would be
+   the one diagnostic here that says nothing about why). It is a SECOND traversal of the recount's
+   gates rather than a call into it, because that prelude bumps the latest-wins version, prunes the
+   transient overlay and invalidates a coverage record — an observer that did any of those would be
+   a cause. `unreadDiagnostic.test.ts` pins the two to the same verdicts:
 
    ```ts
    { status: 'exact' | 'deferred' | 'stale', archiveCount?: number, badgeCount?: number }
@@ -642,13 +662,20 @@ boundary §4.4 already requires for JIDs.
    (`chatStore.ts:2478`) internally, where the private versions actually live, and hands out two
    numbers already known to be mutually consistent. The detector compares two integers and needs no
    view of `InputVersions` at all. Exposing versions to the app would have meant publishing internal
-   race-guard state as API. Unblocks `badge-vs-pointer` (§5.1).
+   race-guard state as API.
 
 4. **A scoped `readStateGeneration` signal:**
 
    ```ts
    { scope: 'store', gen: number } | { scope: 'entity', id: string, gen: number }
    ```
+
+   **Shipped in 5c as a READER, not a signal**, returning both scopes at once:
+   `chatReadStateGeneration(id)` / `roomReadStateGeneration(jid)` → `{ store, entity }`. A detector
+   has to sample the pointer and its generation together; with an event, a generation change
+   delivered after the pointer write it explains produces exactly the false positive §6.1 deletes a
+   detector for. A reader called in the same store-subscription callback cannot race. The scoping
+   the design argued for is unchanged — and it turned out the stores already kept both counters.
 
    **The scope is the whole point.** A single global counter would be wrong, because the underlying
    `chatCacheEpoch` is bumped by conversation *deletion* as well as by logout and account switch —
@@ -823,7 +850,12 @@ Each stage is independently useful and independently revertable.
 | 2 | Scroll/stall sentinel **fan-out** | The pipe works end to end with no new detection logic, and the prose log is untouched | none |
 | 3 | `read-state/` (unread-survives-focus) + `scroll/` (fab-at-live-edge, jump-target-miss) | Real detectors on state observable from public surfaces alone | none |
 | 4 | `resource/` **rates with denominators**, baseline, `npm run anomaly:review` incl. explicit retention pruning | The review loop closes and drift detection starts | none |
-| 5 | Four SDK seams (§5.5), then `xmpp-traffic/`, `badge-vs-pointer` and `pointer-regression` | Everything requiring new SDK visibility | four read-only additions, measured (§5.5) |
+| 5 | Four SDK seams (§5.5), then `xmpp-traffic/` and `pointer-regression` | The safe invariants requiring new SDK visibility | four read-only additions, measured (§5.5) |
+
+Stage 5 shipped in four slices, each with its own plan under `docs/superpowers/plans/`: 5a the
+outbound stanza seam, 5b the archive merge outcome, 5c the read-state generation, 5d the unread
+diagnostic. Three of the four seams turned out smaller than this design assumed, and each plan
+records what the code said instead.
 
 Stage 0 is separated out because the gate correction is a live pre-existing bug (§2.1) that is worth
 landing on its own, and because every later stage depends on the gate being right.

--- a/packages/fluux-sdk/bench/README.md
+++ b/packages/fluux-sdk/bench/README.md
@@ -18,3 +18,20 @@ thing varying is the persistence rule.
 
 Not part of `npm test` — it is a measurement, not an assertion, and it takes far longer than a unit
 test. It IS typechecked by `npm run typecheck -w @fluux/sdk`, so it cannot rot silently.
+
+## Outbound seam dispatch (stage 5a)
+
+```bash
+npm run bench:seam -w @fluux/sdk
+```
+
+The per-stanza cost of `onApplicationStanzaOut`, which ships in `dist` to every SDK consumer, so the
+unsubscribed path has to stay a Map lookup. Variants are interleaved and each reports its fastest
+round: measured one after another, whichever runs last wins, and a seam can appear to make sending
+cheaper.
+
+Measured on 2026-09-01 (macOS, Node 22): dispatch is 5.5 ns/stanza unsubscribed against a 1.6 ns
+control call and 261.3 ns with one subscriber. A full `sendStanza` is 52.4 ns unsubscribed against
+318.9 ns with a subscriber; the subscribed path includes an independent deep stanza snapshot per
+subscriber, isolating the transport, Stream Management replay state, and other observers from
+mutation.

--- a/packages/fluux-sdk/bench/outboundSeam.bench.ts
+++ b/packages/fluux-sdk/bench/outboundSeam.bench.ts
@@ -1,0 +1,156 @@
+/**
+ * Hot-path cost of the outbound application stanza seam.
+ *
+ * The seam ships in `dist` to every SDK consumer, so the design makes its cost a
+ * merge gate rather than a note: with no subscriber attached it must stay within
+ * noise of not having the seam at all
+ * (docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md §5.5).
+ *
+ * Three quantities, because only their differences mean anything:
+ *
+ * - `call` — a method of the same shape with a trivial body. The floor: what a call
+ *   costs on this machine.
+ * - `unsubscribed` — the real dispatcher with no handler. Its excess over `call` is
+ *   what every SDK consumer pays for a seam they never use.
+ * - `subscribed` — the real dispatcher with one handler, i.e. the Dev build.
+ *
+ * Variants are measured in ROUNDS, interleaved, and each reports its fastest round.
+ * A single pass per variant measures the JIT's warm-up order at least as much as the
+ * code: run sequentially, whichever variant goes last wins, which is how a seam can
+ * appear to make sending cheaper.
+ *
+ * Run: `npm run bench:seam -w @fluux/sdk`
+ */
+
+import { describe, it } from 'vitest'
+import { xml, type Element } from '@xmpp/client'
+import { XMPPClient } from '../src/core/XMPPClient'
+
+const ITERATIONS = 1_000_000
+const SENDS = 50_000
+const ROUNDS = 7
+
+interface StubTransport {
+  send: (stanza: Element) => Promise<void>
+  iqCaller: { request: (iq: Element) => Promise<Element> }
+}
+
+/** A client whose transport accepts everything and does nothing. */
+class BenchClient extends XMPPClient {
+  sink = 0
+
+  constructor() {
+    super({})
+    const transport: StubTransport = {
+      send: async () => {},
+      iqCaller: { request: () => new Promise<Element>(() => {}) },
+    }
+    ;(this as unknown as { requireTransport: () => StubTransport }).requireTransport = () =>
+      transport
+  }
+
+  /** The control: same call shape, and it touches the argument as the seam does. */
+  noop(stanza: Element): void {
+    if (stanza.name === '\0') this.sink++
+  }
+
+  dispatch(stanza: Element): void {
+    ;(
+      this as unknown as { emitApplicationStanzaOut: (s: Element) => void }
+    ).emitApplicationStanzaOut(stanza)
+  }
+
+  send(stanza: Element): Promise<void> {
+    return this.sendStanza(stanza)
+  }
+}
+
+interface Variant {
+  label: string
+  run: () => void | Promise<void>
+  ops: number
+}
+
+/** Fastest round per variant, with the variants interleaved. */
+async function race(variants: Variant[]): Promise<Array<{ label: string; ns: number }>> {
+  const best = new Map<string, number>()
+  for (let round = 0; round <= ROUNDS; round++) {
+    for (const variant of variants) {
+      const started = performance.now()
+      await variant.run()
+      const ns = ((performance.now() - started) * 1e6) / variant.ops
+      // Round 0 is warm-up for every variant alike, so it is discarded.
+      if (round === 0) continue
+      const previous = best.get(variant.label)
+      if (previous === undefined || ns < previous) best.set(variant.label, ns)
+    }
+  }
+  return variants.map((v) => ({ label: v.label, ns: best.get(v.label) ?? Number.NaN }))
+}
+
+function report(title: string, rows: Array<{ label: string; ns: number }>): void {
+  const width = Math.max(...rows.map((r) => r.label.length))
+  // Written straight to stdout: a measurement the reporter may swallow is not a
+  // measurement.
+  process.stdout.write(`\n${title} (fastest of ${ROUNDS} rounds)\n`)
+  for (const row of rows) {
+    process.stdout.write(`  ${row.label.padEnd(width)}  ${row.ns.toFixed(2)} ns/stanza\n`)
+  }
+}
+
+describe('outbound seam', () => {
+  it('costs nothing measurable when nobody is subscribed', async () => {
+    const bare = new BenchClient()
+    const subscribed = new BenchClient()
+    let seen = 0
+    subscribed.onApplicationStanzaOut(() => {
+      seen++
+    })
+    const stanza = xml('message', { to: 'a@example.com', id: 'x1' }, xml('body', {}, 'hello'))
+
+    const rows = await race([
+      {
+        label: 'call (control)',
+        ops: ITERATIONS,
+        run: () => {
+          for (let i = 0; i < ITERATIONS; i++) bare.noop(stanza)
+        },
+      },
+      {
+        label: 'dispatch, unsubscribed',
+        ops: ITERATIONS,
+        run: () => {
+          for (let i = 0; i < ITERATIONS; i++) bare.dispatch(stanza)
+        },
+      },
+      {
+        label: 'dispatch, one subscriber',
+        ops: ITERATIONS,
+        run: () => {
+          for (let i = 0; i < ITERATIONS; i++) subscribed.dispatch(stanza)
+        },
+      },
+    ])
+
+    report('dispatch', rows)
+    process.stdout.write(`  (subscriber saw ${seen} stanzas, control sink ${bare.sink})\n`)
+  })
+
+  it('is invisible in the cost of an actual send', async () => {
+    const stanza = xml('message', { to: 'a@example.com', id: 'x1' }, xml('body', {}, 'hello'))
+    const bare = new BenchClient()
+    const subscribed = new BenchClient()
+    subscribed.onApplicationStanzaOut(() => {})
+
+    const sendLoop = (client: BenchClient) => async (): Promise<void> => {
+      for (let i = 0; i < SENDS; i++) await client.send(stanza)
+    }
+
+    const rows = await race([
+      { label: 'sendStanza, unsubscribed', ops: SENDS, run: sendLoop(bare) },
+      { label: 'sendStanza, one subscriber', ops: SENDS, run: sendLoop(subscribed) },
+    ])
+
+    report('end to end', rows)
+  })
+})

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -95,7 +95,8 @@
     "docs:watch": "typedoc --watch",
     "clean": "rm -rf dist",
     "clean:all": "rm -rf dist node_modules docs",
-    "bench:persist": "vitest run --config vitest.bench.config.ts",
+    "bench:persist": "vitest run --config vitest.bench.config.ts bench/persistCost.bench.ts",
+    "bench:seam": "vitest run --config vitest.bench.config.ts bench/outboundSeam.bench.ts",
     "bench:persist:browser": "node bench/browser/run.mjs"
   },
   "dependencies": {

--- a/packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The outbound application stanza seam.
+ *
+ * Drives the two application-layer send paths against a stub transport, so the
+ * assertions are about the seam and nothing else.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { xml, type Element } from '@xmpp/client'
+import { XMPPClient } from './XMPPClient'
+
+interface StubTransport {
+  send: (stanza: Element) => Promise<void>
+  iqCaller: { request: (iq: Element) => Promise<Element> }
+}
+
+/** Reach the protected send paths without a connection. */
+class TestClient extends XMPPClient {
+  public sent: Element[] = []
+  public wire: string[] = []
+  public requested: Element[] = []
+  public failSend = false
+
+  constructor() {
+    super({})
+    const transport: StubTransport = {
+      send: async (stanza: Element) => {
+        this.wire.push(stanza.toString())
+        if (this.failSend) throw new Error('socket closed')
+        this.sent.push(stanza)
+      },
+      iqCaller: {
+        request: (iq: Element) => {
+          // Mirrors @xmpp/iq/caller.js: the id is assigned inside request().
+          if (!iq.attrs.id) iq.attrs.id = 'assigned-1'
+          this.requested.push(iq)
+          return new Promise<Element>(() => {})
+        },
+      },
+    }
+    // `requireTransport` is private to TypeScript only; an own property shadows
+    // the prototype method at runtime, which is what keeps this test free of a
+    // connection, a state machine and a socket.
+    ;(this as unknown as { requireTransport: () => StubTransport }).requireTransport = () =>
+      transport
+  }
+
+  sendStanzaForTest(stanza: Element): Promise<void> {
+    return this.sendStanza(stanza)
+  }
+
+  sendIQForTest(iq: Element): Promise<Element> {
+    return this.sendIQ(iq)
+  }
+}
+
+describe('onApplicationStanzaOut', () => {
+  it('reports a stanza sent through sendStanza', async () => {
+    const client = new TestClient()
+    const seen: Element[] = []
+    client.onApplicationStanzaOut((s) => seen.push(s))
+
+    await client.sendStanzaForTest(xml('message', { to: 'a@example.com' }, xml('body', {}, 'hi')))
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].name).toBe('message')
+  })
+
+  it('does not let an observer alter the stanza retained by the transport', async () => {
+    const client = new TestClient()
+    let observed: Element | null = null
+    client.onApplicationStanzaOut((snapshot) => {
+      observed = snapshot
+      snapshot.attrs.to = 'redirected@example.com'
+      const body = snapshot.getChild('body')!
+      body.attrs.lang = 'redirected'
+      body.children[0] = 'changed'
+    })
+    const stanza = xml('message', { to: 'a@example.com' }, xml('body', {}, 'hi'))
+
+    await client.sendStanzaForTest(stanza)
+
+    expect(observed).not.toBe(stanza)
+    expect(client.sent).toEqual([stanza])
+    expect(stanza.attrs.to).toBe('a@example.com')
+    expect(stanza.getChild('body')?.attrs.lang).toBeUndefined()
+    expect(stanza.getChildText('body')).toBe('hi')
+    expect(client.wire).toHaveLength(1)
+    expect(client.wire[0]).toContain('to="a@example.com"')
+    expect(client.wire[0]).not.toContain('redirected@example.com')
+  })
+
+  it('isolates each subscriber from earlier snapshot mutations', async () => {
+    const client = new TestClient()
+    let secondSnapshot: Element | undefined
+    client.onApplicationStanzaOut((snapshot) => {
+      snapshot.attrs.id = 'tampered'
+      snapshot.getChild('body')!.children[0] = 'changed'
+    })
+    client.onApplicationStanzaOut((snapshot) => {
+      secondSnapshot = snapshot
+    })
+
+    await client.sendStanzaForTest(
+      xml('message', { to: 'a@example.com', id: 'original' }, xml('body', {}, 'hello'))
+    )
+
+    expect(secondSnapshot?.attrs.id).toBe('original')
+    expect(secondSnapshot?.getChildText('body')).toBe('hello')
+  })
+
+  it('still exposes a transport write failure', async () => {
+    const client = new TestClient()
+    client.failSend = true
+
+    await expect(client.sendStanzaForTest(xml('presence'))).rejects.toThrow('socket closed')
+  })
+
+  it('reports an IQ only after the shared send boundary assigns its id', () => {
+    const client = new TestClient()
+    const ids: Array<string | undefined> = []
+    client.onApplicationStanzaOut((s) => ids.push(s.attrs.id as string | undefined))
+
+    void client.sendIQForTest(xml('iq', { type: 'get', to: 'example.com' }))
+
+    // An id-less outbound IQ can never be paired with its reply, so publishing one
+    // would be worse than publishing nothing.
+    expect(ids).toHaveLength(1)
+    expect(ids[0]).toMatch(/^[0-9a-f-]{36}$/)
+    expect(client.requested[0].attrs.id).toBe(ids[0])
+  })
+
+  it('stops reporting after unsubscribe', async () => {
+    const client = new TestClient()
+    const seen: Element[] = []
+    const off = client.onApplicationStanzaOut((s) => seen.push(s))
+    off()
+
+    await client.sendStanzaForTest(xml('presence'))
+
+    expect(seen).toEqual([])
+  })
+
+  it('sends the stanza even when a subscriber throws', async () => {
+    const client = new TestClient()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    client.onApplicationStanzaOut(() => {
+      throw new Error('detector bug')
+    })
+
+    await client.sendStanzaForTest(xml('message', { to: 'a@example.com' }))
+
+    expect(client.sent).toHaveLength(1)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('does not reach connection-level sends', async () => {
+    // The keepalive ping and the SM <r/> go straight to the transport, so nothing
+    // the seam reports may come from there. Asserted by construction: only the two
+    // application paths dispatch, and this drives the transport directly.
+    const client = new TestClient()
+    const seen: Element[] = []
+    client.onApplicationStanzaOut((s) => seen.push(s))
+
+    const transport = (
+      client as unknown as { requireTransport: () => StubTransport }
+    ).requireTransport()
+    await transport.send(xml('iq', { type: 'get', id: 'ping-1' }))
+
+    expect(seen).toEqual([])
+  })
+})

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1420,6 +1420,7 @@ describe('XMPPClient', () => {
       ;(mockXmppClientInstance as any).socket = null
       mockStores.connection.getStatus.mockReturnValue('online' as ConnectionStatus)
       mockStores.console.addEvent.mockClear()
+      const recovery = vi.spyOn(xmppClient.connection, 'handleDeadSocket')
 
       await expect(xmppClient.blocking.fetchBlocklist()).rejects.toThrow('Socket not available')
 
@@ -1427,6 +1428,7 @@ describe('XMPPClient', () => {
         'Socket null but status online (IQ) - triggering reconnect',
         'error'
       )
+      expect(recovery).toHaveBeenCalledTimes(1)
     })
 
     it('should detect dead socket errors on IQ response failure', async () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -47,6 +47,7 @@ import { routeStanza } from './stanzaRouting'
 import { createE2EEDiagnosticLogger } from './e2eeDiagnosticLogger'
 import { getStorageScopeJid, setStorageScopeJid } from '../utils/storageScope'
 import { clearLocallyPublishedDisplayed } from './localMdsPublishes'
+import { generateUUID } from '../utils/uuid'
 
 /**
  * Session storage key for persisting presence machine state.
@@ -113,7 +114,7 @@ import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { DeferredDecryptEngine } from './e2ee/deferredDecrypt'
 import { SessionLifecycleEngine } from './sessionLifecycle'
-import { dataToElement } from './e2ee/stanzaAdapter'
+import { dataToElement, elementToData } from './e2ee/stanzaAdapter'
 import { NS_MAM } from './namespaces'
 import { createDefaultStoreBindings } from './defaultStoreBindings'
 import { createPresenceReader, type PresenceReader } from './presenceReader'
@@ -978,6 +979,51 @@ export class XMPPClient {
     return this.subscribeToBus('stanza', handler)
   }
 
+  /**
+   * Subscribe to application-layer stanzas on their way out.
+   *
+   * The counterpart to {@link onStanza}. Reports everything sent through the
+   * application layer — messages, presence and IQ requests, including the id
+   * assigned before transport hand-off — and nothing sent by the connection
+   * machine itself, so a keepalive ping and a Stream Management `<r/>` are
+   * invisible here by construction.
+   *
+   * @param handler - Callback invoked with an independent snapshot of each outbound
+   * application stanza
+   * @returns A function to unsubscribe
+   *
+   * @example
+   * ```typescript
+   * const unsubscribe = client.onApplicationStanzaOut((stanza) => {
+   *   console.log('Sent:', stanza.toString())
+   * })
+   * ```
+   */
+  onApplicationStanzaOut(handler: (stanza: Element) => void): () => void {
+    return this.subscribeToBus('applicationStanzaOut', handler)
+  }
+
+  /**
+   * Dispatch on the outbound hot path.
+   *
+   * Deliberately not `emit()`: that builds a rest-args array on every call, and
+   * this runs for every stanza the app sends. With no subscriber the cost is one
+   * Map lookup. A handler that throws is contained — a diagnostic subscriber must
+   * never stop a stanza from being sent.
+   */
+  private emitApplicationStanzaOut(stanza: Element): void {
+    const handlers = this.eventHandlers.get('applicationStanzaOut')
+    if (!handlers || handlers.size === 0) return
+    for (const handler of handlers) {
+      try {
+        const snapshot = dataToElement(elementToData(stanza))
+        ;(handler as (s: Element) => void)(snapshot)
+      } catch (err) {
+        console.warn('[XMPPClient] applicationStanzaOut subscriber threw:', err)
+      }
+    }
+  }
+
   // ============================================================================
   // MAM Query Collector Registry
   // ============================================================================
@@ -1823,30 +1869,61 @@ export class XMPPClient {
   }
 
   protected async sendStanza(stanza: Element): Promise<void> {
-    const xmpp = this.requireTransport('', { checkSocket: true })
+    const write = this.beginStanzaSend(stanza)
     try {
-      await xmpp.send(stanza)
+      // The observer receives a deep snapshot, so it cannot alter the wire or
+      // replay form. Dispatch stays ahead of every reply the send can expose.
+      this.emitApplicationStanzaOut(stanza)
+      await write
     } catch (err) {
       this.repairAndRethrowSendError(err)
     }
   }
 
   protected async sendIQ(iq: Element, timeoutMs?: number): Promise<Element> {
-    const xmpp = this.requireTransport('IQ', { checkSocket: true })
+    if (!iq.attrs.id) iq.attrs.id = generateUUID()
+    const request = this.beginIQSend(iq)
     try {
-      const request = xmpp.iqCaller.request(iq)
-      if (timeoutMs != null) {
-        return await Promise.race([
-          request,
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new RequestTimeoutError(timeoutMs)), timeoutMs)
-          ),
-        ])
-      }
-      return await request
+      // The id is present before the observer snapshot, and dispatch stays ahead
+      // of every reply the send can expose.
+      this.emitApplicationStanzaOut(iq)
+      const response = timeoutMs != null
+        ? await Promise.race([
+            request,
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new RequestTimeoutError(timeoutMs)), timeoutMs)
+            ),
+          ])
+        : await request
+      this.observeTransportIQReply(iq, response)
+      return response
     } catch (err) {
       this.repairAndRethrowSendError(err)
     }
+  }
+
+  protected beginStanzaSend(stanza: Element): Promise<void> {
+    const xmpp = this.requireTransport('', { checkSocket: true })
+    try {
+      return xmpp.send(stanza)
+    } catch (err) {
+      this.repairAndRethrowSendError(err)
+    }
+  }
+
+  protected beginIQSend(iq: Element): Promise<Element> {
+    const xmpp = this.requireTransport('IQ', { checkSocket: true })
+    try {
+      return xmpp.iqCaller.request(iq)
+    } catch (err) {
+      this.repairAndRethrowSendError(err)
+    }
+  }
+
+  protected observeTransportIQReply(_request: Element, _response: Element): void {}
+
+  protected emitTransportStanza(stanza: Element): void {
+    this.emit('stanza', stanza)
   }
 
 }

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -33,7 +33,7 @@ export type {
 // ============================================================================
 
 /**
- * The shape of the client's private lifecycle and raw-stanza signal bus.
+ * The shape of the client's lifecycle and raw-stanza signal bus.
  *
  * Anything the SDK emits purely to talk to itself belongs in
  * {@link InternalClientEvents} instead, so the two are not mistaken for each
@@ -43,6 +43,14 @@ export type {
 export interface XMPPClientEvents {
   /** Raw XMPP stanza received */
   stanza: (stanza: Element) => void
+  /**
+   * An application-layer stanza was handed to the transport.
+   *
+   * Connection-level sends — the keepalive ping and the Stream Management `<r/>`
+   * nonza — bypass this layer and are therefore NOT reported. Subscribe through
+   * `XMPPClient.onApplicationStanzaOut`.
+   */
+  applicationStanzaOut: (stanza: Element) => void
   /** New chat message received */
   message: (message: Message) => void
   /** Contact presence changed */

--- a/packages/fluux-sdk/src/core/types/readStateGeneration.ts
+++ b/packages/fluux-sdk/src/core/types/readStateGeneration.ts
@@ -1,0 +1,23 @@
+/**
+ * Which generation of read state a pointer belongs to.
+ *
+ * A read pointer is forward-only WITHIN one generation. Several ordinary
+ * transitions replace it wholesale, and a consumer caching anything derived from
+ * it — a badge, a divider, a diagnostic — needs to know precisely what to discard:
+ *
+ * - `store` moves on logout and on an account switch. Everything is new.
+ * - `entity` moves when THAT conversation or room is deleted. Nothing else is
+ *   affected, which is why this is not one global counter: a single number would
+ *   make deleting one conversation look like a lifecycle change for every other,
+ *   and a consumer would forgive a stale value it should have dropped.
+ *
+ * Both counters only ever move forward within their own scope, but `entity`
+ * restarts at 0 when `store` moves, so the PAIR is the identity — never `entity`
+ * alone.
+ *
+ * @category Read state
+ */
+export interface ReadStateGeneration {
+  store: number
+  entity: number
+}

--- a/packages/fluux-sdk/src/demo/DemoClient.pepDisco.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.pepDisco.test.ts
@@ -16,6 +16,29 @@ interface ElementLike {
 }
 
 describe('DemoClient disco#info on the account bare JID', () => {
+  it('publishes the request before its synchronous demo reply', async () => {
+    const client = new DemoClient()
+    const order: string[] = []
+    let inboundIsIq: boolean | undefined
+    let inboundHasClientNamespace: boolean | undefined
+    client.onApplicationStanzaOut((stanza) => order.push(`out:${stanza.attrs.id}`))
+    client.onStanza((stanza) => {
+      order.push(`in:${stanza.attrs.id}`)
+      inboundIsIq = stanza.is('iq')
+      inboundHasClientNamespace = stanza.is('iq', 'jabber:client')
+    })
+
+    await client.server.queryInfo('unseeded.example')
+    order.push('resolved')
+
+    expect(order).toHaveLength(3)
+    expect(order[0]).toMatch(/^out:disco_info_[0-9a-f-]{36}$/)
+    expect(order[1]).toBe(order[0].replace('out:', 'in:'))
+    expect(order[2]).toBe('resolved')
+    expect(inboundIsIq).toBe(true)
+    expect(inboundHasClientNamespace).toBe(false)
+  })
+
   it('advertises PEP so the encryption settings probe passes', async () => {
     const client = new DemoClient()
     ;(client as unknown as { currentJid: string | null }).currentJid = 'you@fluux.chat'

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -23,6 +23,7 @@
  * @module Demo
  */
 
+import { xml, type Element } from '@xmpp/client'
 import { XMPPClient } from '../core/XMPPClient'
 import { fromCodePointOffset } from '../utils/xep0426'
 import { connectionStore } from '../stores/connectionStore'
@@ -212,8 +213,8 @@ export class DemoClient extends XMPPClient {
   // Stanza/IQ overrides — simulate XMPP server responses in demo mode
   // -------------------------------------------------------------------------
 
-  // Modules call sendStanza/sendIQ via the deps closure, which dispatches
-  // to these overrides. This allows chat.sendMessage() etc. to work:
+  // Modules call the shared send boundary via the deps closure, which delegates
+  // transport behavior to these hooks. This allows chat.sendMessage() etc. to work:
   // the stanza is silently dropped but the SDK events still fire.
   //
   // For groupchat messages we simulate the server echo: a real MUC server
@@ -222,7 +223,8 @@ export class DemoClient extends XMPPClient {
   //
   // For MUC join presence we simulate the server's self-presence response
   // so that joinRoom() completes successfully.
-  protected override async sendStanza(stanza: any): Promise<void> {
+  protected override async beginStanzaSend(stanza: any): Promise<void> {
+    await Promise.resolve()
     // Groupchat message echo
     if (stanza?.name === 'message' && stanza?.attrs?.type === 'groupchat') {
       this.handleGroupchatEcho(stanza)
@@ -243,7 +245,8 @@ export class DemoClient extends XMPPClient {
     // All other stanzas silently dropped (leave presence, etc.)
   }
 
-  protected override async sendIQ(stanza: any): Promise<any> {
+  protected override async beginIQSend(stanza: any): Promise<any> {
+    await Promise.resolve()
     const to = stanza?.attrs?.to as string | undefined
 
     // Inspect children to route IQ responses by namespace
@@ -349,6 +352,11 @@ export class DemoClient extends XMPPClient {
     // Fallback: return empty stub so callers using .getChild() etc.
     // get null/empty results instead of crashing on null.
     return this.buildEmptyStub()
+  }
+
+  protected override observeTransportIQReply(request: Element, response: Element): void {
+    if (!response.attrs.id) response.attrs.id = request.attrs.id
+    this.emitTransportStanza(this.mockElementToElement(response as unknown as MockElement))
   }
 
   /**
@@ -855,6 +863,14 @@ export class DemoClient extends XMPPClient {
       text: () => text ?? '',
       toString: () => `<${name}/>`,
     }
+  }
+
+  private mockElementToElement(element: MockElement): Element {
+    const children: Array<Element | string> = element.children.map((child) =>
+      this.mockElementToElement(child)
+    )
+    if (element._text !== undefined) children.push(element._text)
+    return xml(element.name, element.attrs, ...children) as Element
   }
 
   /** Return an empty stub IQ result (existing fallback behavior). */

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -121,6 +121,15 @@ export type {
   RecountEntityKind,
 } from './stores/shared/recountDiagnostics'
 
+// Read-only diagnostic: what an archive merge did with every row a MAM walk
+// returned. Retention is decided inside the store, downstream of the typed
+// history event, so it is observable from nowhere else.
+export { onArchiveMerge } from './stores/shared/archiveMergeDiagnostics'
+export type {
+  ArchiveMergeReport,
+  ArchiveMergeOutcome,
+} from './stores/shared/archiveMergeDiagnostics'
+
 // Fine-grained metadata subscription hooks
 export {
   // Chat metadata hooks
@@ -234,6 +243,19 @@ export type {
 } from './core/types'
 export type { PointerSource } from './stores/shared/readPointer'
 export { makeReadPointer, withArchiveId, isAhead, advance } from './stores/shared/readPointer'
+
+// The generation a read pointer belongs to: forward-only holds WITHIN one, and
+// several ordinary transitions replace a pointer wholesale. A consumer caching
+// anything derived from read state needs the pair to know what to discard.
+export { chatReadStateGeneration } from './stores/chatStore'
+export { roomReadStateGeneration } from './stores/roomStore'
+export type { ReadStateGeneration } from './core/types/readStateGeneration'
+
+// The archive-derived unread count beside the badge, from ONE validated snapshot.
+// Read-only: it walks the recount's coverage gates and writes nothing.
+export { chatUnreadDiagnostic } from './stores/chatStore'
+export { roomUnreadDiagnostic } from './stores/roomStore'
+export type { UnreadDiagnostic } from './stores/shared/unreadDiagnostic'
 
 // Viewport evidence: SDK-owned, generation-scoped
 // "is the viewport genuinely at the live edge" state. `beginViewportGeneration`

--- a/packages/fluux-sdk/src/stores/chatStore.archiveMerge.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveMerge.test.ts
@@ -1,0 +1,235 @@
+/**
+ * What `mergeMAMMessages` reports about the page it just merged.
+ *
+ * The dispositions themselves are tested in `shared/archiveMergeDiagnostics.test.ts`.
+ * What THIS suite proves is that the store feeds that arithmetic the right inputs —
+ * the counts the merge actually produced — and reports only once the durable write
+ * has settled, which is the whole reason the seam exists.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { chatStore } from './chatStore'
+import {
+  onArchiveMerge,
+  resetArchiveMergeDiagnosticsForTesting,
+  type ArchiveMergeReport,
+} from './shared/archiveMergeDiagnostics'
+import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
+import type { Message } from '../core/types/chat'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    isMessageCacheAvailable: vi.fn().mockReturnValue(true),
+    saveMessages: vi.fn().mockResolvedValue(true),
+    getMessages: vi.fn().mockResolvedValue([]),
+  }
+})
+import * as messageCache from '../utils/messageCache'
+
+/**
+ * A fresh conversation per test.
+ *
+ * `archiveSaveChain` poisons an entity's chain for the whole session after one
+ * failed write — deliberately, so a frozen cursor cannot leap a lost page. Sharing
+ * one id across tests would therefore leak the failure case into every test after
+ * it, reported as `partial`.
+ */
+let CONV = 'alice@example.com'
+let convCounter = 0
+
+function msg(id: string, overrides: Partial<Message> = {}): Message {
+  return {
+    id,
+    conversationId: CONV,
+    from: CONV,
+    to: 'me@example.com',
+    body: `body ${id}`,
+    timestamp: new Date(Date.parse('2026-09-01T10:00:00Z') + Number(id.replace(/\D/g, '')) * 1000),
+    isOutgoing: false,
+    stanzaId: `stanza-${id}`,
+    ...overrides,
+  } as Message
+}
+
+/**
+ * Collect reports and hand them out ONE at a time.
+ *
+ * A queue, not a latest-value: two merges in a row must yield two different
+ * reports, and a helper that re-serves the first would make the second merge look
+ * identical to the first no matter what the store did.
+ */
+function collector(): { pending: ArchiveMergeReport[]; next: () => Promise<ArchiveMergeReport> } {
+  const pending: ArchiveMergeReport[] = []
+  const waiters: Array<(r: ArchiveMergeReport) => void> = []
+  onArchiveMerge((r) => {
+    const waiter = waiters.shift()
+    if (waiter) waiter(r)
+    else pending.push(r)
+  })
+  return {
+    pending,
+    next: () =>
+      new Promise<ArchiveMergeReport>((resolve) => {
+        const queued = pending.shift()
+        if (queued) return resolve(queued)
+        waiters.push(resolve)
+      }),
+  }
+}
+
+beforeEach(() => {
+  convCounter++
+  CONV = `alice-${convCounter}@example.com`
+  localStorageMock.clear()
+  _resetStorageScopeForTesting()
+  _resetThrottledStorageForTesting()
+  chatStore.setState({ messages: new Map(), activeConversationId: null })
+  vi.mocked(messageCache.saveMessages).mockResolvedValue(true)
+})
+
+afterEach(() => {
+  resetArchiveMergeDiagnosticsForTesting()
+})
+
+describe('mergeMAMMessages reporting', () => {
+  it('reports a durable page with every row accounted for', async () => {
+    const { next } = collector()
+
+    chatStore.getState().mergeMAMMessages(
+      CONV,
+      [msg('a1'), msg('a2')],
+      { first: 'a1', last: 'a2', count: 2 },
+      true,
+      'backward'
+    )
+
+    const report = await next()
+    expect(report).toMatchObject({
+      entityKind: 'chat',
+      entityId: CONV,
+      direction: 'backward',
+      complete: true,
+      outcome: 'durable',
+      returned: 2,
+      retained: 2,
+      deduplicated: 0,
+      persistenceFailed: 0,
+    })
+  })
+
+  it('counts a re-merged page as deduplicated for the conversation on screen', async () => {
+    chatStore.setState({ activeConversationId: CONV })
+    const { next } = collector()
+    const page = [msg('a1'), msg('a2')]
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, page, { first: 'a1', last: 'a2', count: 2 }, true, 'backward')
+    await next()
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, page, { first: 'a1', last: 'a2', count: 2 }, true, 'backward')
+    const second = await next()
+
+    expect(second).toMatchObject({
+      outcome: 'durable',
+      returned: 2,
+      retained: 0,
+      deduplicated: 2,
+      persistenceFailed: 0,
+    })
+  })
+
+  it('re-reports a backgrounded conversation page as retained, not deduplicated', async () => {
+    // A conversation that is not on screen keeps NO resident array, so the merge
+    // dedupes against nothing and writes the page again. `retained` therefore means
+    // "written durably", never "new to the archive" — the registry says so, because
+    // reading it as novelty would make every background catch-up look productive.
+    const { next } = collector()
+    const page = [msg('a1'), msg('a2')]
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, page, { first: 'a1', last: 'a2', count: 2 }, true, 'backward')
+    await next()
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, page, { first: 'a1', last: 'a2', count: 2 }, true, 'backward')
+    const second = await next()
+
+    expect(second).toMatchObject({ returned: 2, retained: 2, deduplicated: 0 })
+  })
+
+  it('reports a failed write with its rows under persistenceFailed', async () => {
+    vi.mocked(messageCache.saveMessages).mockResolvedValue(false)
+    const { next } = collector()
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, [msg('a1')], { first: 'a1', last: 'a1', count: 1 }, true, 'forward')
+
+    const report = await next()
+    expect(report).toMatchObject({
+      outcome: 'failed',
+      returned: 1,
+      retained: 0,
+      persistenceFailed: 1,
+    })
+  })
+
+  it('reports nothing at all when no one is subscribed', async () => {
+    const seen: ArchiveMergeReport[] = []
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, [msg('a1')], { first: 'a1', last: 'a1', count: 1 }, true, 'backward')
+    // Let the write settle: a report, if the store made one, would arrive by now.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(seen).toEqual([])
+  })
+
+  it('waits for the write before reporting', async () => {
+    let settle: (ok: boolean) => void = () => {}
+    vi.mocked(messageCache.saveMessages).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        settle = resolve
+      })
+    )
+    const { pending, next } = collector()
+
+    chatStore
+      .getState()
+      .mergeMAMMessages(CONV, [msg('a1')], { first: 'a1', last: 'a1', count: 1 }, true, 'backward')
+    await Promise.resolve()
+
+    // The merge is done in RAM, but its durable outcome is not known yet. Reporting
+    // here would claim a retention that may still fail.
+    expect(pending).toEqual([])
+
+    settle(true)
+    expect((await next()).outcome).toBe('durable')
+  })
+})

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1,6 +1,8 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, PageInfo } from '../core/types'
+import type { ReadStateGeneration } from '../core/types/readStateGeneration'
+import type { UnreadDiagnostic } from './shared/unreadDiagnostic'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -45,6 +47,12 @@ import {
   type EvidenceKey as ViewportEvidenceKey,
 } from './shared/viewportEvidence'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
+import {
+  describeArchiveMerge,
+  hasArchiveMergeSubscribers,
+  reportArchiveMerge,
+  type ArchiveMergeInputs,
+} from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
@@ -573,6 +581,7 @@ const conversationArchiveSaves = createArchiveSaveChain()
 const chatRecountVersion = new Map<string, number>()
 const chatUnreadInputVersion = new Map<string, number>()
 const chatPendingUnreadWrites = createPendingEntityWrites()
+const chatRecountsInFlight = createPendingEntityWrites()
 const chatEntityEpoch = new Map<string, number>()
 const chatRecountRetry = createRecountRetryScheduler((error) => {
   console.warn('Unread recount retry failed for a conversation:', error)
@@ -597,6 +606,109 @@ function chatRecountReady(conversationId: string): boolean {
 
 function currentChatEntityEpoch(conversationId: string): number {
   return chatEntityEpoch.get(conversationId) ?? 0
+}
+
+/**
+ * The generation this conversation's read state belongs to.
+ *
+ * Read it in the SAME turn as the pointer it describes. The two counters are
+ * plain reads, so a caller that samples both together cannot see a pointer from
+ * one generation carrying the number of another.
+ */
+export function chatReadStateGeneration(conversationId: string): ReadStateGeneration {
+  return { store: chatCacheEpoch, entity: currentChatEntityEpoch(conversationId) }
+}
+
+/**
+ * The archive-derived unread count beside the badge, for a diagnostic consumer.
+ *
+ * A SECOND traversal of `recomputeUnreadForConversation`'s gates, deliberately, and
+ * the two must be changed together — `unreadDiagnostic.agreement.test.ts` pins them
+ * to the same verdicts. It cannot call the recount itself, because that prelude has
+ * three side effects an observer must not have:
+ *
+ * - it bumps the latest-wins recount version, which would CANCEL a real recount in
+ *   flight and make the observer a cause;
+ * - it prunes the transient unread overlay;
+ * - it invalidates a persisted coverage record whose bottom no longer resolves.
+ *
+ * It also never counts from the resident slice: that would recreate the very
+ * under-count class a consumer would be comparing against, and go silent exactly
+ * when the badge is wrong.
+ *
+ * Both counts come from one validated context: the badge is read last, and the
+ * movement check runs after it, so an `exact` result holds two numbers that were
+ * true at the same instant.
+ */
+export async function chatUnreadDiagnostic(conversationId: string): Promise<UnreadDiagnostic> {
+  const meta = chatStore.getState().conversationMeta.get(conversationId)
+  if (!meta) return { status: 'deferred', reason: 'no-meta' }
+  if (meta.pendingRemoteDisplayedStanzaId !== undefined) {
+    return { status: 'deferred', reason: 'pending-remote-displayed' }
+  }
+  if (pointerlessDefers(meta.readPointer, meta.unreadCount)) {
+    return { status: 'deferred', reason: 'pointerless-defer' }
+  }
+  if (chatRecountsInFlight.has(conversationId)) return { status: 'stale' }
+
+  const cacheEpochAtStart = chatCacheEpoch
+  const entityEpochAtStart = currentChatEntityEpoch(conversationId)
+  const storageScopeAtStart = getStorageScopeJid()
+  const inputVersionAtStart = chatUnreadInputVersion.get(conversationId) ?? 0
+  // A recount bumps this the moment it commits to running, so a recount starting
+  // during this read makes the result `stale` rather than a false mismatch.
+  const recountVersionAtStart = chatRecountVersion.get(conversationId) ?? 0
+  const floor = computeFloor(meta.readPointer, meta.historyFloor)
+  if (!floor) return { status: 'deferred', reason: 'no-floor' }
+
+  const stateAtStart = chatStore.getState()
+  const mam = mamState.getMAMQueryState(stateAtStart.mamQueryStates, conversationId)
+  if (!isCaughtUpForCounting(mam)) return { status: 'deferred', reason: 'history-not-caught-up' }
+
+  const record = stateAtStart.conversationCoverage.get(conversationId)
+  const moved = (): boolean => {
+    const current = chatStore.getState()
+    const currentMeta = current.conversationMeta.get(conversationId)
+    return chatCacheEpoch !== cacheEpochAtStart ||
+      currentChatEntityEpoch(conversationId) !== entityEpochAtStart ||
+      getStorageScopeJid() !== storageScopeAtStart ||
+      (chatUnreadInputVersion.get(conversationId) ?? 0) !== inputVersionAtStart ||
+      (chatRecountVersion.get(conversationId) ?? 0) !== recountVersionAtStart ||
+      currentMeta?.readPointer !== meta.readPointer ||
+      currentMeta?.historyFloor !== meta.historyFloor ||
+      currentMeta?.pendingRemoteDisplayedStanzaId !== meta.pendingRemoteDisplayedStanzaId ||
+      mamState.getMAMQueryState(current.mamQueryStates, conversationId) !== mam ||
+      current.conversationCoverage.get(conversationId) !== record
+  }
+
+  const bottom = await resolveCoverageBottom(conversationId, record, false)
+  if (moved()) return { status: 'stale' }
+  if (bottom === 'missing') return { status: 'deferred', reason: 'coverage-missing' }
+  // No `clearConversationCoverage` here, unlike the recount: an observer does not
+  // repair state it is observing.
+  if (bottom === 'unresolvable') return { status: 'deferred', reason: 'coverage-unresolvable' }
+
+  const floorPos: PointerOrder = meta.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
+  if (isAfterBoundary(bottom, floorPos)) {
+    return { status: 'deferred', reason: 'coverage-short-of-floor' }
+  }
+
+  const res = await messageCache.countUnreadInArchive(conversationId, {
+    floor,
+    pointer: meta.readPointer?.order,
+  })
+  if (moved()) return { status: 'stale' }
+  if (res === null) return { status: 'deferred', reason: 'cache-unavailable' }
+
+  // No `pruneTransient` either — read the overlay, do not edit it.
+  const transient = transientCounts(chatTransientScopeKey(conversationId), floorPos)
+  const archiveCount = Math.min(999, res.unread + transient.unread)
+
+  const badgeCount = chatStore.getState().conversationMeta.get(conversationId)?.unreadCount
+  if (badgeCount === undefined) return { status: 'deferred', reason: 'no-meta' }
+  // Last: everything above must still describe the same context as this badge.
+  if (moved()) return { status: 'stale' }
+  return { status: 'exact', archiveCount, badgeCount }
 }
 
 let chatCacheEpoch = 0
@@ -692,6 +804,7 @@ function invalidateChatEntity(conversationId: string): void {
   chatEntityEpoch.set(conversationId, currentChatEntityEpoch(conversationId) + 1)
   conversationArchiveSaves.cancel(conversationId)
   chatPendingUnreadWrites.cancel(conversationId)
+  chatRecountsInFlight.cancel(conversationId)
   chatRecountRetry.cancel(conversationId)
   chatRecountVersion.delete(conversationId)
   chatUnreadInputVersion.delete(conversationId)
@@ -2674,6 +2787,9 @@ export const chatStore = createStore<ChatState>()(
         if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
         if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
+        const recountToken = chatRecountsInFlight.begin(conversationId)
+        try {
+
         // Latest-wins: bumped once this call is committed to
         // running — AFTER the defers above, so a call that stands down cannot
         // cancel a recount already in flight for the same conversation — and
@@ -2835,6 +2951,9 @@ export const chatStore = createStore<ChatState>()(
           draft.patchMeta(conversationId, { unreadCount })
           return { ...draft.commit(), firstNewMessageMarkers: newMarkers }
         })
+        } finally {
+          chatRecountsInFlight.finish(conversationId, recountToken)
+        }
       },
 
       triggerAnimation: (conversationId, animation, senderName) => {
@@ -2905,6 +3024,12 @@ export const chatStore = createStore<ChatState>()(
         let shouldRecountAfterMerge = false
         let archiveCommitGate: Promise<boolean> | undefined
         let durableMessages: Message[] = []
+        // Diagnostics only (stage 5b). Null unless something subscribed, so a merge
+        // with no observer counts nothing. A holder rather than a bare `let`: the
+        // assignment happens inside the set() callback, and TypeScript narrows a
+        // captured local to its initializer after the call.
+        const mergeDiagnostics: { inputs: ArchiveMergeInputs | null } = { inputs: null }
+        let ownArchiveWrite: Promise<boolean> | undefined
         let coverageBootstrappedFromWalkExtent = false
         set((state) => {
           // Get existing messages for this conversation
@@ -3006,6 +3131,15 @@ export const chatStore = createStore<ChatState>()(
           const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
           const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
           durableMessages = persistableMessages
+          if (hasArchiveMergeSubscribers()) {
+            mergeDiagnostics.inputs = {
+              returned: mamMessages.length,
+              newMessages: newMessages.length,
+              persistableNew: persistableMessages.length,
+              patched: patched.length,
+              persistablePatched: persistablePatches.length,
+            }
+          }
           // A merge with nothing persistable still defers when earlier pages
           // of this conversation are in flight (or failed): its cursor must
           // not leap them.
@@ -3099,6 +3233,7 @@ export const chatStore = createStore<ChatState>()(
 
           if (archiveWriteMessages.length > 0) {
             const savePromise = messageCache.saveMessages(archiveWriteMessages)
+            ownArchiveWrite = savePromise
             archiveCommitGate = conversationArchiveSaves.chain(conversationId, savePromise)
             if (deferGapCommit || deferCoverageCommit) {
               scheduleDeferredCommit(archiveCommitGate)
@@ -3195,6 +3330,26 @@ export const chatStore = createStore<ChatState>()(
 
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
+
+        // Reported once the durable outcome is KNOWN: a report written at merge time
+        // would claim a retention that can still fail, which is the one thing this
+        // seam exists to distinguish.
+        if (mergeDiagnostics.inputs) {
+          const inputs = mergeDiagnostics.inputs
+          const attempted = inputs.persistableNew + inputs.persistablePatched > 0
+          void Promise.all([
+            ownArchiveWrite ?? Promise.resolve(true),
+            archiveCommitGate ?? Promise.resolve(true),
+          ]).then(([own, chained]) => {
+            reportArchiveMerge({
+              entityKind: 'chat',
+              entityId: conversationId,
+              direction,
+              complete,
+              ...describeArchiveMerge(inputs, own, chained, attempted),
+            })
+          })
+        }
 
         if (archiveCommitGate) {
           void archiveCommitGate.then((committed) => {
@@ -3499,6 +3654,7 @@ export const chatStore = createStore<ChatState>()(
         chatRecountVersion.clear()
         chatUnreadInputVersion.clear()
         chatPendingUnreadWrites.clear()
+        chatRecountsInFlight.clear()
         chatEntityEpoch.clear()
         chatRecountRetry.clear()
         remoteDividerAdvances.reset()
@@ -3521,6 +3677,7 @@ export const chatStore = createStore<ChatState>()(
         chatRecountVersion.clear()
         chatUnreadInputVersion.clear()
         chatPendingUnreadWrites.clear()
+        chatRecountsInFlight.clear()
         chatEntityEpoch.clear()
         chatRecountRetry.clear()
         remoteDividerAdvances.reset()

--- a/packages/fluux-sdk/src/stores/readStateGeneration.test.ts
+++ b/packages/fluux-sdk/src/stores/readStateGeneration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The generation a read pointer belongs to.
+ *
+ * "Forward-only" holds WITHIN one generation. Several normal transitions replace a
+ * pointer wholesale — an account switch, a logout, deleting and re-creating a
+ * conversation — and a consumer that cannot see those boundaries would read every
+ * one of them as the pointer moving backwards.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { chatStore, chatReadStateGeneration } from './chatStore'
+import { roomStore, roomReadStateGeneration } from './roomStore'
+import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
+import type { Conversation, Room } from '../core/types'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    isMessageCacheAvailable: vi.fn().mockReturnValue(true),
+    deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
+    deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
+    getMessages: vi.fn().mockResolvedValue([]),
+    getRoomMessages: vi.fn().mockResolvedValue([]),
+  }
+})
+
+const CONV = 'alice@example.com'
+const ROOM = 'general@conference.example.com'
+
+function conversation(id: string, name: string): Conversation {
+  return { id, name, type: 'chat', unreadCount: 0 }
+}
+
+function room(jid: string): Room {
+  return {
+    jid,
+    name: jid,
+    nickname: 'me',
+    joined: true,
+    isBookmarked: false,
+    occupants: new Map(),
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set(),
+  }
+}
+
+beforeEach(() => {
+  localStorageMock.clear()
+  _resetStorageScopeForTesting()
+  _resetThrottledStorageForTesting()
+})
+
+describe('chatReadStateGeneration', () => {
+  it('reads zero for an entity the store has never seen', () => {
+    expect(chatReadStateGeneration('nobody@example.com').entity).toBe(0)
+  })
+
+  it('holds still across ordinary writes', () => {
+    chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+    const before = chatReadStateGeneration(CONV)
+
+    chatStore.getState().setActiveConversation(CONV)
+    chatStore.getState().setActiveConversation(null)
+
+    expect(chatReadStateGeneration(CONV)).toEqual(before)
+  })
+
+  it('bumps only the entity scope when a conversation is deleted', () => {
+    chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+    const before = chatReadStateGeneration(CONV)
+
+    chatStore.getState().deleteConversation(CONV)
+    const after = chatReadStateGeneration(CONV)
+
+    expect(after.entity).toBe(before.entity + 1)
+    // A deleted conversation must not invalidate everything else's read state:
+    // a global counter here would forgive a real regression elsewhere.
+    expect(after.store).toBe(before.store)
+  })
+
+  it('leaves another conversation alone when one is deleted', () => {
+    const other = 'bob@example.com'
+    chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+    chatStore.getState().addConversation(conversation(other, 'Bob'))
+    const before = chatReadStateGeneration(other)
+
+    chatStore.getState().deleteConversation(CONV)
+
+    expect(chatReadStateGeneration(other)).toEqual(before)
+  })
+
+  it('bumps the store scope on reset', () => {
+    const before = chatReadStateGeneration(CONV)
+
+    chatStore.getState().reset()
+
+    expect(chatReadStateGeneration(CONV).store).toBe(before.store + 1)
+  })
+})
+
+describe('roomReadStateGeneration', () => {
+  it('bumps only the entity scope when a room is removed', () => {
+    roomStore.getState().addRoom(room(ROOM))
+    const before = roomReadStateGeneration(ROOM)
+
+    roomStore.getState().removeRoom(ROOM)
+    const after = roomReadStateGeneration(ROOM)
+
+    expect(after.entity).toBe(before.entity + 1)
+    expect(after.store).toBe(before.store)
+  })
+
+  it('bumps the store scope on reset', () => {
+    const before = roomReadStateGeneration(ROOM)
+
+    roomStore.getState().reset()
+
+    expect(roomReadStateGeneration(ROOM).store).toBe(before.store + 1)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.archiveMerge.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveMerge.test.ts
@@ -1,0 +1,210 @@
+/**
+ * What the room store's `mergeRoomMAMMessages` reports about the page it merged.
+ *
+ * The twin of `chatStore.archiveMerge.test.ts`. Rooms carry the same seam because
+ * they carry the same risk: a room catch-up merges page after page, and a write
+ * that silently failed is invisible from outside the store.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { roomStore } from './roomStore'
+import {
+  onArchiveMerge,
+  resetArchiveMergeDiagnosticsForTesting,
+  type ArchiveMergeReport,
+} from './shared/archiveMergeDiagnostics'
+import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
+import type { Room, RoomMessage } from '../core/types'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    isMessageCacheAvailable: vi.fn().mockReturnValue(true),
+    saveRoomMessages: vi.fn().mockResolvedValue(true),
+    getRoomMessages: vi.fn().mockResolvedValue([]),
+  }
+})
+import * as messageCache from '../utils/messageCache'
+
+/** A fresh room per test: one failed write poisons that room's save chain. */
+let ROOM = 'general@conference.example.com'
+let roomCounter = 0
+
+function createRoom(jid: string): Room {
+  return {
+    jid,
+    name: jid,
+    nickname: 'me',
+    joined: true,
+    isBookmarked: false,
+    occupants: new Map(),
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set(),
+  }
+}
+
+function archiveMsg(id: string, ts: number): RoomMessage {
+  return {
+    type: 'groupchat',
+    id,
+    roomJid: ROOM,
+    from: `${ROOM}/alice`,
+    nick: 'alice',
+    body: 'hi',
+    timestamp: new Date(ts),
+    isOutgoing: false,
+    stanzaId: `stanza-${id}`,
+  } as RoomMessage
+}
+
+/** Reports, handed out one at a time (see the chat twin for why a queue). */
+function collector(): { pending: ArchiveMergeReport[]; next: () => Promise<ArchiveMergeReport> } {
+  const pending: ArchiveMergeReport[] = []
+  const waiters: Array<(r: ArchiveMergeReport) => void> = []
+  onArchiveMerge((r) => {
+    const waiter = waiters.shift()
+    if (waiter) waiter(r)
+    else pending.push(r)
+  })
+  return {
+    pending,
+    next: () =>
+      new Promise<ArchiveMergeReport>((resolve) => {
+        const queued = pending.shift()
+        if (queued) return resolve(queued)
+        waiters.push(resolve)
+      }),
+  }
+}
+
+beforeEach(() => {
+  roomCounter++
+  ROOM = `general-${roomCounter}@conference.example.com`
+  localStorageMock.clear()
+  _resetStorageScopeForTesting()
+  _resetThrottledStorageForTesting()
+  roomStore.setState({ rooms: new Map(), messages: new Map(), activeRoomJid: null })
+  roomStore.getState().addRoom(createRoom(ROOM))
+  vi.mocked(messageCache.saveRoomMessages).mockResolvedValue(true)
+})
+
+afterEach(() => {
+  resetArchiveMergeDiagnosticsForTesting()
+})
+
+describe('mergeRoomMAMMessages reporting', () => {
+  it('reports a durable page with every row accounted for', async () => {
+    const { next } = collector()
+
+    roomStore
+      .getState()
+      .mergeRoomMAMMessages(
+        ROOM,
+        [archiveMsg('r1', 1_000), archiveMsg('r2', 2_000)],
+        { first: 'r1', last: 'r2', count: 2 },
+        true,
+        'backward'
+      )
+
+    expect(await next()).toMatchObject({
+      entityKind: 'room',
+      entityId: ROOM,
+      direction: 'backward',
+      complete: true,
+      outcome: 'durable',
+      returned: 2,
+      retained: 2,
+      deduplicated: 0,
+      persistenceFailed: 0,
+    })
+  })
+
+  it('counts a re-merged page as deduplicated for the room on screen', async () => {
+    roomStore.setState({ activeRoomJid: ROOM })
+    const { next } = collector()
+    const page = [archiveMsg('r1', 1_000), archiveMsg('r2', 2_000)]
+
+    roomStore
+      .getState()
+      .mergeRoomMAMMessages(ROOM, page, { first: 'r1', last: 'r2', count: 2 }, true, 'backward')
+    await next()
+
+    roomStore
+      .getState()
+      .mergeRoomMAMMessages(ROOM, page, { first: 'r1', last: 'r2', count: 2 }, true, 'backward')
+
+    expect(await next()).toMatchObject({
+      outcome: 'durable',
+      returned: 2,
+      retained: 0,
+      deduplicated: 2,
+    })
+  })
+
+  it('reports a failed write with its rows under persistenceFailed', async () => {
+    vi.mocked(messageCache.saveRoomMessages).mockResolvedValue(false)
+    const { next } = collector()
+
+    roomStore
+      .getState()
+      .mergeRoomMAMMessages(
+        ROOM,
+        [archiveMsg('r1', 1_000)],
+        { first: 'r1', last: 'r1', count: 1 },
+        true,
+        'forward'
+      )
+
+    expect(await next()).toMatchObject({
+      outcome: 'failed',
+      returned: 1,
+      retained: 0,
+      persistenceFailed: 1,
+    })
+  })
+
+  it('waits for the write before reporting', async () => {
+    let settle: (ok: boolean) => void = () => {}
+    vi.mocked(messageCache.saveRoomMessages).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        settle = resolve
+      })
+    )
+    const { pending, next } = collector()
+
+    roomStore
+      .getState()
+      .mergeRoomMAMMessages(
+        ROOM,
+        [archiveMsg('r1', 1_000)],
+        { first: 'r1', last: 'r1', count: 1 },
+        true,
+        'backward'
+      )
+    await Promise.resolve()
+
+    expect(pending).toEqual([])
+
+    settle(true)
+    expect((await next()).outcome).toBe('durable')
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -12,6 +12,8 @@ import type {
   HistoryQueryState,
   PageInfo,
 } from '../core/types'
+import type { ReadStateGeneration } from '../core/types/readStateGeneration'
+import type { UnreadDiagnostic } from './shared/unreadDiagnostic'
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -62,6 +64,12 @@ import {
   type EvidenceKey as ViewportEvidenceKey,
 } from './shared/viewportEvidence'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
+import {
+  describeArchiveMerge,
+  hasArchiveMergeSubscribers,
+  reportArchiveMerge,
+  type ArchiveMergeInputs,
+} from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
@@ -423,6 +431,7 @@ export function _resetRoomArchiveSavesForTesting(): void {
 const roomRecountVersion = new Map<string, number>()
 const roomUnreadInputVersion = new Map<string, number>()
 const roomPendingUnreadWrites = createPendingEntityWrites()
+const roomRecountsInFlight = createPendingEntityWrites()
 const roomEntityEpoch = new Map<string, number>()
 const roomRecountRetry = createRecountRetryScheduler((error) => {
   console.warn('Unread recount retry failed for a room:', error)
@@ -450,6 +459,85 @@ function currentRoomEntityEpoch(roomJid: string): number {
 }
 
 /**
+ * The generation this room's read state belongs to. See the chat twin; the
+ * scopes and the sampling rule are identical.
+ */
+export function roomReadStateGeneration(roomJid: string): ReadStateGeneration {
+  return { store: roomCacheEpoch, entity: currentRoomEntityEpoch(roomJid) }
+}
+
+/**
+ * The room twin of `chatUnreadDiagnostic`. See that function for why this is a
+ * second traversal of the recount's gates rather than a call into it, and for what
+ * it deliberately does not do. The gate sequence is identical; only the archive
+ * counter and the coverage flavour differ.
+ */
+export async function roomUnreadDiagnostic(roomJid: string): Promise<UnreadDiagnostic> {
+  const meta = roomStore.getState().roomMeta.get(roomJid)
+  if (!meta) return { status: 'deferred', reason: 'no-meta' }
+  if (meta.pendingRemoteDisplayedStanzaId !== undefined) {
+    return { status: 'deferred', reason: 'pending-remote-displayed' }
+  }
+  if (pointerlessDefers(meta.readPointer, meta.unreadCount)) {
+    return { status: 'deferred', reason: 'pointerless-defer' }
+  }
+  if (roomRecountsInFlight.has(roomJid)) return { status: 'stale' }
+
+  const cacheEpochAtStart = roomCacheEpoch
+  const entityEpochAtStart = currentRoomEntityEpoch(roomJid)
+  const storageScopeAtStart = getStorageScopeJid()
+  const inputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
+  const recountVersionAtStart = roomRecountVersion.get(roomJid) ?? 0
+  const floor = computeFloor(meta.readPointer, meta.historyFloor)
+  if (!floor) return { status: 'deferred', reason: 'no-floor' }
+
+  const stateAtStart = roomStore.getState()
+  const mam = mamState.getMAMQueryState(stateAtStart.mamQueryStates, roomJid)
+  if (!isCaughtUpForCounting(mam)) return { status: 'deferred', reason: 'history-not-caught-up' }
+
+  const record = stateAtStart.roomCoverage.get(roomJid)
+  const moved = (): boolean => {
+    const current = roomStore.getState()
+    const currentMeta = current.roomMeta.get(roomJid)
+    return roomCacheEpoch !== cacheEpochAtStart ||
+      currentRoomEntityEpoch(roomJid) !== entityEpochAtStart ||
+      getStorageScopeJid() !== storageScopeAtStart ||
+      (roomUnreadInputVersion.get(roomJid) ?? 0) !== inputVersionAtStart ||
+      (roomRecountVersion.get(roomJid) ?? 0) !== recountVersionAtStart ||
+      currentMeta?.readPointer !== meta.readPointer ||
+      currentMeta?.historyFloor !== meta.historyFloor ||
+      currentMeta?.pendingRemoteDisplayedStanzaId !== meta.pendingRemoteDisplayedStanzaId ||
+      mamState.getMAMQueryState(current.mamQueryStates, roomJid) !== mam ||
+      current.roomCoverage.get(roomJid) !== record
+  }
+
+  const bottom = await resolveCoverageBottom(roomJid, record, true)
+  if (moved()) return { status: 'stale' }
+  if (bottom === 'missing') return { status: 'deferred', reason: 'coverage-missing' }
+  if (bottom === 'unresolvable') return { status: 'deferred', reason: 'coverage-unresolvable' }
+
+  const floorPos: PointerOrder = meta.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
+  if (isAfterBoundary(bottom, floorPos)) {
+    return { status: 'deferred', reason: 'coverage-short-of-floor' }
+  }
+
+  const res = await messageCache.countRoomUnreadInArchive(roomJid, {
+    floor,
+    pointer: meta.readPointer?.order,
+  })
+  if (moved()) return { status: 'stale' }
+  if (res === null) return { status: 'deferred', reason: 'cache-unavailable' }
+
+  const transient = transientCounts(roomTransientScopeKey(roomJid), floorPos)
+  const archiveCount = Math.min(999, res.unread + transient.unread)
+
+  const badgeCount = roomStore.getState().roomMeta.get(roomJid)?.unreadCount
+  if (badgeCount === undefined) return { status: 'deferred', reason: 'no-meta' }
+  if (moved()) return { status: 'stale' }
+  return { status: 'exact', archiveCount, badgeCount }
+}
+
+/**
  * The transient-overlay scope key for a room. `accountScope` mirrors
  * chatStore's `chatTransientScopeKey` — a bare room JID can collide across
  * accounts, so the overlay is scoped by the account JID, never a bare room JID.
@@ -462,6 +550,7 @@ function invalidateRoomEntity(roomJid: string): void {
   roomEntityEpoch.set(roomJid, currentRoomEntityEpoch(roomJid) + 1)
   roomArchiveSaves.cancel(roomJid)
   roomPendingUnreadWrites.cancel(roomJid)
+  roomRecountsInFlight.cancel(roomJid)
   roomRecountRetry.cancel(roomJid)
   roomRecountVersion.delete(roomJid)
   roomUnreadInputVersion.delete(roomJid)
@@ -1884,6 +1973,7 @@ export const roomStore = createStore<RoomState>()(
     roomRecountVersion.clear()
     roomUnreadInputVersion.clear()
     roomPendingUnreadWrites.clear()
+    roomRecountsInFlight.clear()
     roomEntityEpoch.clear()
     roomRecountRetry.clear()
     remoteDividerAdvances.reset()
@@ -1911,6 +2001,7 @@ export const roomStore = createStore<RoomState>()(
     roomRecountVersion.clear()
     roomUnreadInputVersion.clear()
     roomPendingUnreadWrites.clear()
+    roomRecountsInFlight.clear()
     roomEntityEpoch.clear()
     roomRecountRetry.clear()
     remoteDividerAdvances.reset()
@@ -2528,6 +2619,9 @@ export const roomStore = createStore<RoomState>()(
     if (metaNow.pendingRemoteDisplayedStanzaId !== undefined) return defer('pending-remote-displayed')
     if (pointerlessDefers(metaNow.readPointer, metaNow.unreadCount)) return defer('pointerless-defer')
 
+    const recountToken = roomRecountsInFlight.begin(roomJid)
+    try {
+
     // Latest-wins: bumped once this call is committed to
     // running — AFTER the defers above, so a call that stands down cannot
     // cancel a recount already in flight for the same room — and still before
@@ -2693,6 +2787,9 @@ export const roomStore = createStore<RoomState>()(
       newRooms.set(roomJid, { ...room, unreadCount })
       return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
     })
+    } finally {
+      roomRecountsInFlight.finish(roomJid, recountToken)
+    }
   },
 
   getRoomLastTimestamp: (roomJid) => {
@@ -3923,6 +4020,12 @@ export const roomStore = createStore<RoomState>()(
     let shouldRecountAfterMerge = false
     let archiveCommitGate: Promise<boolean> | undefined
     let durableMessages: RoomMessage[] = []
+    // Diagnostics only (stage 5b). Null unless something subscribed, so a merge
+    // with no observer counts nothing. A holder rather than a bare `let`: the
+    // assignment happens inside the set() callback, and TypeScript narrows a
+    // captured local to its initializer after the call.
+    const mergeDiagnostics: { inputs: ArchiveMergeInputs | null } = { inputs: null }
+    let ownArchiveWrite: Promise<boolean> | undefined
     let coverageBootstrappedFromWalkExtent = false
     set((state) => {
       const room = state.rooms.get(roomJid)
@@ -4030,6 +4133,15 @@ export const roomStore = createStore<RoomState>()(
       const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
       const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
       durableMessages = persistableMessages
+      if (hasArchiveMergeSubscribers()) {
+        mergeDiagnostics.inputs = {
+          returned: mamMessages.length,
+          newMessages: newFromMAM.length,
+          persistableNew: persistableMessages.length,
+          patched: patched.length,
+          persistablePatched: persistablePatches.length,
+        }
+      }
       // A merge with nothing persistable still defers when earlier pages of
       // this room are in flight (or failed): its cursor must not leap them.
       const mustGateOnChain = archiveWriteMessages.length > 0 || roomArchiveSaves.has(roomJid)
@@ -4119,6 +4231,7 @@ export const roomStore = createStore<RoomState>()(
 
       if (archiveWriteMessages.length > 0) {
         const savePromise = messageCache.saveRoomMessages(archiveWriteMessages)
+        ownArchiveWrite = savePromise
         archiveCommitGate = roomArchiveSaves.chain(roomJid, savePromise)
         if (deferGapCommit || deferCoverageCommit) {
           scheduleDeferredCommit(archiveCommitGate)
@@ -4210,6 +4323,26 @@ export const roomStore = createStore<RoomState>()(
 
       return { ...written, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
+
+    // Reported once the durable outcome is KNOWN: a report written at merge time
+    // would claim a retention that can still fail, which is the one thing this seam
+    // exists to distinguish.
+    if (mergeDiagnostics.inputs) {
+      const inputs = mergeDiagnostics.inputs
+      const attempted = inputs.persistableNew + inputs.persistablePatched > 0
+      void Promise.all([
+        ownArchiveWrite ?? Promise.resolve(true),
+        archiveCommitGate ?? Promise.resolve(true),
+      ]).then(([own, chained]) => {
+        reportArchiveMerge({
+          entityKind: 'room',
+          entityId: roomJid,
+          direction,
+          complete,
+          ...describeArchiveMerge(inputs, own, chained, attempted),
+        })
+      })
+    }
 
     if (archiveCommitGate) {
       void archiveCommitGate.then((committed) => {

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  describeArchiveMerge,
+  hasArchiveMergeSubscribers,
+  onArchiveMerge,
+  reportArchiveMerge,
+  resetArchiveMergeDiagnosticsForTesting,
+  type ArchiveMergeReport,
+} from './archiveMergeDiagnostics'
+
+afterEach(() => resetArchiveMergeDiagnosticsForTesting())
+
+const page = { returned: 10, newMessages: 6, persistableNew: 5, patched: 2, persistablePatched: 1 }
+
+type Counts = Pick<
+  ArchiveMergeReport,
+  'returned' | 'retained' | 'deduplicated' | 'patched' | 'intentionallyUnstored' | 'persistenceFailed'
+>
+
+function balances(r: Counts): boolean {
+  return (
+    r.returned ===
+    r.retained + r.deduplicated + r.patched + r.intentionallyUnstored + r.persistenceFailed
+  )
+}
+
+describe('describeArchiveMerge', () => {
+  it('accounts for every returned row when the write commits', () => {
+    const r = describeArchiveMerge(page, true, true, true)
+    expect(r).toMatchObject({
+      outcome: 'durable',
+      returned: 10,
+      retained: 5,
+      patched: 1,
+      // 1 new + 1 patching row were noLocalStore; 10 - 6 new - 2 patched = 2 plain duplicates.
+      intentionallyUnstored: 2,
+      deduplicated: 2,
+      persistenceFailed: 0,
+    })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('moves both written kinds to persistenceFailed when the write fails', () => {
+    const r = describeArchiveMerge(page, false, false, true)
+    expect(r).toMatchObject({
+      outcome: 'failed',
+      retained: 0,
+      patched: 0,
+      persistenceFailed: 6,
+      intentionallyUnstored: 2,
+      deduplicated: 2,
+    })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('calls a merge partial when its own write landed behind a failed earlier page', () => {
+    const r = describeArchiveMerge(page, true, false, true)
+    expect(r.outcome).toBe('partial')
+    // The rows ARE on disk. Only the durable cursor is frozen, so they are retained.
+    expect(r.retained).toBe(5)
+    expect(r.persistenceFailed).toBe(0)
+    expect(balances(r)).toBe(true)
+  })
+
+  it('is durable when nothing was attempted', () => {
+    const nothing = {
+      returned: 4,
+      newMessages: 0,
+      persistableNew: 0,
+      patched: 0,
+      persistablePatched: 0,
+    }
+    const r = describeArchiveMerge(nothing, true, true, false)
+    expect(r).toMatchObject({ outcome: 'durable', deduplicated: 4, retained: 0 })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('reports an empty page without inventing a disposition', () => {
+    const empty = {
+      returned: 0,
+      newMessages: 0,
+      persistableNew: 0,
+      patched: 0,
+      persistablePatched: 0,
+    }
+    const r = describeArchiveMerge(empty, true, true, false)
+    expect(r).toMatchObject({ outcome: 'durable', returned: 0, deduplicated: 0 })
+    expect(balances(r)).toBe(true)
+  })
+
+  it('never reports a negative duplicate count', () => {
+    // Defensive: patched rows are duplicates by construction, so this cannot
+    // happen — but a clamp beats a nonsense record if the timeline ever changes.
+    const odd = {
+      returned: 1,
+      newMessages: 1,
+      persistableNew: 1,
+      patched: 1,
+      persistablePatched: 1,
+    }
+    expect(describeArchiveMerge(odd, true, true, true).deduplicated).toBe(0)
+  })
+})
+
+describe('subscription', () => {
+  const report: ArchiveMergeReport = {
+    entityKind: 'chat',
+    entityId: 'a@example.com',
+    direction: 'forward',
+    complete: true,
+    outcome: 'durable',
+    returned: 1,
+    retained: 1,
+    deduplicated: 0,
+    patched: 0,
+    intentionallyUnstored: 0,
+    persistenceFailed: 0,
+  }
+
+  it('claims no subscribers when nobody listens', () => {
+    expect(hasArchiveMergeSubscribers()).toBe(false)
+    expect(() => reportArchiveMerge(report)).not.toThrow()
+  })
+
+  it('delivers to every subscriber and stops on unsubscribe', () => {
+    const seen: ArchiveMergeReport[] = []
+    const off = onArchiveMerge((r) => seen.push(r))
+    expect(hasArchiveMergeSubscribers()).toBe(true)
+
+    reportArchiveMerge(report)
+    off()
+    reportArchiveMerge(report)
+
+    expect(seen).toEqual([report])
+    expect(hasArchiveMergeSubscribers()).toBe(false)
+  })
+
+  it('contains a throwing subscriber', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seen: string[] = []
+    onArchiveMerge(() => {
+      throw new Error('detector bug')
+    })
+    onArchiveMerge((r) => seen.push(r.entityId))
+
+    reportArchiveMerge({ ...report, entityKind: 'room', entityId: 'room@conf.example.com' })
+
+    // A diagnostic subscriber must not take the merge down with it.
+    expect(seen).toEqual(['room@conf.example.com'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('isolates each subscriber from earlier report mutations', () => {
+    let second: ArchiveMergeReport | undefined
+    onArchiveMerge((received) => {
+      received.outcome = 'durable'
+      received.entityId = 'tampered@example.com'
+    })
+    onArchiveMerge((received) => {
+      second = received
+    })
+    const failed = { ...report, outcome: 'failed' as const, persistenceFailed: 1, retained: 0 }
+
+    reportArchiveMerge(failed)
+
+    expect(second?.outcome).toBe('failed')
+    expect(second?.entityId).toBe('a@example.com')
+    expect(failed.outcome).toBe('failed')
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
@@ -1,0 +1,153 @@
+/**
+ * What an archive merge did with every row it was given.
+ *
+ * A MAM delivery hands a message set to `chatStore.mergeMAMMessages` or its room twin,
+ * which dedupes it against the resident window, back-fills stanza ids onto resident
+ * copies, and writes what is persistable in ONE IndexedDB transaction. From outside
+ * the store none of that is observable: the caller sees the message count the server
+ * returned and nothing about what became of it.
+ *
+ * This module is the read-only view of that outcome. Every returned row gets exactly
+ * one disposition, and they balance:
+ *
+ * ```
+ * returned === retained + deduplicated + patched + intentionallyUnstored + persistenceFailed
+ * ```
+ *
+ * The arithmetic lives here rather than in each store so the two cannot drift apart,
+ * and so the balance can be tested without driving a store.
+ *
+ * @module Stores/Shared/ArchiveMergeDiagnostics
+ */
+
+export type ArchiveMergeOutcome = 'durable' | 'partial' | 'failed'
+
+/** What the merge itself counted, before the write outcome is known. */
+export interface ArchiveMergeInputs {
+  /** Rows delivered to this store merge. */
+  returned: number
+  /** Rows new to the resident window. */
+  newMessages: number
+  /** Of those, the ones the write was allowed to store. */
+  persistableNew: number
+  /** Resident messages that gained a server stanza id from an archived copy. */
+  patched: number
+  /** Of those, the ones the write was allowed to store. */
+  persistablePatched: number
+}
+
+export interface ArchiveMergeCounts {
+  outcome: ArchiveMergeOutcome
+  returned: number
+  retained: number
+  deduplicated: number
+  patched: number
+  intentionallyUnstored: number
+  persistenceFailed: number
+}
+
+export interface ArchiveMergeReport extends ArchiveMergeCounts {
+  entityKind: 'chat' | 'room'
+  /**
+   * The conversation id or room JID, raw.
+   *
+   * A diagnostic consumer that needs a privacy-safe identity derives it at its own
+   * boundary; the SDK has no business minting one.
+   */
+  entityId: string
+  direction: 'backward' | 'forward'
+  /** Whether the walk reported the archive exhausted in that direction. */
+  complete: boolean
+}
+
+type Handler = (report: ArchiveMergeReport) => void
+
+const handlers = new Set<Handler>()
+
+/**
+ * Observe archive merges.
+ *
+ * Each handler receives its own report snapshot.
+ *
+ * @returns an unsubscribe function.
+ */
+export function onArchiveMerge(handler: Handler): () => void {
+  handlers.add(handler)
+  return () => {
+    handlers.delete(handler)
+  }
+}
+
+/**
+ * Whether anything is listening.
+ *
+ * The stores check this BEFORE counting: with no subscriber a merge must not pay for
+ * a diagnostic nobody reads.
+ */
+export function hasArchiveMergeSubscribers(): boolean {
+  return handlers.size > 0
+}
+
+/**
+ * Split the returned rows into dispositions and name the outcome.
+ *
+ * `ownWriteCommitted` is this merge's own transaction; `chainCommitted` additionally
+ * covers every earlier in-flight page for the same entity (see `archiveSaveChain.ts`).
+ * The two differ exactly when an earlier page failed — the rows of THIS merge are on
+ * disk while the durable cursor stays frozen, which is what `partial` names.
+ */
+export function describeArchiveMerge(
+  inputs: ArchiveMergeInputs,
+  ownWriteCommitted: boolean,
+  chainCommitted: boolean,
+  attempted: boolean
+): ArchiveMergeCounts {
+  const { returned, newMessages, persistableNew, patched, persistablePatched } = inputs
+
+  // A patched row is a duplicate that also carried a stanza-id backfill, so the two
+  // never overlap and plain duplicates are what is left. Clamped: a negative count
+  // would be a nonsense record rather than a useful one.
+  const deduplicated = Math.max(0, returned - newMessages - patched)
+  const intentionallyUnstored = newMessages - persistableNew + (patched - persistablePatched)
+
+  const outcome: ArchiveMergeOutcome = !attempted
+    ? 'durable'
+    : !ownWriteCommitted
+      ? 'failed'
+      : chainCommitted
+        ? 'durable'
+        : 'partial'
+
+  const wrote = outcome !== 'failed'
+  return {
+    outcome,
+    returned,
+    retained: wrote ? persistableNew : 0,
+    deduplicated,
+    patched: wrote ? persistablePatched : 0,
+    intentionallyUnstored,
+    persistenceFailed: wrote ? 0 : persistableNew + persistablePatched,
+  }
+}
+
+/**
+ * Hand a report to every subscriber.
+ *
+ * A handler that throws is contained: this runs on the merge's completion path, and
+ * a diagnostic must never break the store operation it observes.
+ */
+export function reportArchiveMerge(report: ArchiveMergeReport): void {
+  if (handlers.size === 0) return
+  for (const handler of handlers) {
+    try {
+      handler({ ...report })
+    } catch (err) {
+      console.warn('[archiveMerge] subscriber threw:', err)
+    }
+  }
+}
+
+/** Test-only: drop every subscriber. */
+export function resetArchiveMergeDiagnosticsForTesting(): void {
+  handlers.clear()
+}

--- a/packages/fluux-sdk/src/stores/shared/unreadDiagnostic.ts
+++ b/packages/fluux-sdk/src/stores/shared/unreadDiagnostic.ts
@@ -1,0 +1,34 @@
+/**
+ * The unread badge, next to the count the archive says it should be.
+ *
+ * A badge and its archive-derived truth legitimately disagree for a window during
+ * an ordinary recount, and the recount itself declines to count in about twenty
+ * situations where any number would be a guess. So a consumer cannot simply ask for
+ * "the real count" and compare: it needs to know whether the two numbers it is
+ * holding were ever comparable at all.
+ *
+ * That is what `status` says, and why both counts arrive together:
+ *
+ * - `exact` — both numbers come from ONE validated snapshot. Only these compare.
+ * - `deferred` — a coverage or metadata gate stood down, and `reason` names it. The
+ *   real recount would have declined here too, so this is not evidence of a bug.
+ * - `stale` — the inputs moved while the count was being computed. Also not a bug:
+ *   a newer recount is on its way with a better answer.
+ *
+ * Declared beside `recountDiagnostics` rather than in `core/types`: it names a
+ * `RecountDeferralReason`, and `core/types` is the leaf layer that must not reach
+ * into a store — `core/types/layering.test.ts` enforces it.
+ *
+ * @category Read state
+ */
+import type { RecountDeferralReason } from './recountDiagnostics'
+
+export interface UnreadDiagnostic {
+  status: 'exact' | 'deferred' | 'stale'
+  /** Archive-derived, including the transient overlay. Present only on `exact`. */
+  archiveCount?: number
+  /** What the badge currently displays. Present only on `exact`. */
+  badgeCount?: number
+  /** Which gate stood down. Present only on `deferred`. */
+  reason?: RecountDeferralReason
+}

--- a/packages/fluux-sdk/src/stores/unreadDiagnostic.test.ts
+++ b/packages/fluux-sdk/src/stores/unreadDiagnostic.test.ts
@@ -1,0 +1,492 @@
+/**
+ * The archive-derived unread count beside the badge.
+ *
+ * Two things are tested here, and the second matters more than the first:
+ *
+ * 1. The diagnostic reports what it says it reports.
+ * 2. It **agrees with the real recount**. It is a second traversal of the same
+ *    gates, side-effect free, so nothing but a test keeps the two from drifting —
+ *    and a diagnostic that declined where the recount counted (or counted where the
+ *    recount declined) would report ordinary catch-up as a bug.
+ *
+ * Real `fake-indexeddb` and the real `countUnreadInArchive`, like
+ * `chatStore.archiveUnread.test.ts`: a mocked archive counter would let the
+ * diagnostic pass while measuring nothing.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { chatStore, chatUnreadDiagnostic } from './chatStore'
+import { roomStore, roomUnreadDiagnostic } from './roomStore'
+import { clearTransientScope } from './shared/transientUnread'
+import { _resetStorageScopeForTesting, getStorageScopeJid } from '../utils/storageScope'
+import {
+  readRecountDeferrals,
+  resetRecountDeferralsForTesting,
+  type RecountDeferralReason,
+} from './shared/recountDiagnostics'
+import type { Conversation, Message, Room, RoomMessage } from '../core/types'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    countUnreadInArchive: vi.fn(actual.countUnreadInArchive),
+    countRoomUnreadInArchive: vi.fn(actual.countRoomUnreadInArchive),
+  }
+})
+import * as messageCache from '../utils/messageCache'
+
+const countUnreadImplementation = vi.mocked(messageCache.countUnreadInArchive).getMockImplementation()!
+const countRoomUnreadImplementation = vi.mocked(messageCache.countRoomUnreadInArchive).getMockImplementation()!
+
+const CID = 'carol@example.com'
+const ROOM = 'general@conference.example.com'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = () => done()
+  })
+  return { promise, resolve }
+}
+
+function createConversation(id: string): Conversation {
+  return { id, name: id, type: 'chat', unreadCount: 0 }
+}
+
+function createRoom(jid: string): Room {
+  return {
+    jid,
+    name: jid,
+    nickname: 'me',
+    joined: true,
+    isBookmarked: false,
+    occupants: new Map(),
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set(),
+  }
+}
+
+function archiveMsg(id: string, ts: number, overrides: Partial<Message> = {}): Message {
+  return {
+    type: 'chat',
+    id,
+    conversationId: CID,
+    from: CID,
+    body: 'hi',
+    timestamp: new Date(ts),
+    isOutgoing: false,
+    ...overrides,
+  }
+}
+
+function roomMsg(id: string, ts: number, overrides: Partial<RoomMessage> = {}): RoomMessage {
+  return {
+    type: 'groupchat',
+    id,
+    roomJid: ROOM,
+    from: `${ROOM}/alice`,
+    nick: 'alice',
+    body: 'hi',
+    timestamp: new Date(ts),
+    isOutgoing: false,
+    ...overrides,
+  } as RoomMessage
+}
+
+function seedCoverage(bottomId: string): void {
+  chatStore.setState((state) => {
+    const mamQueryStates = new Map(state.mamQueryStates)
+    mamQueryStates.set(CID, {
+      isLoading: false,
+      error: null,
+      hasQueried: true,
+      isHistoryComplete: true,
+      isCaughtUpToLive: true,
+    })
+    const conversationCoverage = new Map(state.conversationCoverage)
+    conversationCoverage.set(CID, { bottomId })
+    return { mamQueryStates, conversationCoverage }
+  })
+}
+
+function setMeta(patch: Record<string, unknown>): void {
+  chatStore.setState((state) => {
+    const meta = new Map(state.conversationMeta)
+    meta.set(CID, { ...(meta.get(CID) ?? { unreadCount: 0 }), ...patch } as never)
+    return { conversationMeta: meta }
+  })
+}
+
+/** A pointer at `ts` naming `id`, in the shape the store writes. */
+function pointerAt(ts: number, id: string): Record<string, unknown> {
+  return {
+    order: { role: 'exact', timestamp: new Date(ts).getTime(), tiebreak: { kind: 'chat', id } },
+    identity: { state: 'local', messageId: id },
+  }
+}
+
+function roomPointerAt(ts: number, id: string): Record<string, unknown> {
+  return {
+    order: {
+      role: 'exact',
+      timestamp: ts,
+      tiebreak: { kind: 'room', from: `${ROOM}/alice`, id },
+    },
+    identity: { state: 'local', messageId: id },
+  }
+}
+
+/** The archive, the pointer and the coverage record of a healthy conversation. */
+async function seedHealthyConversation(badge: number): Promise<void> {
+  await messageCache.saveMessages([
+    archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+    archiveMsg('p0', 1000),
+    archiveMsg('u1', 1001),
+    archiveMsg('u2', 1002),
+    archiveMsg('u3', 1003),
+  ])
+  setMeta({ unreadCount: badge, readPointer: pointerAt(1000, 'p0') })
+  seedCoverage('anchor-stanza')
+}
+
+async function seedHealthyRoom(badge: number): Promise<void> {
+  roomStore.getState().addRoom(createRoom(ROOM))
+  await messageCache.saveRoomMessages([
+    roomMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+    roomMsg('p0', 1000),
+    roomMsg('u1', 1001),
+    roomMsg('u2', 1002),
+  ])
+  roomStore.setState((state) => {
+    const roomMeta = new Map(state.roomMeta)
+    roomMeta.set(ROOM, {
+      ...(roomMeta.get(ROOM) ?? { unreadCount: 0 }),
+      unreadCount: badge,
+      readPointer: roomPointerAt(1000, 'p0'),
+    } as never)
+    const mamQueryStates = new Map(state.mamQueryStates)
+    mamQueryStates.set(ROOM, {
+      isLoading: false,
+      error: null,
+      hasQueried: true,
+      isHistoryComplete: true,
+      isCaughtUpToLive: true,
+    })
+    const roomCoverage = new Map(state.roomCoverage)
+    roomCoverage.set(ROOM, { bottomId: 'anchor-stanza' })
+    return { roomMeta, mamQueryStates, roomCoverage }
+  })
+}
+
+/** Which reason the REAL recount declined for, read from its own tally. */
+async function recountDeferralReason(): Promise<RecountDeferralReason | undefined> {
+  resetRecountDeferralsForTesting()
+  await chatStore.getState().recomputeUnreadForConversation(CID)
+  // Keys are `<kind>:<reason>` and the tallies are cumulative for the process,
+  // which is why this resets them first.
+  const entries = Object.entries(readRecountDeferrals()).filter(
+    ([k, count]) => k.startsWith('chat:') && count > 0,
+  )
+  return entries.length > 0
+    ? (entries[0][0].slice('chat:'.length) as RecountDeferralReason)
+    : undefined
+}
+
+beforeEach(async () => {
+  _resetStorageScopeForTesting()
+  globalThis.indexedDB = new IDBFactory()
+  ;(messageCache as unknown as { _resetDBForTesting?: () => void })._resetDBForTesting?.()
+  localStorageMock.clear()
+  chatStore.getState().reset()
+  roomStore.getState().reset()
+  resetRecountDeferralsForTesting()
+  chatStore.getState().addConversation(createConversation(CID))
+  vi.mocked(messageCache.countUnreadInArchive).mockReset()
+  vi.mocked(messageCache.countUnreadInArchive).mockImplementation(countUnreadImplementation)
+  vi.mocked(messageCache.countRoomUnreadInArchive).mockReset()
+  vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementation(countRoomUnreadImplementation)
+  clearTransientScope(getStorageScopeJid() ?? '')
+})
+
+describe('chatUnreadDiagnostic', () => {
+  it('returns both counts from one snapshot when the archive can be counted', async () => {
+    await seedHealthyConversation(3)
+
+    const result = await chatUnreadDiagnostic(CID)
+
+    expect(result).toEqual({ status: 'exact', archiveCount: 3, badgeCount: 3 })
+  })
+
+  it('reports a disagreement without judging it', async () => {
+    await seedHealthyConversation(99)
+
+    const result = await chatUnreadDiagnostic(CID)
+
+    // The diagnostic hands back what it found. Deciding that 99 against 3 is a bug
+    // is the detector's job, and keeping that decision out of the SDK is what lets
+    // the store's own recount fix the badge without the seam taking a view.
+    expect(result).toEqual({ status: 'exact', archiveCount: 3, badgeCount: 99 })
+  })
+
+  it('defers, rather than guessing, when there is no coverage record', async () => {
+    await messageCache.saveMessages([archiveMsg('u1', 1001)])
+    setMeta({ unreadCount: 1, readPointer: pointerAt(1000, 'p0') })
+    chatStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(CID, {
+        isLoading: false,
+        error: null,
+        hasQueried: true,
+        isHistoryComplete: true,
+        isCaughtUpToLive: true,
+      })
+      return { mamQueryStates }
+    })
+
+    expect(await chatUnreadDiagnostic(CID)).toEqual({
+      status: 'deferred',
+      reason: 'coverage-missing',
+    })
+  })
+
+  it('defers while history is not caught up', async () => {
+    await seedHealthyConversation(3)
+    chatStore.setState((state) => {
+      const mamQueryStates = new Map(state.mamQueryStates)
+      mamQueryStates.set(CID, {
+        isLoading: false,
+        error: null,
+        hasQueried: true,
+        isHistoryComplete: false,
+        isCaughtUpToLive: false,
+      })
+      return { mamQueryStates }
+    })
+
+    expect((await chatUnreadDiagnostic(CID)).reason).toBe('history-not-caught-up')
+  })
+
+  it('defers for an entity the store does not know', async () => {
+    expect(await chatUnreadDiagnostic('nobody@example.com')).toEqual({
+      status: 'deferred',
+      reason: 'no-meta',
+    })
+  })
+
+  it('reports stale when the inputs move mid-count', async () => {
+    await seedHealthyConversation(3)
+    vi.mocked(messageCache.countUnreadInArchive).mockImplementation(async (...args) => {
+      // A live arrival lands while the archive is being counted: the two numbers
+      // would no longer describe the same instant.
+      chatStore.getState().addMessage(archiveMsg('live', 2000))
+      return countUnreadImplementation(...args)
+    })
+
+    expect((await chatUnreadDiagnostic(CID)).status).toBe('stale')
+  })
+
+  it('reports stale when the read pointer changes without a version bump', async () => {
+    await seedHealthyConversation(3)
+    vi.mocked(messageCache.countUnreadInArchive).mockImplementationOnce(async (...args) => {
+      setMeta({ unreadCount: 0, readPointer: pointerAt(1003, 'u3') })
+      return countUnreadImplementation(...args)
+    })
+
+    expect(await chatUnreadDiagnostic(CID)).toEqual({ status: 'stale' })
+  })
+
+  it('writes nothing', async () => {
+    await seedHealthyConversation(99)
+    const metaBefore = chatStore.getState().conversationMeta.get(CID)
+    const coverageBefore = chatStore.getState().conversationCoverage
+
+    await chatUnreadDiagnostic(CID)
+
+    // An observer that repaired the badge would hide the very defect it exists to
+    // report, and would make the log's evidence unreproducible.
+    expect(chatStore.getState().conversationMeta.get(CID)).toBe(metaBefore)
+    expect(chatStore.getState().conversationCoverage).toBe(coverageBefore)
+  })
+
+  it('reports stale while an earlier recount is still in flight', async () => {
+    await seedHealthyConversation(99)
+    const gate = deferred()
+    let countCalls = 0
+    vi.mocked(messageCache.countUnreadInArchive).mockImplementation(async (...args) => {
+      countCalls++
+      if (countCalls === 1) await gate.promise
+      return countUnreadImplementation(...args)
+    })
+
+    const recount = chatStore.getState().recomputeUnreadForConversation(CID)
+    await vi.waitFor(() => expect(messageCache.countUnreadInArchive).toHaveBeenCalledTimes(1))
+
+    expect(await chatUnreadDiagnostic(CID)).toEqual({ status: 'stale' })
+
+    gate.resolve()
+    await recount
+
+    expect(readRecountDeferrals()['chat:recount-superseded'] ?? 0).toBe(0)
+    expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(3)
+    expect(await chatUnreadDiagnostic(CID)).toEqual({
+      status: 'exact',
+      archiveCount: 3,
+      badgeCount: 3,
+    })
+  })
+})
+
+describe('agreement with the real recount', () => {
+  it('counts exactly what the recount commits', async () => {
+    await seedHealthyConversation(99)
+
+    const diagnostic = await chatUnreadDiagnostic(CID)
+    await chatStore.getState().recomputeUnreadForConversation(CID)
+
+    expect(diagnostic.archiveCount).toBe(chatStore.getState().conversationMeta.get(CID)?.unreadCount)
+  })
+
+  const gates: Array<{ name: string; reason: RecountDeferralReason; arrange: () => Promise<void> }> = [
+    {
+      name: 'no coverage record',
+      reason: 'coverage-missing',
+      arrange: async () => {
+        await messageCache.saveMessages([archiveMsg('u1', 1001)])
+        setMeta({ unreadCount: 1, readPointer: pointerAt(1000, 'p0') })
+        chatStore.setState((state) => {
+          const mamQueryStates = new Map(state.mamQueryStates)
+          mamQueryStates.set(CID, {
+            isLoading: false,
+            error: null,
+            hasQueried: true,
+            isHistoryComplete: true,
+            isCaughtUpToLive: true,
+          })
+          return { mamQueryStates }
+        })
+      },
+    },
+    {
+      name: 'history not caught up',
+      reason: 'history-not-caught-up',
+      arrange: async () => {
+        await seedHealthyConversation(3)
+        chatStore.setState((state) => {
+          const mamQueryStates = new Map(state.mamQueryStates)
+          mamQueryStates.set(CID, {
+            isLoading: false,
+            error: null,
+            hasQueried: true,
+            isHistoryComplete: false,
+            isCaughtUpToLive: false,
+          })
+          return { mamQueryStates }
+        })
+      },
+    },
+    {
+      name: 'a pointerless entity showing a count',
+      reason: 'pointerless-defer',
+      arrange: async () => {
+        await messageCache.saveMessages([archiveMsg('u1', 1001)])
+        setMeta({ unreadCount: 4, readPointer: undefined, historyFloor: undefined })
+        seedCoverage('anchor-stanza')
+      },
+    },
+  ]
+
+  for (const gate of gates) {
+    it(`declines with ${gate.reason} where the recount does — ${gate.name}`, async () => {
+      await gate.arrange()
+
+      const diagnostic = await chatUnreadDiagnostic(CID)
+      const recount = await recountDeferralReason()
+
+      expect(diagnostic.status).toBe('deferred')
+      expect(diagnostic.reason).toBe(gate.reason)
+      expect(recount).toBe(gate.reason)
+    })
+  }
+})
+
+describe('roomUnreadDiagnostic', () => {
+  it('returns both counts for a room whose archive can be counted', async () => {
+    await seedHealthyRoom(2)
+
+    const result = await roomUnreadDiagnostic(ROOM)
+
+    expect(result.status).toBe('exact')
+    expect(result.badgeCount).toBe(2)
+    expect(result.archiveCount).toBe(2)
+  })
+
+  it('reports stale when the room pointer changes without a version bump', async () => {
+    await seedHealthyRoom(2)
+    vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementationOnce(async (...args) => {
+      roomStore.setState((state) => {
+        const roomMeta = new Map(state.roomMeta)
+        roomMeta.set(ROOM, {
+          ...roomMeta.get(ROOM)!,
+          unreadCount: 0,
+          readPointer: roomPointerAt(1002, 'u2'),
+        } as never)
+        return { roomMeta }
+      })
+      return countRoomUnreadImplementation(...args)
+    })
+
+    expect(await roomUnreadDiagnostic(ROOM)).toEqual({ status: 'stale' })
+  })
+
+  it('reports stale while an earlier room recount is still in flight', async () => {
+    await seedHealthyRoom(99)
+    const gate = deferred()
+    let countCalls = 0
+    vi.mocked(messageCache.countRoomUnreadInArchive).mockImplementation(async (...args) => {
+      countCalls++
+      if (countCalls === 1) await gate.promise
+      return countRoomUnreadImplementation(...args)
+    })
+
+    const recount = roomStore.getState().recomputeUnreadForRoom(ROOM)
+    await vi.waitFor(() => expect(messageCache.countRoomUnreadInArchive).toHaveBeenCalledTimes(1))
+
+    expect(await roomUnreadDiagnostic(ROOM)).toEqual({ status: 'stale' })
+
+    gate.resolve()
+    await recount
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
+    expect(await roomUnreadDiagnostic(ROOM)).toEqual({
+      status: 'exact',
+      archiveCount: 2,
+      badgeCount: 2,
+    })
+  })
+
+  it('defers for a room the store does not know', async () => {
+    expect(await roomUnreadDiagnostic('nowhere@conference.example.com')).toEqual({
+      status: 'deferred',
+      reason: 'no-meta',
+    })
+  })
+})

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -240,6 +240,28 @@ test.describe('anomaly runtime', () => {
       )
       .toBeGreaterThan(0)
 
+    const outboundApplicationStanzas = await page.evaluate(async () => {
+      interface DemoClientLike {
+        onApplicationStanzaOut(handler: () => void): () => void
+        server: { queryInfo(jid: string): Promise<unknown> }
+      }
+      const client = (window as unknown as { __demoClient: DemoClientLike }).__demoClient
+      let observed = 0
+      const off = client.onApplicationStanzaOut(() => {
+        observed++
+      })
+      try {
+        await client.server.queryInfo(`anomaly-smoke-${Date.now()}.invalid`)
+      } finally {
+        off()
+      }
+      return observed
+    })
+    expect(
+      outboundApplicationStanzas,
+      'demo mode emitted no outbound application stanza — the traffic control is vacuous',
+    ).toBe(1)
+
     // Open a room so the sampler has something to look at.
     await openDemoRoom(page)
 
@@ -274,6 +296,10 @@ test.describe('anomaly runtime', () => {
         'read-state/unread-survives-focus',
         'scroll/fab-at-live-edge',
         'scroll/jump-target-miss',
+        'xmpp-traffic/redundant-query',
+        'xmpp-traffic/iq-unanswered',
+        'xmpp-traffic/mam-write-failed',
+        'read-state/pointer-regression',
       ])
       return (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
         .map((l) => JSON.parse(l) as { id?: string })


### PR DESCRIPTION
Stage 5 gives the anomaly log the SDK visibility its remaining invariants needed, and ships the detectors that depend on it: redundant and unanswered application IQs, an archive page's durable yield and a failed archive write, and a read pointer moving backwards.

Four read-only seams are added to the SDK — outbound application stanzas, archive merge outcomes, the read-state generation, and an archive-derived unread count beside the badge. Production builds are unchanged: the detectors are gated out and CI asserts their absence, while the seams are ordinary API whose unsubscribed cost is one map lookup, measured by `npm run bench:seam`.

`read-state/badge-vs-pointer` is deliberately not shipped. Its trigger model recorded the supported count-only mark-read for an active conversation above the live edge as a bug, and a detector that fires during ordinary use is deleted rather than tuned. Its seam did ship, so a future attempt needs a trigger model rather than new SDK visibility. Tracked in #1353, which also proposes collapsing these four seams into one diagnostic channel.
