### PR TITLE
fix(anomaly): name the entity a one-shot record is about

### DIFF
--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -12,6 +12,7 @@ import {
 import { CTX, METRIC, resetValuesForTesting } from './values'
 import { hasAnomalySignalHandler, signalAnomaly } from '../utils/anomalySignal'
 import type { ElementLike } from './detectors/stanzaFacts'
+import { convToken } from './identity'
 import type { TrafficClient } from './install'
 import {
   recordRecountDeferral,
@@ -896,5 +897,93 @@ describe('pointer regression wiring', () => {
 
     expect(records().map((r) => r.id)).not.toContain('read-state/pointer-regression')
     cleanup()
+  })
+})
+
+describe('entity tokens are warmed before a one-shot record', () => {
+  function iqTo(to: string, id: string, ns = 'http://jabber.org/protocol/disco#info'): ElementLike {
+    const children: ElementLike[] = [
+      { name: 'query', attrs: { xmlns: ns }, children: [], getChild: () => undefined },
+    ]
+    return {
+      name: 'iq',
+      attrs: { type: 'get', to, id },
+      children,
+      getChild: (name: string) => children.find((c) => c.name === name),
+    }
+  }
+
+  function reply(id: string): ElementLike {
+    return { name: 'iq', attrs: { type: 'result', id }, children: [], getChild: () => undefined }
+  }
+
+  function stubClient() {
+    const out: Array<(s: ElementLike) => void> = []
+    const inbound: Array<(s: ElementLike) => void> = []
+    const client: TrafficClient = {
+      onApplicationStanzaOut: (h) => {
+        out.push(h)
+        return () => {}
+      },
+      onStanza: (h) => {
+        inbound.push(h)
+        return () => {}
+      },
+    }
+    return { client, out, inbound }
+  }
+
+  /**
+   * Let the tokenizer's HMAC settle.
+   *
+   * A real WebCrypto sign, so draining microtasks is not enough — it needs a turn
+   * of the event loop.
+   */
+  async function settleWarm(): Promise<void> {
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  it('names the queried entity instead of c:unresolved', async () => {
+    const { client, out, inbound } = stubClient()
+    const cleanup = install(client)
+    await whenReady()
+
+    // The first query warms the target; the redundancy is recorded on the second,
+    // which is the one-shot the entity must be nameable in.
+    out[0](iqTo('service.example.com', 'q1'))
+    inbound[0](reply('q1'))
+    await settleWarm()
+    out[0](iqTo('service.example.com', 'q2'))
+
+    const record = records().find((r) => r.id === 'xmpp-traffic/redundant-query')
+    expect(record).toBeDefined()
+    const target = (record.ctx as Record<string, string>).target
+    expect(target).not.toBe('c:unresolved')
+    cleanup()
+  })
+
+  it('identifies a full-JID target by its contact, not by its resource', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, out } = stubClient()
+      const cleanup = install(client)
+      await whenReady()
+
+      // Disco to a full JID is a distinct QUERY — it answers for that resource —
+      // but it is the same CONTACT, and the log correlates by entity. Stated as
+      // the rule rather than inferred from two records, which the recorder's
+      // per-id cooldown would coalesce anyway.
+      out[0](iqTo('alice@example.com/laptop', 'a1'))
+      await vi.advanceTimersByTimeAsync(35_000)
+
+      const record = records().find((r) => r.id === 'xmpp-traffic/iq-unanswered')
+      expect(record).toBeDefined()
+      const target = (record.ctx as Record<string, string>).target
+      expect(target).not.toBe('c:unresolved')
+      expect(target).toBe(convToken('alice@example.com').s)
+      cleanup()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -18,7 +18,7 @@
 import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, onArchiveMerge, readRecountDeferrals, roomReadStateGeneration, roomStore, setMeasurementEnabled } from '@fluux/sdk'
 import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
 import { createDenominatorTracker, type DenominatorName } from './denominators'
-import { warmConversation, warmRoom } from './identity'
+import { convToken, roomToken, warmConversation, warmRoom } from './identity'
 import { createEnvironmentReader, createForegroundShare } from './environment'
 import { watchPerfMeasures, type PerfMeasureWatch } from './perfMeasures'
 import { metricConstant } from './detectors/metricCounts'
@@ -39,7 +39,7 @@ import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
 import { createPluginFsWriter, createTauriSink } from './sinks/tauri'
-import { ID, METRIC, RECOUNT_METRIC, TAG, initTokenizer, isTokenizerReady, tokenSync, type Opaque } from './values'
+import { ID, METRIC, RECOUNT_METRIC, TAG, initTokenizer, isTokenizerReady, type Opaque } from './values'
 
 const DIGEST_INTERVAL_MS = 5 * 60 * 1000
 /**
@@ -358,6 +358,27 @@ export function install(client?: TrafficClient): () => void {
       })
     }
 
+    /**
+     * Warm an entity at OBSERVATION time, not at record time.
+     *
+     * `tokenSync` resolves from cache or returns the unresolved sentinel and warms
+     * in the background — which is enough for a repeating crumb but not for a
+     * ONE-SHOT record: an unanswered IQ or a redundant query names its target once
+     * and never again, and a record that says `c:unresolved` cannot be attributed
+     * to anything. Every observation here precedes its record — a redundancy is
+     * recorded on a later send, an unanswered IQ on a later sweep — so warming
+     * when the entity is first SEEN is what makes the record nameable.
+     *
+     * Idempotent and deduplicated inside the tokenizer, so the steady-state cost
+     * is a map lookup.
+     */
+    const warmEntity = (kind: 'room' | 'conversation', id: string): void => {
+      if (!id || !isTokenizerReady()) return
+      void (kind === 'room' ? warmRoom(id) : warmConversation(id)).catch(() => {
+        // Reported by `recorder/entity-warm-failing`; observation must not throw.
+      })
+    }
+
     let activeEntity = readActiveConversation()
     let activeObservationQueued = false
     let storeObserversAttached = true
@@ -383,7 +404,7 @@ export function install(client?: TrafficClient): () => void {
     // a phantom regression.
     const pointerRegression = createPointerRegressionDetector({
       record: (input) => rec.record(input),
-      token: (kind, id) => (kind === 'room' ? tokenSync('room', id) : tokenSync('jid', id)),
+      token: (kind, id) => (kind === 'room' ? roomToken(id) : convToken(id)),
       isAhead,
     })
 
@@ -402,6 +423,7 @@ export function install(client?: TrafficClient): () => void {
     ): void => {
       for (const [id, meta] of nextMeta) {
         if (prevMeta.get(id) === meta) continue
+        warmEntity(kind === 'room' ? 'room' : 'conversation', id)
         pointerRegression.observe({
           kind,
           id,
@@ -461,9 +483,12 @@ export function install(client?: TrafficClient): () => void {
       record: (input) => rec.record(input),
       count: (key, by) => rec.count(key, by),
       token: (report) =>
-        report.entityKind === 'room' ? tokenSync('room', report.entityId) : tokenSync('jid', report.entityId),
+        report.entityKind === 'room' ? roomToken(report.entityId) : convToken(report.entityId),
     })
-    archiveMergeUnsubscribe = onArchiveMerge((report) => archiveMerge.observe(report))
+    archiveMergeUnsubscribe = onArchiveMerge((report) => {
+      warmEntity(report.entityKind === 'room' ? 'room' : 'conversation', report.entityId)
+      archiveMerge.observe(report)
+    })
 
     // The application IQ traffic detectors. Absent a client — a unit test, or a
     // harness that mounts the runtime on its own — nothing attaches and nothing is
@@ -471,13 +496,15 @@ export function install(client?: TrafficClient): () => void {
     if (client) {
       const traffic = createTrafficDetector({
         record: (input) => rec.record(input),
-        token: (jid) => tokenSync('jid', jid),
+        token: (jid) => convToken(jid),
       })
       trafficDetector = traffic
 
       const offOut = client.onApplicationStanzaOut((stanza) => {
         const facts = outboundFacts(stanza)
-        if (facts) traffic.observeOut(facts, Date.now())
+        if (!facts) return
+        warmEntity('conversation', facts.to)
+        traffic.observeOut(facts, Date.now())
       })
       const offIn = client.onStanza((stanza) => {
         const facts = inboundReplyFacts(stanza)


### PR DESCRIPTION
The first two anomaly records from a real session after #1352 both named `c:unresolved`, so neither could be attributed to an entity. Two defects with one cause.

The detectors asked the tokenizer for a token only at record time. That is enough for a repeating crumb, which gets another chance on the next observation, but not for a one-shot record: an unanswered IQ and a redundant query each name their target once and never again. Every observation precedes its own record — a redundancy is recorded on a later send, an unanswered IQ on a later sweep — so the entity is now warmed when it is first seen. Warming is idempotent and deduplicated inside the tokenizer, so the steady-state cost is a map lookup.

They also reached the tokenizer directly instead of going through `identity.ts`, which skipped the bare-JID narrowing those helpers exist for. An IQ target is often a full JID, and without narrowing one contact addressed at two resources mints two tokens and reads as two entities.

The dedupe key deliberately keeps the full JID: disco to a full JID answers for that resource, so two resources are two queries rather than a redundancy. The token and the dedupe identity are now tested as separate rules.

Dev builds only; no user-visible surface.
