### PR TITLE
refactor(sdk): share the read-state diagnostics between chat and room (#1353)

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2,7 +2,11 @@ import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, PageInfo } from '../core/types'
 import type { ReadStateGeneration } from '../core/types/readStateGeneration'
-import type { UnreadDiagnostic } from './shared/unreadDiagnostic'
+import {
+  computeUnreadDiagnostic,
+  type UnreadDiagnostic,
+  type UnreadDiagnosticConfig,
+} from './shared/unreadDiagnostic'
 import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -49,9 +53,8 @@ import {
 } from './shared/viewportEvidence'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import {
-  describeArchiveMerge,
   hasArchiveMergeSubscribers,
-  reportArchiveMerge,
+  reportArchiveMergeWhenDurable,
   type ArchiveMergeInputs,
 } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
@@ -624,95 +627,46 @@ export function chatReadStateGeneration(conversationId: string): ReadStateGenera
 }
 
 /**
- * The archive-derived unread count beside the badge, for a diagnostic consumer.
- *
- * A SECOND traversal of `recomputeUnreadForConversation`'s gates, deliberately, and
- * the two must be changed together — `unreadDiagnostic.agreement.test.ts` pins them
- * to the same verdicts. It cannot call the recount itself, because that prelude has
- * three side effects an observer must not have:
- *
- * - it bumps the latest-wins recount version, which would CANCEL a real recount in
- *   flight and make the observer a cause;
- * - it prunes the transient unread overlay;
- * - it invalidates a persisted coverage record whose bottom no longer resolves.
- *
- * It also never counts from the resident slice: that would recreate the very
- * under-count class a consumer would be comparing against, and go silent exactly
- * when the badge is wrong.
- *
- * Both counts come from one validated context: the badge is read last, and the
- * movement check runs after it, so an `exact` result holds two numbers that were
- * true at the same instant.
+ * The chat flavour of {@link computeUnreadDiagnostic}: what this store must hand it,
+ * and nothing more. The gate sequence, the side effects an observer must not have,
+ * and the one-snapshot rule all live in that function, shared with the room twin.
  */
-export async function chatUnreadDiagnostic(conversationId: string): Promise<UnreadDiagnostic> {
-  const meta = chatStore.getState().conversationMeta.get(conversationId)
-  if (!meta) return { status: 'deferred', reason: 'no-meta' }
-  if (meta.pendingRemoteDisplayedStanzaId !== undefined) {
-    return { status: 'deferred', reason: 'pending-remote-displayed' }
-  }
-  if (pointerlessDefers(meta.readPointer, meta.unreadCount)) {
-    return { status: 'deferred', reason: 'pointerless-defer' }
-  }
-  if (chatRecountsInFlight.has(conversationId)) return { status: 'stale' }
+const chatUnreadDiagnosticConfig: UnreadDiagnosticConfig = {
+  isRoom: false,
+  isRecountInFlight: (conversationId) => chatRecountsInFlight.has(conversationId),
+  countUnreadInArchive: (conversationId, range) => messageCache.countUnreadInArchive(conversationId, range),
+  transientScopeKey: (conversationId) => chatTransientScopeKey(conversationId),
+  sample: (conversationId) => {
+    const state = chatStore.getState()
+    const meta = state.conversationMeta.get(conversationId)
+    const mam = mamState.getMAMQueryState(state.mamQueryStates, conversationId)
+    const coverage = state.conversationCoverage.get(conversationId)
+    return {
+      meta,
+      historyCaughtUp: isCaughtUpForCounting(mam),
+      coverage,
+      fingerprint: [
+        chatCacheEpoch,
+        currentChatEntityEpoch(conversationId),
+        getStorageScopeJid(),
+        chatUnreadInputVersion.get(conversationId) ?? 0,
+        // A recount bumps this the moment it commits to running, so a recount
+        // starting during this read makes the result `stale` rather than a false
+        // mismatch.
+        chatRecountVersion.get(conversationId) ?? 0,
+        meta?.readPointer,
+        meta?.historyFloor,
+        meta?.pendingRemoteDisplayedStanzaId,
+        mam,
+        coverage,
+      ],
+    }
+  },
+}
 
-  const cacheEpochAtStart = chatCacheEpoch
-  const entityEpochAtStart = currentChatEntityEpoch(conversationId)
-  const storageScopeAtStart = getStorageScopeJid()
-  const inputVersionAtStart = chatUnreadInputVersion.get(conversationId) ?? 0
-  // A recount bumps this the moment it commits to running, so a recount starting
-  // during this read makes the result `stale` rather than a false mismatch.
-  const recountVersionAtStart = chatRecountVersion.get(conversationId) ?? 0
-  const floor = computeFloor(meta.readPointer, meta.historyFloor)
-  if (!floor) return { status: 'deferred', reason: 'no-floor' }
-
-  const stateAtStart = chatStore.getState()
-  const mam = mamState.getMAMQueryState(stateAtStart.mamQueryStates, conversationId)
-  if (!isCaughtUpForCounting(mam)) return { status: 'deferred', reason: 'history-not-caught-up' }
-
-  const record = stateAtStart.conversationCoverage.get(conversationId)
-  const moved = (): boolean => {
-    const current = chatStore.getState()
-    const currentMeta = current.conversationMeta.get(conversationId)
-    return chatCacheEpoch !== cacheEpochAtStart ||
-      currentChatEntityEpoch(conversationId) !== entityEpochAtStart ||
-      getStorageScopeJid() !== storageScopeAtStart ||
-      (chatUnreadInputVersion.get(conversationId) ?? 0) !== inputVersionAtStart ||
-      (chatRecountVersion.get(conversationId) ?? 0) !== recountVersionAtStart ||
-      currentMeta?.readPointer !== meta.readPointer ||
-      currentMeta?.historyFloor !== meta.historyFloor ||
-      currentMeta?.pendingRemoteDisplayedStanzaId !== meta.pendingRemoteDisplayedStanzaId ||
-      mamState.getMAMQueryState(current.mamQueryStates, conversationId) !== mam ||
-      current.conversationCoverage.get(conversationId) !== record
-  }
-
-  const bottom = await resolveCoverageBottom(conversationId, record, false)
-  if (moved()) return { status: 'stale' }
-  if (bottom === 'missing') return { status: 'deferred', reason: 'coverage-missing' }
-  // No `clearConversationCoverage` here, unlike the recount: an observer does not
-  // repair state it is observing.
-  if (bottom === 'unresolvable') return { status: 'deferred', reason: 'coverage-unresolvable' }
-
-  const floorPos: PointerOrder = meta.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
-  if (isAfterBoundary(bottom, floorPos)) {
-    return { status: 'deferred', reason: 'coverage-short-of-floor' }
-  }
-
-  const res = await messageCache.countUnreadInArchive(conversationId, {
-    floor,
-    pointer: meta.readPointer?.order,
-  })
-  if (moved()) return { status: 'stale' }
-  if (res === null) return { status: 'deferred', reason: 'cache-unavailable' }
-
-  // No `pruneTransient` either — read the overlay, do not edit it.
-  const transient = transientCounts(chatTransientScopeKey(conversationId), floorPos)
-  const archiveCount = Math.min(999, res.unread + transient.unread)
-
-  const badgeCount = chatStore.getState().conversationMeta.get(conversationId)?.unreadCount
-  if (badgeCount === undefined) return { status: 'deferred', reason: 'no-meta' }
-  // Last: everything above must still describe the same context as this badge.
-  if (moved()) return { status: 'stale' }
-  return { status: 'exact', archiveCount, badgeCount }
+/** See {@link computeUnreadDiagnostic}. */
+export function chatUnreadDiagnostic(conversationId: string): Promise<UnreadDiagnostic> {
+  return computeUnreadDiagnostic(chatUnreadDiagnosticConfig, conversationId)
 }
 
 let chatCacheEpoch = 0
@@ -3390,24 +3344,12 @@ export const chatStore = createStore<ChatState>()(
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
 
-        // Reported once the durable outcome is KNOWN: a report written at merge time
-        // would claim a retention that can still fail, which is the one thing this
-        // seam exists to distinguish.
         if (mergeDiagnostics.inputs) {
-          const inputs = mergeDiagnostics.inputs
-          const attempted = inputs.persistableNew + inputs.persistablePatched > 0
-          void Promise.all([
-            ownArchiveWrite ?? Promise.resolve(true),
-            archiveCommitGate ?? Promise.resolve(true),
-          ]).then(([own, chained]) => {
-            reportArchiveMerge({
-              entityKind: 'chat',
-              entityId: conversationId,
-              direction,
-              complete,
-              ...describeArchiveMerge(inputs, own, chained, attempted),
-            })
-          })
+          reportArchiveMergeWhenDurable(
+            { entityKind: 'chat', entityId: conversationId, direction, complete },
+            mergeDiagnostics.inputs,
+            { ownWrite: ownArchiveWrite, chainGate: archiveCommitGate }
+          )
         }
 
         if (archiveCommitGate) {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -13,7 +13,11 @@ import type {
   PageInfo,
 } from '../core/types'
 import type { ReadStateGeneration } from '../core/types/readStateGeneration'
-import type { UnreadDiagnostic } from './shared/unreadDiagnostic'
+import {
+  computeUnreadDiagnostic,
+  type UnreadDiagnostic,
+  type UnreadDiagnosticConfig,
+} from './shared/unreadDiagnostic'
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
@@ -65,9 +69,8 @@ import {
 } from './shared/viewportEvidence'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import {
-  describeArchiveMerge,
   hasArchiveMergeSubscribers,
-  reportArchiveMerge,
+  reportArchiveMergeWhenDurable,
   type ArchiveMergeInputs,
 } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
@@ -468,74 +471,43 @@ export function roomReadStateGeneration(roomJid: string): ReadStateGeneration {
 }
 
 /**
- * The room twin of `chatUnreadDiagnostic`. See that function for why this is a
- * second traversal of the recount's gates rather than a call into it, and for what
- * it deliberately does not do. The gate sequence is identical; only the archive
- * counter and the coverage flavour differ.
+ * The room flavour of {@link computeUnreadDiagnostic}. See the chat twin for the
+ * shape; only the coverage flavour, the archive counter and the store's own
+ * counters differ.
  */
-export async function roomUnreadDiagnostic(roomJid: string): Promise<UnreadDiagnostic> {
-  const meta = roomStore.getState().roomMeta.get(roomJid)
-  if (!meta) return { status: 'deferred', reason: 'no-meta' }
-  if (meta.pendingRemoteDisplayedStanzaId !== undefined) {
-    return { status: 'deferred', reason: 'pending-remote-displayed' }
-  }
-  if (pointerlessDefers(meta.readPointer, meta.unreadCount)) {
-    return { status: 'deferred', reason: 'pointerless-defer' }
-  }
-  if (roomRecountsInFlight.has(roomJid)) return { status: 'stale' }
+const roomUnreadDiagnosticConfig: UnreadDiagnosticConfig = {
+  isRoom: true,
+  isRecountInFlight: (roomJid) => roomRecountsInFlight.has(roomJid),
+  countUnreadInArchive: (roomJid, range) => messageCache.countRoomUnreadInArchive(roomJid, range),
+  transientScopeKey: (roomJid) => roomTransientScopeKey(roomJid),
+  sample: (roomJid) => {
+    const state = roomStore.getState()
+    const meta = state.roomMeta.get(roomJid)
+    const mam = mamState.getMAMQueryState(state.mamQueryStates, roomJid)
+    const coverage = state.roomCoverage.get(roomJid)
+    return {
+      meta,
+      historyCaughtUp: isCaughtUpForCounting(mam),
+      coverage,
+      fingerprint: [
+        roomCacheEpoch,
+        currentRoomEntityEpoch(roomJid),
+        getStorageScopeJid(),
+        roomUnreadInputVersion.get(roomJid) ?? 0,
+        roomRecountVersion.get(roomJid) ?? 0,
+        meta?.readPointer,
+        meta?.historyFloor,
+        meta?.pendingRemoteDisplayedStanzaId,
+        mam,
+        coverage,
+      ],
+    }
+  },
+}
 
-  const cacheEpochAtStart = roomCacheEpoch
-  const entityEpochAtStart = currentRoomEntityEpoch(roomJid)
-  const storageScopeAtStart = getStorageScopeJid()
-  const inputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
-  const recountVersionAtStart = roomRecountVersion.get(roomJid) ?? 0
-  const floor = computeFloor(meta.readPointer, meta.historyFloor)
-  if (!floor) return { status: 'deferred', reason: 'no-floor' }
-
-  const stateAtStart = roomStore.getState()
-  const mam = mamState.getMAMQueryState(stateAtStart.mamQueryStates, roomJid)
-  if (!isCaughtUpForCounting(mam)) return { status: 'deferred', reason: 'history-not-caught-up' }
-
-  const record = stateAtStart.roomCoverage.get(roomJid)
-  const moved = (): boolean => {
-    const current = roomStore.getState()
-    const currentMeta = current.roomMeta.get(roomJid)
-    return roomCacheEpoch !== cacheEpochAtStart ||
-      currentRoomEntityEpoch(roomJid) !== entityEpochAtStart ||
-      getStorageScopeJid() !== storageScopeAtStart ||
-      (roomUnreadInputVersion.get(roomJid) ?? 0) !== inputVersionAtStart ||
-      (roomRecountVersion.get(roomJid) ?? 0) !== recountVersionAtStart ||
-      currentMeta?.readPointer !== meta.readPointer ||
-      currentMeta?.historyFloor !== meta.historyFloor ||
-      currentMeta?.pendingRemoteDisplayedStanzaId !== meta.pendingRemoteDisplayedStanzaId ||
-      mamState.getMAMQueryState(current.mamQueryStates, roomJid) !== mam ||
-      current.roomCoverage.get(roomJid) !== record
-  }
-
-  const bottom = await resolveCoverageBottom(roomJid, record, true)
-  if (moved()) return { status: 'stale' }
-  if (bottom === 'missing') return { status: 'deferred', reason: 'coverage-missing' }
-  if (bottom === 'unresolvable') return { status: 'deferred', reason: 'coverage-unresolvable' }
-
-  const floorPos: PointerOrder = meta.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
-  if (isAfterBoundary(bottom, floorPos)) {
-    return { status: 'deferred', reason: 'coverage-short-of-floor' }
-  }
-
-  const res = await messageCache.countRoomUnreadInArchive(roomJid, {
-    floor,
-    pointer: meta.readPointer?.order,
-  })
-  if (moved()) return { status: 'stale' }
-  if (res === null) return { status: 'deferred', reason: 'cache-unavailable' }
-
-  const transient = transientCounts(roomTransientScopeKey(roomJid), floorPos)
-  const archiveCount = Math.min(999, res.unread + transient.unread)
-
-  const badgeCount = roomStore.getState().roomMeta.get(roomJid)?.unreadCount
-  if (badgeCount === undefined) return { status: 'deferred', reason: 'no-meta' }
-  if (moved()) return { status: 'stale' }
-  return { status: 'exact', archiveCount, badgeCount }
+/** See {@link computeUnreadDiagnostic}. */
+export function roomUnreadDiagnostic(roomJid: string): Promise<UnreadDiagnostic> {
+  return computeUnreadDiagnostic(roomUnreadDiagnosticConfig, roomJid)
 }
 
 /**
@@ -4371,24 +4343,12 @@ export const roomStore = createStore<RoomState>()(
       return { ...written, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
-    // Reported once the durable outcome is KNOWN: a report written at merge time
-    // would claim a retention that can still fail, which is the one thing this seam
-    // exists to distinguish.
     if (mergeDiagnostics.inputs) {
-      const inputs = mergeDiagnostics.inputs
-      const attempted = inputs.persistableNew + inputs.persistablePatched > 0
-      void Promise.all([
-        ownArchiveWrite ?? Promise.resolve(true),
-        archiveCommitGate ?? Promise.resolve(true),
-      ]).then(([own, chained]) => {
-        reportArchiveMerge({
-          entityKind: 'room',
-          entityId: roomJid,
-          direction,
-          complete,
-          ...describeArchiveMerge(inputs, own, chained, attempted),
-        })
-      })
+      reportArchiveMergeWhenDurable(
+        { entityKind: 'room', entityId: roomJid, direction, complete },
+        mergeDiagnostics.inputs,
+        { ownWrite: ownArchiveWrite, chainGate: archiveCommitGate }
+      )
     }
 
     if (archiveCommitGate) {

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
@@ -131,6 +131,31 @@ export function describeArchiveMerge(
 }
 
 /**
+ * Report a merge once its durable outcome is KNOWN, not when it is applied.
+ *
+ * A report written at merge time would claim a retention that can still fail, which
+ * is the one distinction this seam exists to make. So the two write outcomes are
+ * awaited first: `ownWrite` is this merge's own transaction, `chainGate` additionally
+ * covers every earlier in-flight page for the same entity. An absent promise means
+ * that gate had nothing to wait for, which counts as committed.
+ *
+ * Shared by both stores so the ordering rule cannot drift into one of them.
+ */
+export function reportArchiveMergeWhenDurable(
+  identity: Omit<ArchiveMergeReport, keyof ArchiveMergeCounts>,
+  inputs: ArchiveMergeInputs,
+  writes: { ownWrite?: Promise<boolean>; chainGate?: Promise<boolean> }
+): void {
+  const attempted = inputs.persistableNew + inputs.persistablePatched > 0
+  void Promise.all([
+    writes.ownWrite ?? Promise.resolve(true),
+    writes.chainGate ?? Promise.resolve(true),
+  ]).then(([own, chained]) => {
+    reportArchiveMerge({ ...identity, ...describeArchiveMerge(inputs, own, chained, attempted) })
+  })
+}
+
+/**
  * Hand a report to every subscriber.
  *
  * A handler that throws is contained: this runs on the merge's completion path, and

--- a/packages/fluux-sdk/src/stores/shared/unreadDiagnostic.ts
+++ b/packages/fluux-sdk/src/stores/shared/unreadDiagnostic.ts
@@ -15,13 +15,23 @@
  * - `stale` — the inputs moved while the count was being computed. Also not a bug:
  *   a newer recount is on its way with a better answer.
  *
- * Declared beside `recountDiagnostics` rather than in `core/types`: it names a
- * `RecountDeferralReason`, and `core/types` is the leaf layer that must not reach
- * into a store — `core/types/layering.test.ts` enforces it.
+ * One implementation, shared by chatStore and roomStore: the gate sequence is a
+ * second traversal of each store's recount, and a second copy of it per store would
+ * drift from its recount silently — a diagnostic that declines where the recount
+ * counts reports ordinary catch-up as a bug. Each store supplies only its own
+ * counters, through {@link UnreadDiagnosticConfig}.
+ *
+ * Declared here rather than in `core/types`: it names a `RecountDeferralReason`, and
+ * `core/types` is the leaf layer that must not reach into a store —
+ * `core/types/layering.test.ts` enforces it.
  *
  * @category Read state
  */
 import type { RecountDeferralReason } from './recountDiagnostics'
+import type { PointerOrder, ReadPointer } from '../../core/types/readState'
+import { computeFloor, isAfterBoundary, pointerlessDefers } from './readState'
+import { resolveCoverageBottom, type CoverageRecord } from './mamCoverage'
+import { transientCounts, type ScopeKey } from './transientUnread'
 
 export interface UnreadDiagnostic {
   status: 'exact' | 'deferred' | 'stale'
@@ -31,4 +41,122 @@ export interface UnreadDiagnostic {
   badgeCount?: number
   /** Which gate stood down. Present only on `deferred`. */
   reason?: RecountDeferralReason
+}
+
+/**
+ * The subset of an entity's metadata the diagnostic reads. `ConversationMetadata`
+ * and `RoomMetadata` both satisfy it structurally.
+ */
+export interface UnreadDiagnosticMeta {
+  readPointer?: ReadPointer
+  historyFloor?: Date
+  unreadCount: number
+  pendingRemoteDisplayedStanzaId?: string
+}
+
+/**
+ * One turn's worth of everything the verdict depends on, read by the store.
+ *
+ * `fingerprint` is the movement test: the module re-samples and compares it
+ * element-wise with `Object.is` around every `await`, and any difference makes the
+ * result `stale`. Which values belong in it is the STORE's decision, because the
+ * store owns the counters — but it must contain every input the gates below read,
+ * or the diagnostic can return an `exact` pair whose two numbers were never true at
+ * the same instant. Its entries must be identity-stable: a getter that allocates a
+ * fresh default on every call would make every result `stale`.
+ */
+export interface UnreadDiagnosticSnapshot {
+  meta: UnreadDiagnosticMeta | undefined
+  /** The MAM catch-up gate, already evaluated against this snapshot's query state. */
+  historyCaughtUp: boolean
+  coverage: CoverageRecord | undefined
+  fingerprint: readonly unknown[]
+}
+
+export interface UnreadDiagnosticConfig {
+  /** Selects the room flavour of coverage resolution and archive counting. */
+  isRoom: boolean
+  /** Samples the whole context in one synchronous turn. Must not write. */
+  sample: (entityId: string) => UnreadDiagnosticSnapshot
+  /** Whether a real recount is already running for this entity. */
+  isRecountInFlight: (entityId: string) => boolean
+  countUnreadInArchive: (
+    entityId: string,
+    range: { floor: Date; pointer: PointerOrder | undefined }
+  ) => Promise<{ unread: number } | null>
+  transientScopeKey: (entityId: string) => ScopeKey
+}
+
+/**
+ * The archive-derived unread count beside the badge, for a diagnostic consumer.
+ *
+ * A SECOND traversal of the stores' `recomputeUnreadFor*` gates, deliberately, and
+ * the two must be changed together — `unreadDiagnostic.test.ts` pins them to the
+ * same verdicts. It cannot call a recount itself, because that prelude has three
+ * side effects an observer must not have:
+ *
+ * - it bumps the latest-wins recount version, which would CANCEL a real recount in
+ *   flight and make the observer a cause;
+ * - it prunes the transient unread overlay;
+ * - it invalidates a persisted coverage record whose bottom no longer resolves.
+ *
+ * It also never counts from the resident slice: that would recreate the very
+ * under-count class a consumer would be comparing against, and go silent exactly
+ * when the badge is wrong.
+ *
+ * Both counts come from one validated context: the badge is read last, and the
+ * movement check runs after it, so an `exact` result holds two numbers that were
+ * true at the same instant.
+ */
+export async function computeUnreadDiagnostic(
+  config: UnreadDiagnosticConfig,
+  entityId: string
+): Promise<UnreadDiagnostic> {
+  const start = config.sample(entityId)
+  const meta = start.meta
+  if (!meta) return { status: 'deferred', reason: 'no-meta' }
+  if (meta.pendingRemoteDisplayedStanzaId !== undefined) {
+    return { status: 'deferred', reason: 'pending-remote-displayed' }
+  }
+  if (pointerlessDefers(meta.readPointer, meta.unreadCount)) {
+    return { status: 'deferred', reason: 'pointerless-defer' }
+  }
+  if (config.isRecountInFlight(entityId)) return { status: 'stale' }
+
+  const floor = computeFloor(meta.readPointer, meta.historyFloor)
+  if (!floor) return { status: 'deferred', reason: 'no-floor' }
+  if (!start.historyCaughtUp) return { status: 'deferred', reason: 'history-not-caught-up' }
+
+  const moved = (): boolean => !sameFingerprint(config.sample(entityId).fingerprint, start.fingerprint)
+
+  const bottom = await resolveCoverageBottom(entityId, start.coverage, config.isRoom)
+  if (moved()) return { status: 'stale' }
+  if (bottom === 'missing') return { status: 'deferred', reason: 'coverage-missing' }
+  // No `clearConversationCoverage` here, unlike the recount: an observer does not
+  // repair state it is observing.
+  if (bottom === 'unresolvable') return { status: 'deferred', reason: 'coverage-unresolvable' }
+
+  const floorPos: PointerOrder = meta.readPointer?.order ?? { role: 'floor', timestamp: floor.getTime() }
+  if (isAfterBoundary(bottom, floorPos)) {
+    return { status: 'deferred', reason: 'coverage-short-of-floor' }
+  }
+
+  const res = await config.countUnreadInArchive(entityId, { floor, pointer: meta.readPointer?.order })
+  if (moved()) return { status: 'stale' }
+  if (res === null) return { status: 'deferred', reason: 'cache-unavailable' }
+
+  // No `pruneTransient` either — read the overlay, do not edit it.
+  const transient = transientCounts(config.transientScopeKey(entityId), floorPos)
+  const archiveCount = Math.min(999, res.unread + transient.unread)
+
+  const badgeCount = config.sample(entityId).meta?.unreadCount
+  if (badgeCount === undefined) return { status: 'deferred', reason: 'no-meta' }
+  // Last: everything above must still describe the same context as this badge.
+  if (moved()) return { status: 'stale' }
+  return { status: 'exact', archiveCount, badgeCount }
+}
+
+function sameFingerprint(a: readonly unknown[], b: readonly unknown[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((value, index) => Object.is(value, b[index]))
 }


### PR DESCRIPTION
First slice of #1353 — the proposal that depends on no field evidence and changes no behaviour.

The unread diagnostic and the archive-merge report shipped as chat/room twins. Both are second traversals of logic the stores already own, so a copy per store drifts from its original silently: a diagnostic that declines where the recount counts would report ordinary catch-up as a bug.

`computeUnreadDiagnostic` now holds the gate sequence, the three side effects an observer must not have, and the one-snapshot rule. Each store supplies only its own counters, through a config whose `sample` returns the whole context in one turn — including the fingerprint the movement check compares element-wise. Which values count as movement stays the store's decision, since the store owns the counters; the comparison itself now exists in one place instead of as a ten-term conjunction repeated twice.

`reportArchiveMergeWhenDurable` holds the other rule the twins repeated: report once the write outcome is known, never at merge time, because a report written at merge time claims a retention that can still fail.

Net: 288 lines out of the two stores, 159 into `stores/shared/`.

The existing diagnostic, recount-agreement and archive-merge suites are untouched — they are what proves the behaviour is unchanged.

Left alone deliberately: `chatReadStateGeneration` / `roomReadStateGeneration` stay duplicated (three lines each; a config to share them would cost more than the duplication), and `describeArchiveMerge` stays exported although its only caller is now internal — proposal 1 of #1353 will dissolve that surface anyway.