### PR TITLE
fix(sdk): order two occupants sharing a room cache position

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -606,8 +606,10 @@ name in a glossary is how a private vocabulary starts.
   counting question) and `mayAdvanceTo` answers "may the pointer advance to this?" (the seen
   question). Their floor rules are *exact inverses*: a floor boundary counts everything in its
   millisecond as after it, while a floor on either side of an advance never overtakes within a
-  millisecond. Both directions err the recoverable way — over-counting clears when the user reads;
-  a position given away is gone. There is no collective name for the pair; say which one you mean.
+  millisecond. At that floor rung both choose the recoverable direction: a later pointer advance can
+  correct an over-count, while a position given away is gone. The occupant rung has one accepted
+  non-clearing direction; `docs/MESSAGE_IDENTIFIERS.md` section 5 owns that limit. There is no
+  collective name for the pair; say which one you mean.
   `packages/fluux-sdk/src/stores/shared/readState.ts`.
 - **The transition classes of a coverage record.** `created`, `deepened`, `topRefreshed` and
   `replaced` are named individually, but the property that matters — that every one except `replaced`

--- a/docs/MESSAGE_IDENTIFIERS.md
+++ b/docs/MESSAGE_IDENTIFIERS.md
@@ -151,12 +151,47 @@ The cache stores them under different primary keys:
 - room messages: `keyPath: 'cacheKey'` — the **canonical identity key** above
   (`utils/messageCache.ts:202`)
 
-`CacheOrderKey` (`packages/fluux-sdk/src/core/types/readState.ts:14-33`) is discriminated by kind
+`CacheOrderKey` (`packages/fluux-sdk/src/core/types/readState.ts:14-59`) is discriminated by kind
 for the same reason, and states why an archive id could never serve here: XEP-0313 §6.2 makes
 archive ids opaque, unique only per archive, with no ordering. Chat breaks same-millisecond ties by
-`id` alone; room breaks them by `from` then `id`, matching the `room_ts_from_id` index. Chat
+`id` alone; room breaks them by `from`, then `id`, then the XEP-0421 occupant-id. Chat
 messages also carry `from`, so a single "from then id" comparator would be wrong for chat — hence
 the discriminant. Do not generalise the two shapes into one.
+
+The room key's third rung is §4's row/message split reaching the ORDER. `(from, id)` names a
+message, not a row: a reassigned nick puts two occupants under one `from`, and a client id carries
+no uniqueness guarantee, so two rows can share a millisecond, a `from` and an id. Without the
+occupant they compare EQUAL, and a read pointer on one silently drops the other from the unread
+count — the unrecoverable direction.
+
+Three rules govern that rung, and each is load-bearing:
+
+- **An absent occupant-id sorts first, and the direction is arbitrary; being TOTAL is not.** A rule
+  that made an absent occupant compare equal to every present one would be intransitive, and
+  `sortMessagesByTimestamp` hands the comparator to `Array.prototype.sort`, which answers an
+  intransitive one with an arbitrary permutation of the resident array the viewport observer walks.
+- **Where only one side names an occupant, the rung cannot decide**, and the two questions of §5's
+  comparators answer that differently — the same asymmetry `floor` already has one rung up.
+  `isAfterBoundary` counts the row to avoid hiding it. In the clearable direction, `mayAdvanceTo`
+  reads the total order so a pointer holding no occupant-id may advance onto the row that names one
+  and stop being ambiguous. In the opposite direction, a row holding no occupant-id cannot move a
+  pointer that already names one backwards within the shared millisecond. The accepted limit needs
+  three separate rows sharing that millisecond, sender JID and client id: one pre-change row without
+  occupant identity and two rows with conflicting occupant ids, which keeps all three separate. The
+  legacy row can then remain unread after the pointer names a qualified occupant. Even the two-row
+  mixed form occurred zero times across 50,163 measured cached room rows; the wider same-room,
+  same-millisecond superset had 11 pairs (0.02%), and the three-row form is narrower still. The limit
+  ends for the legacy row once a new mint carrying occupant identity replaces its pre-change
+  representation, because the pair is no longer mixed.
+- **Nothing new is written to disk.** A row already stores its occupant-id (`StoredRoomMessage`)
+  and a pointer already stores its own (`PointerIdentity`), so the key is rebuilt from what is
+  there — exactly as its `id` is rebuilt from the pointer's `messageId`. `room_ts_from_id` is
+  unchanged: its one consumer re-adjudicates every row in range, so the index orders the walk but
+  decides nothing.
+
+**This is forward-looking, not a repair.** Rows and pointers written before the rung existed carry
+no occupant identity and cannot acquire one, so a pair already ordered wrong stays ordered wrong.
+Nothing recovers an occupant-id that was never stored.
 
 Protocol references follow the same split. `getMessageReferenceId`
 (`packages/fluux-sdk/src/core/modules/Chat.ts:1873-1880`) returns the `stanzaId` for a groupchat
@@ -171,17 +206,17 @@ On the receiving side, an incoming reference is resolved by `id`/`stanzaId` firs
 ## 6. When the archive id is missing
 
 A read position names itself through `PointerIdentity`
-(`packages/fluux-sdk/src/core/types/readState.ts:92-133`), a two-state discriminated union:
+(`packages/fluux-sdk/src/core/types/readState.ts:118-159`), a two-state discriminated union:
 
 - **`addressable`** — the named message carried an archive id when the pointer was minted.
   Publishable as-is.
 - **`local`** — no archive id. Explicitly degraded, not degraded by omission.
 
-`makeReadPointer` (`packages/fluux-sdk/src/stores/shared/readPointer.ts:160-180`) mints
+`makeReadPointer` (`packages/fluux-sdk/src/stores/shared/readPointer.ts:167-187`) mints
 `addressable` exactly when `message.stanzaId` is present: every peer message and every MUC
 reflection converges for free. `local` arises for a message whose archive id has not arrived yet —
 and, for the user's own 1:1 sends, may never arrive: the server does not echo them back, so their
-only id is the client-generated `origin-id`, which is not publishable (`readState.ts:103-109`).
+only id is the client-generated `origin-id`, which is not publishable (`readState.ts:129-135`).
 
 What a caller should do with a missing archive id:
 
@@ -190,11 +225,11 @@ What a caller should do with a missing archive id:
 - **Keep using the lower tiers.** Dedup, cache lookups and local rendering work on
   `originId`/`from`+`id` (§3).
 - **Wait for convergence, bound by identity.** `withArchiveId`
-  (`stores/shared/readPointer.ts:200-235`) attaches a later-known archive id to a `local` pointer.
+  (`stores/shared/readPointer.ts:207-243`) attaches a later-known archive id to a `local` pointer.
   It touches the name only, never the order; the caller must bind by identity, never by timestamp
   or by an `origin-id` two rows share; and a `floor` pointer is never enriched.
 - **Fall back on order, not on name.** `PointerOrder`
-  (`core/types/readState.ts:35-90`) separates an exact position from a `floor` — "at least here" —
+  (`core/types/readState.ts:61-116`) separates an exact position from a `floor` — "at least here" —
   and comparators answer the two differently on purpose.
 
 ## 7. Do not
@@ -211,11 +246,11 @@ What a caller should do with a missing archive id:
   scoping exists to prevent (`messageIdentity.ts`, `messageCache.ts:202-210`).
 - **Do not read stability as identity.** `originId` is stable and sender-assigned, which makes it a
   good echo-dedup key — but two rows can share one, which is why `withArchiveId` forbids binding
-  through it (`readPointer.ts:200-235`) and why references resolve it last
+  through it (`readPointer.ts:207-243`) and why references resolve it last
   (`chatStore.ts:2457`, `:2518`).
 - **Do not assume an archive id, once seen, is permanent.** It can be revoked when the archive
   purges it (`chatStore.ts:2588-2602`, `roomStore.ts:2527-2547`).
-- **Do not use an archive id for ordering.** It carries none (`core/types/readState.ts:14-33`).
+- **Do not use an archive id for ordering.** It carries none (`core/types/readState.ts:14-25`).
 
 ## Related
 

--- a/packages/fluux-sdk/src/core/types/readState.ts
+++ b/packages/fluux-sdk/src/core/types/readState.ts
@@ -16,21 +16,47 @@
  * CLIENT message id. It has never held an archive id, and could not: XEP-0313
  * §6.2 makes archive ids opaque strings with no guarantee of being numeric,
  * sequenced or globally unique, and unique only per archive — they carry no
- * ordering. This key is chosen to agree with the cache's cursors, and is
- * kind-discriminated because chat and room break same-millisecond ties
- * differently:
+ * ordering. This key refines the cache cursor's order: the room cursor stops at
+ * `id`, and its consumer re-adjudicates every row before counting. The key stays
+ * kind-discriminated because chat and room break same-millisecond ties differently:
  *
  * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'` in
  *   `messageCache.ts`).
- * - Room breaks ties by `from` then `id` (the `room_ts_from_id` index).
+ * - Room breaks ties by `from`, then `id`, then the XEP-0421 occupant-id.
  *
  * Chat messages also carry `from`, so a generic "from then id" comparator
  * would be wrong for chat — the `kind` discriminant is what keeps the two
  * apart. Do not generalise this into a single shape.
  *
+ * The occupant rung is there because `(from, id)` does not name a row: a
+ * reassigned nick puts two occupants under one `from`, and a client id carries
+ * no uniqueness guarantee, so two rows can share a millisecond, a `from` and an
+ * id. Without the occupant they compare EQUAL, and a read pointer sitting on one
+ * silently swallows the other.
+ *
+ * It is optional because it genuinely is: a pre-XEP-0421 room, a 1:1 message
+ * and every row and pointer written before this component existed carry none.
+ * An absent occupant-id is NOT evidence — `occupantConflict` in
+ * `utils/messageIdentity.ts` states that rule for identity, and ordering has to
+ * honour it too. Where only one side of a comparison names an occupant, the rung
+ * cannot decide, and the comparators in `stores/shared/readState.ts` answer that
+ * differently for the counting question and the advance question, on purpose.
+ *
+ * Nothing new is written to disk for it. A row already stores its occupant-id
+ * (`StoredRoomMessage`), and a pointer already stores its own
+ * ({@link PointerIdentity}), so the key is rebuilt from what is there —
+ * exactly as its `id` is rebuilt from the pointer's `messageId`.
+ *
+ * This rung is FORWARD-LOOKING, not a repair. Rows and pointers written before
+ * it existed carry no occupant identity and cannot acquire one, so a pair
+ * already ordered wrong stays ordered wrong. Nothing recovers an occupant-id
+ * that was never stored.
+ *
  * @category Read state
  */
-export type CacheOrderKey = { kind: 'chat'; id: string } | { kind: 'room'; from: string; id: string }
+export type CacheOrderKey =
+  | { kind: 'chat'; id: string }
+  | { kind: 'room'; from: string; id: string; occupantId?: string }
 
 /**
  * A position that is exactly located in message-cache order: a timestamp

--- a/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
@@ -50,11 +50,12 @@ export function createRoom(jid: string, options: Partial<Room> = {}): Room {
  * migrated from the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair, whose
  * timestamp cannot certify its own position.
  *
- * The reason to be explicit is that the ROOM tie-break is `(from, id)`. Under
- * fake timers `new Date()` returns the same instant every call, so the order of
- * two same-instant messages is then decided by sender JID and, for one sender,
- * by LEXICOGRAPHIC id — 'msg-10' sorts before 'msg-2'. Distinct timestamps keep
- * the fixture's intended order the one the pointer actually sees.
+ * The reason to be explicit is that these occupant-less fixtures use the first
+ * two rungs of the ROOM tie-break, `(from, id, occupantId)`. Under fake timers
+ * `new Date()` returns the same instant every call, so the order of two
+ * same-instant messages is then decided by sender JID and, for one sender, by
+ * LEXICOGRAPHIC id — 'msg-10' sorts before 'msg-2'. Distinct timestamps keep the
+ * fixture's intended order the one the pointer actually sees.
  */
 export function createMessage(
   id: string,

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -14,12 +14,15 @@ import { compareExact, exactPosition } from './readState'
  * `id` and `from` are required for the timestamp-tiebreak sort below — the
  * resident array must break same-millisecond ties with the SAME total order
  * as the archive (`readState.ts`'s `compareExact`), or the two can disagree
- * about which message came second.
+ * about which message came second. `occupantId` is the room key's third
+ * component: drop it and two occupants under one reassigned nick sort as one
+ * position again.
  */
 export interface TimestampedMessage {
   timestamp: Date
   id: string
   from?: string
+  occupantId?: string
 }
 
 /**
@@ -216,15 +219,17 @@ export function backfillArchiveIds<T extends ArchiveIdentifiableMessage>(
  *
  * Same-millisecond ties break by the message cache's own tie-break key
  * (`readState.ts`'s `compareExact`), kind-discriminated: chat by `id` only,
- * room by `from` then `id`. This is deliberately NOT a generic `from`-then-`id`
- * comparator — chat messages carry `from` too, so inferring the tiebreak from
- * field presence would silently apply the room rule to chat. The resident
- * array and IndexedDB must agree on this order, or the read pointer
- * (positioned in cache order) and the viewport observer (walking
- * this resident order) can disagree about which message came second.
+ * room by `from`, then `id`, then the occupant-id. This is deliberately NOT a
+ * generic `from`-then-`id` comparator — chat messages carry `from` too, so
+ * inferring the tiebreak from field presence would silently apply the room rule
+ * to chat. The resident array and archive adjudicator must agree on this order;
+ * the room IndexedDB cursor stops at `id`, and every row it visits is compared
+ * again here. Otherwise the read pointer (positioned in cache order) and the
+ * viewport observer (walking this resident order) can disagree about which
+ * message came second.
  *
  * @param messages - Array of messages to sort
- * @param kind - Which tie-break rule applies (`'chat'` = id only, `'room'` = from then id)
+ * @param kind - Which tie-break rule applies (`'chat'` = id only, `'room'` = from, id, occupant)
  * @returns New sorted array (does not mutate input)
  */
 export function sortMessagesByTimestamp<T extends TimestampedMessage>(

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -102,8 +102,8 @@ export function appendLive<T extends TimelineMessage>(
 
   // Sort before trimming.
   // Live arrivals land in ARRIVAL order, but the cache orders same-millisecond
-  // rows by the shared comparator (id for chat, (from, id) for room — see
-  // `compareExact`/`makeCacheOrderKey`). The viewport observer advances the
+  // rows by the shared comparator (id for chat, (from, id, occupantId) for room
+  // — see `compareExact`/`makeCacheOrderKey`). The viewport observer advances the
   // read pointer by RESIDENT INDEX, so an unsorted resident array can place a
   // same-ms sibling later than the cache would — the pointer then advances
   // past it while the cache walk still counts it as unread: a silent

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -111,7 +111,7 @@ export interface NotificationMessage extends RenderabilityCheckFields {
   isOutgoing: boolean
   isDelayed?: boolean
   isMention?: boolean
-  /** Sender's JID — feeds the ROOM cache order key's (from, id) tie-break. */
+  /** Sender's JID — feeds the first rung of the ROOM key's `(from, id, occupantId)` tie-break. */
   from?: string
   /**
    * XEP-0359 archive id, when the server has assigned one.

--- a/packages/fluux-sdk/src/stores/shared/readPointer.property.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.property.test.ts
@@ -28,6 +28,13 @@ import type { ReadPointer } from '../../core/types/readState'
 const TIMESTAMPS = [0, 1, 2] as const
 const IDS = ['a', 'b', 'c'] as const
 const FROMS = ['x@s', 'y@s'] as const
+/**
+ * `undefined` is in the pool on purpose: a pre-XEP-0421 room, and every row and
+ * pointer written before the occupant rung existed, supply none. Mixing it with
+ * known ids is what makes the laws below cover the pair where only ONE side
+ * knows its occupant — the pair a convention, not a fact, has to order.
+ */
+const OCCUPANTS = [undefined, 'o1', 'o2'] as const
 
 type Kind = 'chat' | 'room'
 
@@ -44,8 +51,11 @@ const exactArbFor = (kind: Kind): fc.Arbitrary<ExactPosition> =>
       timestamp: fc.constantFrom(...TIMESTAMPS),
       id: fc.constantFrom(...IDS),
       from: fc.constantFrom(...FROMS),
+      occupantId: fc.constantFrom(...OCCUPANTS),
     })
-    .map(({ timestamp, id, from }) => exactPosition({ id, from, timestamp: new Date(timestamp) }, kind))
+    .map(({ timestamp, id, from, occupantId }) =>
+      exactPosition({ id, from, occupantId, timestamp: new Date(timestamp) }, kind),
+    )
 
 const floorArb: fc.Arbitrary<PointerOrder> = fc
   .constantFrom(...TIMESTAMPS)
@@ -60,10 +70,11 @@ const pointerArbFor = (kind: Kind): fc.Arbitrary<ReadPointer> =>
       timestamp: fc.constantFrom(...TIMESTAMPS),
       id: fc.constantFrom(...IDS),
       from: fc.constantFrom(...FROMS),
+      occupantId: fc.constantFrom(...OCCUPANTS),
       stanzaId: fc.option(fc.constantFrom('s1', 's2'), { nil: undefined }),
     })
-    .map(({ timestamp, id, from, stanzaId }) =>
-      makeReadPointer({ id, from, timestamp: new Date(timestamp), stanzaId }, kind),
+    .map(({ timestamp, id, from, occupantId, stanzaId }) =>
+      makeReadPointer({ id, from, occupantId, timestamp: new Date(timestamp), stanzaId }, kind),
     )
 
 /** A pointer carrying a floor order, as the #1081 legacy migration produces. */

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -8,7 +8,7 @@ import {
   deserializeReadPointer,
 } from './readPointer'
 import type { ReadPointer } from './readPointer'
-import { isAfterBoundary, type CacheOrderKey } from './readState'
+import { exactPosition, isAfterBoundary, type CacheOrderKey } from './readState'
 
 const at = (ms: number) => new Date(ms)
 
@@ -517,5 +517,58 @@ describe('an old build reading the identity-variant on-disk form', () => {
     ]) {
       expect(deserializeReadPointer(raw)).toBeDefined()
     }
+  })
+})
+
+/**
+ * The occupant rung crosses storage on the IDENTITY, never in the stored key.
+ * Both halves are pinned here: what a current pointer gets back, and what a
+ * pointer written before the field existed does when it meets a row that has
+ * one — the path every existing room takes on first read.
+ */
+describe('the occupant rung across storage', () => {
+  const roomMsg = { id: 'm1', from: 'r@c/nick', timestamp: at(1000) }
+
+  /** A room pointer as it was written before the pointer carried an occupant-id. */
+  const legacyOnDisk = {
+    order: { role: 'exact', timestamp: 1000, tiebreak: { kind: 'room', from: 'r@c/nick' } },
+    identity: { state: 'local', messageId: 'm1' },
+  }
+
+  it('rebuilds the tie-break occupant from the identity', () => {
+    const p = makeReadPointer({ ...roomMsg, occupantId: 'occ-a' }, 'room')
+    const back = deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))!
+    expect(back).toEqual(p)
+    expect(back.order.role === 'exact' && back.order.tiebreak).toEqual({
+      kind: 'room',
+      from: 'r@c/nick',
+      id: 'm1',
+      occupantId: 'occ-a',
+    })
+  })
+
+  it('writes no occupant into the stored key, leaving the on-disk shape unchanged', () => {
+    const written = serializeReadPointer(makeReadPointer({ ...roomMsg, occupantId: 'occ-a' }, 'room'))
+    expect(written.order).toEqual({
+      role: 'exact',
+      timestamp: 1000,
+      tiebreak: { kind: 'room', from: 'r@c/nick' },
+    })
+    expect(JSON.parse(JSON.stringify(written)).order.tiebreak).not.toHaveProperty('occupantId')
+  })
+
+  it('hydrates a pointer written before the field existed without one', () => {
+    const back = deserializeReadPointer(legacyOnDisk)!
+    expect(back.order.role === 'exact' && back.order.tiebreak).toEqual({
+      kind: 'room',
+      from: 'r@c/nick',
+      id: 'm1',
+    })
+  })
+
+  it('OVER-COUNTS the other occupant under such a pointer rather than swallowing it', () => {
+    const legacy = deserializeReadPointer(legacyOnDisk)!
+    const otherOccupant = exactPosition({ ...roomMsg, occupantId: 'occ-b' }, 'room')
+    expect(isAfterBoundary(otherOccupant, legacy.order)).toBe(true)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -62,8 +62,15 @@ export type { PointerIdentity, ReadPointer } from '../../core/types/readState'
  * for a forward-only pointer. Not persisting the second copy makes that
  * disagreement unrepresentable rather than merely rejected at read time.
  *
- * `from` stays: it is the room cache's `(from, id)` tie-break component and is
- * NOT derivable from the pointer.
+ * `from` stays: it is the room cache's first `(from, id, occupantId)` tie-break
+ * component and is NOT derivable from the pointer.
+ *
+ * The room key's occupant-id is absent here for the same reason as the `id`:
+ * it is `identity.occupantId`, already on disk, and reconstructed at hydration.
+ * Writing a second copy would rebuild exactly the two-names-that-can-disagree
+ * shape this type exists to remove — and it would be the worse copy, since the
+ * one under `identity` is what every row lookup resolves through. So this shape
+ * does not change, and neither does any byte already written under it.
  */
 export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
 
@@ -92,7 +99,7 @@ export interface SerializedReadPointer {
 /** The minimal message shape a pointer can be built from. */
 export interface PointerSource {
   id: string
-  /** Sender's JID — needed for the ROOM cache order key's (from, id) tie-break. */
+  /** Sender's JID — needed for the ROOM key's `(from, id, occupantId)` tie-break. */
   from?: string
   timestamp: Date
   /**
@@ -343,12 +350,25 @@ export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointe
  * inconsistent data. What remains validated is what cannot be reconstructed: the
  * `kind` discriminant, and `from` for a room key. Anything else yields no key at
  * all, which degrades the order to a `floor` (over-count, the safe direction).
+ *
+ * `occupantId` arrives the same way the `id` does — off the identity, never off
+ * the stored key. A blob written before the pointer carried an occupant-id
+ * supplies none, and the key is then one that names a room row without saying
+ * which occupant wrote it. That is not a defect to repair here: it is the true
+ * state of that pointer, and `readState.ts` is where the comparison decides what
+ * to do about it.
  */
-function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | undefined {
+function hydrateCacheOrderKey(
+  raw: unknown,
+  messageId: string,
+  occupantId: string | undefined
+): CacheOrderKey | undefined {
   if (!raw || typeof raw !== 'object') return undefined
   const k = raw as Record<string, unknown>
   if (k.kind === 'chat') return { kind: 'chat', id: messageId }
-  if (k.kind === 'room' && typeof k.from === 'string') return { kind: 'room', from: k.from, id: messageId }
+  if (k.kind === 'room' && typeof k.from === 'string') {
+    return { kind: 'room', from: k.from, id: messageId, ...(occupantId ? { occupantId } : {}) }
+  }
   return undefined
 }
 
@@ -403,13 +423,17 @@ function hydrateNested(raw: Record<string, unknown>): ReadPointer | undefined {
   const timestamp = hydrateTimestamp(orderFields.timestamp)
   if (timestamp === undefined) return undefined
 
-  const tiebreak =
-    orderFields.role === 'exact' ? hydrateCacheOrderKey(orderFields.tiebreak, messageId) : undefined
-
   const archiveId = identityFields.archiveId
   const rawOccupantId = identityFields.occupantId
-  const occupant =
-    typeof rawOccupantId === 'string' && rawOccupantId.length > 0 ? { occupantId: rawOccupantId } : {}
+  const occupantId =
+    typeof rawOccupantId === 'string' && rawOccupantId.length > 0 ? rawOccupantId : undefined
+  const occupant = occupantId ? { occupantId } : {}
+
+  const tiebreak =
+    orderFields.role === 'exact'
+      ? hydrateCacheOrderKey(orderFields.tiebreak, messageId, occupantId)
+      : undefined
+
   return {
     order: tiebreak ? { role: 'exact', timestamp, tiebreak } : { role: 'floor', timestamp },
     identity:
@@ -456,7 +480,9 @@ function hydrateLegacyFlat(raw: Record<string, unknown>): ReadPointer | undefine
   // before the on-disk rename — a name that was always wrong (the key never held
   // an archive id; it is the IndexedDB cursor tie-break built from the CLIENT
   // message id). Both are read here and neither is written any more.
-  const tiebreak = hydrateCacheOrderKey(raw.tiebreak ?? raw.archiveOrderKey, messageId)
+  // No occupant-id: this format predates the field entirely, which is also why
+  // the identity it rebuilds is `local` with a bare client id.
+  const tiebreak = hydrateCacheOrderKey(raw.tiebreak ?? raw.archiveOrderKey, messageId, undefined)
 
   return {
     order: tiebreak ? { role: 'exact', timestamp, tiebreak } : { role: 'floor', timestamp },

--- a/packages/fluux-sdk/src/stores/shared/readState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.test.ts
@@ -87,3 +87,83 @@ describe('pointerlessDefers', () => {
   it('defers pointerless with a real persisted count', () => expect(pointerlessDefers(undefined, 3)).toBe(true))
   it('allows a pointerless zero (genuinely fresh)', () => expect(pointerlessDefers(undefined, 0)).toBe(false))
 })
+
+/**
+ * A reused MUC nick puts two occupants under one `(from, id)`. The occupant rung
+ * is what separates their positions; these tests pin the rung itself.
+ */
+describe('the occupant rung', () => {
+  const roomRow = (occupantId?: string): ExactPosition => ({
+    role: 'exact',
+    timestamp: 5,
+    tiebreak: makeCacheOrderKey({ from: 'r@c/nick', id: 'm1', occupantId }, 'room'),
+  })
+
+  it('separates two rows that differ only by occupant-id', () => {
+    expect(compareExact(roomRow('a'), roomRow('b'))).toBeLessThan(0)
+    expect(compareExact(roomRow('b'), roomRow('a'))).toBeGreaterThan(0)
+    expect(compareExact(roomRow('a'), roomRow('a'))).toBe(0)
+  })
+
+  it("counts the other occupant's row instead of swallowing it", () => {
+    // The defect this rung closes: with the pointer on occupant a's row, b's
+    // row compared EQUAL and was silently dropped from the unread count.
+    expect(isAfterBoundary(roomRow('b'), roomRow('a'))).toBe(true)
+    expect(mayAdvanceTo(roomRow('b'), roomRow('a'))).toBe(true)
+  })
+
+  it('leaves two occupant-less rows tied, exactly as before', () => {
+    expect(compareExact(roomRow(), roomRow())).toBe(0)
+    expect(isAfterBoundary(roomRow(), roomRow())).toBe(false)
+    expect(mayAdvanceTo(roomRow(), roomRow())).toBe(false)
+  })
+
+  it('never lets an occupant-id reach a CHAT key', () => {
+    const chatRow = (occupantId?: string): ExactPosition => ({
+      role: 'exact',
+      timestamp: 5,
+      tiebreak: makeCacheOrderKey({ from: 'r@c/nick', id: 'm1', occupantId }, 'chat'),
+    })
+    expect(compareExact(chatRow('a'), chatRow('b'))).toBe(0)
+  })
+})
+
+/**
+ * The MIXED pair: one side names its occupant and the other CANNOT — a pointer
+ * hydrated from a blob written before occupant-ids were carried, against a row
+ * that has one (or the reverse, a legacy cached row under a current pointer).
+ *
+ * This is the pair the change actually has to get right. Every existing user
+ * meets it on first read; the new/new pair above is the easy case.
+ */
+describe('the MIXED pair — one side has no occupant identity', () => {
+  const room = (occupantId?: string): ExactPosition => ({
+    role: 'exact',
+    timestamp: 5,
+    tiebreak: makeCacheOrderKey({ from: 'r@c/nick', id: 'm1', occupantId }, 'room'),
+  })
+
+  it('COUNTS the row in both directions of the mixture — over-count, never under-count', () => {
+    expect(isAfterBoundary(room('x'), room())).toBe(true)
+    // The direction a bare sentinel order loses: an occupant-less row under a
+    // pointer that names one would sort BEFORE the boundary and vanish.
+    expect(isAfterBoundary(room(), room('x'))).toBe(true)
+  })
+
+  it('lets the pointer advance onto the row that names its occupant, so the over-count clears', () => {
+    expect(mayAdvanceTo(room('x'), room())).toBe(true)
+  })
+
+  it('refuses to advance onto a row that cannot name the occupant the pointer holds', () => {
+    expect(mayAdvanceTo(room(), room('x'))).toBe(false)
+  })
+
+  it('keeps compareExact a TOTAL order across the mixed pair', () => {
+    // Transitive: absent, then 'a', then 'b'. A rule that made an absent
+    // occupant compare EQUAL to every present one would not be, and
+    // `sortMessagesByTimestamp` would then produce an arbitrary permutation.
+    expect(compareExact(room(), room('a'))).toBeLessThan(0)
+    expect(compareExact(room('a'), room('b'))).toBeLessThan(0)
+    expect(compareExact(room(), room('b'))).toBeLessThan(0)
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -32,9 +32,24 @@ export { isRenderableStoredMessage, type RenderabilityCheckFields } from '../../
  */
 export type { CacheOrderKey, ExactPosition, FloorPosition, PointerOrder } from '../../core/types/readState'
 
-/** Build the kind-appropriate order key for a message. */
-export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'chat' | 'room'): CacheOrderKey {
-  return kind === 'room' ? { kind: 'room', from: msg.from ?? '', id: msg.id } : { kind: 'chat', id: msg.id }
+/**
+ * Build the kind-appropriate order key for a message.
+ *
+ * `occupantId` is read for a ROOM key only. A chat message has no XEP-0421
+ * occupant, and admitting one here would give the chat cache a tie-break
+ * component its `keyPath: 'id'` store cannot reproduce.
+ */
+export function makeCacheOrderKey(
+  msg: { from?: string; id: string; occupantId?: string },
+  kind: 'chat' | 'room'
+): CacheOrderKey {
+  if (kind !== 'room') return { kind: 'chat', id: msg.id }
+  return {
+    kind: 'room',
+    from: msg.from ?? '',
+    id: msg.id,
+    ...(msg.occupantId ? { occupantId: msg.occupantId } : {}),
+  }
 }
 
 /**
@@ -46,7 +61,7 @@ export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'cha
  * position.
  */
 export function exactPosition(
-  msg: { from?: string; id: string; timestamp: Date },
+  msg: { from?: string; id: string; occupantId?: string; timestamp: Date },
   kind: 'chat' | 'room'
 ): ExactPosition {
   return { role: 'exact', timestamp: msg.timestamp.getTime(), tiebreak: makeCacheOrderKey(msg, kind) }
@@ -54,8 +69,8 @@ export function exactPosition(
 
 /**
  * Break a same-millisecond tie between two known tie-breaks. Kind-aware: chat
- * compares `id` only, room compares `from` then `id` — see {@link CacheOrderKey}
- * for why one generic shape would be wrong.
+ * compares `id` only, room compares `from`, then `id`, then the occupant-id —
+ * see {@link CacheOrderKey} for why one generic shape would be wrong.
  *
  * Private, and takes the KEYS rather than the positions, so it cannot be
  * mistaken for a general comparator over positions and cannot be reached with a
@@ -64,9 +79,42 @@ export function exactPosition(
 function compareTiebreak(a: CacheOrderKey, b: CacheOrderKey): number {
   if (a.kind === 'room' && b.kind === 'room') {
     if (a.from !== b.from) return a.from < b.from ? -1 : 1
-    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+    if (a.id !== b.id) return a.id < b.id ? -1 : 1
+    // An absent occupant-id sorts FIRST. The direction is arbitrary; being
+    // TOTAL is not. A rule that made an absent occupant compare equal to every
+    // present one would be intransitive — absent = A and absent = B while
+    // A < B — and `sortMessagesByTimestamp` feeds this straight to
+    // `Array.prototype.sort`, which answers an intransitive comparator with an
+    // arbitrary permutation. The resident order is what the viewport observer
+    // walks, so that permutation would move the read pointer.
+    //
+    // Whether the pair is DECIDABLE at all is a separate question, and the two
+    // callers below answer it differently — see {@link occupantEvidenceMissing}.
+    const ao = a.occupantId ?? ''
+    const bo = b.occupantId ?? ''
+    return ao < bo ? -1 : ao > bo ? 1 : 0
   }
   return a.id < b.id ? -1 : a.id > b.id ? 1 : 0 // chat: id only
+}
+
+/**
+ * Whether two keys name the same room row but only ONE of them knows which
+ * occupant wrote it.
+ *
+ * This is the rung's "no evidence" state, and it is not hypothetical: a pointer
+ * hydrated from a blob written before the occupant-id was carried has none and
+ * can never acquire one, while the row it names does. Every existing room meets
+ * this pair on first read.
+ *
+ * An absent occupant-id must not SEPARATE two copies — `occupantConflict` in
+ * `utils/messageIdentity.ts` — so the order {@link compareTiebreak} imposes on
+ * such a pair is a convention, not a fact, and a caller that must not be wrong
+ * has to ask this instead of reading that order.
+ */
+function occupantEvidenceMissing(a: CacheOrderKey, b: CacheOrderKey): boolean {
+  if (a.kind !== 'room' || b.kind !== 'room') return false
+  if (a.from !== b.from || a.id !== b.id) return false
+  return (a.occupantId === undefined) !== (b.occupantId === undefined)
 }
 
 /**
@@ -91,9 +139,10 @@ export function compareExact(a: ExactPosition, b: ExactPosition): number {
  *
  * A FLOOR boundary means AT-OR-AFTER its timestamp: every row sharing the
  * boundary's millisecond, including the boundary's own message, counts as after
- * it. That over-counts by up to the same-millisecond sibling set, which is the
- * recoverable direction — an over-count clears the moment the user reads, while
- * an under-count hides a message permanently.
+ * it. That over-counts by up to the same-millisecond sibling set, choosing the
+ * recoverable direction: a later pointer advance can correct an over-count,
+ * while an under-count hides a message permanently. The occupant-evidence
+ * branch below has one accepted, narrower case that reading does not clear.
  *
  * `row` is an {@link ExactPosition} because an archive row always resolves to
  * one. That is not a formality: it is what stops this function from being used
@@ -102,6 +151,24 @@ export function compareExact(a: ExactPosition, b: ExactPosition): number {
 export function isAfterBoundary(row: ExactPosition, boundary: PointerOrder): boolean {
   if (boundary.role === 'floor') return row.timestamp >= boundary.timestamp // over-count (safe)
   if (row.timestamp !== boundary.timestamp) return row.timestamp > boundary.timestamp
+  // No occupant evidence — the same choice the floor branch above makes, one
+  // rung down. This DIRECTION IS A DECISION, not a consequence of how the
+  // operators happen to order a missing value: counting protects a genuinely
+  // unread row from disappearing whenever the boundary names an occupant.
+  //
+  // Accepted limit: three separate rows can share one millisecond, sender JID
+  // and client id when one was written before occupant identity was carried and
+  // the other two carry conflicting occupant ids, keeping all three separate.
+  // Once the pointer names one of those qualified occupants, the occupant-less
+  // row counts as unread and reading does not clear it: the advance question
+  // will not move the pointer backwards within the shared millisecond. Zero
+  // occurrences of even the two-row mixed form were found across 50,163 real
+  // cached room rows; the wider same-room, same-millisecond superset had 11
+  // pairs (0.02%), and this three-row shape is narrower still. This is accepted
+  // rather than overlooked. It ends for the legacy row once a new mint carrying
+  // occupant identity replaces its pre-change representation, because the
+  // comparison is then no longer mixed.
+  if (occupantEvidenceMissing(row.tiebreak, boundary.tiebreak)) return true
   return compareTiebreak(row.tiebreak, boundary.tiebreak) > 0
 }
 
@@ -113,7 +180,7 @@ export function isAfterBoundary(row: ExactPosition, boundary: PointerOrder): boo
  * either side is only a floor, nothing about their relative order within a
  * shared millisecond is provable. The read pointer is forward-only, so a
  * position given away here is unrecoverable; refusing to move merely
- * over-counts, which the user clears by reading.
+ * over-counts, which a later provable pointer advance can correct.
  *
  * `candidate` is a {@link PointerOrder} rather than an `ExactPosition` because
  * a pointer migrated from the legacy pair really is a floor and really does get
@@ -123,6 +190,15 @@ export function isAfterBoundary(row: ExactPosition, boundary: PointerOrder): boo
  * This is the exact inverse of {@link isAfterBoundary}'s rule, on purpose. The
  * two questions are not interchangeable — that is why they are two functions
  * (#1173) rather than one comparator with a warning attached to it.
+ *
+ * The occupant rung is where the two stop being mirror images. In the clearable
+ * direction, a pointer holding no occupant-id may advance onto a row that names
+ * one. Refusing there would strand the pointer: the pair shares a millisecond,
+ * so no later position could lift it. Advancing refines the pointer's name
+ * rather than overtaking a message, and the next mint carries the occupant-id.
+ * In the opposite direction, a row holding no occupant-id cannot move a pointer
+ * that already names one; the total order refuses that backwards move. This is
+ * the accepted non-clearing limit described at {@link isAfterBoundary}.
  */
 export function mayAdvanceTo(candidate: PointerOrder, current: PointerOrder): boolean {
   if (candidate.role === 'floor' || current.role === 'floor') {

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1935,6 +1935,52 @@ describe('countRoomUnreadInArchive (room)', () => {
     expect(res).toEqual({ unread: 1 })
   })
 
+  /**
+   * The nick `alice` was reassigned, so two occupants produced rows sharing this
+   * room, `from`, client id and millisecond. Only the XEP-0421 occupant-id
+   * separates them, and without it in the order key the walk compared them EQUAL
+   * and dropped the second — a silently swallowed unread message.
+   */
+  it('same-ms, same from AND same id: counts the row the OTHER occupant wrote', async () => {
+    const t = new Date(5000)
+    const shared = { id: 'm1', from: `${ROOM}/alice`, timestamp: t, isOutgoing: false }
+    await messageCache.saveRoomMessages([
+      createMockRoomMessage(ROOM, { ...shared, stanzaId: 'arch-a', occupantId: 'occ-a' }),
+      createMockRoomMessage(ROOM, { ...shared, stanzaId: 'arch-b', occupantId: 'occ-b' }),
+    ])
+    // Two rows, not one: conflicting occupant-ids block the merge.
+    expect(await messageCache.getRoomMessageCount(ROOM)).toBe(2)
+
+    const res = await messageCache.countRoomUnreadInArchive(ROOM, {
+      floor: t,
+      pointer: {
+        role: 'exact',
+        timestamp: t.getTime(),
+        tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm1', occupantId: 'occ-a' },
+      },
+    })
+    expect(res).toEqual({ unread: 1 })
+  })
+
+  /**
+   * The same pair under a pointer written before the occupant rung existed. It
+   * cannot say which row it sits on, so BOTH count: an over-count the user
+   * clears by reading, never an unread message hidden for good.
+   */
+  it('same-ms pair under an occupant-less pointer over-counts rather than swallowing', async () => {
+    const t = new Date(5000)
+    const shared = { id: 'm1', from: `${ROOM}/alice`, timestamp: t, isOutgoing: false }
+    await messageCache.saveRoomMessages([
+      createMockRoomMessage(ROOM, { ...shared, stanzaId: 'arch-a', occupantId: 'occ-a' }),
+      createMockRoomMessage(ROOM, { ...shared, stanzaId: 'arch-b', occupantId: 'occ-b' }),
+    ])
+    const res = await messageCache.countRoomUnreadInArchive(ROOM, {
+      floor: t,
+      pointer: { role: 'exact', timestamp: t.getTime(), tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm1' } },
+    })
+    expect(res).toEqual({ unread: 2 })
+  })
+
   it('missing tiebreak falls back to at-or-after-timestamp (over-counts, safe)', async () => {
     const t = new Date(5000)
     await messageCache.saveRoomMessages([

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1209,8 +1209,8 @@ export interface UnreadCountArgs {
    * every row at the pointer's exact millisecond, including the pointer's own
    * message, resolves as "after" the pointer and gets counted. That is
    * at-or-after-TIMESTAMP semantics, not strict-after-timestamp: it over-counts
-   * by up to the same-ms sibling set, which is the safe direction (an
-   * over-count clears the moment the user reads; an under-count would hide a
+   * by up to the same-ms sibling set, which is the safe direction (a later
+   * pointer advance can correct an over-count; an under-count would hide a
    * message permanently). Omitting `pointer` entirely counts everything from
    * `floor`.
    */


### PR DESCRIPTION
The room cache order key broke a same-millisecond tie by `from` then `id`, and neither names a row.
XEP-0421 lets a MUC reassign a nick, so two occupants can produce rows sharing a room, a `from` and a
client id, and a client id carries no uniqueness guarantee of its own. Without the occupant-id those
rows compared equal: the archive walk dropped the second from the unread count and the pointer could
never advance across the pair, so a genuinely unread message was silently swallowed.

The occupant-id becomes the room key's third rung. Nothing new is written to disk for it — a row
already stores its occupant-id and a pointer already stores its own, so the key is rebuilt at
hydration from what is there, exactly as its `id` is rebuilt from the pointer's `messageId`.
`room_ts_from_id` is unchanged: its one consumer range-walks from a floor and re-adjudicates every
row it visits, so the index orders the walk and decides nothing. No schema version, no migration, and
no byte already written changes.

The pair that needed the care is the mixed one, where only one side names an occupant — a pointer
written before the rung existed against the row it names, which every existing room meets on first
read. `compareTiebreak` stays a total order because `sortMessagesByTimestamp` hands it to
`Array.prototype.sort`; whether such a pair can be decided at all is asked separately, and the
counting and advance questions answer it differently, as they already do for a floor.

This is forward-looking, not a repair. Rows and pointers written before the rung existed carry no
occupant identity and cannot acquire one, so a pair already ordered wrong stays ordered wrong. One
limit is accepted and documented at the code: three rows sharing a millisecond, a sender and a client
id, one of them pre-change, leave the occupant-less row counted as unread with no read able to clear
it. Even the two-row form occurred zero times across 50,163 measured cached room rows, and the wider
same-room, same-millisecond superset in 11 pairs (0.02%).