### PR TITLE
feat(anomaly): detect a live-edge pin that settles short of the bottom

### DIFF
--- a/apps/fluux/src/anomaly/detectors/liveEdgePinShort.test.ts
+++ b/apps/fluux/src/anomaly/detectors/liveEdgePinShort.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `scroll/live-edge-pin-short` — a pin to the live edge that settled short of it.
+ *
+ * The control question for every case here: could a healthy session produce it? The
+ * family this joins watches loud failures (loops fighting, a loop that will not
+ * converge, a resize storm). This one watches a QUIET one — a correction that was
+ * asked for, reported itself settled, and left the reader off the bottom anyway.
+ */
+import { describe, it, expect } from 'vitest'
+import { createLiveEdgePinShortDetector, type PinShortSample } from './liveEdgePinShort'
+
+const CID = 'carol@example.com'
+const THRESHOLD = 150
+const SCOPE = 'me@example.com'
+
+const sample = (over: Partial<PinShortSample> = {}): PinShortSample => ({
+  active: { kind: 'conversation', id: CID },
+  distFromBottom: 400,
+  windowAtLiveEdge: true,
+  scopeKey: SCOPE,
+  ...over,
+})
+
+const settledShort = { conversationId: CID, distFromBottom: 400, thresholdPx: THRESHOLD }
+
+describe('createLiveEdgePinShortDetector', () => {
+  it('reports a settle that stayed short for the hold window', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+
+    expect(d.observe(sample(), 1500)).toBeNull() // inside the hold window
+    const verdict = d.observe(sample(), 2100)
+    expect(verdict).toEqual({ distFromBottom: 400, heldMs: 1100 })
+  })
+
+  it('reports at most once per episode', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample(), 2100)).not.toBeNull()
+    expect(d.observe(sample(), 3100)).toBeNull()
+  })
+
+  it('stays silent with nothing armed', () => {
+    const d = createLiveEdgePinShortDetector()
+    expect(d.observe(sample(), 2100)).toBeNull()
+  })
+
+  it('ignores a settle that reached the bottom', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort({ ...settledShort, distFromBottom: 10 }, SCOPE, 1000)
+    expect(d.observe(sample(), 2100)).toBeNull()
+  })
+
+  // The absorbed case: a later frame, a later run, or the browser's own clamp
+  // brought the reader back. Nothing was wrong.
+  it('disarms when the viewport comes back to the bottom', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 20 }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2600)).toBeNull()
+  })
+
+  // The FAB detector's named non-case, and it applies identically here: with the
+  // loaded window slid up, the bottom of what is loaded is not the live edge.
+  it('disarms when the loaded window is not at the live edge', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ windowAtLiveEdge: false }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  it('disarms when the reader moved to another conversation', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ active: { kind: 'conversation', id: 'dave@example.com' } }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  it('disarms when the store was rebuilt underneath', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ scopeKey: 'other@example.com' }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  // A frozen WebView resumes with a huge apparent hold. Reporting it would turn a
+  // suspension into a fabricated defect.
+  it('disarms rather than report across a sampling gap', () => {
+    const d = createLiveEdgePinShortDetector({ maxSampleGapMs: 5000 })
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample(), 1500)).toBeNull()
+    expect(d.observe(sample(), 90_000)).toBeNull()
+    expect(d.observe(sample(), 91_000)).toBeNull()
+  })
+
+  it('keeps the episode armed while the distance cannot be measured', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: null }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2100)).toEqual({ distFromBottom: 400, heldMs: 1100 })
+  })
+
+  it('disarms when no conversation is open', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ active: null }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  // The reader's own scroll away is not a failed pin. Only the distance measured
+  // at the settle is reported, so a later drift cannot inflate it.
+  it('reports the distance measured at the settle, not the latest one', () => {
+    const d = createLiveEdgePinShortDetector()
+    d.noteSettledShort(settledShort, SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 9000 }), 2100)).toEqual({
+      distFromBottom: 400,
+      heldMs: 1100,
+    })
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/liveEdgePinShort.ts
+++ b/apps/fluux/src/anomaly/detectors/liveEdgePinShort.ts
@@ -1,0 +1,188 @@
+/**
+ * `scroll/live-edge-pin-short` — a pin to the live edge that settled short of it.
+ *
+ * The rest of the `scroll/` family watches loud failures: two re-assert loops fighting
+ * over `scrollTop`, a loop that will not converge, a `ResizeObserver` storm, a
+ * correction that took too long. Every one of them needs pathological ACTIVITY, or an
+ * action that completed and landed wrong.
+ *
+ * A correction that quietly does not happen produces none of that. When a resident row
+ * grows in place — a reaction, a link preview, a decrypted attachment, a correction —
+ * the growth must be absorbed above so the newest message stays on screen. If it is
+ * not, there is no loop, no write, no resize, no slow frame: the reader is simply left
+ * short of the bottom, and every existing detector reports health. That silence is
+ * what this detector exists to break.
+ *
+ * Two halves, because neither is trustworthy alone:
+ *
+ * - The executor reports a FACT it has already measured — a live-edge run reached
+ *   `settled` with the viewport still beyond its own at-bottom threshold. It adds no
+ *   measurement: the settle path already reads that distance for `setMeasuredAtBottom`.
+ * - This detector holds the CONFIRMATION. A single settle short of the bottom is
+ *   ordinary: a smooth scroll is still animating, a commit lands a frame behind the
+ *   DOM, a message arrived during the settle and a later run will absorb it. Reporting
+ *   that would fire on healthy scrolling, and by the design's own rule a detector that
+ *   cries wolf is deleted rather than tuned. So the shortfall must still be there when
+ *   the tick looks again.
+ *
+ * PURE: every input is passed in, including the clock. The detector retains only the
+ * current episode.
+ *
+ * @module Anomaly/Detectors/LiveEdgePinShort
+ */
+
+/** What the executor already knows when a live-edge run settles. */
+export interface PinSettledShort {
+  conversationId: string
+  /** Distance still remaining, as the settle path measured it. */
+  distFromBottom: number
+  /** The executor's own at-bottom threshold, so the detector never invents one. */
+  thresholdPx: number
+}
+
+/*
+ * On the pin TRIGGER, deliberately absent.
+ *
+ * `trigger` is an open string at the executor (`row-growth`, `new-message`, `switch`,
+ * …), and the record layer only accepts a closed table — an unmapped label must lose
+ * the detail rather than pass a raw string into a record. Rather than freeze a table
+ * that the next trigger silently falls out of, the trigger stays where it already is:
+ * the `PIN completed` and `[PinLoopProbe]` lines in `fluux.log`, the same division
+ * `perf/main-thread-stall` makes with the route.
+ */
+
+/** Everything the confirmation depends on, sampled at one instant. */
+export interface PinShortSample {
+  /** Active conversation, or null when none is open. */
+  active: { kind: 'conversation' | 'room'; id: string } | null
+  /** Independently measured distance to the content bottom, or null when unmeasurable. */
+  distFromBottom: number | null
+  /**
+   * Is the loaded message window at the tail of the archive.
+   *
+   * Required for the same reason `fab-at-live-edge` requires it: with the window slid
+   * up, the bottom of what is loaded is not the live edge, so sitting away from it is
+   * not a failed pin.
+   */
+  windowAtLiveEdge: boolean
+  /** Account / storage scope. A change means the store was rebuilt under us. */
+  scopeKey: string
+}
+
+export interface PinShortVerdict {
+  /** The shortfall measured AT THE SETTLE, never a later drift the reader caused. */
+  distFromBottom: number
+  heldMs: number
+}
+
+export interface LiveEdgePinShortDetector {
+  /**
+   * A live-edge run settled. Arms an episode only when it settled short.
+   *
+   * `scopeKey` is supplied by the caller in the anomaly layer, not by the executor:
+   * the executor ships in release builds and has no business reading a store, but the
+   * scope has to be pinned at ARMING. Adopting it from the first sample instead would
+   * let an account switch land between the settle and the confirmation and then be
+   * confirmed against a store that had already been rebuilt.
+   */
+  noteSettledShort(settle: PinSettledShort, scopeKey: string, now: number): void
+  /** At most one verdict per episode. */
+  observe(sample: PinShortSample, now: number): PinShortVerdict | null
+}
+
+/**
+ * How long the shortfall must survive.
+ *
+ * Matches `fab-at-live-edge`: during a normal settle a fresh measurement and the
+ * position the loop just wrote legitimately disagree for a few frames.
+ */
+const DEFAULT_HOLD_MS = 1000
+
+/** Largest observed interval that still counts as continuous sampling. */
+const DEFAULT_MAX_SAMPLE_GAP_MS = 5000
+
+export interface LiveEdgePinShortOptions {
+  holdMs?: number
+  maxSampleGapMs?: number
+}
+
+interface Episode {
+  entityId: string
+  scopeKey: string
+  at: number
+  distFromBottom: number
+  thresholdPx: number
+  lastSeenAt: number
+}
+
+export function createLiveEdgePinShortDetector(
+  opts: LiveEdgePinShortOptions = {},
+): LiveEdgePinShortDetector {
+  const holdMs = opts.holdMs ?? DEFAULT_HOLD_MS
+  const maxSampleGapMs = opts.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS
+
+  let episode: Episode | null = null
+
+  return {
+    noteSettledShort(settle: PinSettledShort, scopeKey: string, now: number): void {
+      // The executor reports every settle; deciding what counts as short is the
+      // detector's job, so the threshold travels with the fact rather than being
+      // duplicated here.
+      if (settle.distFromBottom < settle.thresholdPx) return
+      episode = {
+        entityId: settle.conversationId,
+        scopeKey,
+        at: now,
+        distFromBottom: settle.distFromBottom,
+        thresholdPx: settle.thresholdPx,
+        lastSeenAt: now,
+      }
+    },
+
+    observe(sample: PinShortSample, now: number): PinShortVerdict | null {
+      const current = episode
+      if (!current) return null
+
+      // A frozen WebView resumes with a huge apparent hold. Reporting it would turn a
+      // suspension into a fabricated defect, so the episode is abandoned instead.
+      const gap = now - current.lastSeenAt
+      if (!Number.isFinite(gap) || gap < 0 || gap > maxSampleGapMs) {
+        episode = null
+        return null
+      }
+      current.lastSeenAt = now
+
+      if (current.scopeKey !== sample.scopeKey) {
+        episode = null
+        return null
+      }
+
+      if (!sample.active || sample.active.id !== current.entityId) {
+        episode = null
+        return null
+      }
+      if (!sample.windowAtLiveEdge) {
+        episode = null
+        return null
+      }
+
+      // Unmeasurable is not evidence either way — an unmounted list, a view we do not
+      // track. Keep waiting rather than guess in either direction.
+      if (sample.distFromBottom === null) return null
+
+      if (sample.distFromBottom < current.thresholdPx) {
+        episode = null
+        return null
+      }
+
+      const heldMs = now - current.at
+      if (heldMs < holdMs) return null
+
+      episode = null
+      return {
+        distFromBottom: current.distFromBottom,
+        heldMs,
+      }
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
@@ -504,6 +504,7 @@ describe('FANOUT_IDS', () => {
             peakUnread: 21,
           },
           { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
+          { name: 'scroll/live-edge-pin-short', distFromBottom: 420, heldMs: 1000 },
           { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'm' },
         ] as AnomalySignal[]
       ).map((s) => recordForSignal(s)!.id.s),

--- a/apps/fluux/src/anomaly/detectors/signalRecords.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.ts
@@ -216,6 +216,18 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
         ctx: [[CTX.heldMs, signal.heldMs]],
       }
 
+    case 'scroll/live-edge-pin-short':
+      // `expected: 0` reads as "nothing left between the reader and the newest
+      // message after a pin that reported itself settled". `observed` is the
+      // shortfall, which is what makes the record reviewable.
+      return {
+        id: ID.liveEdgePinShort,
+        sev: 'suspect',
+        expected: 0,
+        observed: signal.distFromBottom,
+        ctx: [[CTX.heldMs, signal.heldMs]],
+      }
+
     case 'scroll/jump-target-miss': {
       // A session-local ref, not a token: a message id is seen once, so hashing it
       // into the cross-session space would fill the cache with singletons and
@@ -259,6 +271,7 @@ export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
   ID.unreadPersists,
   ID.unreadFocusCleared,
   ID.fabAtLiveEdge,
+  ID.liveEdgePinShort,
   ID.jumpTargetMiss,
 ])
 

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -17,6 +17,11 @@ import {
 import { initTokenizer, resetValuesForTesting, tokenSync } from '../values'
 import { warmConversation, warmRoom } from '../identity'
 import { recordForSignal } from './signalRecords'
+import {
+  clearAnomalyObservationHandler,
+  observeAnomaly,
+  setAnomalyObservationHandler,
+} from '../../utils/anomalyObservation'
 
 const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
 
@@ -483,5 +488,88 @@ describe('the sampler reports that the app is alive', () => {
     tick.stop()
 
     expect(seen).toEqual([1000, 2000])
+  })
+})
+
+
+/**
+ * The wiring, not the verdict.
+ *
+ * `liveEdgePinShort.test.ts` covers what the detector decides. What is proved here is
+ * that a measurement leaving the release-shipped executor actually reaches it: the
+ * observation seam, the tick's `observeRaw`, the tick's own sample, and the verdict
+ * signal. A control that forced `hasAnomalyObservationHandler()` to `false` passed
+ * 1612 tests before this existed — the whole path was unproven.
+ */
+describe('live-edge pin shortfall, end to end through the seams', () => {
+  function seamHarness(distFromBottom: number) {
+    let clock = 0
+    const tick = startDetectorTick(
+      world({ now: () => clock, distFromBottom: () => distFromBottom, fabShown: () => false }),
+    )
+    setAnomalyObservationHandler((observation) => tick.observeRaw(observation))
+    return {
+      tick,
+      at: (ms: number) => {
+        clock = ms
+      },
+      settleShort: () =>
+        observeAnomaly({
+          kind: 'live-edge-pin-settled',
+          conversationId: ACTIVE.id,
+          distFromBottom: 420,
+          thresholdPx: 150,
+        }),
+      shortfalls: () => seen.filter((s) => s.name === 'scroll/live-edge-pin-short'),
+      stop: () => {
+        clearAnomalyObservationHandler()
+        tick.stop()
+      },
+    }
+  }
+
+  it('carries a confirmed shortfall from the executor to a signal', () => {
+    const h = seamHarness(420)
+    try {
+      h.settleShort()
+
+      h.at(500)
+      h.tick.sample()
+      expect(h.shortfalls()).toEqual([])
+
+      h.at(1200)
+      h.tick.sample()
+      expect(h.shortfalls()).toEqual([
+        { name: 'scroll/live-edge-pin-short', distFromBottom: 420, heldMs: 1200 },
+      ])
+    } finally {
+      h.stop()
+    }
+  })
+
+  it('stays silent when the viewport came back to the bottom', () => {
+    const h = seamHarness(10)
+    try {
+      h.settleShort()
+      h.at(1200)
+      h.tick.sample()
+      expect(h.shortfalls()).toEqual([])
+    } finally {
+      h.stop()
+    }
+  })
+
+  it('produces a record the registry accepts', () => {
+    const h = seamHarness(420)
+    try {
+      h.settleShort()
+      h.at(1200)
+      h.tick.sample()
+      const record = recordForSignal(h.shortfalls()[0])
+      expect(record?.id.s).toBe('scroll/live-edge-pin-short')
+      expect(record?.observed).toBe(420)
+    } finally {
+      h.stop()
+    }
   })
 })

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -19,11 +19,13 @@
  * @module Anomaly/Detectors/Tick
  */
 import { signalAnomaly } from '../../utils/anomalySignal'
+import type { AnomalyObservation } from '../../utils/anomalyObservation'
 import { isViewportAtBottom, type ViewportKind } from '../../utils/viewportAtBottom'
 import { measureViewport } from '../../utils/viewportScroller'
 import { isTokenizerReady } from '../values'
 import { warmConversation, warmRoom } from '../identity'
 import { createFabAtLiveEdgeDetector } from './fabAtLiveEdge'
+import { createLiveEdgePinShortDetector } from './liveEdgePinShort'
 import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
 
 /** How often the world is sampled. */
@@ -113,6 +115,15 @@ export interface DetectorTick {
   /** Sample once and emit any verdicts. Exposed so a test need not wait a second. */
   sample(): void
   /**
+   * Route a raw measurement from the release-shipped scroll subsystem.
+   *
+   * Arrives out of band, on the executor's schedule rather than the tick's, so it
+   * cannot be read inside `sample()`. The scope is stamped HERE — at arming — because
+   * an account switch between the settle and the confirmation must void the episode
+   * rather than have it confirmed against a rebuilt store.
+   */
+  observeRaw(observation: AnomalyObservation): void
+  /**
    * Resolves once the warm started by the most recent `sample()` has settled.
    *
    * Test-only, and a seam rather than a sleep on purpose: the warm ends in an async
@@ -130,6 +141,9 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
     maxSampleGapMs: intervalMs * MAX_SAMPLE_GAP_TICKS,
   })
   const fab = createFabAtLiveEdgeDetector()
+  const pinShort = createLiveEdgePinShortDetector({
+    maxSampleGapMs: intervalMs * MAX_SAMPLE_GAP_TICKS,
+  })
 
   /**
    * Which conversation the tokenizer has CONFIRMED warm.
@@ -261,11 +275,40 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
         heldMs: fabVerdict.heldMs,
       })
     }
+
+    const pinShortVerdict = pinShort.observe(
+      {
+        active,
+        distFromBottom: active ? world.distFromBottom(active.kind, active.id) : null,
+        windowAtLiveEdge: active ? world.windowAtLiveEdge(active.kind, active.id) : false,
+        scopeKey: world.scopeKey(),
+      },
+      now,
+    )
+    if (pinShortVerdict) {
+      signalAnomaly({
+        name: 'scroll/live-edge-pin-short',
+        distFromBottom: pinShortVerdict.distFromBottom,
+        heldMs: pinShortVerdict.heldMs,
+      })
+    }
   }
 
   const id = setInterval(sample, intervalMs)
   return {
     sample,
+    observeRaw: (observation) => {
+      if (observation.kind !== 'live-edge-pin-settled') return
+      pinShort.noteSettledShort(
+        {
+          conversationId: observation.conversationId,
+          distFromBottom: observation.distFromBottom,
+          thresholdPx: observation.thresholdPx,
+        },
+        world.scopeKey(),
+        world.now(),
+      )
+    },
     warmSettled: () => pendingWarm,
     stop: () => clearInterval(id),
   }

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -17,6 +17,10 @@
  */
 import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, onArchiveMerge, readRecountDeferrals, roomReadStateGeneration, roomStore, setMeasurementEnabled } from '@fluux/sdk'
 import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
+import {
+  clearAnomalyObservationHandler,
+  setAnomalyObservationHandler,
+} from '../utils/anomalyObservation'
 import { createDenominatorTracker, type DenominatorName } from './denominators'
 import { convToken, roomToken, warmConversation, warmRoom } from './identity'
 import { createEnvironmentReader, createForegroundShare } from './environment'
@@ -552,6 +556,13 @@ export function install(client?: TrafficClient): () => void {
       },
     })
 
+    // Raw measurements from the release-shipped scroll subsystem. Registered after
+    // the tick exists, since it is the tick that holds the clock they need
+    // confirming against.
+    setAnomalyObservationHandler((observation) => {
+      detectorTick?.observeRaw(observation)
+    })
+
     digestTimer = setInterval(() => {
       foldRecountDeferrals(rec)
       rec.flushDigest(DIGEST_INTERVAL_MS)
@@ -614,6 +625,7 @@ export function install(client?: TrafficClient): () => void {
     perfWatch?.stop()
     perfWatch = null
     setMeasurementEnabled(false)
+    clearAnomalyObservationHandler()
     detectorTick?.stop()
     detectorTick = null
     detachListener?.()

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -176,6 +176,7 @@ export const ID = Object.freeze({
   unreadPersists: mint('read-state/unread-persists', 'id'),
   unreadFocusCleared: mint('read-state/unread-focus-cleared', 'id'),
   fabAtLiveEdge: mint('scroll/fab-at-live-edge', 'id'),
+  liveEdgePinShort: mint('scroll/live-edge-pin-short', 'id'),
   jumpTargetMiss: mint('scroll/jump-target-miss', 'id'),
   redundantQuery: mint('xmpp-traffic/redundant-query', 'id'),
   iqUnanswered: mint('xmpp-traffic/iq-unanswered', 'id'),

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.test.ts
@@ -12,6 +12,13 @@ import {
   type LiveEdgeBrowserPorts,
 } from './liveEdgeBrowserAdapter'
 
+import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
+import {
+  clearAnomalyObservationHandler,
+  setAnomalyObservationHandler,
+  type AnomalyObservation,
+} from '../../utils/anomalyObservation'
+
 function scrollerHarness(input: {
   scrollTop?: number
   scrollHeight?: number
@@ -454,5 +461,51 @@ describe('LiveEdgeBrowserAdapter repaint debt', () => {
     activeConversation = 'room-a'
     executor.complete(request(), 'settled')
     expect(scope.recordProgrammaticWrite).toHaveBeenCalledWith('room-a')
+  })
+
+  describe('the live-edge shortfall observation', () => {
+    let seen: AnomalyObservation[] = []
+
+    beforeEach(() => {
+      seen = []
+      setAnomalyObservationHandler((observation) => seen.push(observation))
+    })
+    afterEach(() => clearAnomalyObservationHandler())
+
+    it('reports the distance a settled run left, measured at the settle', () => {
+      // 2000 - 600 - 100 = 1300px still below the fold.
+      const viewport = scrollerHarness({ scrollTop: 100 })
+      const scope = harness({ scroller: viewport.scroller })
+
+      scope.create().complete(request(), 'settled')
+
+      expect(seen).toEqual([
+        {
+          kind: 'live-edge-pin-settled',
+          conversationId: 'room-a',
+          distFromBottom: 1300,
+          thresholdPx: AT_BOTTOM_THRESHOLD,
+        },
+      ])
+    })
+
+    it('reports a run that reached the bottom too — the detector decides, not the executor', () => {
+      const viewport = scrollerHarness({ scrollTop: 1400 })
+      const scope = harness({ scroller: viewport.scroller })
+
+      scope.create().complete(request(), 'settled')
+
+      expect(seen).toHaveLength(1)
+      expect(seen[0].distFromBottom).toBe(0)
+    })
+
+    it('says nothing about a run that never settled', () => {
+      const viewport = scrollerHarness({ scrollTop: 100 })
+      const scope = harness({ scroller: viewport.scroller })
+
+      scope.create().complete(request(), 'superseded')
+
+      expect(seen).toEqual([])
+    })
   })
 })

--- a/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
+++ b/apps/fluux/src/components/conversation/liveEdgeBrowserAdapter.ts
@@ -13,6 +13,7 @@ import {
   shouldForceRepaint,
   type PinRepaintMode,
 } from './pinBottomRun'
+import { hasAnomalyObservationHandler, observeAnomaly } from '../../utils/anomalyObservation'
 import {
   createPinRepaintBurst,
   pinBurstProbeLine,
@@ -325,10 +326,23 @@ export class LiveEdgeBrowserAdapter {
         }
 
         if (scroller) {
-          options.setMeasuredAtBottom(
-            distanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
-          )
+          const remaining = distanceFromBottom(scroller)
+          options.setMeasuredAtBottom(remaining < AT_BOTTOM_THRESHOLD)
           options.recordProgrammaticWrite(request.conversationId)
+          // A run that reports itself settled while the viewport is still beyond the
+          // threshold it just used has not done what it was asked. Reported as the
+          // measurement it already is, never as a verdict: one short settle is
+          // ordinary (a smooth scroll still animating, a commit a frame behind), and
+          // only a clock can tell that from a growth nothing absorbed. Reuses
+          // `remaining` — this adds no layout read to the pin's forced work.
+          if (outcome === 'settled' && hasAnomalyObservationHandler()) {
+            observeAnomaly({
+              kind: 'live-edge-pin-settled',
+              conversationId: request.conversationId,
+              distFromBottom: remaining,
+              thresholdPx: AT_BOTTOM_THRESHOLD,
+            })
+          }
         }
         const probe = (this.runProbe ??= createRenderCostProbe({
           thresholdMs: PIN_PROBE_THRESHOLD_MS,

--- a/apps/fluux/src/utils/anomalyObservation.ts
+++ b/apps/fluux/src/utils/anomalyObservation.ts
@@ -1,0 +1,76 @@
+/**
+ * The neutral seam for a raw OBSERVATION, as opposed to a verdict.
+ *
+ * `anomalySignal.ts` carries verdicts: every case is named for the invariant id it
+ * becomes, and `signalRecords.ts` translates it with no decision of its own. That
+ * contract is worth keeping, and it does not fit a fact that still needs confirming.
+ *
+ * A live-edge pin settling short of the bottom is such a fact. The executor knows it
+ * and has already measured it, but a single short settle is ordinary — a smooth scroll
+ * still animating, a commit a frame behind the DOM. Only a dev-only detector holding a
+ * clock can tell that apart, so what crosses here is the measurement, not a claim.
+ *
+ * Same inversion and same cost as the verdict seam: the executor ships in release
+ * builds and must never import anything under `src/anomaly/`, so this module holds a
+ * nullable handler that the anomaly runtime installs into. In a release build nothing
+ * ever registers and `observeAnomaly` is a null check.
+ *
+ * @module Utils/AnomalyObservation
+ */
+
+/**
+ * One measured fact, as its source measured it.
+ *
+ * Thresholds travel WITH the fact rather than being restated on the anomaly side: the
+ * executor owns what "at the bottom" means, and a detector inventing its own number
+ * would judge the executor against a rule the executor does not follow.
+ */
+export type AnomalyObservation = {
+  kind: 'live-edge-pin-settled'
+  conversationId: string
+  /** Distance still remaining when the run reached `settled`. */
+  distFromBottom: number
+  /** The executor's own at-bottom threshold. */
+  thresholdPx: number
+}
+
+export type AnomalyObservationHandler = (observation: AnomalyObservation) => void
+
+let handler: AnomalyObservationHandler | null = null
+
+/** Last registration wins, matching the verdict seam's refcounted install. */
+export function setAnomalyObservationHandler(fn: AnomalyObservationHandler): void {
+  handler = fn
+}
+
+/** Stop routing. Observations become no-ops again. */
+export function clearAnomalyObservationHandler(): void {
+  handler = null
+}
+
+/**
+ * Is anything listening.
+ *
+ * Exported so a caller can skip BUILDING an observation, not merely skip delivering
+ * one. `observeAnomaly` alone would still cost the argument's allocation on every
+ * settled pin run — which is every message that lands while the reader is at the
+ * bottom. In a release build this is a constant `false`.
+ */
+export function hasAnomalyObservationHandler(): boolean {
+  return handler !== null
+}
+
+/**
+ * Report one measurement, if anything is listening.
+ *
+ * Never throws: a detector bug on the anomaly side must not take down the pin loop
+ * that reported it.
+ */
+export function observeAnomaly(observation: AnomalyObservation): void {
+  if (!handler) return
+  try {
+    handler(observation)
+  } catch {
+    // Swallowed on purpose — see above.
+  }
+}

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -106,6 +106,13 @@ export type AnomalySignal =
       heldMs: number
     }
   | {
+      name: 'scroll/live-edge-pin-short'
+      /** The shortfall as the settle measured it, not a later drift. */
+      distFromBottom: number
+      /** How long it was still there when the tick confirmed it. */
+      heldMs: number
+    }
+  | {
       name: 'scroll/jump-target-miss'
       /** Signed px outside the viewport: negative above, positive below. */
       offBy: number

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -259,6 +259,7 @@ These two are genuine detectors rather than fan-out, so they have **no** matchin
 
 | id | sev | Meaning | What to do |
 |---|---|---|---|
+| `scroll/live-edge-pin-short` | suspect | A live-edge pin run reported itself `settled` while the viewport was still `observed` px beyond the executor's own at-bottom threshold, and it was **still** there `ctx.heldMs` later | A correction that was asked for and did not arrive. Classically a resident row that grew in place — a reaction, a link preview, a decrypted attachment, a correction, a retraction — whose growth nothing absorbed. `rowGrowthDecision.ts` skips the re-pin when a pin loop already claims the bottom, on the bet that the running loop absorbs it, and that skip is final. The `PIN completed` and `[PinLoopProbe]` lines in `fluux.log` carry the trigger |
 | `scroll/fab-at-live-edge` | bug | The scroll-to-bottom button was shown for `ctx.heldMs` while an independent measurement put the viewport `observed` px from the content bottom, already at the newest message  | Stale `showScrollToBottom` React state: the scroll handler stopped firing after the list returned to the bottom. Not a fault in `shouldShowScrollToBottomFab`, which cannot produce this state |
 | `scroll/jump-target-miss` | bug | A go-to-message reported that it applied a position, but the target row landed `ctx.offBy` px outside the viewport, negative above, positive below  | The anchor resolved to the wrong offset, or content grew after the jump settled. `ctx.msg` is the session-local ref for the target |
 
@@ -275,6 +276,22 @@ These two are genuine detectors rather than fan-out, so they have **no** matchin
 - `fab-at-live-edge` measures through `utils/viewportScroller.ts`, deliberately not the
   scroll hook's own at-bottom state, a detector reading the suspect value cannot
   disagree with it, and would go silent exactly when the bug is present.
+- `live-edge-pin-short` is the family's only detector of a correction that did **not**
+  happen. The other five all need pathological activity, or an action that completed and
+  landed wrong; a growth nothing absorbs produces no loop, no write, no resize and no
+  slow frame, so it was invisible to all of them.
+- `live-edge-pin-short` takes its threshold FROM the executor rather than declaring one.
+  A detector judging the pin against a number the pin does not use would report a
+  disagreement about the rule instead of a failure to follow it.
+- `live-edge-pin-short` sees a growth only when a live-edge run actually settles. A
+  growth that `rowGrowthDecision.ts` skips with no loop in flight — the reader judged
+  away from the bottom, or an ambient growth refused during a navigation — produces no
+  run and so no record. The claim-held bet IS covered, because the loop holding the
+  claim reports its own settle.
+- `live-edge-pin-short` cannot tell a reader who scrolled away during the hold window
+  from a shortfall that persisted, so its `observed` is the distance measured AT THE
+  SETTLE and never the later one. The confirmation is a noise filter, not the claim.
+  Reported as `suspect` for that reason.
 
 ### `perf/`
 

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -295,6 +295,7 @@ test.describe('anomaly runtime', () => {
         'recorder/entity-warm-failing',
         'read-state/unread-survives-focus',
         'scroll/fab-at-live-edge',
+        'scroll/live-edge-pin-short',
         'scroll/jump-target-miss',
         'xmpp-traffic/redundant-query',
         'xmpp-traffic/iq-unanswered',


### PR DESCRIPTION
The `scroll/` family watches loud failures: two re-assert loops fighting over `scrollTop`, a loop that will not converge, a `ResizeObserver` storm, a correction that ran too long — or an action that completed and landed wrong. A correction that quietly does not happen produces none of that.

When a resident row grows in place — a reaction, a link preview, a decrypted attachment, a correction, a retraction — the growth must be absorbed above so the newest message stays on screen. If it is not, there is no loop, no write, no resize and no slow frame: the reader is simply left short of the bottom, and all six existing detectors report health. That is the gap this closes.

## Two halves

**The executor reports a fact it has already measured.** The settle path in `liveEdgeBrowserAdapter.ts` already read `distanceFromBottom(scroller)` for `setMeasuredAtBottom`; it is now held in a local and reused. The pin's forced work is unchanged — no layout read is added.

**The detector holds the confirmation.** A single short settle is ordinary: a smooth scroll still animating, a commit a frame behind the DOM. Reporting that would fire on healthy scrolling, and by the design's own rule (§6.1) such a detector is deleted rather than tuned. So the shortfall must still be there when the tick looks again, using the `distFromBottom` the tick already samples every second in Dev builds.

The threshold travels with the fact rather than being declared on the anomaly side: a detector judging the pin against a number the pin does not use would report a disagreement about the rule instead of a failure to follow it.

## Cost

One string comparison and one null check per settled run. `hasAnomalyObservationHandler` keeps the observation from even being allocated when nothing listens — which matters, because a settle happens on every message that lands while the reader is at the bottom. Both bundle gates pass.

## A third seam

Observations travel on `utils/anomalyObservation.ts` rather than the verdict seam. `anomalySignal` names every case for the invariant id it becomes, and `signalRecords` translates with no decision of its own; a fact that still needs confirming fits neither contract.

## Named non-cases, in the registry

- it sees a growth only when a live-edge run actually settles — the claim-held bet IS covered, since the loop holding the claim reports its own settle, but a growth skipped with no loop in flight is not;
- it cannot tell a reader who scrolled away during the hold window from a persistent shortfall, so `observed` is the distance measured AT THE SETTLE and the severity is `suspect`.

## Verification

`npm test` (6471 SDK + 6390 app), `typecheck`, `lint` (0 errors), `check:anomaly:prod`, `check:anomaly:dev`, and `test:scroll` (108/108 across both engines). The detector is added to the healthy-session control in `scripts/anomaly-smoke.ts`.

Three wiring controls were added after a control test showed the executor-to-detector path was covered by nothing: forcing the handler check to `false` passed 1612 tests before the two integration tests in this PR existed.

https://claude.ai/code/session_01HnQT1vrpuLtLKfuLbqFQbx