### PR TITLE
fix(connection): let XEP-0156 discovery outrank a known endpoint

### DIFF
--- a/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
@@ -40,8 +40,10 @@ vi.mock('@/utils/keychain', () => ({
   deleteCredentials: vi.fn(),
 }))
 vi.mock('@/config/wellKnownServers', () => ({
-  getDomainFromJid: () => null,
-  getWebsocketUrlForDomain: () => null,
+  getConnectionServerOptions: (jid: string, server: string) => ({
+    server: server || jid.split('@')[1] || '',
+    fallbackWebSocketUrl: undefined,
+  }),
 }))
 vi.mock('@/stores/encryptionSettingsStore', () => ({ isOpenpgpEnabled: () => false }))
 

--- a/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
@@ -41,8 +41,10 @@ vi.mock('@/utils/keychain', () => ({
   deleteCredentials: vi.fn(),
 }))
 vi.mock('@/config/wellKnownServers', () => ({
-  getDomainFromJid: () => null,
-  getWebsocketUrlForDomain: () => null,
+  getConnectionServerOptions: (jid: string, server: string) => ({
+    server: server || jid.split('@')[1] || '',
+    fallbackWebSocketUrl: undefined,
+  }),
 }))
 vi.mock('@/stores/encryptionSettingsStore', () => ({ isOpenpgpEnabled: () => false }))
 

--- a/apps/fluux/src/components/LoginScreen.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.test.tsx
@@ -79,9 +79,9 @@ vi.mock('@/utils/xmppResource', () => ({
     getResource: () => 'test-resource',
 }))
 
-const { mockGetDomainFromJid, mockGetWebsocketUrlForDomain } = vi.hoisted(() => ({
+const { mockGetDomainFromJid, mockGetFallbackWebsocketUrlForDomain } = vi.hoisted(() => ({
     mockGetDomainFromJid: vi.fn(),
-    mockGetWebsocketUrlForDomain: vi.fn(),
+    mockGetFallbackWebsocketUrlForDomain: vi.fn(),
 }))
 
 // Keychain + Tauri detection are overridable per-test so the desktop
@@ -111,8 +111,14 @@ function usePlatform(shell: 'desktop' | 'web', os: 'macos' | 'windows' | 'linux'
 }
 
 vi.mock('@/config/wellKnownServers', () => ({
-    getDomainFromJid: (...args: unknown[]) => mockGetDomainFromJid(...args),
-    getWebsocketUrlForDomain: (...args: unknown[]) => mockGetWebsocketUrlForDomain(...args),
+    getConnectionServerOptions: (jid: string, server: string) => {
+        const domain = mockGetDomainFromJid(jid) as string | null
+        const target = server || domain || ''
+        const fallbackWebSocketUrl = domain && target.toLowerCase() === domain.toLowerCase()
+            ? mockGetFallbackWebsocketUrlForDomain(domain) || undefined
+            : undefined
+        return { server: target, fallbackWebSocketUrl }
+    },
 }))
 
 describe('LoginScreen', () => {
@@ -121,7 +127,7 @@ describe('LoginScreen', () => {
         localStorage.clear()
         mockConnect.mockResolvedValue(undefined)
         mockGetDomainFromJid.mockReturnValue(null)
-        mockGetWebsocketUrlForDomain.mockReturnValue(null)
+        mockGetFallbackWebsocketUrlForDomain.mockReturnValue(null)
         // Reset to default offline state
         mockUseConnection.mockReturnValue({
             status: 'offline',
@@ -272,9 +278,9 @@ describe('LoginScreen', () => {
     })
 
     describe('server resolution priority', () => {
-        it('should prefer well-known websocket URL when server field is empty', async () => {
+        it('should connect to the domain and offer the known endpoint as a fallback', async () => {
             mockGetDomainFromJid.mockReturnValue('process-one.net')
-            mockGetWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
+            mockGetFallbackWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
 
             render(<LoginScreen />)
 
@@ -282,11 +288,14 @@ describe('LoginScreen', () => {
             fireEvent.change(screen.getByLabelText('login.passwordLabel'), { target: { value: 'secret' } })
             fireEvent.click(screen.getByRole('button', { name: 'login.connect' }))
 
+            // The domain is the target, so XEP-0156 discovery runs; the known
+            // endpoint only answers if the domain advertises none.
             await waitFor(() => {
                 expect(mockConnect).toHaveBeenCalledWith({
                     jid: 'alice@process-one.net',
                     password: 'secret',
-                    server: 'wss://chat.process-one.net/xmpp',
+                    server: 'process-one.net',
+                    fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
                     resource: 'test-resource',
                     lang: 'en',
                     disableSmKeepalive: false,
@@ -297,16 +306,16 @@ describe('LoginScreen', () => {
 
         it('should keep explicit server input over well-known mapping', async () => {
             mockGetDomainFromJid.mockReturnValue('process-one.net')
-            mockGetWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
+            mockGetFallbackWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
 
             render(<LoginScreen />)
 
             fireEvent.change(screen.getByLabelText('login.jidLabel'), { target: { value: 'alice@process-one.net' } })
-            await waitFor(() => {
-                expect(screen.getByPlaceholderText('login.serverPlaceholder')).toBeInTheDocument()
-            })
             fireEvent.change(screen.getByLabelText('login.passwordLabel'), { target: { value: 'secret' } })
-            fireEvent.change(screen.getByPlaceholderText('login.serverPlaceholder'), { target: { value: 'chat.custom.net' } })
+            fireEvent.click(screen.getByRole('button', { name: 'common.options' }))
+            fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'login.advancedMode' }))
+            const serverInput = await screen.findByPlaceholderText('login.serverPlaceholder')
+            fireEvent.change(serverInput, { target: { value: 'chat.custom.net' } })
             fireEvent.click(screen.getByRole('button', { name: 'login.connect' }))
 
             await waitFor(() => {
@@ -314,6 +323,7 @@ describe('LoginScreen', () => {
                     jid: 'alice@process-one.net',
                     password: 'secret',
                     server: 'chat.custom.net',
+                    fallbackWebSocketUrl: undefined,
                     resource: 'test-resource',
                     lang: 'en',
                     disableSmKeepalive: false,
@@ -327,7 +337,7 @@ describe('LoginScreen', () => {
         it('should store resolved domain when server field is empty', async () => {
             // Domain not in well-known list, so resolveServerForConnection falls back to bare domain
             mockGetDomainFromJid.mockReturnValue('chat.example.com')
-            mockGetWebsocketUrlForDomain.mockReturnValue(null)
+            mockGetFallbackWebsocketUrlForDomain.mockReturnValue(null)
 
             render(<LoginScreen />)
 
@@ -343,9 +353,9 @@ describe('LoginScreen', () => {
             expect(localStorage.getItem('xmpp-last-server')).toBe('chat.example.com')
         })
 
-        it('should store well-known WebSocket URL when available', async () => {
+        it('should store the domain rather than the known endpoint', async () => {
             mockGetDomainFromJid.mockReturnValue('process-one.net')
-            mockGetWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
+            mockGetFallbackWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
 
             render(<LoginScreen />)
 
@@ -357,12 +367,13 @@ describe('LoginScreen', () => {
                 expect(mockConnect).toHaveBeenCalled()
             })
 
-            expect(localStorage.getItem('xmpp-last-server')).toBe('wss://chat.process-one.net/xmpp')
+            // Remembering the endpoint would skip discovery on the next login.
+            expect(localStorage.getItem('xmpp-last-server')).toBe('process-one.net')
         })
 
         it('should store explicit server input as-is', async () => {
             mockGetDomainFromJid.mockReturnValue('example.com')
-            mockGetWebsocketUrlForDomain.mockReturnValue(null)
+            mockGetFallbackWebsocketUrlForDomain.mockReturnValue(null)
 
             render(<LoginScreen />)
 
@@ -500,7 +511,7 @@ describe('LoginScreen prefill', () => {
         localStorage.clear()
         useLoginPrefillStore.getState().clearPrefill()
         mockGetDomainFromJid.mockReturnValue(null)
-        mockGetWebsocketUrlForDomain.mockReturnValue(null)
+        mockGetFallbackWebsocketUrlForDomain.mockReturnValue(null)
         mockConnect.mockResolvedValue(undefined)
         mockUseConnection.mockReturnValue({
             status: 'offline',

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next'
 import { AppIconMark } from './brand/AppIconMark'
 import { HollowIconMark } from './brand/HollowIconMark'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useConnectionStatus, useConnectionActions, deleteFastToken, classifyConnectionError, getBareJid, getDomain, validateBareJid } from '@fluux/sdk'
+import { useConnectionStatus, useConnectionActions, deleteFastToken, classifyConnectionError, getBareJid, validateBareJid } from '@fluux/sdk'
 import { Loader2, KeyRound, Eye, EyeOff, Wrench } from 'lucide-react'
 import { saveSession } from '@/hooks/useSessionPersistence'
 import { getResource } from '@/utils/xmppResource'
 import { hasSavedCredentials, getCredentials, saveCredentials, deleteCredentials } from '@/utils/keychain'
 import { platform } from '@/platform'
-import { getDomainFromJid, getWebsocketUrlForDomain } from '@/config/wellKnownServers'
+import { getConnectionServerOptions } from '@/config/wellKnownServers'
 import { useWindowDrag } from '@/hooks'
 import { isOpenpgpEnabled } from '@/stores/encryptionSettingsStore'
 import { getReconnectIntent } from '@/utils/reconnectIntent'
@@ -52,19 +52,6 @@ async function prewarmOpenpgpUnlock(jid: string): Promise<void> {
   } catch (err) {
     console.warn('[Fluux] openpgp_prewarm failed (will unlock lazily):', err)
   }
-}
-
-/**
- * Resolve the connection target with explicit priority:
- * 1. User-provided server value
- * 2. Well-known WebSocket endpoint for the JID domain
- * 3. Raw JID domain (for XEP-0156 / proxy fallback paths)
- */
-function resolveServerForConnection(jid: string, server: string): string {
-  if (server) return server
-  const domain = getDomainFromJid(jid) || getDomain(jid)
-  if (!domain) return ''
-  return getWebsocketUrlForDomain(domain) || domain
 }
 
 /**
@@ -183,8 +170,8 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
       const savedServer = localStorage.getItem(STORAGE_KEY_SERVER)
       if (!hasLinkPrefill) {
         if (savedJid) setJid(savedJid)
-        // On web, ignore bare-domain server values (e.g. from desktop sessions)
-        // so well-known auto-fill can provide the correct WebSocket URL
+        // Web restores only explicit WebSocket endpoints; desktop also restores
+        // native connection targets such as bare domains.
         const isWebSocketUrl = savedServer?.startsWith('ws://') || savedServer?.startsWith('wss://')
         if (savedServer && (inTauri || isWebSocketUrl)) {
           setServer(savedServer)
@@ -219,29 +206,6 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     })
   }, [])
 
-  // Auto-fill WebSocket URL for well-known servers when JID domain changes (web only).
-  // Desktop keeps the field untouched, but submit-time resolution still prefers
-  // known WebSocket URLs before falling back to domain/proxy flow.
-  // Track if user has manually interacted with server field to prevent auto-fill after user clears it
-  const [hasManuallySetServer, setHasManuallySetServer] = useState(false)
-
-  useEffect(() => {
-    if (isDesktopApp) return // Skip auto-fill for desktop - TCP proxy handles this
-    if (hasManuallySetServer) return // Don't auto-fill if user has manually set/cleared the field
-    if (isLoadingCredentials) return // Wait for credentials to load first
-    // Only skip auto-fill if server is already a WebSocket URL
-    // A bare domain (from desktop/previous session) should be overridable
-    if (server.startsWith('ws://') || server.startsWith('wss://')) return
-
-    const domain = getDomainFromJid(jid)
-    if (domain) {
-      const websocketUrl = getWebsocketUrlForDomain(domain)
-      if (websocketUrl) {
-        setServer(websocketUrl)
-      }
-    }
-  }, [jid, server, isLoadingCredentials, isDesktopApp, hasManuallySetServer])
-
   // Show server field if a saved server value was loaded
   useEffect(() => {
     if (!isLoadingCredentials && server) {
@@ -257,7 +221,6 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     if (prefill.server) {
       setServer(prefill.server)
       setShowServerField(true)
-      setHasManuallySetServer(true) // stop web auto-fill from clobbering the link value
       setLinkServerHost(serverHostLabel(prefill.server))
     }
     if (prefill.resource) linkResourceRef.current = prefill.resource
@@ -337,7 +300,8 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
 
     // Trigger connection with keychain credentials
     const autoConnect = async () => {
-      const actualServer = resolveServerForConnection(jid, server)
+      const serverOptions = getConnectionServerOptions(jid, server)
+      const actualServer = serverOptions.server
       try {
         // Check if another tab already holds this JID
         if (claimConnection && !(await claimConnection(jid))) return
@@ -346,7 +310,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
         // first fingerprint / encrypted send after `online`.
         void prewarmOpenpgpUnlock(jid)
         const resource = getResource()
-        await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: true })
+        await connect({ jid, password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: true })
         // Save session for auto-reconnect on page reload
         saveSession(jid, password, actualServer)
       } catch {
@@ -369,7 +333,8 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    const actualServer = resolveServerForConnection(jid, server)
+    const serverOptions = getConnectionServerOptions(jid, server)
+    const actualServer = serverOptions.server
 
     // Save JID and server for next time
     // Store the resolved server (not the raw input) so FAST token auto-reconnect
@@ -408,7 +373,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
       // KDF (~500 ms) overlaps with the TCP/TLS/XMPP handshake.
       void prewarmOpenpgpUnlock(jid)
       const resource = linkResourceRef.current || getResource()
-      await connect({ jid, password, server: actualServer, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: rememberMe })
+      await connect({ jid, password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive: platform().hasNativeConnectionKeepalive, rememberSession: rememberMe })
       // Save session for auto-reconnect on page reload
       saveSession(jid, password, actualServer)
 
@@ -567,7 +532,6 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
                 onChange={(e) => {
                   setServer(e.target.value)
                   setCredentialsModified(true)
-                  setHasManuallySetServer(true) // Prevent auto-fill after manual edit
                 }}
                 placeholder={isDesktopApp ? t('login.serverPlaceholderDesktop') : t('login.serverPlaceholder')}
                 disabled={isLoading}

--- a/apps/fluux/src/config/wellKnownServers.test.ts
+++ b/apps/fluux/src/config/wellKnownServers.test.ts
@@ -1,32 +1,57 @@
 import { describe, it, expect } from 'vitest'
-import { getWebsocketUrlForDomain, getDomainFromJid } from './wellKnownServers'
+import { getConnectionServerOptions, getFallbackWebsocketUrlForDomain, getDomainFromJid } from './wellKnownServers'
 
-describe('getWebsocketUrlForDomain', () => {
+describe('getFallbackWebsocketUrlForDomain', () => {
   it('returns URL for exact match', () => {
-    expect(getWebsocketUrlForDomain('process-one.net')).toBe('wss://chat.process-one.net/xmpp')
-    expect(getWebsocketUrlForDomain('jabber.fr')).toBe('wss://jabber.fr/ws')
+    expect(getFallbackWebsocketUrlForDomain('process-one.net')).toBe('wss://chat.process-one.net/xmpp')
   })
 
   it('is case-insensitive', () => {
-    expect(getWebsocketUrlForDomain('Jabber.FR')).toBe('wss://jabber.fr/ws')
+    expect(getFallbackWebsocketUrlForDomain('Process-One.NET')).toBe('wss://chat.process-one.net/xmpp')
   })
 
   it('returns null for unknown domain', () => {
-    expect(getWebsocketUrlForDomain('unknown.org')).toBeNull()
+    expect(getFallbackWebsocketUrlForDomain('unknown.org')).toBeNull()
+  })
+
+  it('has no entry for a domain that advertises its own endpoint', () => {
+    // jabber.fr publishes a host-meta (through a redirect) advertising
+    // wss://ws.jabberfr.org/, so it needs no configured fallback.
+    expect(getFallbackWebsocketUrlForDomain('jabber.fr')).toBeNull()
   })
 
   it('matches wildcard suffix for *.m.in-app.io', () => {
-    expect(getWebsocketUrlForDomain('chat.m.in-app.io')).toBe('wss://chat.m.in-app.io/xmpp')
-    expect(getWebsocketUrlForDomain('demo.m.in-app.io')).toBe('wss://demo.m.in-app.io/xmpp')
+    expect(getFallbackWebsocketUrlForDomain('chat.m.in-app.io')).toBe('wss://chat.m.in-app.io/xmpp')
+    expect(getFallbackWebsocketUrlForDomain('demo.m.in-app.io')).toBe('wss://demo.m.in-app.io/xmpp')
   })
 
   it('does not match bare suffix domain', () => {
     // 'm.in-app.io' alone should not match the '*.m.in-app.io' wildcard
-    expect(getWebsocketUrlForDomain('m.in-app.io')).toBeNull()
+    expect(getFallbackWebsocketUrlForDomain('m.in-app.io')).toBeNull()
   })
 
   it('wildcard match is case-insensitive', () => {
-    expect(getWebsocketUrlForDomain('Chat.M.In-App.IO')).toBe('wss://chat.m.in-app.io/xmpp')
+    expect(getFallbackWebsocketUrlForDomain('Chat.M.In-App.IO')).toBe('wss://chat.m.in-app.io/xmpp')
+  })
+})
+
+describe('getConnectionServerOptions', () => {
+  it('adds the configured fallback when connecting to the JID domain', () => {
+    expect(getConnectionServerOptions('alice@process-one.net', '')).toEqual({
+      server: 'process-one.net',
+      fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
+    })
+    expect(getConnectionServerOptions('alice@process-one.net', 'PROCESS-ONE.NET')).toEqual({
+      server: 'PROCESS-ONE.NET',
+      fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
+    })
+  })
+
+  it('does not attach the JID domain fallback to an explicit custom target', () => {
+    expect(getConnectionServerOptions('alice@process-one.net', 'chat.custom.net')).toEqual({
+      server: 'chat.custom.net',
+      fallbackWebSocketUrl: undefined,
+    })
   })
 })
 

--- a/apps/fluux/src/config/wellKnownServers.ts
+++ b/apps/fluux/src/config/wellKnownServers.ts
@@ -1,9 +1,12 @@
 /**
- * Well-known XMPP server WebSocket URLs
+ * Fallback WebSocket endpoints for known XMPP servers.
  *
- * This config maps domain names to their WebSocket endpoints.
- * Used to auto-fill the WebSocket URL field when the user types a JID
- * from a known domain.
+ * XEP-0156 discovery answers this question for any domain that publishes a
+ * discovery document, and it wins: these entries are consulted only when a
+ * domain advertises no WebSocket endpoint at all. That case is real —
+ * process-one.net serves a host-meta whose links are a webfinger template and
+ * nothing else. A fallback is attached only when the JID domain is also the
+ * connection target, so an explicit target keeps its own resolution path.
  */
 import { getDomain } from '@fluux/sdk'
 
@@ -24,16 +27,14 @@ export interface WildcardServerConfig {
 
 /**
  * Map of domain -> server configuration
- * Add entries here for known XMPP servers
+ *
+ * Add an entry only for a server that advertises no WebSocket endpoint of its
+ * own. A domain that publishes one needs nothing here.
  */
 export const wellKnownServers: Record<string, ServerConfig> = {
   'process-one.net': {
     websocketUrl: 'wss://chat.process-one.net/xmpp',
     name: 'ProcessOne',
-  },
-  'jabber.fr': {
-    websocketUrl: 'wss://jabber.fr/ws',
-    name: 'Jabber.fr',
   },
 }
 
@@ -50,10 +51,11 @@ export const wildcardServers: WildcardServerConfig[] = [
 ]
 
 /**
- * Get WebSocket URL for a domain if it's a well-known server.
- * Checks exact matches first, then wildcard suffix matches.
+ * Get the fallback WebSocket URL for a domain, used only when XEP-0156
+ * discovery advertises none. Checks exact matches first, then wildcard
+ * suffix matches.
  */
-export function getWebsocketUrlForDomain(domain: string): string | null {
+export function getFallbackWebsocketUrlForDomain(domain: string): string | null {
   const lower = domain.toLowerCase()
 
   // Exact match
@@ -68,6 +70,21 @@ export function getWebsocketUrlForDomain(domain: string): string | null {
   }
 
   return null
+}
+
+export interface ConnectionServerOptions {
+  server: string
+  fallbackWebSocketUrl: string | undefined
+}
+
+export function getConnectionServerOptions(jid: string, server: string): ConnectionServerOptions {
+  const domain = getDomainFromJid(jid) || ''
+  const target = server || domain
+  const fallbackWebSocketUrl = domain && target.toLowerCase() === domain.toLowerCase()
+    ? getFallbackWebsocketUrlForDomain(domain) || undefined
+    : undefined
+
+  return { server: target, fallbackWebSocketUrl }
 }
 
 /**

--- a/apps/fluux/src/hooks/useSessionPersistence.keychainRetry.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.keychainRetry.test.tsx
@@ -21,8 +21,8 @@ function setStatus(next: ConnectionStatus): void {
 // Spy for the SDK connect action the retry effect invokes.
 const mockConnect = vi.fn().mockResolvedValue(undefined)
 
-const JID = 'user@example.com'
-const SERVER = 'example.com'
+const JID = 'user@process-one.net'
+const SERVER = 'process-one.net'
 
 // Force the Tauri code path and a present-but-wrong stored credential.
 // JID/server are inlined here: vi.mock factories are hoisted above module
@@ -31,7 +31,7 @@ import { setPlatformForTesting } from '@/platform'
 setPlatformForTesting({ shell: 'desktop', os: 'macos' })
 vi.mock('@/utils/keychain', () => ({
   hasSavedCredentials: () => true,
-  getCredentials: vi.fn().mockResolvedValue({ jid: 'user@example.com', password: 'stale-password', server: 'example.com' }),
+  getCredentials: vi.fn().mockResolvedValue({ jid: 'user@process-one.net', password: 'stale-password', server: 'process-one.net' }),
 }))
 
 // Override the SDK mock so connect() is our spy and the status the hook reads
@@ -96,6 +96,10 @@ describe('useSessionPersistence — keychain retry one-shot (issue #995)', () =>
     await flush()
 
     expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({
+      server: 'process-one.net',
+      fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
+    }))
   })
 
   // ★ The core regression guard for the infinite loop.

--- a/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
@@ -32,14 +32,14 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
 const JID = 'user@example.com'
 const SERVER = 'example.com'
 
-function seedFastTokenSession(): void {
+function seedFastTokenSession(jid = JID, server = SERVER): void {
   // "Remember Me" + last account + a valid FAST token => Path B auto-connect arms.
   localStorage.setItem('xmpp-remember-me', 'true')
-  localStorage.setItem('xmpp-last-jid', JID)
-  localStorage.setItem('xmpp-last-server', SERVER)
+  localStorage.setItem('xmpp-last-jid', jid)
+  localStorage.setItem('xmpp-last-server', server)
   const expiry = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
   localStorage.setItem(
-    `fluux:fast-token:${JID}`,
+    `fluux:fast-token:${jid}`,
     JSON.stringify({ mechanism: 'HT-SHA-256-NONE', token: 'tok', expiry })
   )
 }
@@ -60,12 +60,28 @@ describe('useSessionPersistence — reconnect intent gate', () => {
   // Positive control: proves the harness actually arms Path B, so a "not called"
   // assertion below is meaningful (the gate, not broken wiring).
   it('auto-connects via FAST token when intent is active (default)', async () => {
-    seedFastTokenSession()
+    seedFastTokenSession('user@process-one.net', 'process-one.net')
     markConnectActive()
 
     renderHook(() => useSessionPersistence())
 
     await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1))
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({
+      server: 'process-one.net',
+      fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
+    }))
+  })
+
+  it('restores a session with the fallback for its JID domain', async () => {
+    saveSession('user@process-one.net', 'secret', 'process-one.net')
+    markConnectActive()
+
+    renderHook(() => useSessionPersistence())
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({
+      server: 'process-one.net',
+      fallbackWebSocketUrl: 'wss://chat.process-one.net/xmpp',
+    })))
   })
 
   // ★ The core regression guard.

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -7,6 +7,7 @@ import { getResource } from '@/utils/xmppResource'
 import { platform } from '@/platform'
 import { getCredentials, hasSavedCredentials } from '@/utils/keychain'
 import { getReconnectIntent } from '@/utils/reconnectIntent'
+import { getConnectionServerOptions } from '@/config/wellKnownServers'
 
 const SESSION_KEY = 'xmpp-session'
 const ROSTER_KEY = 'xmpp-roster'
@@ -459,6 +460,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
       // Auth failures and server conflicts still surface immediately via the
       // machine's AUTH_ERROR / CONFLICT events.
       const autoRetry = true
+      const serverOptions = getConnectionServerOptions(session.jid, session.server)
 
       // Check if another tab already holds this JID (web only)
       if (claimConnection) {
@@ -468,14 +470,14 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
             isResumptionRef.current = false
             return
           }
-          connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
+          connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
           })
         }).catch(() => {
           // Claim check failed, try connecting anyway
-          connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
+          connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
@@ -484,7 +486,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         return
       }
 
-      connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
+      connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
         console.log('[Auth] Reconnection failed:', err?.message || err)
         // If auto-reconnect fails, clear session
         clearSession()
@@ -508,6 +510,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     const effectiveServer = savedServer || (savedJid ? getDomain(savedJid) : null)
     if (rememberMe && savedJid && effectiveServer && hasFastToken(savedJid)) {
       const resource = getResource()
+      const serverOptions = getConnectionServerOptions(savedJid, effectiveServer)
 
       const attemptFastConnect = async () => {
         // On Tauri, load the keychain password as a fallback. xmpp.js will
@@ -537,12 +540,12 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         // flakiness as page-reload. Auth failures (bad/expired token) still
         // surface via the machine's AUTH_ERROR path and delete the token.
         try {
-          await connect({ jid: savedJid, password: fallbackPassword, server: effectiveServer, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
+          await connect({ jid: savedJid, password: fallbackPassword, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
           // Save session for subsequent in-tab reconnects. Store the
           // fallback password so reloads (Path A) don't have to re-hit
           // the keychain; empty string preserves prior behavior when no
           // password is available.
-          saveSession(savedJid, fallbackPassword ?? '', effectiveServer)
+          saveSession(savedJid, fallbackPassword ?? '', serverOptions.server)
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           console.log('[Auth] FAST token connect failed:', message)
@@ -610,6 +613,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
 
     keychainRetryAttempted.current = true
     const effectiveServer = savedServer || getDomain(savedJid)
+    const serverOptions = getConnectionServerOptions(savedJid, effectiveServer)
 
     const retryWithKeychain = async () => {
       try {
@@ -617,8 +621,8 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         if (!creds || getBareJid(creds.jid) !== getBareJid(savedJid)) return
         console.log('[Auth] Auth failure on Tauri: retrying with keychain credentials')
         const resource = getResource()
-        await connect({ jid: savedJid, password: creds.password, server: effectiveServer, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
-        saveSession(savedJid, creds.password, effectiveServer)
+        await connect({ jid: savedJid, password: creds.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
+        saveSession(savedJid, creds.password, serverOptions.server)
       } catch (err) {
         console.log('[Auth] Keychain retry after auth failure failed:', err instanceof Error ? err.message : err)
       }

--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -19,8 +19,8 @@ The server field in the login screen accepts several formats. Parsing is central
 
 | Format             | Example                       | Behavior                                  |
 |--------------------|-------------------------------|-------------------------------------------|
-| *(empty)*          |                               | Domain extracted from JID, SRV resolution |
-| Domain only        | `process-one.net`             | SRV resolution                            |
+| *(empty)*          |                               | Domain extracted from JID, then resolved  |
+| Domain only        | `process-one.net`             | XEP-0156 discovery, with platform fallbacks |
 | Domain + port      | `chat.example.com:5222`       | Direct connect, STARTTLS                  |
 | Domain + port 5223 | `chat.example.com:5223`       | Direct connect, direct TLS                |
 | `tls://` URI       | `tls://chat.example.com:5223` | Direct TLS, skip SRV                      |
@@ -102,13 +102,23 @@ When the connection drops, the SDK's reconnection logic:
 
 The original server string is preserved separately from the resolved credentials to ensure reconnection always goes through the full resolution path.
 
-## Web Platform
+## Connection Resolution
 
-On the web platform (no Tauri), the TCP proxy is not available. The connection resolves as follows:
+For a domain target, both platforms first try XEP-0156 WebSocket discovery via
+`/.well-known/host-meta`. A configured `ConnectOptions.fallbackWebSocketUrl` is tried only when
+discovery produces no endpoint, so an advertised endpoint always wins. A `wss://` or `ws://` server
+value is explicit and skips discovery.
 
-1. If the server is a `wss://` or `ws://` URL → used directly
-2. If the server is a domain → XEP-0156 WebSocket discovery is attempted via `/.well-known/host-meta`
-3. Fallback → `wss://{domain}/ws`
+After those shared steps, the platform paths differ:
+
+- On web, the last fallback is the synthesised `wss://{domain}/ws` URL.
+- On proxy-capable desktop, a discovered or configured WebSocket endpoint is tried first. If it fails,
+  or if neither exists, the native TCP/TLS proxy performs SRV resolution.
+
+Serving the discovery document through a redirect is an ordinary configuration. Readable redirect
+chains may use at most two hops; where browsers hide redirect targets, discovery delegates one follow
+to the browser and requires the reported final URL to remain HTTPS. Loops, insecure targets, and
+over-budget chains produce no discovered endpoint, allowing the applicable fallback above to take over.
 
 The `tls://` and `tcp://` schemes are not usable on web. If specified (e.g., from saved settings), the SDK falls back to WebSocket discovery using the JID domain.
 

--- a/docs/URL_SCHEMES.md
+++ b/docs/URL_SCHEMES.md
@@ -49,7 +49,7 @@ The `server` value accepts the same formats as the manual login server field
 | BOSH URL          | `https://chat.example.com/http-bind` | Web and desktop.        |
 | `tls://` URL      | `tls://chat.example.com:5223` | Desktop only (native proxy).   |
 | `tcp://` URL      | `tcp://chat.example.com:5222` | Desktop only (native proxy).   |
-| Bare domain       | `process-one.net`             | Desktop only (SRV resolution). |
+| Bare domain       | `process-one.net`             | WebSocket discovery; desktop can fall back to SRV. |
 | `host:port`       | `chat.example.com:5222`       | Desktop only (native proxy).   |
 
 Validation (`normalizeServer`):
@@ -69,12 +69,12 @@ Validation (`normalizeServer`):
 
 When the `server` is dropped, a valid `jid` in the same link still applies.
 
-> **Platform note:** The native-TCP formats (`tls://`, `tcp://`, bare domain,
-> `host:port`) only connect on **desktop**, where the Rust proxy provides native
-> TCP/TLS. On **web**, only a `wss://`/`ws://` or `https://` (BOSH) endpoint can
-> actually connect, a web link should use one of those. The validator itself is
-> platform-agnostic; it does not reject a desktop-only format on web, it simply
-> won't connect there.
+> **Platform note:** The native-TCP formats (`tls://`, `tcp://`, and `host:port`)
+> only connect on **desktop**, where the Rust proxy provides native TCP/TLS. A
+> bare domain also works on **web** when XEP-0156 discovery or the standard
+> WebSocket fallback finds a usable endpoint. The validator itself is
+> platform-agnostic; it does not reject a desktop-only format on web, but that
+> format will not connect there.
 
 ## Desktop: the `xmpp:` URI scheme
 
@@ -152,9 +152,9 @@ prefill is invalid, so a malformed link cannot survive a reload.
 ## Limitations
 
 - **No password / token transport** by design (would change the security model).
-- **Web transport:** native-TCP server formats (`tls://`, `tcp://`, bare domain,
-  `host:port`) are accepted by the validator but only connect on desktop; a web
-  link should use a `wss://` or `https://` endpoint (see the platform note above).
+- **Web transport:** native-TCP server formats (`tls://`, `tcp://`, and
+  `host:port`) are accepted by the validator but only connect on desktop. Bare
+  domains use the web discovery path described in the platform note above.
 - **Bare-domain JID on desktop:** `parseXmppUri` requires a JID containing `@`, so
   `xmpp:example.com` does not parse and is ignored on desktop. The web path
   accepts a bare domain.

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -68,9 +68,9 @@ export type { ParsedJid } from './jid'
 // when spoken to, so this is on the path of the first room bot anyone writes.
 export { checkForMention } from './mentionDetection'
 
-// XEP-0156: resolve a domain to its WebSocket endpoint. `ConnectOptions.server`
-// wants a `wss://` URL rather than a domain, so without this a bot author has
-// to know their server's endpoint by heart.
+// XEP-0156: inspect the alternative endpoints a domain advertises. Connection
+// setup performs this discovery automatically for domain-valued servers; these
+// exports let headless consumers inspect the advertised endpoints directly.
 export { discoverWebSocket, discoverXmppEndpoints } from '../utils/websocketDiscovery'
 export type { DiscoveryResult } from '../utils/websocketDiscovery'
 

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -157,6 +157,26 @@ describe('XMPPClient Connection', () => {
       )
     })
 
+    it('should use the configured fallback when discovery advertises nothing on web/no-proxy', async () => {
+      mockDiscoverWebSocket.mockResolvedValueOnce(null)
+
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        fallbackWebSocketUrl: 'wss://chat.example.com/xmpp',
+      })
+
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      expect(mockClientFactory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'wss://chat.example.com/xmpp',
+        })
+      )
+    })
+
     it('should use custom WebSocket URL if provided', async () => {
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -929,6 +949,35 @@ describe('XMPPClient Connection', () => {
         expect.objectContaining({ service: 'wss://discovered.example.com/ws' })
       )
       expect(mockProxyAdapter.startProxy).not.toHaveBeenCalled()
+
+      proxyClient.cancelReconnect()
+    })
+
+    it('should use the configured fallback before proxy when discovery advertises nothing', async () => {
+      mockDiscoverWebSocket.mockResolvedValue(null)
+
+      const mockProxyAdapter = {
+        startProxy: vi.fn().mockResolvedValue({ url: 'ws://127.0.0.1:12345' }),
+        stopProxy: vi.fn().mockResolvedValue(undefined),
+      }
+      const proxyClient = new XMPPClient({ debug: false, proxyAdapter: mockProxyAdapter })
+      bindStoresForTesting(proxyClient, mockStores)
+
+      const connectPromise = proxyClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        fallbackWebSocketUrl: 'wss://chat.example.com/xmpp',
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      expect(mockClientFactory).toHaveBeenCalledWith(
+        expect.objectContaining({ service: 'wss://chat.example.com/xmpp' })
+      )
+      expect(mockProxyAdapter.startProxy).not.toHaveBeenCalled()
+      expect(mockStores.connection.setConnectionMethod).toHaveBeenCalledWith('websocket')
 
       proxyClient.cancelReconnect()
     })

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -49,6 +49,7 @@ import {
   discoverWebSocketUrl,
   FAST_XEP0156_DISCOVERY_TIMEOUT_MS,
   resolveWebSocketUrl,
+  fallbackWebSocketUrlFor,
 } from './serverResolution'
 import { SmPersistence } from './smPersistence'
 import { fetchFastToken, saveFastToken, deleteFastToken } from '../fastTokenStorage'
@@ -544,12 +545,12 @@ export class Connection extends BaseModule {
    * Connect to XMPP server.
    *
    * The server parameter can be:
-   * - A full WebSocket URL (wss://example.com:5443/ws) - used directly
+   * - A full WebSocket URL (wss://example.com:5443/ws) - used directly, no discovery
    * - A domain name (example.com)
-   *   - Web/no-proxy: XEP-0156 discovery, then fallback to wss://{domain}/ws
-   *   - Desktop with proxy: fast XEP-0156 check only, then fallback to TCP/SRV via proxy
+   *   - Web/no-proxy: XEP-0156 discovery, then `fallbackWebSocketUrl`, then wss://{domain}/ws
+   *   - Desktop with proxy: fast XEP-0156 check, then `fallbackWebSocketUrl`, then TCP/SRV via proxy
    */
-  async connect({ jid, password, server, resource, smState, lang, previouslyJoinedRooms, skipDiscovery, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure }: ConnectOptions): Promise<void> {
+  async connect({ jid, password, server, resource, smState, lang, previouslyJoinedRooms, skipDiscovery, fallbackWebSocketUrl, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure }: ConnectOptions): Promise<void> {
     // Guard: if already connecting, connected, or reconnecting, ignore the call.
     // This prevents double-connect races (e.g., rapid button clicks, concurrent
     // auto-connect paths) that would create two XMPP sockets binding the same
@@ -614,12 +615,13 @@ export class Connection extends BaseModule {
 
     const resolveDirectWebSocket = async (): Promise<string | null> => {
       // Proxy-capable desktop path: check XEP-0156 only with a short timeout.
-      // If no endpoint is advertised, immediately switch to TCP/SRV proxy.
+      // If no endpoint is advertised, try the configured fallback before the
+      // TCP/SRV proxy.
       if (preferWebSocketFirst) {
-        // In Tauri proxy-capable mode we only try WebSocket when explicitly
-        // configured by the app (already a ws:// / wss:// URL) or discovered
-        // via XEP-0156. For plain domains with skipDiscovery enabled, do not
-        // synthesize a default wss://domain/ws URL; switch directly to proxy.
+        // In Tauri proxy-capable mode a domain uses only a WebSocket discovered
+        // through XEP-0156 or supplied as fallback by the app. With discovery
+        // disabled, do not use either fallback or the synthesized
+        // wss://domain/ws URL; switch directly to the proxy.
         if (skipDiscovery === true) {
           this.stores.console.addEvent(
             'Connection strategy: skipDiscovery enabled on proxy-capable desktop, switching directly to SRV/proxy',
@@ -627,17 +629,20 @@ export class Connection extends BaseModule {
           )
           return null
         }
-        return discoverWebSocketUrl(
+        const discovered = await discoverWebSocketUrl(
           server,
           domain,
           this.stores.console,
           FAST_XEP0156_DISCOVERY_TIMEOUT_MS
         )
+        // A configured endpoint answers for hosts that advertise none; the
+        // TCP/SRV proxy remains the answer when there is no endpoint at all.
+        return discovered ?? fallbackWebSocketUrlFor(fallbackWebSocketUrl)
       }
       if (shouldSkipDiscovery(server, skipDiscovery)) {
         return getWebSocketUrl(server, domain)
       }
-      return resolveWebSocketUrl(server, domain, this.stores.console)
+      return resolveWebSocketUrl(server, domain, this.stores.console, fallbackWebSocketUrl)
     }
 
     const attemptConnection = async (resolvedServer: string, connectionMethod: ConnectionMethod): Promise<void> => {
@@ -659,7 +664,7 @@ export class Connection extends BaseModule {
 
     try {
       // Preferred path on desktop for domain inputs:
-      // 1) try direct WebSocket first (XEP-0156 discovery only),
+      // 1) try a discovered or configured-fallback WebSocket first,
       // 2) then fall back to SRV/proxy only if direct WebSocket fails.
       // The winning endpoint is persisted in this.credentials.server and reused
       // by reconnect attempts so we avoid repeating discovery/SRV checks each time.
@@ -747,7 +752,7 @@ export class Connection extends BaseModule {
         this.stores.console.addEvent(`TCP URI "${server}" not usable without proxy, falling back to WebSocket discovery`, 'connection')
         const fallbackWebSocket = shouldSkipDiscovery('', skipDiscovery)
           ? getWebSocketUrl('', domain)
-          : await resolveWebSocketUrl('', domain, this.stores.console)
+          : await resolveWebSocketUrl('', domain, this.stores.console, fallbackWebSocketUrl)
         await attemptConnection(fallbackWebSocket, 'websocket')
         return
       }

--- a/packages/fluux-sdk/src/core/modules/serverResolution.test.ts
+++ b/packages/fluux-sdk/src/core/modules/serverResolution.test.ts
@@ -5,6 +5,7 @@ import {
   discoverWebSocketUrl,
   FAST_XEP0156_DISCOVERY_TIMEOUT_MS,
   resolveWebSocketUrl,
+  defaultWebSocketUrl,
 } from './serverResolution'
 
 // Mock the discovery module
@@ -162,6 +163,58 @@ describe('serverResolution', () => {
       )
 
       expect(mockDiscover).toHaveBeenCalledWith('example.com', FAST_XEP0156_DISCOVERY_TIMEOUT_MS)
+    })
+  })
+  describe('resolveWebSocketUrl precedence', () => {
+    it('prefers a discovered endpoint over the configured fallback', async () => {
+      mockDiscover.mockResolvedValue('wss://discovered.example/ws')
+
+      const result = await resolveWebSocketUrl(
+        'example.com',
+        'example.com',
+        undefined,
+        'wss://configured.example/xmpp'
+      )
+
+      expect(result).toBe('wss://discovered.example/ws')
+    })
+
+    it('uses the configured fallback when discovery advertises nothing', async () => {
+      mockDiscover.mockResolvedValue(null)
+
+      const result = await resolveWebSocketUrl(
+        'example.com',
+        'example.com',
+        undefined,
+        'wss://configured.example/xmpp'
+      )
+
+      expect(result).toBe('wss://configured.example/xmpp')
+    })
+
+    it('ignores a fallback that is not a WebSocket URL', async () => {
+      mockDiscover.mockResolvedValue(null)
+
+      const result = await resolveWebSocketUrl(
+        'example.com',
+        'example.com',
+        undefined,
+        'chat.example.com'
+      )
+
+      expect(result).toBe('wss://example.com/ws')
+    })
+
+    it('synthesises the default URL when nothing else applies', async () => {
+      mockDiscover.mockResolvedValue(null)
+
+      expect(await resolveWebSocketUrl('example.com', 'example.com')).toBe('wss://example.com/ws')
+    })
+  })
+
+  describe('defaultWebSocketUrl', () => {
+    it('is the URL synthesised for a domain that advertises nothing', () => {
+      expect(defaultWebSocketUrl('example.com')).toBe('wss://example.com/ws')
     })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/serverResolution.ts
+++ b/packages/fluux-sdk/src/core/modules/serverResolution.ts
@@ -32,14 +32,29 @@ export function shouldSkipDiscovery(server: string, skipDiscovery?: boolean): bo
 }
 
 /**
+ * The WebSocket URL assumed for a host that advertises none.
+ *
+ * The conventional endpoint of an XMPP server that terminates WebSocket on the
+ * same host. It is a guess, and it is the last thing tried.
+ */
+export function defaultWebSocketUrl(host: string): string {
+  return `wss://${host}/ws`
+}
+
+/**
+ * Return the value when it is already a WebSocket URL, otherwise null.
+ */
+function asWebSocketUrl(value?: string): string | null {
+  if (!value) return null
+  return value.startsWith('ws://') || value.startsWith('wss://') ? value : null
+}
+
+/**
  * Get WebSocket URL synchronously (used when discovery is skipped).
  * Returns the server if it's already a WebSocket URL, otherwise constructs default URL.
  */
 export function getWebSocketUrl(server: string, domain: string): string {
-  if (server.startsWith('ws://') || server.startsWith('wss://')) {
-    return server
-  }
-  return `wss://${server || domain}/ws`
+  return asWebSocketUrl(server) ?? defaultWebSocketUrl(server || domain)
 }
 
 /**
@@ -91,18 +106,24 @@ export async function discoverWebSocketUrl(
 /**
  * Resolve WebSocket URL for a server via XEP-0156 discovery.
  *
- * Attempts discovery on the domain and falls back to default URL if discovery fails.
  * Note: This function is only called when discovery is NOT skipped.
+ *
+ * The order is deliberate. What the server advertises wins, so a host that
+ * publishes a correct discovery document cannot be shadowed by a value the
+ * application configured earlier; the configured endpoint answers for the
+ * hosts that advertise nothing; the synthesised default is the last guess.
  *
  * @param server - Server parameter (domain name)
  * @param domain - XMPP domain from the JID (used for discovery)
  * @param logger - Optional logger for console events
+ * @param fallbackWebSocketUrl - Endpoint to use when discovery advertises none
  * @returns Resolved WebSocket URL
  */
 export async function resolveWebSocketUrl(
   server: string,
   domain: string,
-  logger?: ResolutionLogger
+  logger?: ResolutionLogger,
+  fallbackWebSocketUrl?: string
 ): Promise<string> {
   // The server parameter might be a domain - attempt XEP-0156 discovery
   // Use the JID domain for discovery (more reliable than server param)
@@ -118,11 +139,29 @@ export async function resolveWebSocketUrl(
     return discoveredUrl
   }
 
-  // Fall back to default URL pattern
-  const fallbackUrl = `wss://${discoveryDomain}/ws`
+  const configuredUrl = asWebSocketUrl(fallbackWebSocketUrl)
+  if (configuredUrl) {
+    logger?.addEvent(
+      `Using configured fallback WebSocket URL: ${configuredUrl}`,
+      'connection'
+    )
+    return configuredUrl
+  }
+
+  const fallbackUrl = defaultWebSocketUrl(discoveryDomain)
   logger?.addEvent(
     `Using default WebSocket URL: ${fallbackUrl}`,
     'connection'
   )
   return fallbackUrl
+}
+
+/**
+ * Endpoint to try when XEP-0156 advertises none, or null when there is none.
+ *
+ * Exposed so the proxy-capable desktop path can apply the same precedence
+ * before it gives up on a direct WebSocket and starts the TCP proxy.
+ */
+export function fallbackWebSocketUrlFor(fallbackWebSocketUrl?: string): string | null {
+  return asWebSocketUrl(fallbackWebSocketUrl)
 }

--- a/packages/fluux-sdk/src/core/types/connection.ts
+++ b/packages/fluux-sdk/src/core/types/connection.ts
@@ -118,6 +118,15 @@ export interface ConnectOptions {
    */
   skipDiscovery?: boolean
   /**
+   * WebSocket endpoint to use when XEP-0156 discovery advertises none.
+   *
+   * A hint about a deployment, never an override: what the server advertises
+   * always wins, so a stale configured value cannot shadow a host that
+   * publishes a correct discovery document. Ignored unless it is a ws:// or
+   * wss:// URL.
+   */
+  fallbackWebSocketUrl?: string
+  /**
    * Disable xmpp.js's built-in Stream Management keepalive interval.
    * When true, the SDK will not send periodic SM acknowledgment requests.
    * Use this when the application implements its own keepalive mechanism

--- a/packages/fluux-sdk/src/utils/websocketDiscovery.test.ts
+++ b/packages/fluux-sdk/src/utils/websocketDiscovery.test.ts
@@ -321,4 +321,159 @@ describe('websocketDiscovery', () => {
       expect(result.bosh).toBe('https://example.com/http-bind')
     })
   })
+  describe('redirected discovery documents', () => {
+    /** A document served through a redirect, as jabber.fr serves it. */
+    const XRD = `<?xml version='1.0' encoding='utf-8'?>
+      <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
+        <Link rel='urn:xmpp:alt-connections:xbosh'
+              href='https://bosh.elsewhere.example/'/>
+        <Link rel='urn:xmpp:alt-connections:websocket'
+              href='wss://ws.elsewhere.example/'/>
+      </XRD>`
+
+    /** A 3xx as a runtime that lets us read it reports one (Node, undici). */
+    const redirect = (location: string, status = 301) => ({
+      ok: false,
+      status,
+      headers: { get: (name: string) => (name.toLowerCase() === 'location' ? location : null) },
+    })
+
+    /** The opaque response a browser returns for `redirect: 'manual'`. */
+    const opaqueRedirect = () => ({ ok: false, status: 0, type: 'opaqueredirect' })
+
+    const document = (url: string) => ({
+      ok: true,
+      status: 200,
+      url,
+      text: () => Promise.resolve(XRD),
+    })
+
+    /** Every attempt starts with the JSON document, which these hosts lack. */
+    const noJson = () => Promise.reject(new Error('JSON not found'))
+
+    it('finds a document served through a redirect', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(redirect('https://elsewhere.example/.well-known/host-meta'))
+        .mockResolvedValueOnce(document('https://elsewhere.example/.well-known/host-meta'))
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      expect(result.websocket).toBe('wss://ws.elsewhere.example/')
+      expect(result.bosh).toBe('https://bosh.elsewhere.example/')
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/.well-known/host-meta',
+        expect.objectContaining({ redirect: 'manual' })
+      )
+    })
+
+    it('resolves a relative redirect target against the document URL', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(redirect('/host-meta'))
+        .mockResolvedValueOnce(document('https://example.com/host-meta'))
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      expect(result.websocket).toBe('wss://ws.elsewhere.example/')
+      expect(global.fetch).toHaveBeenNthCalledWith(3, 'https://example.com/host-meta', expect.anything())
+    })
+
+    it('follows a chain up to the budget', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(redirect('https://one.example/.well-known/host-meta'))
+        .mockResolvedValueOnce(redirect('https://two.example/.well-known/host-meta', 308))
+        .mockResolvedValueOnce(document('https://two.example/.well-known/host-meta'))
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      expect(result.websocket).toBe('wss://ws.elsewhere.example/')
+    })
+
+    it('stops at the budget instead of following further', async () => {
+      global.fetch = vi.fn()
+        .mockImplementation((url: string) =>
+          url.endsWith('.json')
+            ? noJson()
+            : Promise.resolve(redirect(`https://hop-${Math.random()}.example/.well-known/host-meta`))
+        )
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      // Nothing found, and the chain was cut: the JSON attempt plus the first
+      // request and the hops the budget allows.
+      expect(result).toEqual({})
+      expect(global.fetch).toHaveBeenCalledTimes(4)
+    })
+
+    it('terminates on a redirect loop', async () => {
+      const loop: Record<string, string> = {
+        'https://example.com/.well-known/host-meta': 'https://other.example/.well-known/host-meta',
+        'https://other.example/.well-known/host-meta': 'https://example.com/.well-known/host-meta',
+      }
+      global.fetch = vi.fn().mockImplementation((url: string) =>
+        url.endsWith('.json') ? noJson() : Promise.resolve(redirect(loop[url]))
+      )
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      expect(result).toEqual({})
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(4)
+    })
+
+    it('refuses a redirect that leaves https', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(redirect('http://insecure.example/.well-known/host-meta'))
+
+      expect(await discoverXmppEndpoints('example.com')).toEqual({})
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('refuses a redirect without a target', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce({ ok: false, status: 301, headers: { get: () => null } })
+
+      expect(await discoverXmppEndpoints('example.com')).toEqual({})
+    })
+
+    it('delegates one follow when the redirect target is opaque, as in a browser', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(opaqueRedirect())
+        .mockResolvedValueOnce(document('https://elsewhere.example/.well-known/host-meta'))
+
+      const result = await discoverXmppEndpoints('example.com')
+
+      expect(result.websocket).toBe('wss://ws.elsewhere.example/')
+      // Exactly one delegated follow: the budget is spent, never renewed.
+      expect(global.fetch).toHaveBeenCalledTimes(3)
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        3,
+        'https://example.com/.well-known/host-meta',
+        expect.objectContaining({ redirect: 'follow' })
+      )
+    })
+
+    it('refuses a delegated follow that lands outside https', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(opaqueRedirect())
+        .mockResolvedValueOnce(document('http://insecure.example/.well-known/host-meta'))
+
+      expect(await discoverXmppEndpoints('example.com')).toEqual({})
+    })
+
+    it('refuses a delegated follow that does not report where it landed', async () => {
+      global.fetch = vi.fn()
+        .mockImplementationOnce(noJson)
+        .mockResolvedValueOnce(opaqueRedirect())
+        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(XRD) })
+
+      expect(await discoverXmppEndpoints('example.com')).toEqual({})
+    })
+  })
 })

--- a/packages/fluux-sdk/src/utils/websocketDiscovery.ts
+++ b/packages/fluux-sdk/src/utils/websocketDiscovery.ts
@@ -119,7 +119,7 @@ async function fetchHostMetaJson(
   timeout: number
 ): Promise<DiscoveryResult> {
   const url = `https://${domain}/.well-known/host-meta.json`
-  const response = await fetchWithTimeout(url, timeout)
+  const response = await fetchDiscoveryDocument(url, timeout)
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`)
@@ -137,7 +137,7 @@ async function fetchHostMetaXml(
   timeout: number
 ): Promise<DiscoveryResult> {
   const url = `https://${domain}/.well-known/host-meta`
-  const response = await fetchWithTimeout(url, timeout)
+  const response = await fetchDiscoveryDocument(url, timeout)
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`)
@@ -148,15 +148,113 @@ async function fetchHostMetaXml(
 }
 
 /**
+ * Maximum number of redirect hops accepted while fetching a discovery document.
+ *
+ * Delegating `.well-known` to another host is an ordinary configuration and
+ * costs one hop; a second covers a host that then normalises the target (apex
+ * to `www`, or a trailing-slash form). Past that, a document is not being
+ * served, it is being bounced, and we stop.
+ *
+ * The budget cannot mean the same thing on both platforms this client runs on:
+ *
+ * - Where a 3xx response is readable — Node and other native runtimes — every
+ *   hop is counted here: this module reads `Location`, spends one unit of the
+ *   budget per hop, and refuses a chain that revisits a URL.
+ * - In a browser, `redirect: 'manual'` yields an opaque-redirect response:
+ *   status 0, no headers, no body. `Location` cannot be read, so the hops
+ *   cannot be counted here at all. There the whole budget buys exactly ONE
+ *   follow delegated to the user agent — never a second — and the URL it
+ *   reports landing on must still be https. The user agent applies its own
+ *   hop limit inside that single follow, so an over-long chain or a loop
+ *   surfaces as a network error, which is a failed discovery.
+ *
+ * Either way, an exhausted budget yields no endpoint: a capped chain is never
+ * a successful discovery.
+ */
+const MAX_HOST_META_REDIRECTS = 2
+
+/** Status codes that carry a redirect target in `Location`. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+/**
+ * Fetch a discovery document, following redirects within the budget above.
+ */
+async function fetchDiscoveryDocument(url: string, timeout: number): Promise<Response> {
+  const visited = new Set<string>([url])
+  let target = url
+
+  for (let hopsLeft = MAX_HOST_META_REDIRECTS; ; hopsLeft--) {
+    const response = await fetchWithTimeout(target, timeout, 'manual')
+
+    // A browser hides the target of a redirect it did not follow. Spend the
+    // whole budget on a single follow it performs for us, and check where it
+    // says it landed.
+    if (response.type === 'opaqueredirect') {
+      return followRedirectInUserAgent(target, timeout)
+    }
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return response
+    }
+
+    if (hopsLeft <= 0) {
+      throw new Error(`Redirect budget of ${MAX_HOST_META_REDIRECTS} hops exhausted`)
+    }
+
+    const location = response.headers.get('location')
+    if (!location) {
+      throw new Error(`HTTP ${response.status} without a Location header`)
+    }
+
+    const next = new URL(location, target)
+    if (next.protocol !== 'https:') {
+      throw new Error(`Redirect to a non-https discovery document: ${next.href}`)
+    }
+    if (visited.has(next.href)) {
+      throw new Error(`Redirect loop at ${next.href}`)
+    }
+
+    visited.add(next.href)
+    target = next.href
+  }
+}
+
+/**
+ * Let the user agent follow a redirect whose target this module cannot read.
+ *
+ * The final URL is the only part of the chain a browser exposes, so it is the
+ * one bound we can still enforce: the document has to have been served over
+ * https. A response that does not report where it landed is refused rather
+ * than trusted.
+ */
+async function followRedirectInUserAgent(url: string, timeout: number): Promise<Response> {
+  const response = await fetchWithTimeout(url, timeout, 'follow')
+
+  if (!response.url) {
+    throw new Error('Redirected discovery document did not report a final URL')
+  }
+  if (!response.url.startsWith('https://')) {
+    throw new Error(`Redirected discovery document is not served over https: ${response.url}`)
+  }
+
+  return response
+}
+
+/**
  * Fetch with timeout support.
  */
-async function fetchWithTimeout(url: string, timeout: number): Promise<Response> {
+async function fetchWithTimeout(
+  url: string,
+  timeout: number,
+  redirect: RequestRedirect
+): Promise<Response> {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeout)
 
   try {
     const response = await fetch(url, {
       signal: controller.signal,
+      redirect,
       headers: {
         'Accept': 'application/json, application/xrd+xml, application/xml',
       },


### PR DESCRIPTION
A jabber.fr account could only log in after typing the domain by hand in the advanced server field.

The cause was not the redirect that serves jabber.fr's discovery document: a browser follows it and the document parses correctly. XEP-0156 discovery was never attempted. The client substituted a hard-coded endpoint for a known domain, and a `wss://` target skips discovery entirely, so one stale table entry left every account on that domain unable to connect. On desktop that value also suppressed the SRV/TCP proxy fallback.

The table of known servers is now a fallback rather than a substitute. `getConnectionServerOptions` derives the connection target and its fallback together, and login, session restoration, FAST-token auto-connect and the keychain retry all resolve through it. The fallback attaches only when the JID domain is also the target, so an explicit server keeps its own resolution path, and it applies only when discovery advertises no endpoint. The table still earns its place: process-one.net serves a discovery document that advertises no XMPP endpoint at all, so it cannot simply be deleted.

Discovery now follows redirects deliberately, within a named budget of two hops. Where a 3xx response is readable the hops are counted and a chain that revisits a URL is refused. In a browser a manual redirect is opaque and carries no `Location`, so the budget buys exactly one follow delegated to the user agent, never a second, and the URL it reports landing on must still be https. An exhausted budget yields no endpoint.

One note for anyone who worked around this: an advanced server field still holding an endpoint filled in by an earlier version keeps precedence over discovery. Clearing it once is enough for the domain to be discovered.
