### PR TITLE
fix(app): hold the bottom when the composer shrinks back

### DIFF
--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
@@ -167,6 +167,39 @@ describe('useViewportResizeReconciliation', () => {
     expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink', true)
   })
 
+  it('reconciles a container growth that left the view short of the bottom', () => {
+    const scope = mount()
+    observers[0].fire(400, 800)
+    flushFrames()
+
+    // The composer collapses: the scroller grows back, but content measured in the same commit
+    // leaves the view below the bottom. The at-bottom latch already reads that drifted distance,
+    // so the branch must not consult it.
+    scope.state.atBottom = false
+    scope.scroller.geometry.clientHeight = 600
+    scope.scroller.geometry.scrollHeight = 1_286
+    scope.scroller.geometry.scrollTop = 400
+    observers[0].fire(600, 800)
+    flushFrames()
+
+    // `false`: re-open an existing follow only. Post-resize geometry cannot tell a follower from a
+    // reader who scrolled up, so it must never mint a new one.
+    expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-growth', false)
+  })
+
+  it('leaves a container growth alone once the view is already at the bottom', () => {
+    const scope = mount()
+    observers[0].fire(400, 800)
+    flushFrames()
+
+    scope.scroller.geometry.clientHeight = 600
+    scope.scroller.geometry.scrollTop = 400
+    observers[0].fire(600, 800)
+    flushFrames()
+
+    expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+  })
+
   it('requests width-change only when the reader remains at the live edge', () => {
     const scope = mount()
     observers[0].fire(600, 800)

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
@@ -15,6 +15,7 @@ import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
 export type ViewportResizeReconciliationTrigger =
   | 'viewport-resize'
   | 'container-shrink'
+  | 'container-growth'
   | 'width-change'
 
 export interface ViewportResizeReconciliationPorts {
@@ -107,6 +108,20 @@ export function useViewportResizeReconciliation({
         active.isAtBottom()
       ) {
         active.reconcileLiveEdge('width-change', true)
+      } else if (shrunk < 0 && liveScroller) {
+        // The container GREW (the composer shrank back). Extra scroller height can only bring a
+        // follower closer to the bottom: the browser clamps scrollTop as the growth uncovers the
+        // tail. So a view left short of the bottom across this growth is content that grew
+        // underneath in the same commit and that nothing absorbed — not a position the reader chose.
+        //
+        // Post-resize geometry cannot tell a follower from a reader who scrolled up: the clamp fires
+        // a scroll event whose handler reads a DOM already carrying that growth, so both the
+        // measured distance and the at-bottom latch report "scrolled away". Re-open the EXISTING
+        // follow only (`rearmEligibleFromGeometry: false`); a reader who left the live edge has no
+        // live-edge owner to re-open and is untouched.
+        if (distanceFromBottom(liveScroller) > BOTTOM_PIN_TOLERANCE) {
+          active.reconcileLiveEdge('container-growth', false)
+        }
       }
 
       lastHeight = newHeight

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -240,6 +240,10 @@ preservation step is still pending, matching the existing send-stick suppression
 owner releases after its first position is applied, not after the entire measurement-settle loop.
 Later ordinary stimuli handle content from any dropped attempt.
 
+Container growth after the composer shrinks is re-open-only: post-resize geometry cannot distinguish
+a follower left short of the bottom from a reader who deliberately scrolled up, so this stimulus
+never creates an ambient live-edge request.
+
 ## Entry arbitration and later supersession
 
 Entry selects exactly one provisional request:
@@ -386,7 +390,7 @@ abort valid deep growth and media-settle runs.
 | Unread divider moves while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; subject to ambient request precedence above |
 | Load older/newer | Fixed top-relative offset anchor | Subject to ambient request precedence above; wait for the directional window change and release if the load settles without one; if the anchor disappears after a shift, preserve captured distance from bottom and clamp |
 | Home / resident-top command | Resident top | Does not itself trigger load-older; later genuine user travel can re-arm ordinary boundary loading |
-| Reaction, typing, resize, MAM completion | Current or geometry-rearmed live edge | Normally a reconciliation stimulus; an eligible paused/null state creates an ambient live-edge request that yields to navigation |
+| Reaction, typing, resize, MAM completion | Current or geometry-rearmed live edge | Normally a reconciliation stimulus; an eligible paused/null state creates an ambient live-edge request that yields to navigation, except container growth, which can only re-open an existing follow |
 
 The FAB/End choice is made from current geometry, not a remembered click state. If the unread marker
 is already visible or above the viewport, the same activation goes directly to live edge.

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2368,6 +2368,14 @@ test.describe('Typing indicator never covers message text', () => {
     })
   }
 
+  interface BottomAnchorProbe {
+    /** Id of the row whose bottom edge is lowest — the one bottom anchoring is about. */
+    tailRowId: string | null
+    tailOnScreen: boolean
+    distFromBottom: number
+    scrollHeight: number
+  }
+
   interface OverlapProbe {
     pillFound: boolean
     pillHeight: number
@@ -2445,6 +2453,35 @@ test.describe('Typing indicator never covers message text', () => {
     }, offset)
   }
 
+  /**
+   * Read-only bottom-anchor reading: which row is at the tail, whether its bottom edge is on
+   * screen, and how far the view sits from the true bottom. Deliberately writes nothing —
+   * `probeOverlap` parks the viewport itself, so anchoring has to be read BEFORE it runs or the
+   * measurement is of the probe, not of the app.
+   */
+  async function probeBottomAnchor(page: Page): Promise<BottomAnchorProbe> {
+    return page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { tailRowId: null, tailOnScreen: false, distFromBottom: -1, scrollHeight: -1 }
+      const sRect = s.getBoundingClientRect()
+      let tailRowId: string | null = null
+      let tailBottom = -Infinity
+      for (const el of Array.from(s.querySelectorAll('[data-message-id]'))) {
+        const bottom = el.getBoundingClientRect().bottom
+        if (bottom > tailBottom) {
+          tailBottom = bottom
+          tailRowId = el.getAttribute('data-message-id')
+        }
+      }
+      return {
+        tailRowId,
+        tailOnScreen: tailBottom > sRect.top && tailBottom <= sRect.bottom + 8,
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+        scrollHeight: Math.round(s.scrollHeight),
+      }
+    })
+  }
+
   test('no scroll offset puts a visible message row under the pill', async ({ page }) => {
     await loadDemo(page)
     await activateChat(page, AVA)
@@ -2472,9 +2509,28 @@ test.describe('Typing indicator never covers message text', () => {
     ).toEqual([])
   })
 
-  test('growing the composer to two lines and shrinking it back never parks text under the pill', async ({ page }) => {
+  test('growing the composer to two lines and shrinking it back holds the bottom and never parks text under the pill', async ({ page }) => {
     await loadDemo(page)
     await activateChat(page, AVA)
+
+    // The seeded conversation ends on an unsupported-encryption placeholder, whose row height does
+    // not follow its body. Anchoring is a claim about the TAIL row, so give the list one whose
+    // height the test can actually move.
+    const tailId = `composer-tail-${Date.now()}`
+    await page.evaluate(([jid, id]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = (window as any).__demoClient
+      if (!client) throw new Error('no __demoClient')
+      client.emitSDK('chat:message', {
+        message: {
+          type: 'chat', conversationId: jid, from: jid, id,
+          body: 'the newest message, whose row the composer must keep at the bottom',
+          timestamp: new Date(), isOutgoing: false,
+        },
+      })
+    }, [AVA, tailId] as const)
+    await page.waitForSelector(`[data-message-id="${tailId}"]`, { timeout: 5_000 })
+
     await scrollToBottom(page)
     await startTyping(page, AVA)
     await page.waitForTimeout(SETTLE_MS)
@@ -2498,19 +2554,97 @@ test.describe('Typing indicator never covers message text', () => {
       'This draft is long enough to wrap the composer onto a second line, which shrinks the ' +
       'message viewport under a pill that does not move with it.'
 
+    const anchored = await probeBottomAnchor(page)
+    expect(anchored.tailRowId, 'precondition: the newest message must be the tail row').toBe(tailId)
+    expect(anchored.distFromBottom, 'precondition: must start at the bottom').toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
+
+    // ── Composer GROWS ──────────────────────────────────────────────────────
     await setDraft(twoLines)
+
+    // Anchoring is read FIRST: probeOverlap parks the viewport itself, so any bottom claim made
+    // after it would be a claim about the probe.
+    const grownAnchor = await probeBottomAnchor(page)
+    expect(
+      grownAnchor.tailRowId,
+      `the row at the bottom changed while the composer grew (${anchored.tailRowId} → ${grownAnchor.tailRowId})`,
+    ).toBe(anchored.tailRowId)
+    expect(
+      grownAnchor.distFromBottom,
+      `bottom lost while the composer grew — ${grownAnchor.distFromBottom}px short`,
+    ).toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
+    expect(grownAnchor.tailOnScreen, 'the newest row went below the fold while the composer grew').toBe(true)
+
     const grown = await probeOverlap(page, 0)
     expect(grown.pillFound && grown.visibleRows > 0, 'pill/rows missing after composer grew').toBe(true)
     expect(grown.worstOverlap, `pill covers ${grown.worstRowId} while the composer is two lines`).toBe(0)
 
-    await setDraft('')
+    // ── Composer SHRINKS, with growth the row-growth SIGNATURE cannot see ───
+    // The composer collapsing on its own is absorbed by the browser clamping scrollTop, so a bare
+    // shrink cannot tell whether the app holds the bottom or the engine does. What separates them
+    // is content that grows in the same commit: the clamp fires a scroll event whose handler reads
+    // a DOM already carrying that growth, so the recorded "where the reader was" baseline arrives
+    // pre-drifted and the measured-growth backstop nets the growth out against itself.
+    //
+    // The growth is deliberately invisible to computeRowGrowthSignature (no reaction, preview,
+    // attachment, correction or retraction flag): that is what the measured backstop exists for —
+    // a resident row that simply re-measures taller, the way a late bitmap decode or a webfont swap
+    // leaves it after an earlier signature-triggered loop has settled.
+    await page.evaluate((jid) => {
+      const ta = document.querySelector('textarea') as HTMLTextAreaElement | null
+      if (!ta) throw new Error('no composer textarea')
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!
+      setter.call(ta, '')
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chatStore = (window as any).__chatStore
+      const state = chatStore.getState()
+      const messages = (state.messages.get(jid) ?? []).slice()
+      const last = messages.length - 1
+      messages[last] = {
+        ...messages[last],
+        body: Array.from({ length: 14 }, (_, line) => `re-measured taller, line ${line}`).join('\n'),
+      }
+      const next = new Map(state.messages)
+      next.set(jid, messages)
+      chatStore.setState({ messages: next })
+    }, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const shrunkAnchor = await probeBottomAnchor(page)
+
+    // Control: without this the anchoring claim below would pass on a growth too small to push the
+    // newest row out of the at-bottom band, and would prove nothing about re-pinning.
+    expect(
+      shrunkAnchor.scrollHeight - grownAnchor.scrollHeight,
+      `the row must grow by more than the at-bottom band (${grownAnchor.scrollHeight} → ${shrunkAnchor.scrollHeight}) — otherwise this case is vacuous`,
+    ).toBeGreaterThan(AT_BOTTOM_OK_PX)
+
+    expect(
+      shrunkAnchor.tailRowId,
+      `the row at the bottom changed while the composer shrank (${anchored.tailRowId} → ${shrunkAnchor.tailRowId})`,
+    ).toBe(anchored.tailRowId)
+    expect(
+      shrunkAnchor.distFromBottom,
+      `bottom not readjusted after the composer shrank back — ${shrunkAnchor.distFromBottom}px short`,
+    ).toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
+    expect(shrunkAnchor.tailOnScreen, 'the newest row went below the fold when the composer shrank').toBe(true)
+
     const shrunk = await probeOverlap(page, 0)
     expect(shrunk.pillFound && shrunk.visibleRows > 0, 'pill/rows missing after composer shrank').toBe(true)
     expect(shrunk.worstOverlap, `pill covers ${shrunk.worstRowId} after the composer shrank back`).toBe(0)
 
-    expect(await readPinStarts(), 'composer growth must retain container-shrink reconciliation').toContain(
+    const pinStarts = await readPinStarts()
+    expect(pinStarts, 'composer growth must retain container-shrink reconciliation').toContain(
       'container-shrink',
     )
+    // The shrink direction has two possible rescuers and which one runs is an engine fact, so name
+    // the obligation rather than the engine: Chromium's scroll anchoring leaves the measured-growth
+    // baseline intact and `row-growth` absorbs the growth, while WebKit's clamp refreshes that
+    // baseline post-growth and only the container-growth branch is left to see it.
+    expect(
+      pinStarts.filter((trigger) => trigger === 'container-growth' || trigger === 'row-growth'),
+      `nothing reconciled the live edge after the composer shrank (pins: ${pinStarts.join(', ')})`,
+    ).not.toEqual([])
   })
 
   /** Emit `composing`/`paused` for a set of MUC nicks. `room:typing` carries one nick at a time. */


### PR DESCRIPTION
The bottom alignment could fail to readjust when the composer changed height.

A composer height change resizes the message scroller from below. The grow direction was already
reconciled; the shrink direction relied on the browser clamping `scrollTop`, which is enough only
while content height stands still.

When a resident row re-measures taller in the same commit, that clamp fires a scroll event whose
handler records the viewport geometry from a DOM already carrying the growth. The measured-growth
backstop then nets the growth out against its own baseline and refuses the re-pin, leaving the newest
message below the fold with nothing later to correct it. Measured at 286px short, permanently, with
no pin emitted at all. WebKit shows this; Chromium's scroll anchoring keeps the baseline intact and
masks it.

The fix reconciles on container growth as well. Growing the scroller can only bring a follower closer
to the bottom, so a view left short of it across that growth is unabsorbed content rather than a
position the reader chose. The branch re-opens an existing follow only and never re-arms from
geometry, which here cannot tell a follower from a reader who scrolled up — so a reader who
deliberately scrolled away is untouched.

The composer grow/shrink scroll invariant already exercised this gesture but only asserted that the
typing pill covered no text. It now also asserts bottom anchoring: the same tail row still at the
bottom, within the section's glued tolerance.
