### PR TITLE
build(deps): move the hickory crates to 0.26.2 together

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -2686,9 +2686,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
 dependencies = [
  "data-encoding",
  "idna",
@@ -2730,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
 dependencies = [
  "cfg-if",
  "futures-util",


### PR DESCRIPTION
Supersedes #1366 — that pull request can be closed.

#1366 bumps only `hickory-resolver` (0.26.1 → 0.26.2) and leaves its companions `hickory-net` and
`hickory-proto` at 0.26.1. The build then fails inside `hickory-resolver` itself, in `name_server.rs`
and `name_server_pool.rs`, on `NetError::is_connection_closed` and variants that exist only in
hickory-net 0.26.2. Both the Linux and the Windows Rust jobs fail.

The cause is upstream: hickory-resolver 0.26.2 declares its companions as `^0.26.0`, so cargo is free
to leave them at 0.26.1 in an existing lock even though the code requires the newer API.

This moves the three crates together instead. Nothing outside the family depends on them —
`hickory-resolver` has a single consumer, `fluux`, and `hickory-net`/`hickory-proto` are only reached
through it — so the bump is contained to six lines of `Cargo.lock` and needs no manifest change.
