### PR TITLE
fix(sdk): name the mock factory return types explicitly

### DIFF
--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -3,9 +3,9 @@
  *
  * Provides mock client with event emitter support and fresh session simulation.
  */
-import { vi } from 'vitest'
+import { vi, type Mock } from 'vitest'
 import { connectionStore } from '../stores/connectionStore'
-import type { SideEffectHost } from './sideEffectHost'
+import type { E2EEWarmupHost, SideEffectHost } from './sideEffectHost'
 
 // Mock localStorage for tests that need it
 export const localStorageMock = (() => {
@@ -28,15 +28,54 @@ export const localStorageMock = (() => {
 })()
 
 /**
+ * Shape of the mock built by {@link createMockClient}, annotated explicitly: a
+ * bare `vi.fn()` infers as `Mock<Procedure>`, and `Procedure` is not part of
+ * vitest's public export surface, so an inferred type here cannot be named
+ * outside this package (TS2742).
+ */
+export interface MockSideEffectClient {
+  messages: {
+    queryMAM: Mock
+    queryRoomMAM: Mock
+  }
+  internal: {
+    on: Mock<(event: string, handler: (...args: unknown[]) => void) => () => boolean | undefined>
+    mam: {
+      refreshConversationPreviews: Mock
+      refreshArchivedConversationPreviews: Mock
+      catchUpAllConversations: Mock
+      catchUpRoom: Mock
+      catchUpConversationHistory: Mock
+      catchUpRoomHistory: Mock
+      discoverNewConversationsFromRoster: Mock
+    }
+  }
+  rooms: {
+    queryRoomMembers: Mock
+  }
+  server: {
+    discoverMAMSearchCapability: Mock
+  }
+  isConnected: Mock
+  retryPendingDecrypts: Mock
+  e2ee: E2EEWarmupHost | null
+  subscribe: Mock<(event: string, handler: (payload: unknown) => void) => () => boolean | undefined>
+  /** Emit an internal (`on`/`emit`) event to the handlers registered above. */
+  _emit: (event: string, ...args: unknown[]) => void
+  /** Emit an SDK (`subscribe`/`emitSDK`) event to the handlers registered above. */
+  _emitSDK: (event: string, payload: unknown) => void
+}
+
+/**
  * Create a minimal mock side-effect host with event emitter support.
  */
-export function createMockClient() {
+export function createMockClient(): MockSideEffectClient & SideEffectHost {
   // Internal events (on/emit pattern: 'online', 'resumed', etc.)
   const handlers = new Map<string, Set<(...args: unknown[]) => void>>()
   // SDK events (subscribe/emitSDK pattern: 'room:joined', 'chat:message', etc.)
   const sdkHandlers = new Map<string, Set<(payload: unknown) => void>>()
 
-  const client = {
+  const client: MockSideEffectClient = {
     messages: {
       queryMAM: vi.fn().mockResolvedValue(undefined),
       queryRoomMAM: vi.fn().mockResolvedValue(undefined),
@@ -65,7 +104,7 @@ export function createMockClient() {
     },
     isConnected: vi.fn().mockReturnValue(true),
     retryPendingDecrypts: vi.fn().mockResolvedValue(0),
-    e2ee: null as any,
+    e2ee: null,
     subscribe: vi.fn((event: string, handler: (payload: unknown) => void) => {
       if (!sdkHandlers.has(event)) sdkHandlers.set(event, new Set())
       sdkHandlers.get(event)!.add(handler)
@@ -81,7 +120,7 @@ export function createMockClient() {
     },
   }
 
-  return client as typeof client & SideEffectHost
+  return client as MockSideEffectClient & SideEffectHost
 }
 
 /**

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -5,6 +5,7 @@ import { vi, type Mock } from 'vitest'
 import type { Element } from '@xmpp/client'
 import type { Room, StoreBindings, SDKEvents, SDKEventPayload } from './types'
 import type { StoreRefs } from '../bindings/storeBindings'
+import type { PresenceReader } from './presenceReader'
 import {
   connectionBindingMethodKeys,
   chatBindingMethodKeys,
@@ -59,8 +60,55 @@ export const createMockRoom = (jid: string, overrides: Partial<Room> = {}): Room
   notifyAllPersistent: overrides.notifyAllPersistent,
 })
 
+/**
+ * Shape of the mock built by {@link createMockXmppClient}. Annotated explicitly
+ * because a bare `vi.fn()` infers as `Mock<Procedure>`, and `Procedure` is not
+ * part of vitest's public export surface (TS2742).
+ */
+export interface MockXmppClient {
+  on: Mock<(event: string, handler: Function) => undefined>
+  removeListener: Mock<(event: string, handler: Function) => undefined>
+  off: Mock<(event: string, handler: Function) => undefined>
+  start: Mock
+  stop: Mock
+  send: Mock
+  write: Mock
+  socket: { writable: boolean }
+  iqCallee: {
+    set: Mock<(xmlns: string, element: string, handler: Function) => void>
+    get: Mock<(xmlns: string, element: string, handler: Function) => void>
+    _handlers: Map<string, Function>
+    /** Invoke a registered handler directly; the result is the handler's own. */
+    _call: (xmlns: string, element: string, context: unknown, type?: 'set' | 'get') => any
+    _processIQ: (stanza: any, sendFn: Function) => boolean
+  }
+  reconnect: {
+    stop: Mock
+    start: Mock
+  }
+  iqCaller: {
+    request: Mock
+  }
+  streamManagement: {
+    id: string | null
+    enabled: boolean
+    inbound: number
+    outbound: number
+    on: Mock<(event: string, handler: Function) => void>
+  }
+  prependListener: Mock
+  removeAllListeners: Mock<() => void>
+  /** Deliver an internal event, queueing lifecycle events until a handler registers. */
+  _emit: (event: string, ...args: unknown[]) => void
+  /** Deliver a stream-management event, queueing it until a handler registers. */
+  _emitSM: (event: string, ...args: unknown[]) => void
+  _hasHandlers: (event: string) => boolean
+  _handlers: Record<string, Function[]>
+  _smHandlers: Record<string, Function[]>
+}
+
 // Mock EventEmitter behavior for the XMPP client
-export const createMockXmppClient = () => {
+export const createMockXmppClient = (): MockXmppClient => {
   const handlers: Record<string, Function[]> = {}
   const smHandlers: Record<string, Function[]> = {}
   const iqCalleeHandlers: Map<string, Function> = new Map()
@@ -303,8 +351,6 @@ export const createMockXmppClient = () => {
     _smHandlers: smHandlers,
   }
 }
-
-export type MockXmppClient = ReturnType<typeof createMockXmppClient>
 
 // Type for mock element children - supports nested elements with optional methods
 type MockChildInput = {
@@ -709,7 +755,9 @@ export const createMockStores = (): MockStoreBindings => ({
  * module tests, or pass to `new XMPPClient({ presenceOptions })` so tests that
  * drive presence-dependent behaviour can `.mockReturnValue(...)` on a getter.
  */
-export const createMockPresenceReader = () => ({
+export type MockPresenceReader = MockifyFunctions<PresenceReader>
+
+export const createMockPresenceReader = (): MockPresenceReader => ({
   getPresenceShow: vi.fn().mockReturnValue('online' as const),
   getStatusMessage: vi.fn().mockReturnValue(null),
   getIsAutoAway: vi.fn().mockReturnValue(false),
@@ -718,10 +766,106 @@ export const createMockPresenceReader = () => ({
 })
 
 /**
+ * Shape of the mock built by {@link createMockXMPPClientForHooks}. Annotated
+ * explicitly because a bare `vi.fn()` infers as `Mock<Procedure>`, and
+ * `Procedure` is not part of vitest's public export surface (TS2742).
+ */
+export interface MockXMPPClientForHooks {
+  connect: Mock
+  disconnect: Mock
+  cancelReconnect: Mock
+  getStreamManagementState: Mock
+  isConnected: Mock
+  getJid: Mock
+  on: Mock
+  off: Mock
+  onStanza: Mock
+  sendRawXml: Mock
+  contacts: {
+    addContact: Mock
+    removeContact: Mock
+    renameContact: Mock
+    acceptSubscription: Mock
+    rejectSubscription: Mock
+    setPresence: Mock
+    fetchRoster: Mock
+  }
+  profile: {
+    fetchContactNickname: Mock
+    fetchProfileDetails: Mock
+    fetchOwnProfileDetails: Mock
+    publishOwnProfileDetails: Mock
+    fetchOwnNickname: Mock
+    publishOwnNickname: Mock
+    clearOwnNickname: Mock
+    publishOwnAvatar: Mock
+    clearOwnAvatar: Mock
+    fetchAppearance: Mock
+    setAppearance: Mock
+    fetchOwnProfile: Mock
+    restoreContactAvatarFromCache: Mock
+    restoreOwnAvatarFromCache: Mock
+    restoreRoomAvatarFromCache: Mock
+    setRoomAvatar: Mock
+    clearRoomAvatar: Mock
+    changePassword: Mock
+  }
+  messages: {
+    sendMessage: Mock
+    sendChatState: Mock
+    sendReaction: Mock
+    sendCorrection: Mock
+    sendRetraction: Mock
+    sendEasterEgg: Mock
+    sendLinkPreview: Mock
+    queryMAM: Mock
+    queryRoomMAM: Mock
+    refreshHistory: Mock
+    searchMessages: Mock
+    searchRoomMessages: Mock
+    searchConversationHistory: Mock
+  }
+  internal: {
+    mam: {
+      catchUpConversationHistory: Mock
+      catchUpRoomHistory: Mock
+    }
+  }
+  rooms: {
+    joinRoom: Mock
+    joinResult: Mock
+    leaveRoom: Mock
+    setBookmark: Mock
+    removeBookmark: Mock
+    setRoomNotifyAll: Mock
+    createQuickChat: Mock
+    sendMediatedInvitation: Mock
+    sendMediatedInvitations: Mock
+  }
+  admin: {
+    executeAdminCommand: Mock
+    cancelAdminCommand: Mock
+    fetchVhosts: Mock
+    fetchUserList: Mock
+    discoverMucService: Mock
+    fetchRoomList: Mock
+    fetchRoomOptions: Mock
+  }
+  server: {
+    requestUploadSlot: Mock
+  }
+  poll: {
+    sendPoll: Mock
+    vote: Mock
+    closePoll: Mock
+  }
+}
+
+/**
  * Create a mock XMPPClient instance with namespace structure for hook tests.
  * This provides the same API structure as the real XMPPClient class.
  */
-export const createMockXMPPClientForHooks = () => ({
+export const createMockXMPPClientForHooks = (): MockXMPPClientForHooks => ({
   // Core methods (on XMPPClient directly)
   connect: vi.fn(),
   disconnect: vi.fn(),
@@ -816,8 +960,6 @@ export const createMockXMPPClientForHooks = () => ({
     closePoll: vi.fn(),
   },
 })
-
-export type MockXMPPClientForHooks = ReturnType<typeof createMockXMPPClientForHooks>
 
 // Top-level module mocks — Vitest hoists these before any test runs.
 vi.mock('@xmpp/client', () => ({


### PR DESCRIPTION
A bare `vi.fn()` infers as `Mock<Procedure>`, and vitest does not re-export
`Procedure`, so the inferred return type of an exported mock factory can only be
named through a versioned internal chunk file. When the test runner release
changes that chunk's hashed filename, the SDK typecheck fails with TS2742.

Four exported factories relied on that inference. They now carry explicit return
types:

- `createMockClient` (`sideEffects.testHelpers.ts`)
- `createMockXmppClient`, `createMockPresenceReader`, `createMockXMPPClientForHooks` (`test-utils.ts`)

The mock presence reader derives from the real `PresenceReader` interface, and
the side-effect host mock now carries a real `E2EEWarmupHost | null` instead of a
cast to `any`. No test behaviour and no dependency version changes.

This unblocks #1367 without superseding it: once that branch rebases, its
typecheck goes green on its own.
