### PR TITLE
refactor(sdk): one diagnostic channel for the anomaly seams (#1353)

### DIFF
--- a/apps/fluux/src/anomaly/detectors/archiveMerge.ts
+++ b/apps/fluux/src/anomaly/detectors/archiveMerge.ts
@@ -1,7 +1,8 @@
 /**
  * What an archive merge cost and what it kept.
  *
- * The SDK reports one outcome per archive merge (`onArchiveMerge`). Two things are
+ * The SDK reports one outcome per archive merge (`subscribeDiagnostics`, kind
+ * `archive-merge`). Two things are
  * derived here: the merge-yield rate's two counters, and one invariant — a durable
  * write that did not commit, which freezes that entity's catch-up cursor for the
  * rest of the session and is invisible everywhere else.

--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { chatStore, connectionStore, roomStore } from '@fluux/sdk'
+import { chatStore, connectionStore, roomStore, type ArchiveMergeReport } from '@fluux/sdk'
 import {
   getRecorder,
   install,
@@ -13,15 +13,11 @@ import { CTX, METRIC, resetValuesForTesting } from './values'
 import { hasAnomalySignalHandler, signalAnomaly } from '../utils/anomalySignal'
 import type { ElementLike } from './detectors/stanzaFacts'
 import { convToken } from './identity'
-import type { TrafficClient } from './install'
+import type { DiagnosticObservation, DiagnosticsChannel, TrafficClient } from './install'
 import {
   recordRecountDeferral,
   resetRecountDeferralsForTesting,
 } from '../../../../packages/fluux-sdk/src/stores/shared/recountDiagnostics'
-import {
-  reportArchiveMerge,
-  type ArchiveMergeReport,
-} from '../../../../packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics'
 import { measured } from '../../../../packages/fluux-sdk/src/utils/measure'
 
 type WindowWithSink = Record<string, unknown> & { __fluuxAnomalies?: string[] }
@@ -39,6 +35,26 @@ type ChatSubscriptionState = {
 const w = () => window as unknown as WindowWithSink
 const lines = () => w().__fluuxAnomalies ?? []
 const records = () => lines().map((l) => JSON.parse(l))
+
+/** A diagnostic channel the test publishes into. */
+function stubDiagnostics() {
+  const handlers: Array<(event: DiagnosticObservation) => void> = []
+  const released: string[] = []
+  const diagnostics: DiagnosticsChannel = (handler) => {
+    handlers.push(handler)
+    return () => {
+      released.push('diagnostics')
+      handlers.splice(handlers.indexOf(handler), 1)
+    }
+  }
+  const sendOut = (stanza: ElementLike): void => {
+    for (const handler of handlers) handler({ kind: 'application-stanza-out', stanza })
+  }
+  const reportMerge = (report: ArchiveMergeReport): void => {
+    for (const handler of handlers) handler({ kind: 'archive-merge', report })
+  }
+  return { diagnostics, sendOut, reportMerge, released }
+}
 
 class QueuedPerformanceObserver {
   static supportedEntryTypes = ['measure']
@@ -656,22 +672,17 @@ describe('readiness', () => {
 })
 
 describe('traffic detector wiring', () => {
-  /** A client that hands back the handlers it was given. */
+  /** A client that hands back the inbound handler it was given. */
   function stubClient() {
-    const out: Array<(s: ElementLike) => void> = []
     const inbound: Array<(s: ElementLike) => void> = []
     const released: string[] = []
     const client: TrafficClient = {
-      onApplicationStanzaOut: (h) => {
-        out.push(h)
-        return () => released.push('out')
-      },
       onStanza: (h) => {
         inbound.push(h)
         return () => released.push('in')
       },
     }
-    return { client, out, inbound, released }
+    return { client, inbound, released }
   }
 
   function iq(attrs: Record<string, unknown>, ns?: string): ElementLike {
@@ -689,14 +700,15 @@ describe('traffic detector wiring', () => {
   it('records a redundant query seen through the client seams', async () => {
     vi.useFakeTimers()
     try {
-      const { client, out, inbound } = stubClient()
-      const cleanup = install(client)
+      const { client, inbound } = stubClient()
+      const { diagnostics, sendOut } = stubDiagnostics()
+      const cleanup = install(client, diagnostics)
       await whenReady()
 
       const disco = 'http://jabber.org/protocol/disco#info'
-      out[0](iq({ type: 'get', to: 'example.com', id: 'q1' }, disco))
+      sendOut(iq({ type: 'get', to: 'example.com', id: 'q1' }, disco))
       inbound[0](iq({ type: 'result', id: 'q1' }))
-      out[0](iq({ type: 'get', to: 'example.com', id: 'q2' }, disco))
+      sendOut(iq({ type: 'get', to: 'example.com', id: 'q2' }, disco))
 
       expect(records().map((r) => r.id)).toContain('xmpp-traffic/redundant-query')
       cleanup()
@@ -708,11 +720,12 @@ describe('traffic detector wiring', () => {
   it('forgets pending requests when the connection drops', async () => {
     vi.useFakeTimers()
     try {
-      const { client, out } = stubClient()
-      const cleanup = install(client)
+      const { client } = stubClient()
+      const { diagnostics, sendOut } = stubDiagnostics()
+      const cleanup = install(client, diagnostics)
       await whenReady()
 
-      out[0](iq({ type: 'get', to: 'example.com', id: 'q1' }, 'http://jabber.org/protocol/disco#info'))
+      sendOut(iq({ type: 'get', to: 'example.com', id: 'q1' }, 'http://jabber.org/protocol/disco#info'))
       // Any connection status change resets: everything in flight when the
       // connection moved is unanswerable through no fault of the app.
       const onConnection = vi.mocked(connectionStore.subscribe).mock.calls.at(-1)?.[0] as
@@ -727,12 +740,14 @@ describe('traffic detector wiring', () => {
     }
   })
 
-  it('releases the client subscriptions with the last hold', () => {
+  it('releases the client and channel subscriptions with the last hold', () => {
     const { client, released } = stubClient()
+    const { diagnostics, released: channelReleased } = stubDiagnostics()
 
-    install(client)()
+    install(client, diagnostics)()
 
-    expect(released).toEqual(expect.arrayContaining(['out', 'in']))
+    expect(released).toEqual(['in'])
+    expect(channelReleased).toEqual(['diagnostics'])
   })
 
   it('installs without a client', () => {
@@ -759,31 +774,35 @@ describe('archive merge wiring', () => {
   }
 
   it('records a failed archive write reported by a store', async () => {
-    const cleanup = install()
+    const { diagnostics, reportMerge } = stubDiagnostics()
+    const cleanup = install(undefined, diagnostics)
     await whenReady()
 
-    reportArchiveMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
+    reportMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
 
     expect(records().map((r) => r.id)).toContain('xmpp-traffic/mam-write-failed')
     cleanup()
   })
 
   it('leaves a healthy merge to the counters', async () => {
-    const cleanup = install()
+    const { diagnostics, reportMerge } = stubDiagnostics()
+    const cleanup = install(undefined, diagnostics)
     await whenReady()
 
-    reportArchiveMerge(merge())
+    reportMerge(merge())
 
     expect(records().map((r) => r.id)).not.toContain('xmpp-traffic/mam-write-failed')
     cleanup()
   })
 
   it('stops observing merges once the last hold is released', async () => {
-    const cleanup = install()
+    const { diagnostics, reportMerge, released } = stubDiagnostics()
+    const cleanup = install(undefined, diagnostics)
     await whenReady()
     cleanup()
+    expect(released).toEqual(['diagnostics'])
 
-    reportArchiveMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
+    reportMerge(merge({ outcome: 'failed', retained: 0, persistenceFailed: 7 }))
 
     expect(records().map((r) => r.id)).not.toContain('xmpp-traffic/mam-write-failed')
   })
@@ -918,19 +937,14 @@ describe('entity tokens are warmed before a one-shot record', () => {
   }
 
   function stubClient() {
-    const out: Array<(s: ElementLike) => void> = []
     const inbound: Array<(s: ElementLike) => void> = []
     const client: TrafficClient = {
-      onApplicationStanzaOut: (h) => {
-        out.push(h)
-        return () => {}
-      },
       onStanza: (h) => {
         inbound.push(h)
         return () => {}
       },
     }
-    return { client, out, inbound }
+    return { client, inbound }
   }
 
   /**
@@ -944,16 +958,17 @@ describe('entity tokens are warmed before a one-shot record', () => {
   }
 
   it('names the queried entity instead of c:unresolved', async () => {
-    const { client, out, inbound } = stubClient()
-    const cleanup = install(client)
+    const { client, inbound } = stubClient()
+    const { diagnostics, sendOut } = stubDiagnostics()
+    const cleanup = install(client, diagnostics)
     await whenReady()
 
     // The first query warms the target; the redundancy is recorded on the second,
     // which is the one-shot the entity must be nameable in.
-    out[0](iqTo('service.example.com', 'q1'))
+    sendOut(iqTo('service.example.com', 'q1'))
     inbound[0](reply('q1'))
     await settleWarm()
-    out[0](iqTo('service.example.com', 'q2'))
+    sendOut(iqTo('service.example.com', 'q2'))
 
     const record = records().find((r) => r.id === 'xmpp-traffic/redundant-query')
     expect(record).toBeDefined()
@@ -965,15 +980,16 @@ describe('entity tokens are warmed before a one-shot record', () => {
   it('identifies a full-JID target by its contact, not by its resource', async () => {
     vi.useFakeTimers()
     try {
-      const { client, out } = stubClient()
-      const cleanup = install(client)
+      const { client } = stubClient()
+      const { diagnostics, sendOut } = stubDiagnostics()
+      const cleanup = install(client, diagnostics)
       await whenReady()
 
       // Disco to a full JID is a distinct QUERY — it answers for that resource —
       // but it is the same CONTACT, and the log correlates by entity. Stated as
       // the rule rather than inferred from two records, which the recorder's
       // per-id cooldown would coalesce anyway.
-      out[0](iqTo('alice@example.com/laptop', 'a1'))
+      sendOut(iqTo('alice@example.com/laptop', 'a1'))
       await vi.advanceTimersByTimeAsync(35_000)
 
       const record = records().find((r) => r.id === 'xmpp-traffic/iq-unanswered')

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -15,7 +15,7 @@
  *
  * @module Anomaly/Install
  */
-import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, onArchiveMerge, readRecountDeferrals, roomReadStateGeneration, roomStore, setMeasurementEnabled } from '@fluux/sdk'
+import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, readRecountDeferrals, roomReadStateGeneration, roomStore, setMeasurementEnabled, subscribeDiagnostics, type ArchiveMergeReport } from '@fluux/sdk'
 import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
 import {
   clearAnomalyObservationHandler,
@@ -95,20 +95,38 @@ let detachListener: (() => void) | null = null
 let detectorTick: DetectorTick | null = null
 let storeUnsubscribes: (() => void) | null = null
 let clientUnsubscribes: (() => void) | null = null
-let archiveMergeUnsubscribe: (() => void) | null = null
+let diagnosticsUnsubscribe: (() => void) | null = null
 let trafficDetector: TrafficDetector | null = null
 let perfWatch: PerfMeasureWatch | null = null
 
 /**
  * What the traffic detector needs from the client.
  *
+ * Only the inbound half: outbound application stanzas arrive on the SDK's
+ * diagnostic channel instead.
+ *
  * Structural rather than `XMPPClient`: this module is unit-tested without a client,
  * and a type naming the class would drag the SDK barrel into those tests.
  */
 export interface TrafficClient {
-  onApplicationStanzaOut(handler: (stanza: ElementLike) => void): () => void
   onStanza(handler: (stanza: ElementLike) => void): () => void
 }
+
+/**
+ * What this runtime reads off the SDK's diagnostic channel.
+ *
+ * Structural for the same reason as {@link TrafficClient}, and it names
+ * `ElementLike` rather than the SDK's `Element` because the app's TypeScript
+ * program has no `@xmpp/client` types by design. The mirror cannot drift: the
+ * default argument below assigns the real `subscribeDiagnostics` to
+ * {@link DiagnosticsChannel}, so a kind the SDK union gains and this one lacks
+ * fails to compile rather than going unobserved.
+ */
+export type DiagnosticObservation =
+  | { kind: 'application-stanza-out'; stanza: ElementLike }
+  | { kind: 'archive-merge'; report: ArchiveMergeReport }
+
+export type DiagnosticsChannel = (handler: (event: DiagnosticObservation) => void) => () => void
 
 type ProbeWindow = Window & {
   __fluuxAnomalies?: string[]
@@ -297,10 +315,17 @@ function attemptSessionRecord(rec: Recorder): void {
  * required — skipping it would leave the timer and listener alive for the rest of
  * the session.
  *
+ * @param client - the inbound stanza source; absent, the traffic detectors report
+ * nothing rather than observing a half-wired session.
+ * @param diagnostics - the SDK's diagnostic channel, injectable so this runtime can
+ * be driven without an SDK.
  * @returns a release for THIS hold. The subscriptions come down when the last hold
  * is released; the runtime itself is never destroyed.
  */
-export function install(client?: TrafficClient): () => void {
+export function install(
+  client?: TrafficClient,
+  diagnostics: DiagnosticsChannel = subscribeDiagnostics,
+): () => void {
   const rec = runtime()
   markAnomalyBuild()
   announceSessionOnce(rec)
@@ -481,22 +506,39 @@ export function install(client?: TrafficClient): () => void {
       unsubRooms()
     }
 
-    // The archive merge seam. Store-side, so it attaches with or without a client:
-    // a merge can be driven by a cache rehydrate as well as by a live walk.
     const archiveMerge = createArchiveMergeDetector({
       record: (input) => rec.record(input),
       count: (key, by) => rec.count(key, by),
       token: (report) =>
         report.entityKind === 'room' ? roomToken(report.entityId) : convToken(report.entityId),
     })
-    archiveMergeUnsubscribe = onArchiveMerge((report) => {
-      warmEntity(report.entityKind === 'room' ? 'room' : 'conversation', report.entityId)
-      archiveMerge.observe(report)
+
+    // The SDK's diagnostic channel. Store-side, so it attaches with or without a
+    // client: a merge can be driven by a cache rehydrate as well as by a live walk,
+    // and the outbound stanzas are published by the process, not by a connection.
+    diagnosticsUnsubscribe = diagnostics((event) => {
+      switch (event.kind) {
+        case 'archive-merge': {
+          const report = event.report
+          warmEntity(report.entityKind === 'room' ? 'room' : 'conversation', report.entityId)
+          archiveMerge.observe(report)
+          return
+        }
+        case 'application-stanza-out': {
+          // Absent a client there is no traffic detector, so nothing is reported
+          // rather than a detector observing a half-wired session.
+          if (!trafficDetector) return
+          const facts = outboundFacts(event.stanza)
+          if (!facts) return
+          warmEntity('conversation', facts.to)
+          trafficDetector.observeOut(facts, Date.now())
+          return
+        }
+      }
     })
 
-    // The application IQ traffic detectors. Absent a client — a unit test, or a
-    // harness that mounts the runtime on its own — nothing attaches and nothing is
-    // reported, rather than a detector observing a half-wired session.
+    // The application IQ traffic detectors. Their inbound half is the only thing
+    // still read from the client.
     if (client) {
       const traffic = createTrafficDetector({
         record: (input) => rec.record(input),
@@ -504,12 +546,6 @@ export function install(client?: TrafficClient): () => void {
       })
       trafficDetector = traffic
 
-      const offOut = client.onApplicationStanzaOut((stanza) => {
-        const facts = outboundFacts(stanza)
-        if (!facts) return
-        warmEntity('conversation', facts.to)
-        traffic.observeOut(facts, Date.now())
-      })
       const offIn = client.onStanza((stanza) => {
         const facts = inboundReplyFacts(stanza)
         if (facts) traffic.observeIn(facts, Date.now())
@@ -522,7 +558,6 @@ export function install(client?: TrafficClient): () => void {
         if (next.status !== prev.status) traffic.reset()
       })
       clientUnsubscribes = () => {
-        offOut()
         offIn()
         offConnection()
       }
@@ -619,8 +654,8 @@ export function install(client?: TrafficClient): () => void {
     storeUnsubscribes = null
     clientUnsubscribes?.()
     clientUnsubscribes = null
-    archiveMergeUnsubscribe?.()
-    archiveMergeUnsubscribe = null
+    diagnosticsUnsubscribe?.()
+    diagnosticsUnsubscribe = null
     trafficDetector = null
     perfWatch?.stop()
     perfWatch = null
@@ -649,8 +684,8 @@ export function resetInstallForTesting(): void {
   storeUnsubscribes = null
   clientUnsubscribes?.()
   clientUnsubscribes = null
-  archiveMergeUnsubscribe?.()
-  archiveMergeUnsubscribe = null
+  diagnosticsUnsubscribe?.()
+  diagnosticsUnsubscribe = null
   trafficDetector = null
   perfWatch?.stop()
   perfWatch = null

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -11,7 +11,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router'
-import { XMPPProvider, E2EEManager, InMemoryStorageBackend } from '@fluux/sdk'
+import { XMPPProvider, E2EEManager, InMemoryStorageBackend, subscribeDiagnostics } from '@fluux/sdk'
 import { DemoClient, setResidentWindowSize } from '@fluux/sdk/demo'
 import { adminStore, chatStore, ignoreStore, roomStore } from '@fluux/sdk/stores'
 import { DemoOpenPGPPlugin, DEMO_AVA_FINGERPRINT } from './demo/DemoOpenPGPPlugin'
@@ -160,6 +160,9 @@ setSessionPassphrase('demo')
 
 // Expose demo client and stores for automation (screenshot scripts, testing)
 ;(window as any).__demoClient = demoClient
+// The SDK's diagnostic channel is module-scoped, so automation reaches it here
+// rather than through the client.
+;(window as any).__fluuxDiagnostics = subscribeDiagnostics
 ;(window as any).__adminStore = adminStore
 ;(window as any).__roomStore = roomStore
 ;(window as any).__chatStore = chatStore

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -200,8 +200,9 @@ unobserved interval into persistence evidence.
 
 ### `xmpp-traffic/`
 
-Both read the outbound application stanza seam (`client.onApplicationStanzaOut`) and
-pair it with the inbound stanzas `onStanza` already carries.
+Both read the outbound application stanza seam (`subscribeDiagnostics`, kind
+`application-stanza-out`) and pair it with the inbound stanzas `onStanza` already
+carries.
 
 | id | sev | Meaning | What to do |
 |---|---|---|---|

--- a/packages/fluux-sdk/bench/README.md
+++ b/packages/fluux-sdk/bench/README.md
@@ -25,13 +25,13 @@ test. It IS typechecked by `npm run typecheck -w @fluux/sdk`, so it cannot rot s
 npm run bench:seam -w @fluux/sdk
 ```
 
-The per-stanza cost of `onApplicationStanzaOut`, which ships in `dist` to every SDK consumer, so the
-unsubscribed path has to stay a Map lookup. Variants are interleaved and each reports its fastest
-round: measured one after another, whichever runs last wins, and a seam can appear to make sending
-cheaper.
+The per-stanza cost of the `application-stanza-out` diagnostic published through
+`subscribeDiagnostics`, which ships in `dist` to every SDK consumer. The unsubscribed path has to
+stay at one handler-registry check. Variants are interleaved and each reports its fastest round:
+measured one after another, whichever runs last wins, and a seam can appear to make sending cheaper.
 
-Measured on 2026-09-01 (macOS, Node 22): dispatch is 5.5 ns/stanza unsubscribed against a 1.6 ns
-control call and 261.3 ns with one subscriber. A full `sendStanza` is 52.4 ns unsubscribed against
-318.9 ns with a subscriber; the subscribed path includes an independent deep stanza snapshot per
-subscriber, isolating the transport, Stream Management replay state, and other observers from
-mutation.
+The 2026-09-01 pre-channel baseline (macOS, Node 22) measured 5.5 ns/stanza unsubscribed against a
+1.6 ns control call and 261.3 ns with one subscriber. A full `sendStanza` was 52.4 ns unsubscribed
+against 318.9 ns with a subscriber. The subscribed path still includes an independent deep stanza
+snapshot per subscriber, isolating the transport, Stream Management replay state, and other
+observers from mutation.

--- a/packages/fluux-sdk/bench/outboundSeam.bench.ts
+++ b/packages/fluux-sdk/bench/outboundSeam.bench.ts
@@ -19,12 +19,18 @@
  * code: run sequentially, whichever variant goes last wins, which is how a seam can
  * appear to make sending cheaper.
  *
+ * The diagnostic channel is module-scoped, so a variant owns its subscription for the
+ * length of its own loop rather than owning a client of its own. One subscribe and one
+ * unsubscribe per round is nothing against the iteration count, and both dispatch
+ * variants then run on the same client.
+ *
  * Run: `npm run bench:seam -w @fluux/sdk`
  */
 
 import { describe, it } from 'vitest'
 import { xml, type Element } from '@xmpp/client'
 import { XMPPClient } from '../src/core/XMPPClient'
+import { subscribeDiagnostics } from '../src/diagnostics/channel'
 
 const ITERATIONS = 1_000_000
 const SENDS = 50_000
@@ -101,11 +107,7 @@ function report(title: string, rows: Array<{ label: string; ns: number }>): void
 describe('outbound seam', () => {
   it('costs nothing measurable when nobody is subscribed', async () => {
     const bare = new BenchClient()
-    const subscribed = new BenchClient()
     let seen = 0
-    subscribed.onApplicationStanzaOut(() => {
-      seen++
-    })
     const stanza = xml('message', { to: 'a@example.com', id: 'x1' }, xml('body', {}, 'hello'))
 
     const rows = await race([
@@ -127,7 +129,14 @@ describe('outbound seam', () => {
         label: 'dispatch, one subscriber',
         ops: ITERATIONS,
         run: () => {
-          for (let i = 0; i < ITERATIONS; i++) subscribed.dispatch(stanza)
+          const off = subscribeDiagnostics(() => {
+            seen++
+          })
+          try {
+            for (let i = 0; i < ITERATIONS; i++) bare.dispatch(stanza)
+          } finally {
+            off()
+          }
         },
       },
     ])
@@ -138,17 +147,23 @@ describe('outbound seam', () => {
 
   it('is invisible in the cost of an actual send', async () => {
     const stanza = xml('message', { to: 'a@example.com', id: 'x1' }, xml('body', {}, 'hello'))
-    const bare = new BenchClient()
-    const subscribed = new BenchClient()
-    subscribed.onApplicationStanzaOut(() => {})
+    const client = new BenchClient()
 
-    const sendLoop = (client: BenchClient) => async (): Promise<void> => {
+    const sendLoop = async (): Promise<void> => {
       for (let i = 0; i < SENDS; i++) await client.send(stanza)
+    }
+    const subscribedSendLoop = async (): Promise<void> => {
+      const off = subscribeDiagnostics(() => {})
+      try {
+        await sendLoop()
+      } finally {
+        off()
+      }
     }
 
     const rows = await race([
-      { label: 'sendStanza, unsubscribed', ops: SENDS, run: sendLoop(bare) },
-      { label: 'sendStanza, one subscriber', ops: SENDS, run: sendLoop(subscribed) },
+      { label: 'sendStanza, unsubscribed', ops: SENDS, run: sendLoop },
+      { label: 'sendStanza, one subscriber', ops: SENDS, run: subscribedSendLoop },
     ])
 
     report('end to end', rows)

--- a/packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.outboundStanza.test.ts
@@ -4,9 +4,19 @@
  * Drives the two application-layer send paths against a stub transport, so the
  * assertions are about the seam and nothing else.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { xml, type Element } from '@xmpp/client'
 import { XMPPClient } from './XMPPClient'
+import { resetDiagnosticsForTesting, subscribeDiagnostics } from '../diagnostics/channel'
+
+afterEach(() => resetDiagnosticsForTesting())
+
+/** The outbound-stanza slice of the diagnostic channel. */
+function onApplicationStanzaOut(handler: (stanza: Element) => void): () => void {
+  return subscribeDiagnostics((event) => {
+    if (event.kind === 'application-stanza-out') handler(event.stanza)
+  })
+}
 
 interface StubTransport {
   send: (stanza: Element) => Promise<void>
@@ -53,11 +63,11 @@ class TestClient extends XMPPClient {
   }
 }
 
-describe('onApplicationStanzaOut', () => {
+describe('the outbound application stanza diagnostic', () => {
   it('reports a stanza sent through sendStanza', async () => {
     const client = new TestClient()
     const seen: Element[] = []
-    client.onApplicationStanzaOut((s) => seen.push(s))
+    onApplicationStanzaOut((s) => seen.push(s))
 
     await client.sendStanzaForTest(xml('message', { to: 'a@example.com' }, xml('body', {}, 'hi')))
 
@@ -68,7 +78,7 @@ describe('onApplicationStanzaOut', () => {
   it('does not let an observer alter the stanza retained by the transport', async () => {
     const client = new TestClient()
     let observed: Element | null = null
-    client.onApplicationStanzaOut((snapshot) => {
+    onApplicationStanzaOut((snapshot) => {
       observed = snapshot
       snapshot.attrs.to = 'redirected@example.com'
       const body = snapshot.getChild('body')!
@@ -92,11 +102,11 @@ describe('onApplicationStanzaOut', () => {
   it('isolates each subscriber from earlier snapshot mutations', async () => {
     const client = new TestClient()
     let secondSnapshot: Element | undefined
-    client.onApplicationStanzaOut((snapshot) => {
+    onApplicationStanzaOut((snapshot) => {
       snapshot.attrs.id = 'tampered'
       snapshot.getChild('body')!.children[0] = 'changed'
     })
-    client.onApplicationStanzaOut((snapshot) => {
+    onApplicationStanzaOut((snapshot) => {
       secondSnapshot = snapshot
     })
 
@@ -118,7 +128,7 @@ describe('onApplicationStanzaOut', () => {
   it('reports an IQ only after the shared send boundary assigns its id', () => {
     const client = new TestClient()
     const ids: Array<string | undefined> = []
-    client.onApplicationStanzaOut((s) => ids.push(s.attrs.id as string | undefined))
+    onApplicationStanzaOut((s) => ids.push(s.attrs.id as string | undefined))
 
     void client.sendIQForTest(xml('iq', { type: 'get', to: 'example.com' }))
 
@@ -132,7 +142,7 @@ describe('onApplicationStanzaOut', () => {
   it('stops reporting after unsubscribe', async () => {
     const client = new TestClient()
     const seen: Element[] = []
-    const off = client.onApplicationStanzaOut((s) => seen.push(s))
+    const off = onApplicationStanzaOut((s) => seen.push(s))
     off()
 
     await client.sendStanzaForTest(xml('presence'))
@@ -143,7 +153,7 @@ describe('onApplicationStanzaOut', () => {
   it('sends the stanza even when a subscriber throws', async () => {
     const client = new TestClient()
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    client.onApplicationStanzaOut(() => {
+    onApplicationStanzaOut(() => {
       throw new Error('detector bug')
     })
 
@@ -160,7 +170,7 @@ describe('onApplicationStanzaOut', () => {
     // application paths dispatch, and this drives the transport directly.
     const client = new TestClient()
     const seen: Element[] = []
-    client.onApplicationStanzaOut((s) => seen.push(s))
+    onApplicationStanzaOut((s) => seen.push(s))
 
     const transport = (
       client as unknown as { requireTransport: () => StubTransport }

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -55,6 +55,15 @@ import { generateUUID } from '../utils/uuid'
 const PRESENCE_STORAGE_KEY = 'fluux:presence-machine'
 
 /**
+ * The diagnostic event an outbound application stanza publishes.
+ *
+ * Module scope so the outbound path allocates no closure per stanza.
+ */
+function applicationStanzaOutEvent(stanza: Element): DiagnosticEvent {
+  return { kind: 'application-stanza-out', stanza }
+}
+
+/**
  * Load persisted presence machine snapshot from sessionStorage.
  * Returns undefined if storage is unavailable (Node.js) or no saved state.
  */
@@ -114,7 +123,8 @@ import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { DeferredDecryptEngine } from './e2ee/deferredDecrypt'
 import { SessionLifecycleEngine } from './sessionLifecycle'
-import { dataToElement, elementToData } from './e2ee/stanzaAdapter'
+import { dataToElement } from './e2ee/stanzaAdapter'
+import { publishDiagnostic, type DiagnosticEvent } from '../diagnostics/channel'
 import { NS_MAM } from './namespaces'
 import { createDefaultStoreBindings } from './defaultStoreBindings'
 import { createPresenceReader, type PresenceReader } from './presenceReader'
@@ -980,48 +990,16 @@ export class XMPPClient {
   }
 
   /**
-   * Subscribe to application-layer stanzas on their way out.
-   *
-   * The counterpart to {@link onStanza}. Reports everything sent through the
-   * application layer — messages, presence and IQ requests, including the id
-   * assigned before transport hand-off — and nothing sent by the connection
-   * machine itself, so a keepalive ping and a Stream Management `<r/>` are
-   * invisible here by construction.
-   *
-   * @param handler - Callback invoked with an independent snapshot of each outbound
-   * application stanza
-   * @returns A function to unsubscribe
-   *
-   * @example
-   * ```typescript
-   * const unsubscribe = client.onApplicationStanzaOut((stanza) => {
-   *   console.log('Sent:', stanza.toString())
-   * })
-   * ```
-   */
-  onApplicationStanzaOut(handler: (stanza: Element) => void): () => void {
-    return this.subscribeToBus('applicationStanzaOut', handler)
-  }
-
-  /**
-   * Dispatch on the outbound hot path.
+   * Publish an outbound application stanza on the diagnostic channel.
    *
    * Deliberately not `emit()`: that builds a rest-args array on every call, and
-   * this runs for every stanza the app sends. With no subscriber the cost is one
-   * Map lookup. A handler that throws is contained — a diagnostic subscriber must
-   * never stop a stanza from being sent.
+   * this runs for every stanza the app sends. The subscriber check, the snapshot
+   * and the containment of a throwing handler all belong to
+   * {@link publishDiagnostic}, which is why the builder is a module-level function
+   * rather than a closure over `stanza`.
    */
   private emitApplicationStanzaOut(stanza: Element): void {
-    const handlers = this.eventHandlers.get('applicationStanzaOut')
-    if (!handlers || handlers.size === 0) return
-    for (const handler of handlers) {
-      try {
-        const snapshot = dataToElement(elementToData(stanza))
-        ;(handler as (s: Element) => void)(snapshot)
-      } catch (err) {
-        console.warn('[XMPPClient] applicationStanzaOut subscriber threw:', err)
-      }
-    }
+    publishDiagnostic(applicationStanzaOutEvent, stanza)
   }
 
   // ============================================================================

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -43,14 +43,6 @@ export type {
 export interface XMPPClientEvents {
   /** Raw XMPP stanza received */
   stanza: (stanza: Element) => void
-  /**
-   * An application-layer stanza was handed to the transport.
-   *
-   * Connection-level sends — the keepalive ping and the Stream Management `<r/>`
-   * nonza — bypass this layer and are therefore NOT reported. Subscribe through
-   * `XMPPClient.onApplicationStanzaOut`.
-   */
-  applicationStanzaOut: (stanza: Element) => void
   /** New chat message received */
   message: (message: Message) => void
   /** Contact presence changed */

--- a/packages/fluux-sdk/src/demo/DemoClient.pepDisco.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.pepDisco.test.ts
@@ -5,9 +5,12 @@
  * answer that probe positively — otherwise the demo shows a bogus
  * "your server does not support PEP" warning.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { DemoClient } from './DemoClient'
 import { discoSupportsPep } from '../core/modules/Discovery'
+import { resetDiagnosticsForTesting, subscribeDiagnostics } from '../diagnostics/channel'
+
+afterEach(() => resetDiagnosticsForTesting())
 
 interface ElementLike {
   attrs: Record<string, string>
@@ -21,7 +24,9 @@ describe('DemoClient disco#info on the account bare JID', () => {
     const order: string[] = []
     let inboundIsIq: boolean | undefined
     let inboundHasClientNamespace: boolean | undefined
-    client.onApplicationStanzaOut((stanza) => order.push(`out:${stanza.attrs.id}`))
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'application-stanza-out') order.push(`out:${event.stanza.attrs.id}`)
+    })
     client.onStanza((stanza) => {
       order.push(`in:${stanza.attrs.id}`)
       inboundIsIq = stanza.is('iq')

--- a/packages/fluux-sdk/src/diagnostics/channel.test.ts
+++ b/packages/fluux-sdk/src/diagnostics/channel.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The two rules the channel exists to hold, tested at the boundary that holds
+ * them rather than once per seam.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  publishDiagnostic,
+  publishDeferredDiagnostic,
+  resetDiagnosticsForTesting,
+  subscribeDiagnostics,
+  type DiagnosticEvent,
+} from './channel'
+
+afterEach(() => resetDiagnosticsForTesting())
+
+const merge = (entityId: string): DiagnosticEvent => ({
+  kind: 'archive-merge',
+  report: {
+    entityKind: 'chat',
+    entityId,
+    direction: 'forward',
+    complete: true,
+    outcome: 'durable',
+    returned: 1,
+    retained: 1,
+    deduplicated: 0,
+    patched: 0,
+    intentionallyUnstored: 0,
+    persistenceFailed: 0,
+  },
+})
+
+describe('diagnostic channel', () => {
+  it('builds nothing when nobody subscribes', () => {
+    const build = vi.fn(merge)
+
+    publishDiagnostic(build, 'a@example.com')
+
+    expect(build).not.toHaveBeenCalled()
+  })
+
+  it('delivers to every subscriber and stops on unsubscribe', () => {
+    const seen: string[] = []
+    const off = subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(event.report.entityId)
+    })
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(`second:${event.report.entityId}`)
+    })
+
+    publishDiagnostic(merge, 'a@example.com')
+    off()
+    publishDiagnostic(merge, 'b@example.com')
+
+    expect(seen).toEqual(['a@example.com', 'second:a@example.com', 'second:b@example.com'])
+  })
+
+  it('builds once and isolates every subscriber from earlier mutations', () => {
+    const build = vi.fn(merge)
+    let second: DiagnosticEvent | undefined
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') event.report.entityId = 'tampered@example.com'
+    })
+    subscribeDiagnostics((event) => {
+      second = event
+    })
+
+    publishDiagnostic(build, 'a@example.com')
+
+    expect(build).toHaveBeenCalledTimes(1)
+    expect(second?.kind === 'archive-merge' && second.report.entityId).toBe('a@example.com')
+  })
+
+  it('does not run a deferred producer when nobody subscribes', () => {
+    const produce = vi.fn(async () => 'a@example.com')
+
+    publishDeferredDiagnostic(merge, produce)
+
+    expect(produce).not.toHaveBeenCalled()
+  })
+
+  it('builds a deferred event once after its source is ready', async () => {
+    const build = vi.fn(merge)
+    const produce = vi.fn(async () => 'a@example.com')
+    const seen: string[] = []
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(event.report.entityId)
+    })
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(`second:${event.report.entityId}`)
+    })
+
+    publishDeferredDiagnostic(build, produce)
+    await vi.waitFor(() => expect(seen).toHaveLength(2))
+
+    expect(produce).toHaveBeenCalledTimes(1)
+    expect(build).toHaveBeenCalledTimes(1)
+    expect(seen).toEqual(['a@example.com', 'second:a@example.com'])
+  })
+
+  it('contains a throwing subscriber', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seen: string[] = []
+    subscribeDiagnostics(() => {
+      throw new Error('detector bug')
+    })
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(event.report.entityId)
+    })
+
+    expect(() => publishDiagnostic(merge, 'a@example.com')).not.toThrow()
+
+    // A diagnostic subscriber must not take down the operation it observes.
+    expect(seen).toEqual(['a@example.com'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('contains a throwing builder', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seen: string[] = []
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(event.report.entityId)
+    })
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'archive-merge') seen.push(`second:${event.report.entityId}`)
+    })
+    const build = vi.fn((_entityId: string): DiagnosticEvent => {
+      throw new Error('builder bug')
+    })
+
+    expect(() => publishDiagnostic(build, 'a@example.com')).not.toThrow()
+
+    expect(build).toHaveBeenCalledTimes(1)
+    expect(seen).toEqual([])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('shares subscriptions across distinct module instances', async () => {
+    vi.resetModules()
+    const first = await import('./channel')
+    vi.resetModules()
+    const second = await import('./channel')
+    const handler = vi.fn()
+    const unsubscribe = first.subscribeDiagnostics(handler)
+
+    try {
+      second.publishDiagnostic(merge, 'a@example.com')
+      expect(handler).toHaveBeenCalledOnce()
+    } finally {
+      unsubscribe()
+    }
+  })
+})

--- a/packages/fluux-sdk/src/diagnostics/channel.ts
+++ b/packages/fluux-sdk/src/diagnostics/channel.ts
@@ -1,0 +1,235 @@
+/**
+ * The SDK's diagnostic channel: one subscription, one payload union.
+ *
+ * Every diagnostic occurrence the SDK reports to an outside observer arrives here,
+ * discriminated by `kind`. A new occurrence seam becomes a member of
+ * {@link DiagnosticEvent} and a publisher calling {@link publishDiagnostic}; it does
+ * not become another exported function, and it does not restate the two rules below.
+ *
+ * Both rules live in the channel's publication boundary, which is the only place
+ * in the SDK that hands a payload to a subscriber:
+ *
+ * - **Nothing is built when nobody subscribes.** A publisher supplies a builder and
+ *   its source, never a finished payload, so an unsubscribed build pays the call and
+ *   one `Set` read. `bench/outboundSeam.bench.ts` gates that cost on the one hot
+ *   path the channel carries.
+ * - **No two subscribers share a payload.** The builder runs once, then the
+ *   kind-specific isolator snapshots the event for each subscriber.
+ *
+ * A handler that throws is contained. Publication happens on the send path and on
+ * merge completion, and a diagnostic must never break the operation it observes.
+ *
+ * Module scope, not per client: the stores this channel reports from are module
+ * singletons, so a diagnostic is a property of the process, not of a connection.
+ * The handler registry is shared through `globalThis` because the published package
+ * compiles this module into several entry points.
+ *
+ * Only occurrences are event kinds here. `chatUnreadDiagnostic` and
+ * `roomUnreadDiagnostic` remain asynchronous questions over one validated snapshot
+ * until the recount can report either its committed count or why it declined.
+ * `chatReadStateGeneration` and `roomReadStateGeneration` remain values read in the
+ * same turn as the pointers they explain; publishing them separately would let an
+ * account switch look like a pointer regression. Their epochs also change outside
+ * store updates, so event publication would first require ordering guarantees at
+ * every bump site. Those store changes belong to the next diagnostic-surface slice.
+ *
+ * @module Diagnostics/Channel
+ */
+import type { Element } from '@xmpp/client'
+import { dataToElement, elementToData } from '../core/e2ee/stanzaAdapter'
+
+/**
+ * An application-layer stanza handed to the transport.
+ *
+ * Reports messages, presence and IQ requests, including the id assigned before
+ * hand-off. Connection-level sends — the keepalive ping, the Stream Management
+ * `<r/>` nonza — bypass the application layer and are invisible here by
+ * construction.
+ *
+ * `stanza` is an independent deep snapshot, so a subscriber can neither alter the
+ * wire form nor reach what another subscriber received.
+ */
+export interface ApplicationStanzaOutDiagnostic {
+  kind: 'application-stanza-out'
+  stanza: Element
+}
+
+export type ArchiveMergeOutcome = 'durable' | 'partial' | 'failed'
+
+/**
+ * How a merge disposed of the rows it was given. Every returned row gets exactly
+ * one disposition, and they balance:
+ *
+ * ```
+ * returned === retained + deduplicated + patched + intentionallyUnstored + persistenceFailed
+ * ```
+ *
+ * `stores/shared/archiveMergeDiagnostics.ts` holds the arithmetic that fills them.
+ */
+export interface ArchiveMergeCounts {
+  outcome: ArchiveMergeOutcome
+  returned: number
+  retained: number
+  deduplicated: number
+  patched: number
+  intentionallyUnstored: number
+  persistenceFailed: number
+}
+
+export interface ArchiveMergeReport extends ArchiveMergeCounts {
+  entityKind: 'chat' | 'room'
+  /**
+   * The conversation id or room JID, raw.
+   *
+   * A diagnostic consumer that needs a privacy-safe identity derives it at its own
+   * boundary; the SDK has no business minting one.
+   */
+  entityId: string
+  direction: 'backward' | 'forward'
+  /** Whether the walk reported the archive exhausted in that direction. */
+  complete: boolean
+}
+
+/**
+ * What an archive merge did with every row a MAM walk returned.
+ *
+ * Published once the durable outcome is KNOWN, not when the merge is applied: a
+ * report written at merge time would claim a retention that can still fail.
+ *
+ * Retention is decided inside the store, downstream of the typed history event, so
+ * it is observable from nowhere else.
+ */
+export interface ArchiveMergeDiagnostic {
+  kind: 'archive-merge'
+  report: ArchiveMergeReport
+}
+
+export type DiagnosticEvent = ApplicationStanzaOutDiagnostic | ArchiveMergeDiagnostic
+
+export type DiagnosticHandler = (event: DiagnosticEvent) => void
+
+type DiagnosticKind = DiagnosticEvent['kind']
+type DiagnosticOfKind<K extends DiagnosticKind> = Extract<DiagnosticEvent, { kind: K }>
+type DiagnosticIsolators = {
+  [K in DiagnosticKind]: (event: DiagnosticOfKind<K>) => DiagnosticOfKind<K>
+}
+
+const diagnosticIsolators: DiagnosticIsolators = {
+  'application-stanza-out': (event) => ({
+    kind: event.kind,
+    stanza: dataToElement(elementToData(event.stanza)),
+  }),
+  'archive-merge': (event) => ({
+    kind: event.kind,
+    report: { ...event.report },
+  }),
+}
+
+const diagnosticHandlersKey = Symbol.for('fluux.sdk.diagnostics.handlers')
+const diagnosticsGlobal = globalThis as typeof globalThis & Record<symbol, unknown>
+const handlers = (diagnosticsGlobal[diagnosticHandlersKey] ??=
+  new Set<DiagnosticHandler>()) as Set<DiagnosticHandler>
+
+function isolateDiagnostic(event: DiagnosticEvent): DiagnosticEvent {
+  switch (event.kind) {
+    case 'application-stanza-out':
+      return diagnosticIsolators[event.kind](event)
+    case 'archive-merge':
+      return diagnosticIsolators[event.kind](event)
+  }
+}
+
+/**
+ * Observe every diagnostic the SDK publishes.
+ *
+ * @param handler - invoked with its own payload for each event; switch on
+ * `event.kind`.
+ * @returns an unsubscribe function.
+ *
+ * @example
+ * ```typescript
+ * const unsubscribe = subscribeDiagnostics((event) => {
+ *   if (event.kind === 'application-stanza-out') console.log('Sent:', event.stanza.toString())
+ * })
+ * ```
+ */
+export function subscribeDiagnostics(handler: DiagnosticHandler): () => void {
+  handlers.add(handler)
+  return () => {
+    handlers.delete(handler)
+  }
+}
+
+/**
+ * Build the event once and hand every subscriber its own isolated payload.
+ *
+ * Reached only with at least one subscriber: both entry points below answer that
+ * question first, so nothing here runs for an unsubscribed build.
+ */
+function deliverDiagnostic<S>(build: (source: S) => DiagnosticEvent, source: S): void {
+  let event: DiagnosticEvent
+  try {
+    event = build(source)
+  } catch (err) {
+    console.warn('[diagnostics] publisher threw:', err)
+    return
+  }
+
+  for (const handler of handlers) {
+    try {
+      handler(isolateDiagnostic(event))
+    } catch (err) {
+      console.warn('[diagnostics] subscriber threw:', err)
+    }
+  }
+}
+
+/**
+ * The channel's publication boundary, for a source that is already in hand.
+ *
+ * `build` and `source` are two parameters rather than one thunk because the
+ * outbound stanza path calls this for every stanza the application sends: a closure
+ * built at that call site would put an allocation on the hot path even with nothing
+ * subscribed. A module-level builder taking the source keeps the unsubscribed cost
+ * to the call and the `Set` read.
+ *
+ * The subscriber check is repeated here rather than delegated so that an
+ * unsubscribed send returns from THIS frame: `bench/outboundSeam.bench.ts` measures
+ * the difference, and one more call on the way to the same answer is visible in it.
+ *
+ * @internal Publishers are SDK-side. A consumer subscribes; it does not publish.
+ */
+export function publishDiagnostic<S>(build: (source: S) => DiagnosticEvent, source: S): void {
+  if (handlers.size === 0) return
+  deliverDiagnostic(build, source)
+}
+
+/**
+ * The same boundary for a source only known after an await.
+ *
+ * `produce` runs only when something is listening, so a publisher whose payload
+ * costs work to obtain — awaiting a write gate, then counting — pays none of it for
+ * an unsubscribed build, and states that rule nowhere itself.
+ *
+ * @internal Publishers are SDK-side. A consumer subscribes; it does not publish.
+ */
+export function publishDeferredDiagnostic<S>(
+  build: (source: S) => DiagnosticEvent,
+  produce: () => Promise<S>
+): void {
+  if (handlers.size === 0) return
+  try {
+    void produce()
+      .then((source) => deliverDiagnostic(build, source))
+      .catch((err) => {
+        console.warn('[diagnostics] publisher threw:', err)
+      })
+  } catch (err) {
+    console.warn('[diagnostics] publisher threw:', err)
+  }
+}
+
+/** Test-only: drop every subscriber. */
+export function resetDiagnosticsForTesting(): void {
+  handlers.clear()
+}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -121,14 +121,19 @@ export type {
   RecountEntityKind,
 } from './stores/shared/recountDiagnostics'
 
-// Read-only diagnostic: what an archive merge did with every row a MAM walk
-// returned. Retention is decided inside the store, downstream of the typed
-// history event, so it is observable from nowhere else.
-export { onArchiveMerge } from './stores/shared/archiveMergeDiagnostics'
+// The SDK's diagnostic channel: one subscription carrying every seam the SDK
+// reports, discriminated by `kind`. The payload-isolation and no-subscriber rules
+// live at its publication boundary, so a new seam is a union member rather than
+// another export. See `diagnostics/channel.ts` for the contract.
+export { subscribeDiagnostics } from './diagnostics/channel'
 export type {
+  DiagnosticEvent,
+  DiagnosticHandler,
+  ApplicationStanzaOutDiagnostic,
+  ArchiveMergeDiagnostic,
   ArchiveMergeReport,
   ArchiveMergeOutcome,
-} from './stores/shared/archiveMergeDiagnostics'
+} from './diagnostics/channel'
 
 // Fine-grained metadata subscription hooks
 export {

--- a/packages/fluux-sdk/src/stores/chatStore.archiveMerge.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveMerge.test.ts
@@ -9,10 +9,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { chatStore } from './chatStore'
 import {
-  onArchiveMerge,
-  resetArchiveMergeDiagnosticsForTesting,
+  resetDiagnosticsForTesting,
+  subscribeDiagnostics,
   type ArchiveMergeReport,
-} from './shared/archiveMergeDiagnostics'
+} from '../diagnostics/channel'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
 import type { Message } from '../core/types/chat'
@@ -80,7 +80,9 @@ function msg(id: string, overrides: Partial<Message> = {}): Message {
 function collector(): { pending: ArchiveMergeReport[]; next: () => Promise<ArchiveMergeReport> } {
   const pending: ArchiveMergeReport[] = []
   const waiters: Array<(r: ArchiveMergeReport) => void> = []
-  onArchiveMerge((r) => {
+  subscribeDiagnostics((event) => {
+    if (event.kind !== 'archive-merge') return
+    const r = event.report
     const waiter = waiters.shift()
     if (waiter) waiter(r)
     else pending.push(r)
@@ -107,7 +109,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  resetArchiveMergeDiagnosticsForTesting()
+  resetDiagnosticsForTesting()
 })
 
 describe('mergeMAMMessages reporting', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -69,7 +69,6 @@ import {
 } from './shared/purgedMarkers'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import {
-  hasArchiveMergeSubscribers,
   reportArchiveMergeWhenDurable,
   type ArchiveMergeInputs,
 } from './shared/archiveMergeDiagnostics'
@@ -3101,11 +3100,17 @@ export const chatStore = createStore<ChatState>()(
         let shouldRecountAfterMerge = false
         let archiveCommitGate: Promise<boolean> | undefined
         let durableMessages: Message[] = []
-        // Diagnostics only (stage 5b). Null unless something subscribed, so a merge
-        // with no observer counts nothing. A holder rather than a bare `let`: the
-        // assignment happens inside the set() callback, and TypeScript narrows a
-        // captured local to its initializer after the call.
-        const mergeDiagnostics: { inputs: ArchiveMergeInputs | null } = { inputs: null }
+        // Diagnostics only. A holder rather than bare locals lets the set() callback
+        // write the counters without allocating a payload. `counted` stays false when
+        // the merge returns before reaching them.
+        const mergeDiagnostics: ArchiveMergeInputs & { counted: boolean } = {
+          counted: false,
+          returned: 0,
+          newMessages: 0,
+          persistableNew: 0,
+          patched: 0,
+          persistablePatched: 0,
+        }
         let ownArchiveWrite: Promise<boolean> | undefined
         let coverageBootstrappedFromWalkExtent = false
         set((state) => {
@@ -3208,15 +3213,12 @@ export const chatStore = createStore<ChatState>()(
           const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
           const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
           durableMessages = persistableMessages
-          if (hasArchiveMergeSubscribers()) {
-            mergeDiagnostics.inputs = {
-              returned: mamMessages.length,
-              newMessages: newMessages.length,
-              persistableNew: persistableMessages.length,
-              patched: patched.length,
-              persistablePatched: persistablePatches.length,
-            }
-          }
+          mergeDiagnostics.returned = mamMessages.length
+          mergeDiagnostics.newMessages = newMessages.length
+          mergeDiagnostics.persistableNew = persistableMessages.length
+          mergeDiagnostics.patched = patched.length
+          mergeDiagnostics.persistablePatched = persistablePatches.length
+          mergeDiagnostics.counted = true
           // A merge with nothing persistable still defers when earlier pages
           // of this conversation are in flight (or failed): its cursor must
           // not leap them.
@@ -3408,11 +3410,15 @@ export const chatStore = createStore<ChatState>()(
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
 
-        if (mergeDiagnostics.inputs) {
+        if (mergeDiagnostics.counted) {
           reportArchiveMergeWhenDurable(
-            { entityKind: 'chat', entityId: conversationId, direction, complete },
-            mergeDiagnostics.inputs,
-            { ownWrite: ownArchiveWrite, chainGate: archiveCommitGate }
+            'chat',
+            conversationId,
+            direction,
+            complete,
+            mergeDiagnostics,
+            ownArchiveWrite,
+            archiveCommitGate
           )
         }
 

--- a/packages/fluux-sdk/src/stores/roomStore.archiveMerge.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveMerge.test.ts
@@ -8,10 +8,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { roomStore } from './roomStore'
 import {
-  onArchiveMerge,
-  resetArchiveMergeDiagnosticsForTesting,
+  resetDiagnosticsForTesting,
+  subscribeDiagnostics,
   type ArchiveMergeReport,
-} from './shared/archiveMergeDiagnostics'
+} from '../diagnostics/channel'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
 import type { Room, RoomMessage } from '../core/types'
@@ -80,7 +80,9 @@ function archiveMsg(id: string, ts: number): RoomMessage {
 function collector(): { pending: ArchiveMergeReport[]; next: () => Promise<ArchiveMergeReport> } {
   const pending: ArchiveMergeReport[] = []
   const waiters: Array<(r: ArchiveMergeReport) => void> = []
-  onArchiveMerge((r) => {
+  subscribeDiagnostics((event) => {
+    if (event.kind !== 'archive-merge') return
+    const r = event.report
     const waiter = waiters.shift()
     if (waiter) waiter(r)
     else pending.push(r)
@@ -108,7 +110,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  resetArchiveMergeDiagnosticsForTesting()
+  resetDiagnosticsForTesting()
 })
 
 describe('mergeRoomMAMMessages reporting', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -87,7 +87,6 @@ import {
 } from './shared/purgedMarkers'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import {
-  hasArchiveMergeSubscribers,
   reportArchiveMergeWhenDurable,
   type ArchiveMergeInputs,
 } from './shared/archiveMergeDiagnostics'
@@ -4173,11 +4172,17 @@ export const roomStore = createStore<RoomState>()(
     let shouldRecountAfterMerge = false
     let archiveCommitGate: Promise<boolean> | undefined
     let durableMessages: RoomMessage[] = []
-    // Diagnostics only (stage 5b). Null unless something subscribed, so a merge
-    // with no observer counts nothing. A holder rather than a bare `let`: the
-    // assignment happens inside the set() callback, and TypeScript narrows a
-    // captured local to its initializer after the call.
-    const mergeDiagnostics: { inputs: ArchiveMergeInputs | null } = { inputs: null }
+    // Diagnostics only. A holder rather than bare locals lets the set() callback
+    // write the counters without allocating a payload. `counted` stays false when
+    // the merge returns before reaching them.
+    const mergeDiagnostics: ArchiveMergeInputs & { counted: boolean } = {
+      counted: false,
+      returned: 0,
+      newMessages: 0,
+      persistableNew: 0,
+      patched: 0,
+      persistablePatched: 0,
+    }
     let ownArchiveWrite: Promise<boolean> | undefined
     let coverageBootstrappedFromWalkExtent = false
     set((state) => {
@@ -4286,15 +4291,12 @@ export const roomStore = createStore<RoomState>()(
       const persistablePatches = patched.filter(msg => !isNoLocalStore(msg))
       const archiveWriteMessages = [...persistableMessages, ...persistablePatches]
       durableMessages = persistableMessages
-      if (hasArchiveMergeSubscribers()) {
-        mergeDiagnostics.inputs = {
-          returned: mamMessages.length,
-          newMessages: newFromMAM.length,
-          persistableNew: persistableMessages.length,
-          patched: patched.length,
-          persistablePatched: persistablePatches.length,
-        }
-      }
+      mergeDiagnostics.returned = mamMessages.length
+      mergeDiagnostics.newMessages = newFromMAM.length
+      mergeDiagnostics.persistableNew = persistableMessages.length
+      mergeDiagnostics.patched = patched.length
+      mergeDiagnostics.persistablePatched = persistablePatches.length
+      mergeDiagnostics.counted = true
       // A merge with nothing persistable still defers when earlier pages of
       // this room are in flight (or failed): its cursor must not leap them.
       const mustGateOnChain = archiveWriteMessages.length > 0 || roomArchiveSaves.has(roomJid)
@@ -4477,11 +4479,15 @@ export const roomStore = createStore<RoomState>()(
       return { ...written, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
-    if (mergeDiagnostics.inputs) {
+    if (mergeDiagnostics.counted) {
       reportArchiveMergeWhenDurable(
-        { entityKind: 'room', entityId: roomJid, direction, complete },
-        mergeDiagnostics.inputs,
-        { ownWrite: ownArchiveWrite, chainGate: archiveCommitGate }
+        'room',
+        roomJid,
+        direction,
+        complete,
+        mergeDiagnostics,
+        ownArchiveWrite,
+        archiveCommitGate
       )
     }
 

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.test.ts
@@ -1,14 +1,19 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describeArchiveMerge, reportArchiveMerge } from './archiveMergeDiagnostics'
 import {
-  describeArchiveMerge,
-  hasArchiveMergeSubscribers,
-  onArchiveMerge,
-  reportArchiveMerge,
-  resetArchiveMergeDiagnosticsForTesting,
+  resetDiagnosticsForTesting,
+  subscribeDiagnostics,
   type ArchiveMergeReport,
-} from './archiveMergeDiagnostics'
+} from '../../diagnostics/channel'
 
-afterEach(() => resetArchiveMergeDiagnosticsForTesting())
+afterEach(() => resetDiagnosticsForTesting())
+
+/** The archive-merge slice of the diagnostic channel. */
+function onArchiveMerge(handler: (report: ArchiveMergeReport) => void): () => void {
+  return subscribeDiagnostics((event) => {
+    if (event.kind === 'archive-merge') handler(event.report)
+  })
+}
 
 const page = { returned: 10, newMessages: 6, persistableNew: 5, patched: 2, persistablePatched: 1 }
 
@@ -117,22 +122,19 @@ describe('subscription', () => {
     persistenceFailed: 0,
   }
 
-  it('claims no subscribers when nobody listens', () => {
-    expect(hasArchiveMergeSubscribers()).toBe(false)
+  it('publishes nothing when nobody listens', () => {
     expect(() => reportArchiveMerge(report)).not.toThrow()
   })
 
   it('delivers to every subscriber and stops on unsubscribe', () => {
     const seen: ArchiveMergeReport[] = []
     const off = onArchiveMerge((r) => seen.push(r))
-    expect(hasArchiveMergeSubscribers()).toBe(true)
 
     reportArchiveMerge(report)
     off()
     reportArchiveMerge(report)
 
     expect(seen).toEqual([report])
-    expect(hasArchiveMergeSubscribers()).toBe(false)
   })
 
   it('contains a throwing subscriber', () => {

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
@@ -7,20 +7,23 @@
  * the store none of that is observable: the caller sees the message count the server
  * returned and nothing about what became of it.
  *
- * This module is the read-only view of that outcome. Every returned row gets exactly
- * one disposition, and they balance:
- *
- * ```
- * returned === retained + deduplicated + patched + intentionallyUnstored + persistenceFailed
- * ```
- *
- * The arithmetic lives here rather than in each store so the two cannot drift apart,
- * and so the balance can be tested without driving a store.
+ * This module turns a merge's own counters into the `archive-merge` record the
+ * diagnostic channel publishes. The arithmetic lives here rather than in each store
+ * so the two cannot drift apart, and so the balance the record promises can be
+ * tested without driving a store. `diagnostics/channel.ts` declares the record
+ * itself.
  *
  * @module Stores/Shared/ArchiveMergeDiagnostics
  */
 
-export type ArchiveMergeOutcome = 'durable' | 'partial' | 'failed'
+import {
+  publishDeferredDiagnostic,
+  publishDiagnostic,
+  type ArchiveMergeCounts,
+  type ArchiveMergeOutcome,
+  type ArchiveMergeReport,
+  type DiagnosticEvent,
+} from '../../diagnostics/channel'
 
 /** What the merge itself counted, before the write outcome is known. */
 export interface ArchiveMergeInputs {
@@ -34,58 +37,6 @@ export interface ArchiveMergeInputs {
   patched: number
   /** Of those, the ones the write was allowed to store. */
   persistablePatched: number
-}
-
-export interface ArchiveMergeCounts {
-  outcome: ArchiveMergeOutcome
-  returned: number
-  retained: number
-  deduplicated: number
-  patched: number
-  intentionallyUnstored: number
-  persistenceFailed: number
-}
-
-export interface ArchiveMergeReport extends ArchiveMergeCounts {
-  entityKind: 'chat' | 'room'
-  /**
-   * The conversation id or room JID, raw.
-   *
-   * A diagnostic consumer that needs a privacy-safe identity derives it at its own
-   * boundary; the SDK has no business minting one.
-   */
-  entityId: string
-  direction: 'backward' | 'forward'
-  /** Whether the walk reported the archive exhausted in that direction. */
-  complete: boolean
-}
-
-type Handler = (report: ArchiveMergeReport) => void
-
-const handlers = new Set<Handler>()
-
-/**
- * Observe archive merges.
- *
- * Each handler receives its own report snapshot.
- *
- * @returns an unsubscribe function.
- */
-export function onArchiveMerge(handler: Handler): () => void {
-  handlers.add(handler)
-  return () => {
-    handlers.delete(handler)
-  }
-}
-
-/**
- * Whether anything is listening.
- *
- * The stores check this BEFORE counting: with no subscriber a merge must not pay for
- * a diagnostic nobody reads.
- */
-export function hasArchiveMergeSubscribers(): boolean {
-  return handlers.size > 0
 }
 
 /**
@@ -142,37 +93,37 @@ export function describeArchiveMerge(
  * Shared by both stores so the ordering rule cannot drift into one of them.
  */
 export function reportArchiveMergeWhenDurable(
-  identity: Omit<ArchiveMergeReport, keyof ArchiveMergeCounts>,
+  entityKind: ArchiveMergeReport['entityKind'],
+  entityId: string,
+  direction: ArchiveMergeReport['direction'],
+  complete: boolean,
   inputs: ArchiveMergeInputs,
-  writes: { ownWrite?: Promise<boolean>; chainGate?: Promise<boolean> }
+  ownWrite?: Promise<boolean>,
+  chainGate?: Promise<boolean>
 ): void {
-  const attempted = inputs.persistableNew + inputs.persistablePatched > 0
-  void Promise.all([
-    writes.ownWrite ?? Promise.resolve(true),
-    writes.chainGate ?? Promise.resolve(true),
-  ]).then(([own, chained]) => {
-    reportArchiveMerge({ ...identity, ...describeArchiveMerge(inputs, own, chained, attempted) })
+  publishDeferredDiagnostic(archiveMergeEvent, async () => {
+    const attempted = inputs.persistableNew + inputs.persistablePatched > 0
+    const [own, chained] = await Promise.all([ownWrite ?? true, chainGate ?? true])
+    return {
+      entityKind,
+      entityId,
+      direction,
+      complete,
+      ...describeArchiveMerge(inputs, own, chained, attempted),
+    }
   })
 }
 
 /**
- * Hand a report to every subscriber.
+ * Publish a merge report on the SDK's diagnostic channel.
  *
- * A handler that throws is contained: this runs on the merge's completion path, and
- * a diagnostic must never break the store operation it observes.
+ * The channel isolates the flat report for each subscriber.
  */
 export function reportArchiveMerge(report: ArchiveMergeReport): void {
-  if (handlers.size === 0) return
-  for (const handler of handlers) {
-    try {
-      handler({ ...report })
-    } catch (err) {
-      console.warn('[archiveMerge] subscriber threw:', err)
-    }
-  }
+  publishDiagnostic(archiveMergeEvent, report)
 }
 
-/** Test-only: drop every subscriber. */
-export function resetArchiveMergeDiagnosticsForTesting(): void {
-  handlers.clear()
-}
+const archiveMergeEvent = (report: ArchiveMergeReport): DiagnosticEvent => ({
+  kind: 'archive-merge',
+  report,
+})

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -242,16 +242,19 @@ test.describe('anomaly runtime', () => {
 
     const outboundApplicationStanzas = await page.evaluate(async () => {
       interface DemoClientLike {
-        onApplicationStanzaOut(handler: () => void): () => void
         server: { queryInfo(jid: string): Promise<unknown> }
       }
-      const client = (window as unknown as { __demoClient: DemoClientLike }).__demoClient
+      type SubscribeDiagnostics = (handler: (event: { kind: string }) => void) => () => void
+      const scope = window as unknown as {
+        __demoClient: DemoClientLike
+        __fluuxDiagnostics: SubscribeDiagnostics
+      }
       let observed = 0
-      const off = client.onApplicationStanzaOut(() => {
-        observed++
+      const off = scope.__fluuxDiagnostics((event) => {
+        if (event.kind === 'application-stanza-out') observed++
       })
       try {
-        await client.server.queryInfo(`anomaly-smoke-${Date.now()}.invalid`)
+        await scope.__demoClient.server.queryInfo(`anomaly-smoke-${Date.now()}.invalid`)
       } finally {
         off()
       }


### PR DESCRIPTION
First of the three changes proposed in #1353: the shape of the SDK's diagnostic surface.

The SDK published its anomaly diagnostics through two boundaries in two idioms — a method on `XMPPClient` for outbound application stanzas, a module subscription for archive merges. Each carried its own copy of the two rules a diagnostic seam has to hold, and the "build nothing when nobody subscribes" rule was restated again at every store call site.

`subscribeDiagnostics(handler)` now carries both as a discriminated union, with the rules structural rather than repeated:

- A publisher hands over a builder and its source, never a finished payload, so nothing is built unless something is listening. `publishDeferredDiagnostic` does the same for a payload only known after an await, which is what lets an archive merge stop assembling its report, its identity and its write-gate chain for an observer that does not exist.
- The boundary builds once and gives each subscriber its own payload through a per-kind isolator table. Copying lives there and nowhere else.

The handler registry is anchored on `globalThis`: `tsup` builds seven entry points with `splitting: false`, so the module is compiled into each one, and without a shared registry a subscriber reached through `@fluux/sdk` would never see an event published by an `XMPPClient` reached through `@fluux/sdk/core` — a delivery that fails silently. `chatStore`, `roomStore` and `recountDiagnostics` have the same per-entry-point duplication; that is pre-existing and left alone.

### Which kinds are in, and which are not

`application-stanza-out` and `archive-merge` are kinds: each is an occurrence carrying a payload.

Four exports deliberately stay on their current shape, and the union's documentation says so:

- `chatUnreadDiagnostic` / `roomUnreadDiagnostic` are asynchronous questions answered on demand from one validated snapshot. The honest push form needs the unread recount to report its own committed count or the reason it declined — the second proposal in #1353, deliberately a separate change.
- `chatReadStateGeneration` / `roomReadStateGeneration` are values, not occurrences: a generation identifies the current read state and is only meaningful read in the same turn as the pointer it explains, since a generation learned later than its pointer turns an account switch into a phantom pointer regression. Publishing generation moves as events would make every consumer rebuild that pairing from a shadow copy. Their epochs also move outside the store's own updates, so an event form would first need ordering guarantees at every bump site.

### Public surface

`subscribeDiagnostics` replaces `XMPPClient.onApplicationStanzaOut` and `onArchiveMerge`, and the `applicationStanzaOut` client event is removed.

Closes #1353 partially — the first of its three proposals.
