### PR TITLE
fix(sdk): send SASL PLAIN credentials as UTF-8 (#1219)

### DIFF
--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
@@ -27,6 +27,8 @@ interface MockXmppInstance {
   _runAuth: () => Promise<void>
   _capturedFastElement: { name: string; attrs: Record<string, string> } | null
   _capturedInnerArgs: unknown
+  /** Present so the UTF-8 SASL PLAIN patch finds a registry to act on. */
+  saslFactory: { _mechs: Array<{ name: string; mech: new () => unknown }> }
   _startCalled: boolean
   _stopCalled: boolean
 }
@@ -81,6 +83,7 @@ const createMockInstance = (): MockXmppInstance => {
     },
     _capturedFastElement: fastElement,
     _capturedInnerArgs: null,
+    saslFactory: { _mechs: [{ name: 'PLAIN', mech: class {} }] },
     _startCalled: false,
     _stopCalled: false,
   }

--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
@@ -19,6 +19,7 @@ import { fetchFastToken, type FastToken } from './fastTokenStorage'
 import { getBareJid, getDomain, getLocalPart } from './jid'
 import { logInfo, logWarn } from './logger'
 import { FAST_TOKEN_INVALIDATION_TIMEOUT_MS } from './modules/connectionTimeouts'
+import { installUtf8SaslPlain } from './saslPlainUtf8'
 import { buildUserAgentElement } from './userAgent'
 
 export interface InvalidateFastTokenOptions {
@@ -153,6 +154,10 @@ export async function invalidateFastTokenOnServer(
           )
         },
       })
+
+      // Keeps this client's mechanism registry identical to the connection
+      // client's, so the two never disagree on what PLAIN puts on the wire.
+      installUtf8SaslPlain(xmppClient)
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const fastModule = (xmppClient as any).fast

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -137,6 +137,30 @@ describe('XMPPClient Connection', () => {
       )
     })
 
+    it('should leave the connection client sending SASL PLAIN as UTF-8', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      // Ask the factory for PLAIN the way the SASL layer does, then base64 the
+      // response the way it does, and read the bytes back out: `ô` must reach
+      // the wire as c3 b4, not as the latin-1 f4 the stock mechanism produces.
+      const mechanism = mockXmppClientInstance.saslFactory.create(['PLAIN'])
+      const response = mechanism!.response({ username: 'user', password: 'aeztKehsdlanalfô91' })
+      const bytes = Uint8Array.from(atob(btoa(response)), (ch) => ch.charCodeAt(0))
+
+      expect([...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')).toBe(
+        [...new TextEncoder().encode('\0user\0aeztKehsdlanalfô91')]
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('')
+      )
+    })
+
     it('should use XEP-0156 discovery first, then default wss://<domain>/ws as last resort on web/no-proxy', async () => {
       mockDiscoverWebSocket.mockResolvedValueOnce(null)
 

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -7,6 +7,7 @@ import { getBareJid, getDomain, getLocalPart, getResource } from '../jid'
 import { getClientIdentity, CLIENT_FEATURES } from '../caps'
 import { NS_DISCO_INFO, NS_PING, NS_TIME } from '../namespaces'
 import { logDebug, logInfo, logWarn, logError as logErr } from '../logger'
+import { installUtf8SaslPlain } from '../saslPlainUtf8'
 import {
   type SmPatchState,
   createSmPatchState,
@@ -1772,6 +1773,8 @@ export class Connection extends BaseModule {
         ])
       },
     })
+
+    installUtf8SaslPlain(xmppClient)
 
     // Wire FAST token persistence to the platform adapter (XEP-0484).
     // Browsers default to localStorage; headless runtimes default to memory.

--- a/packages/fluux-sdk/src/core/saslPlainUtf8.test.ts
+++ b/packages/fluux-sdk/src/core/saslPlainUtf8.test.ts
@@ -1,0 +1,152 @@
+/**
+ * What SASL PLAIN puts on the wire (#1219).
+ *
+ * These drive a real `@xmpp/client` and read the base64 out of the `<auth/>`
+ * stanza the library itself builds, rather than calling our mechanism directly:
+ * the point is the bytes that reach the server, through the library's own
+ * mechanism selection and its own base64 step. The expected byte strings below
+ * are the ones measured against ejabberd 26.7.0, where the UTF-8 form
+ * authenticates and the latin-1 form is answered with `not-authorized`.
+ */
+import { describe, it, expect } from 'vitest'
+import { client, xml, type Element } from '@xmpp/client'
+import { installUtf8SaslPlain } from './saslPlainUtf8'
+
+const USERNAME = 'alice'
+/** The reporter's password shape: `ô` is U+00F4, inside btoa()'s latin-1 range. */
+const ACCENTED = 'aeztKehsdlanalfô91'
+/** `Ł` is U+0141, above that range, where btoa() throws instead of mangling. */
+const ABOVE_LATIN1 = 'aeztKehsdlanalfŁ91'
+/** Deliberately decomposed: this encoding fix must not apply SASLprep or normalization. */
+const DECOMPOSED = 'aeztKehsdlanalfo\u030291'
+
+function toHex(bytes: Uint8Array): string {
+  return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function utf8Hex(text: string): string {
+  return toHex(new TextEncoder().encode(text))
+}
+
+function decodeBase64(text: string): Uint8Array {
+  return Uint8Array.from(atob(text), (ch) => ch.charCodeAt(0))
+}
+
+/**
+ * Run the library's SASL negotiation far enough to capture the `<auth/>` it
+ * sends, without a socket: `<stream:features>` goes in as an incoming element
+ * and the outgoing stanza is intercepted at `send`.
+ */
+async function captureAuthStanza(options: {
+  password: string
+  install: boolean
+}): Promise<Element> {
+  const xmppClient = client({
+    service: 'wss://example.invalid/ws',
+    domain: 'example.invalid',
+    username: USERNAME,
+    credentials: async (authenticate) => {
+      await authenticate({ username: USERNAME, password: options.password }, 'PLAIN')
+    },
+  })
+
+  if (options.install) installUtf8SaslPlain(xmppClient)
+
+  let captured: (element: Element) => void = () => {}
+  const sent = new Promise<Element>((resolve) => {
+    captured = resolve
+  })
+  let failed: (error: unknown) => void = () => {}
+  const errored = new Promise<never>((_, reject) => {
+    failed = reject
+  })
+
+  xmppClient.send = async (element: Element) => captured(element)
+  // The SASL layer routes a mechanism that throws into the entity's error event.
+  xmppClient.on('error', (error) => failed(error))
+
+  // The client is an EventEmitter underneath; `emit` is not on the SDK-facing
+  // declaration because nothing in the SDK should be injecting stream elements.
+  const emitter = xmppClient as unknown as { emit: (event: string, element: Element) => void }
+  emitter.emit('element', xml(
+    'features',
+    { xmlns: 'http://etherx.jabber.org/streams' },
+    xml('mechanisms', { xmlns: 'urn:ietf:params:xml:ns:xmpp-sasl' }, xml('mechanism', {}, 'PLAIN'))
+  ))
+
+  return Promise.race([sent, errored])
+}
+
+async function captureAuthBytes(options: {
+  password: string
+  install: boolean
+}): Promise<Uint8Array> {
+  const auth = await captureAuthStanza(options)
+  expect(auth.name).toBe('auth')
+  expect(auth.attrs.mechanism).toBe('PLAIN')
+  return decodeBase64(auth.text())
+}
+
+describe('SASL PLAIN wire encoding', () => {
+  it('sends an accented password as UTF-8', async () => {
+    const bytes = await captureAuthBytes({ password: ACCENTED, install: true })
+
+    expect(toHex(bytes)).toBe(utf8Hex(`\0${USERNAME}\0${ACCENTED}`))
+    // Spelled out so the assertion is anchored on the bytes ejabberd accepted,
+    // not on a second call to the encoder under test: `ô` is c3 b4, not f4.
+    expect(toHex(bytes)).toBe('00616c6963650061657a744b656873646c616e616c66c3b43931')
+  })
+
+  it('sends a password above U+00FF instead of throwing', async () => {
+    const bytes = await captureAuthBytes({ password: ABOVE_LATIN1, install: true })
+
+    expect(toHex(bytes)).toBe(utf8Hex(`\0${USERNAME}\0${ABOVE_LATIN1}`))
+  })
+
+  it('leaves an ASCII password byte-for-byte unchanged', async () => {
+    const bytes = await captureAuthBytes({ password: 'aeztKehsdlanalfo91', install: true })
+
+    expect(toHex(bytes)).toBe(utf8Hex(`\0${USERNAME}\0aeztKehsdlanalfo91`))
+  })
+
+  it('preserves a non-normalized password byte-for-byte', async () => {
+    const bytes = await captureAuthBytes({ password: DECOMPOSED, install: true })
+
+    expect(toHex(bytes)).toBe(utf8Hex(`\0${USERNAME}\0${DECOMPOSED}`))
+    expect(toHex(bytes)).not.toBe(utf8Hex(`\0${USERNAME}\0${ACCENTED}`))
+  })
+
+  describe('without the patch', () => {
+    /**
+     * These two pin the defect the patch exists for, so its cost stays visible.
+     * If either starts failing, xmpp.js has fixed PLAIN upstream and this whole
+     * module — patch, install calls, and these tests — should be deleted.
+     */
+    it('mangles an accented password to latin-1', async () => {
+      const bytes = await captureAuthBytes({ password: ACCENTED, install: false })
+
+      expect(toHex(bytes)).toBe('00616c6963650061657a744b656873646c616e616c66f43931')
+      expect(toHex(bytes)).not.toBe(utf8Hex(`\0${USERNAME}\0${ACCENTED}`))
+    })
+
+    it('throws on a password above U+00FF', async () => {
+      await expect(
+        captureAuthBytes({ password: ABOVE_LATIN1, install: false })
+      ).rejects.toThrow(/latin1|Latin1|character/i)
+    })
+  })
+
+  describe('installUtf8SaslPlain', () => {
+    it('leaves a client alone when no PLAIN mechanism is registered', () => {
+      const withoutPlain = {
+        saslFactory: { _mechs: [{ name: 'SCRAM-SHA-1', mech: class {} }], create: () => null },
+      }
+
+      expect(() =>
+        installUtf8SaslPlain(withoutPlain as unknown as Parameters<typeof installUtf8SaslPlain>[0])
+      ).not.toThrow()
+      expect(withoutPlain.saslFactory._mechs).toHaveLength(1)
+      expect(withoutPlain.saslFactory._mechs[0].name).toBe('SCRAM-SHA-1')
+    })
+  })
+})

--- a/packages/fluux-sdk/src/core/saslPlainUtf8.ts
+++ b/packages/fluux-sdk/src/core/saslPlainUtf8.ts
@@ -1,0 +1,63 @@
+import type { Client, SaslMechanismEntry } from '@xmpp/client'
+import { logError as logErr } from './logger'
+
+/**
+ * SASL PLAIN whose response reaches the wire as UTF-8.
+ *
+ * RFC 4616 §2 defines the PLAIN message as UTF-8 encoded Unicode. xmpp.js
+ * base64s whatever a mechanism returns with `btoa()`, which serialises one
+ * latin-1 byte per code unit, so a mechanism must hand back a binary string:
+ * one code unit per byte. The mechanisms xmpp.js ships for SCRAM-SHA-1 and
+ * HT-SHA-256 do exactly that; its PLAIN returns the raw password instead, so
+ * `ô` (U+00F4) leaves as `f4` where the server expects `c3 b4`, and anything
+ * above U+00FF makes `btoa()` throw outright.
+ *
+ * This is an interim local patch. The permanent home for it is `@xmpp/sasl-plain`
+ * upstream, and this file goes away when that lands (#1219).
+ */
+class Utf8SaslPlain {
+  readonly name = 'PLAIN'
+  readonly clientFirst = true
+
+  response(cred: { authzid?: string; username: string; password: string }): string {
+    const bytes = new TextEncoder().encode(
+      `${cred.authzid ?? ''}\0${cred.username}\0${cred.password}`
+    )
+    // btoa() maps code units 0-255 to the identical byte, so a binary string
+    // survives base64 unchanged.
+    return String.fromCharCode(...bytes)
+  }
+
+  challenge(): this {
+    return this
+  }
+}
+
+/**
+ * Replace the PLAIN mechanism xmpp.js registered with the UTF-8 one above.
+ *
+ * Replacement rather than registration: `saslmechanisms`' factory returns the
+ * first entry whose name matches, so an appended mechanism never wins. The
+ * entry list is a private field of that package, which is why the loss of this
+ * patch has to stay detectable — `saslPlainUtf8.test.ts` asserts the bytes the
+ * client actually sends, so a dependency bump that moves the field fails there
+ * rather than silently restoring the bug.
+ *
+ * A missing entry is reported and left alone: ASCII passwords keep working on
+ * the stock mechanism, which is a better outcome than refusing every login.
+ *
+ * Call this before `start()`; the registry is read during stream negotiation.
+ */
+export function installUtf8SaslPlain(client: Client): void {
+  const mechanisms: SaslMechanismEntry[] | undefined = client.saslFactory?._mechs
+  const index = mechanisms?.findIndex((entry) => entry.name === 'PLAIN') ?? -1
+
+  if (!mechanisms || index === -1) {
+    logErr(
+      'SASL PLAIN mechanism not found in the xmpp.js factory: passwords with non-ASCII characters will fail to authenticate'
+    )
+    return
+  }
+
+  mechanisms[index] = { name: 'PLAIN', mech: Utf8SaslPlain }
+}

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -98,6 +98,15 @@ export interface MockXmppClient {
   }
   prependListener: Mock
   removeAllListeners: Mock<() => void>
+  /**
+   * Mechanism registry, seeded with the stock PLAIN xmpp.js registers — the one
+   * that returns the raw password string. Tests that care about the wire bytes
+   * read the entry back after connect().
+   */
+  saslFactory: {
+    _mechs: Array<{ name: string; mech: new () => SaslMechanism }>
+    create: (mechanisms: string[]) => SaslMechanism | null
+  }
   /** Deliver an internal event, queueing lifecycle events until a handler registers. */
   _emit: (event: string, ...args: unknown[]) => void
   /** Deliver a stream-management event, queueing it until a handler registers. */
@@ -105,6 +114,27 @@ export interface MockXmppClient {
   _hasHandlers: (event: string) => boolean
   _handlers: Record<string, Function[]>
   _smHandlers: Record<string, Function[]>
+}
+
+export interface SaslCredentials {
+  authzid?: string
+  username: string
+  password: string
+}
+
+export interface SaslMechanism {
+  response: (cred: SaslCredentials) => string
+}
+
+/**
+ * The PLAIN mechanism xmpp.js ships: it hands back the raw password string, so
+ * `btoa()` serialises it as latin-1. Seeded into the mock factory so tests see
+ * the same starting point production does, and so a replacement is observable.
+ */
+class StockSaslPlain implements SaslMechanism {
+  response(cred: SaslCredentials): string {
+    return `${cred.authzid ?? ''}\0${cred.username}\0${cred.password}`
+  }
 }
 
 // Mock EventEmitter behavior for the XMPP client
@@ -313,6 +343,13 @@ export const createMockXmppClient = (): MockXmppClient => {
     // element interceptor used to strip <sm> from post-auth <stream:features>.
     // The real xmpp.js client inherits this from Node's EventEmitter.
     prependListener: vi.fn(),
+    saslFactory: {
+      _mechs: [{ name: 'PLAIN', mech: StockSaslPlain }],
+      create(mechanisms: string[]) {
+        const entry = this._mechs.find((m) => mechanisms.includes(m.name))
+        return entry ? new entry.mech() : null
+      },
+    },
     // Remove all event listeners — called by forceDestroyClient() during cleanup.
     // Must actually clear handlers so destroyed clients cannot emit stale events
     // into the Connection module (e.g., a belated 'online' after timeout).

--- a/packages/fluux-sdk/src/xmpp.d.ts
+++ b/packages/fluux-sdk/src/xmpp.d.ts
@@ -102,6 +102,22 @@ declare module '@xmpp/client' {
     disconnect: (context: DisconnectContext) => void
   }
 
+  /** One entry of `saslmechanisms`' private mechanism list. */
+  export interface SaslMechanismEntry {
+    name: string
+    mech: new () => unknown
+  }
+
+  export interface SaslFactory {
+    /**
+     * Private to `saslmechanisms`, and the only way to override a mechanism:
+     * `create()` returns the first entry whose name matches, so appending one
+     * never wins. See `core/saslPlainUtf8.ts`.
+     */
+    _mechs: SaslMechanismEntry[]
+    create(mechanisms: string[]): unknown
+  }
+
   export interface Client {
     on<K extends keyof ClientEventMap>(event: K, handler: ClientEventMap[K]): void
     off<K extends keyof ClientEventMap>(event: K, handler: ClientEventMap[K]): void
@@ -122,6 +138,8 @@ declare module '@xmpp/client' {
     status: string
     /** Underlying transport socket; null once the socket dies. */
     socket: unknown
+    /** SASL mechanism registry, built by `client()` before stream negotiation. */
+    saslFactory: SaslFactory
     /** Present only when the server offers FAST (XEP-0484). */
     fast?: FastModule
     /** Present unless the reconnect plugin was left out of the client build. */


### PR DESCRIPTION
Fixes #1219.

A password containing a non-ASCII character was refused with `not-authorized - Invalid username or password`, and swapping the one character for its ASCII lookalike made the login work.

xmpp.js base64s a SASL mechanism's response with `btoa()`, which serialises one latin-1 byte per code unit, so a mechanism has to hand back a binary string. Its SCRAM-SHA-1 and HT-SHA-256 mechanisms do; its PLAIN returns the raw password instead. A password with `ô` therefore left as `f4` where the server expects `c3 b4`, and a character above U+00FF made `btoa()` throw before the stanza was built.

This replaces the registered PLAIN mechanism with one that encodes to UTF-8 first. Only servers offering no SCRAM-SHA-1 were affected, since xmpp.js implements SCRAM-SHA-1, PLAIN and ANONYMOUS only and takes the first the server offers; SCRAM already handled non-ASCII correctly.

**This is an interim local patch.** The permanent home for the fix is `@xmpp/sasl-plain` upstream, filed separately. When that lands, `saslPlainUtf8.ts` and its test should be removed together — removing the test alone would be worse than never adding it, because the mechanism registry the patch edits is private to the `saslmechanisms` package and a dependency bump can undo the patch with nothing to announce it.

That is why the test drives a real client and asserts the bytes it puts on the wire rather than asserting the patch is installed. It was verified to fail for that reason and not merely to pass: renaming the private field turns the two byte assertions red, restoring it turns them green. The expected bytes are the ones measured against ejabberd 26.7.0, where the UTF-8 form authenticates and the latin-1 form is refused.

Client-side SASLprep is deliberately out of scope — adding it can lock out users whose stored password is non-normalised on a server that does not normalise. A test pins that a decomposed password still reaches the wire unnormalised.
