### PR TITLE
refactor(sdk): collapse the chat/room diagnostic twins (#1353)

### DIFF
--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -15,7 +15,7 @@
  *
  * @module Anomaly/Install
  */
-import { chatReadStateGeneration, chatStore, connectionStore, getStorageScopeJid, isAhead, roomReadStateGeneration, roomStore, setMeasurementEnabled, subscribeDiagnostics, type ArchiveMergeReport, type RecountEntityKind, type UnreadRecountVerdict } from '@fluux/sdk'
+import { chatStore, connectionStore, getStorageScopeJid, isAhead, readStateGeneration, roomStore, setMeasurementEnabled, subscribeDiagnostics, type ArchiveMergeReport, type RecountEntityKind, type UnreadRecountVerdict } from '@fluux/sdk'
 import { clearAnomalyMetricHandler, setAnomalyMetricHandler } from '../utils/anomalyMetric'
 import {
   clearAnomalyObservationHandler,
@@ -448,7 +448,6 @@ export function install(
       kind: 'chat' | 'room',
       nextMeta: ReadonlyMap<string, T>,
       prevMeta: ReadonlyMap<string, T>,
-      generation: (id: string) => { store: number; entity: number },
     ): void => {
       for (const [id, meta] of nextMeta) {
         if (prevMeta.get(id) === meta) continue
@@ -457,7 +456,7 @@ export function install(
           kind,
           id,
           pointer: meta.readPointer,
-          generation: generation(id),
+          generation: readStateGeneration(kind, id),
         })
       }
     }
@@ -465,20 +464,19 @@ export function install(
     const seedPointers = <T extends { readPointer?: Parameters<typeof isAhead>[0] }>(
       kind: 'chat' | 'room',
       meta: ReadonlyMap<string, T>,
-      generation: (id: string) => { store: number; entity: number },
     ): void => {
       for (const [id, value] of meta) {
         pointerRegression.observe({
           kind,
           id,
           pointer: value.readPointer,
-          generation: generation(id),
+          generation: readStateGeneration(kind, id),
         })
       }
     }
 
-    seedPointers('chat', chatStore.getState().conversationMeta, chatReadStateGeneration)
-    seedPointers('room', roomStore.getState().roomMeta, roomReadStateGeneration)
+    seedPointers('chat', chatStore.getState().conversationMeta)
+    seedPointers('room', roomStore.getState().roomMeta)
 
     const unsubChat = chatStore.subscribe((next, prev) => {
       denominators.observeArrivals(
@@ -486,7 +484,7 @@ export function install(
         { lastArrivedMessage: prev.lastArrivedMessage, isRoom: false },
       )
       if (next.conversationMeta !== prev.conversationMeta) {
-        scanPointers('chat', next.conversationMeta, prev.conversationMeta, chatReadStateGeneration)
+        scanPointers('chat', next.conversationMeta, prev.conversationMeta)
       }
       observeActiveEntity()
     })
@@ -496,7 +494,7 @@ export function install(
         { lastArrivedMessage: prev.lastArrivedMessage, isRoom: true },
       )
       if (next.roomMeta !== prev.roomMeta) {
-        scanPointers('room', next.roomMeta, prev.roomMeta, roomReadStateGeneration)
+        scanPointers('room', next.roomMeta, prev.roomMeta)
       }
       observeActiveEntity()
     })

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -191,8 +191,8 @@ unobserved interval into persistence evidence.
 
 **Named non-cases:**
 
-- A generation change is never a regression. `chatReadStateGeneration` /
-  `roomReadStateGeneration` report a `store` scope (logout, account switch) and an
+- A generation change is never a regression. `readStateGeneration(kind, id)` reports a
+  `store` scope (logout, account switch) and an
   `entity` scope (that conversation or room deleted); a move in **either** resets the
   comparison, and the first pointer of a new generation has no predecessor.
 - Writing the same pointer twice is idempotence. Only a pointer strictly behind its

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -702,12 +702,13 @@ boundary §4.4 already requires for JIDs.
    { scope: 'store', gen: number } | { scope: 'entity', id: string, gen: number }
    ```
 
-   **Shipped in 5c as a READER, not a signal**, returning both scopes at once:
-   `chatReadStateGeneration(id)` / `roomReadStateGeneration(jid)` → `{ store, entity }`. A detector
-   has to sample the pointer and its generation together; with an event, a generation change
-   delivered after the pointer write it explains produces exactly the false positive §6.1 deletes a
-   detector for. A reader called in the same store-subscription callback cannot race. The scoping
-   the design argued for is unchanged — and it turned out the stores already kept both counters.
+   **Shipped in 5c as a READER, not a signal**, returning both scopes at once. The current
+   `readStateGeneration(kind, id)` API and its reset contract are owned by
+   `docs/ANOMALY_INVARIANTS.md`. A detector has to sample the pointer and its generation together;
+   with an event, a generation change delivered after the pointer write it explains produces exactly
+   the false positive §6.1 deletes a detector for. A reader called in the same store-subscription
+   callback cannot race. The scoping the design argued for is unchanged — and it turned out the
+   stores already kept both counters.
 
    **The scope is the whole point.** A single global counter would be wrong, because the underlying
    `chatCacheEpoch` is bumped by conversation *deletion* as well as by logout and account switch —

--- a/packages/fluux-sdk/src/diagnostics/channel.ts
+++ b/packages/fluux-sdk/src/diagnostics/channel.ts
@@ -25,13 +25,12 @@
  * The handler registry is shared through `globalThis` because the published package
  * compiles this module into several entry points.
  *
- * Only occurrences are event kinds here. `chatReadStateGeneration` and
- * `roomReadStateGeneration` stay plain readers because a generation is a VALUE, not
- * an occurrence: it is only meaningful read in the same turn as the pointer it
- * explains, and a generation learned later than that pointer turns an account switch
- * into a phantom pointer regression. An event form would have to carry the pointer
- * and its generation in ONE payload, which is a change to every pointer write site
- * rather than to this channel.
+ * Only occurrences are event kinds here. `readStateGeneration` stays a plain reader
+ * because a generation is a VALUE, not an occurrence: it is only meaningful read in
+ * the same turn as the pointer it explains, and a generation learned later than that
+ * pointer turns an account switch into a phantom pointer regression. An event form
+ * would have to carry the pointer and its generation in ONE payload, which is a
+ * change to every pointer write site rather than to this channel.
  *
  * @module Diagnostics/Channel
  */

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -250,8 +250,7 @@ export { makeReadPointer, pointerRowRef, rowRefOfPointer, withArchiveId, isAhead
 // The generation a read pointer belongs to: forward-only holds WITHIN one, and
 // several ordinary transitions replace a pointer wholesale. A consumer caching
 // anything derived from read state needs the pair to know what to discard.
-export { chatReadStateGeneration } from './stores/chatStore'
-export { roomReadStateGeneration } from './stores/roomStore'
+export { readStateGeneration } from './stores/readStateGeneration'
 export type { ReadStateGeneration } from './core/types/readStateGeneration'
 
 // Viewport evidence: SDK-owned, generation-scoped

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -63,10 +63,7 @@ import {
   type PurgedMarkerKey,
 } from './shared/purgedMarkers'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
-import {
-  reportArchiveMergeWhenDurable,
-  type ArchiveMergeInputs,
-} from './shared/archiveMergeDiagnostics'
+import { newArchiveMergeTally, reportArchiveMergeWhenDurable } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
@@ -76,7 +73,7 @@ import { addPendingRetraction, applyPendingRetractions, removePendingRetraction,
 import { retractChatMessageInStorage, retractUnresidentChatTarget } from './shared/retractionStorage'
 import { createRemoteDividerAdvanceTracker } from './shared/dividerAdvance'
 import { locallyPublishedDisplayed } from '../core/localMdsPublishes'
-import { isAhead, pointerRowRef, rowRefOfPointer } from './shared/readPointer'
+import { isAhead, rowRefOfPointer } from './shared/readPointer'
 import { getBareJid } from '../core/jid'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import {
@@ -89,8 +86,8 @@ import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
-import { reportRecountVerdict, reportUnreadCleared } from './shared/recountDiagnostics'
-import type { RecountDeferralReason, UnreadRecountVerdict } from '../diagnostics/channel'
+import { countOnlyClear, recountLedger, reportUnreadCleared } from './shared/recountDiagnostics'
+import type { RecountDeferralReason } from '../diagnostics/channel'
 import { createRecountRetryScheduler } from './shared/recountRetry'
 import { createPendingEntityWrites } from './shared/pendingEntityWrites'
 import { flushKey, flush as flushThrottledStorage } from './shared/throttledStorage'
@@ -633,11 +630,8 @@ function currentChatEntityEpoch(conversationId: string): number {
 }
 
 /**
- * The generation this conversation's read state belongs to.
- *
- * Read it in the SAME turn as the pointer it describes. The two counters are
- * plain reads, so a caller that samples both together cannot see a pointer from
- * one generation carrying the number of another.
+ * This store's half of `readStateGeneration`, which is what consumers call. Kept
+ * here because both counters are module scope, bumped by this store's own teardown.
  */
 export function chatReadStateGeneration(conversationId: string): ReadStateGeneration {
   return { store: chatCacheEpoch, entity: currentChatEntityEpoch(conversationId) }
@@ -2004,20 +1998,7 @@ export const chatStore = createStore<ChatState>()(
           // Pure function returns the same reference when nothing changed.
           if (updated === notifInput) return {}
 
-          const readPositionStayed =
-            updated.readPointer && notifInput.readPointer
-              ? sameMessageRow(
-                  pointerRowRef(updated.readPointer),
-                  pointerRowRef(notifInput.readPointer),
-                )
-              : updated.readPointer === notifInput.readPointer
-          if (
-            notifInput.unreadCount > 0 &&
-            updated.unreadCount === 0 &&
-            readPositionStayed
-          ) {
-            clearedFrom = notifInput.unreadCount
-          }
+          clearedFrom = countOnlyClear(notifInput, updated)
 
           // The read pointer just moved (or the counts were cleared) — bound the
           // transient overlay's memory now rather than waiting for a later
@@ -2771,26 +2752,16 @@ export const chatStore = createStore<ChatState>()(
 
       recomputeUnreadForConversation: async (conversationId, options) => {
         const allowActive = options?.allowActive ?? false
-        // EVERY exit funnels through `defer` or `counted`, and the verdict is published
-        // once in the `finally` below — after the store update, so a subscriber never
-        // reads a store halfway through committing. A new guard therefore cannot be
-        // added without naming a reason, and the commit cannot change without saying
-        // what it committed.
-        let verdict: UnreadRecountVerdict | undefined
-        const defer = (reason: RecountDeferralReason): void => {
-          verdict = { status: 'deferred', reason }
-          if (reason === 'input-version-changed') {
-            chatRecountRetry.schedule(
-              conversationId,
-              allowActive,
-              (retryOptions) => get().recomputeUnreadForConversation(conversationId, retryOptions),
-              () => chatRecountReady(conversationId)
-            )
-          }
-        }
-        const counted = (count: number, previousCount: number): void => {
-          verdict = { status: 'counted', count, previousCount }
-        }
+        // Every exit below goes through `defer` or `counted`; the `finally` publishes.
+        const ledger = recountLedger('chat', conversationId, () =>
+          chatRecountRetry.schedule(
+            conversationId,
+            allowActive,
+            (retryOptions) => get().recomputeUnreadForConversation(conversationId, retryOptions),
+            () => chatRecountReady(conversationId)
+          )
+        )
+        const { defer, counted } = ledger
         try {
         // Active conversation counts are usually reconciled by their own
         // synchronous path (the live-edge convergence) — skip here unless the
@@ -3015,8 +2986,7 @@ export const chatStore = createStore<ChatState>()(
           chatRecountsInFlight.finish(conversationId, recountToken)
         }
         } finally {
-          // Absent only when the body threw, which is not a verdict about anything.
-          if (verdict) reportRecountVerdict('chat', conversationId, verdict)
+          ledger.publish()
         }
       },
 
@@ -3089,16 +3059,8 @@ export const chatStore = createStore<ChatState>()(
         let archiveCommitGate: Promise<boolean> | undefined
         let durableMessages: Message[] = []
         // Diagnostics only. A holder rather than bare locals lets the set() callback
-        // write the counters without allocating a payload. `counted` stays false when
-        // the merge returns before reaching them.
-        const mergeDiagnostics: ArchiveMergeInputs & { counted: boolean } = {
-          counted: false,
-          returned: 0,
-          newMessages: 0,
-          persistableNew: 0,
-          patched: 0,
-          persistablePatched: 0,
-        }
+        // write the counters without allocating a payload.
+        const mergeDiagnostics = newArchiveMergeTally()
         let ownArchiveWrite: Promise<boolean> | undefined
         let coverageBootstrappedFromWalkExtent = false
         set((state) => {
@@ -3398,17 +3360,15 @@ export const chatStore = createStore<ChatState>()(
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
 
-        if (mergeDiagnostics.counted) {
-          reportArchiveMergeWhenDurable(
-            'chat',
-            conversationId,
-            direction,
-            complete,
-            mergeDiagnostics,
-            ownArchiveWrite,
-            archiveCommitGate
-          )
-        }
+        reportArchiveMergeWhenDurable(
+          'chat',
+          conversationId,
+          direction,
+          complete,
+          mergeDiagnostics,
+          ownArchiveWrite,
+          archiveCommitGate
+        )
 
         if (archiveCommitGate) {
           void archiveCommitGate.then((committed) => {

--- a/packages/fluux-sdk/src/stores/readStateGeneration.test.ts
+++ b/packages/fluux-sdk/src/stores/readStateGeneration.test.ts
@@ -7,8 +7,9 @@
  * one of them as the pointer moving backwards.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { chatStore, chatReadStateGeneration } from './chatStore'
-import { roomStore, roomReadStateGeneration } from './roomStore'
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+import { readStateGeneration } from './readStateGeneration'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 import { _resetForTesting as _resetThrottledStorageForTesting } from './shared/throttledStorage'
 import type { Conversation, Room } from '../core/types'
@@ -69,27 +70,27 @@ beforeEach(() => {
   _resetThrottledStorageForTesting()
 })
 
-describe('chatReadStateGeneration', () => {
+describe('readStateGeneration, chat', () => {
   it('reads zero for an entity the store has never seen', () => {
-    expect(chatReadStateGeneration('nobody@example.com').entity).toBe(0)
+    expect(readStateGeneration('chat', 'nobody@example.com').entity).toBe(0)
   })
 
   it('holds still across ordinary writes', () => {
     chatStore.getState().addConversation(conversation(CONV, 'Alice'))
-    const before = chatReadStateGeneration(CONV)
+    const before = readStateGeneration('chat', CONV)
 
     chatStore.getState().setActiveConversation(CONV)
     chatStore.getState().setActiveConversation(null)
 
-    expect(chatReadStateGeneration(CONV)).toEqual(before)
+    expect(readStateGeneration('chat', CONV)).toEqual(before)
   })
 
   it('bumps only the entity scope when a conversation is deleted', () => {
     chatStore.getState().addConversation(conversation(CONV, 'Alice'))
-    const before = chatReadStateGeneration(CONV)
+    const before = readStateGeneration('chat', CONV)
 
     chatStore.getState().deleteConversation(CONV)
-    const after = chatReadStateGeneration(CONV)
+    const after = readStateGeneration('chat', CONV)
 
     expect(after.entity).toBe(before.entity + 1)
     // A deleted conversation must not invalidate everything else's read state:
@@ -101,39 +102,55 @@ describe('chatReadStateGeneration', () => {
     const other = 'bob@example.com'
     chatStore.getState().addConversation(conversation(CONV, 'Alice'))
     chatStore.getState().addConversation(conversation(other, 'Bob'))
-    const before = chatReadStateGeneration(other)
+    const before = readStateGeneration('chat', other)
 
     chatStore.getState().deleteConversation(CONV)
 
-    expect(chatReadStateGeneration(other)).toEqual(before)
+    expect(readStateGeneration('chat', other)).toEqual(before)
   })
 
   it('bumps the store scope on reset', () => {
-    const before = chatReadStateGeneration(CONV)
+    const before = readStateGeneration('chat', CONV)
 
     chatStore.getState().reset()
 
-    expect(chatReadStateGeneration(CONV).store).toBe(before.store + 1)
+    expect(readStateGeneration('chat', CONV).store).toBe(before.store + 1)
   })
 })
 
-describe('roomReadStateGeneration', () => {
+describe('readStateGeneration, room', () => {
   it('bumps only the entity scope when a room is removed', () => {
     roomStore.getState().addRoom(room(ROOM))
-    const before = roomReadStateGeneration(ROOM)
+    const before = readStateGeneration('room', ROOM)
 
     roomStore.getState().removeRoom(ROOM)
-    const after = roomReadStateGeneration(ROOM)
+    const after = readStateGeneration('room', ROOM)
 
     expect(after.entity).toBe(before.entity + 1)
     expect(after.store).toBe(before.store)
   })
 
   it('bumps the store scope on reset', () => {
-    const before = roomReadStateGeneration(ROOM)
+    const before = readStateGeneration('room', ROOM)
 
     roomStore.getState().reset()
 
-    expect(roomReadStateGeneration(ROOM).store).toBe(before.store + 1)
+    expect(readStateGeneration('room', ROOM).store).toBe(before.store + 1)
+  })
+})
+
+describe('readStateGeneration routing', () => {
+  // The kind picks the store's counters. Reading the wrong store's would make a
+  // room's teardown look like a chat pointer regression, and vice versa.
+  it('reads each kind from its own store', () => {
+    chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+    roomStore.getState().addRoom(room(ROOM))
+    const chatBefore = readStateGeneration('chat', CONV)
+    const roomBefore = readStateGeneration('room', ROOM)
+
+    roomStore.getState().reset()
+
+    expect(readStateGeneration('room', ROOM).store).toBe(roomBefore.store + 1)
+    expect(readStateGeneration('chat', CONV)).toEqual(chatBefore)
   })
 })

--- a/packages/fluux-sdk/src/stores/readStateGeneration.ts
+++ b/packages/fluux-sdk/src/stores/readStateGeneration.ts
@@ -1,0 +1,37 @@
+/**
+ * The generation a conversation's read state belongs to, for either entity kind.
+ *
+ * Read state is forward-only WITHIN one generation: a cache wipe or an entity
+ * invalidation replaces a pointer wholesale, and a consumer caching anything derived
+ * from read state needs the pair to know what to discard. Both counters live in the
+ * store that owns them, because both are bumped by that store's own teardown paths.
+ *
+ * The two stores' readers are identical apart from which module-scope counters they
+ * name, so the kind is a parameter here rather than a second exported function —
+ * the same shape `readPointer` and `transientUnread` already use for the chat/room
+ * split.
+ *
+ * Unlike `conversationLens`, this resolves nothing: the caller says which kind it
+ * holds. It binds to both store modules, so it is a barrel export for consumers
+ * rather than something SDK-internal code reaches for after it already knows the
+ * kind's own reader.
+ *
+ * @module Stores/ReadStateGeneration
+ */
+import type { ReadStateGeneration } from '../core/types/readStateGeneration'
+import { chatReadStateGeneration } from './chatStore'
+import { roomReadStateGeneration } from './roomStore'
+
+/**
+ * The generation this entity's read state belongs to.
+ *
+ * Read it in the SAME turn as the pointer it describes. Both counters are plain
+ * reads, so a caller that samples them together cannot see a pointer from one
+ * generation carrying the number of another.
+ */
+export function readStateGeneration(
+  kind: 'chat' | 'room',
+  entityId: string
+): ReadStateGeneration {
+  return kind === 'room' ? roomReadStateGeneration(entityId) : chatReadStateGeneration(entityId)
+}

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -81,10 +81,7 @@ import {
   type PurgedMarkerKey,
 } from './shared/purgedMarkers'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
-import {
-  reportArchiveMergeWhenDurable,
-  type ArchiveMergeInputs,
-} from './shared/archiveMergeDiagnostics'
+import { newArchiveMergeTally, reportArchiveMergeWhenDurable } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
@@ -103,8 +100,8 @@ import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
-import { reportRecountVerdict, reportUnreadCleared } from './shared/recountDiagnostics'
-import type { RecountDeferralReason, UnreadRecountVerdict } from '../diagnostics/channel'
+import { countOnlyClear, recountLedger, reportUnreadCleared } from './shared/recountDiagnostics'
+import type { RecountDeferralReason } from '../diagnostics/channel'
 import { createRecountRetryScheduler } from './shared/recountRetry'
 import { createPendingEntityWrites } from './shared/pendingEntityWrites'
 import { schedule, flush as flushThrottledStorage } from './shared/throttledStorage'
@@ -473,8 +470,8 @@ function currentRoomEntityEpoch(roomJid: string): number {
 }
 
 /**
- * The generation this room's read state belongs to. See the chat twin; the
- * scopes and the sampling rule are identical.
+ * This store's half of `readStateGeneration`, which is what consumers call. Kept
+ * here because both counters are module scope, bumped by this store's own teardown.
  */
 export function roomReadStateGeneration(roomJid: string): ReadStateGeneration {
   return { store: roomCacheEpoch, entity: currentRoomEntityEpoch(roomJid) }
@@ -2612,26 +2609,16 @@ export const roomStore = createStore<RoomState>()(
 
   recomputeUnreadForRoom: async (roomJid, options) => {
     const allowActive = options?.allowActive ?? false
-    // EVERY exit funnels through `defer` or `counted`, and the verdict is published
-    // once in the `finally` below — after the store update, so a subscriber never
-    // reads a store halfway through committing. A new guard therefore cannot be
-    // added without naming a reason, and the commit cannot change without saying
-    // what it committed.
-    let verdict: UnreadRecountVerdict | undefined
-    const defer = (reason: RecountDeferralReason): void => {
-      verdict = { status: 'deferred', reason }
-      if (reason === 'input-version-changed') {
-        roomRecountRetry.schedule(
-          roomJid,
-          allowActive,
-          (retryOptions) => get().recomputeUnreadForRoom(roomJid, retryOptions),
-          () => roomRecountReady(roomJid)
-        )
-      }
-    }
-    const counted = (count: number, previousCount: number): void => {
-      verdict = { status: 'counted', count, previousCount }
-    }
+    // Every exit below goes through `defer` or `counted`; the `finally` publishes.
+    const ledger = recountLedger('room', roomJid, () =>
+      roomRecountRetry.schedule(
+        roomJid,
+        allowActive,
+        (retryOptions) => get().recomputeUnreadForRoom(roomJid, retryOptions),
+        () => roomRecountReady(roomJid)
+      )
+    )
+    const { defer, counted } = ledger
     try {
     // Active room counts are usually reconciled by their own synchronous path
     // (the live-edge convergence) — skip here unless the caller explicitly
@@ -2861,8 +2848,7 @@ export const roomStore = createStore<RoomState>()(
       roomRecountsInFlight.finish(roomJid, recountToken)
     }
     } finally {
-      // Absent only when the body threw, which is not a verdict about anything.
-      if (verdict) reportRecountVerdict('room', roomJid, verdict)
+      ledger.publish()
     }
   },
 
@@ -2900,20 +2886,7 @@ export const roomStore = createStore<RoomState>()(
       // Skip update if no change
       if (updated === notifInput) return {}
 
-      const readPositionStayed =
-        updated.readPointer && notifInput.readPointer
-          ? sameMessageRow(
-              pointerRowRef(updated.readPointer),
-              pointerRowRef(notifInput.readPointer),
-            )
-          : updated.readPointer === notifInput.readPointer
-      if (
-        notifInput.unreadCount > 0 &&
-        updated.unreadCount === 0 &&
-        readPositionStayed
-      ) {
-        clearedFrom = notifInput.unreadCount
-      }
+      clearedFrom = countOnlyClear(notifInput, updated)
 
       // The read pointer just moved (or the counts were cleared) — bound the
       // transient overlay's memory now rather than waiting for a later
@@ -4164,16 +4137,8 @@ export const roomStore = createStore<RoomState>()(
     let archiveCommitGate: Promise<boolean> | undefined
     let durableMessages: RoomMessage[] = []
     // Diagnostics only. A holder rather than bare locals lets the set() callback
-    // write the counters without allocating a payload. `counted` stays false when
-    // the merge returns before reaching them.
-    const mergeDiagnostics: ArchiveMergeInputs & { counted: boolean } = {
-      counted: false,
-      returned: 0,
-      newMessages: 0,
-      persistableNew: 0,
-      patched: 0,
-      persistablePatched: 0,
-    }
+    // write the counters without allocating a payload.
+    const mergeDiagnostics = newArchiveMergeTally()
     let ownArchiveWrite: Promise<boolean> | undefined
     let coverageBootstrappedFromWalkExtent = false
     set((state) => {
@@ -4470,17 +4435,15 @@ export const roomStore = createStore<RoomState>()(
       return { ...written, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
-    if (mergeDiagnostics.counted) {
-      reportArchiveMergeWhenDurable(
-        'room',
-        roomJid,
-        direction,
-        complete,
-        mergeDiagnostics,
-        ownArchiveWrite,
-        archiveCommitGate
-      )
-    }
+    reportArchiveMergeWhenDurable(
+      'room',
+      roomJid,
+      direction,
+      complete,
+      mergeDiagnostics,
+      ownArchiveWrite,
+      archiveCommitGate
+    )
 
     if (archiveCommitGate) {
       void archiveCommitGate.then((committed) => {

--- a/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/archiveMergeDiagnostics.ts
@@ -82,6 +82,29 @@ export function describeArchiveMerge(
 }
 
 /**
+ * A merge's counters plus whether the merge body reached them at all.
+ *
+ * The stores fill one of these as they merge, so the accumulator is created zeroed
+ * and `counted` is what a merge that bailed early leaves false.
+ */
+export interface ArchiveMergeTally extends ArchiveMergeInputs {
+  /** True once the merge counted its rows. A merge that bailed reports nothing. */
+  counted: boolean
+}
+
+/** A zeroed tally for a merge about to run. */
+export function newArchiveMergeTally(): ArchiveMergeTally {
+  return {
+    counted: false,
+    returned: 0,
+    newMessages: 0,
+    persistableNew: 0,
+    patched: 0,
+    persistablePatched: 0,
+  }
+}
+
+/**
  * Report a merge once its durable outcome is KNOWN, not when it is applied.
  *
  * A report written at merge time would claim a retention that can still fail, which
@@ -90,6 +113,9 @@ export function describeArchiveMerge(
  * covers every earlier in-flight page for the same entity. An absent promise means
  * that gate had nothing to wait for, which counts as committed.
  *
+ * A merge that never counted its rows reports nothing — there is no disposition to
+ * describe, and a zeroed record would claim a merge that did not happen.
+ *
  * Shared by both stores so the ordering rule cannot drift into one of them.
  */
 export function reportArchiveMergeWhenDurable(
@@ -97,10 +123,11 @@ export function reportArchiveMergeWhenDurable(
   entityId: string,
   direction: ArchiveMergeReport['direction'],
   complete: boolean,
-  inputs: ArchiveMergeInputs,
+  inputs: ArchiveMergeTally,
   ownWrite?: Promise<boolean>,
   chainGate?: Promise<boolean>
 ): void {
+  if (!inputs.counted) return
   publishDeferredDiagnostic('archive-merge', archiveMergeEvent, async () => {
     const attempted = inputs.persistableNew + inputs.persistablePatched > 0
     const [own, chained] = await Promise.all([ownWrite ?? true, chainGate ?? true])

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The two rules the chat and room recounts share.
+ *
+ * Both used to be stated inline in each store, which is why they could differ
+ * without anything failing. Tested here directly, without driving a store, so a
+ * change to either rule fails at the rule rather than in one entity's suite.
+ * `recountVerdict.test.ts` covers the same rules as the stores exercise them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { countOnlyClear, recountLedger } from './recountDiagnostics'
+import { makeReadPointer } from './readPointer'
+import { subscribeDiagnostics, type DiagnosticEvent } from '../../diagnostics/channel'
+import type { EntityNotificationState } from './notificationState'
+import type { ReadPointer } from '../../core/types/readState'
+
+const at = (id: string, extra: { occupantId?: string } = {}): ReadPointer =>
+  makeReadPointer(
+    { id, from: 'room@conf.example.com/nick', timestamp: new Date(1_000), ...extra },
+    'room'
+  )
+
+const state = (unreadCount: number, readPointer?: ReadPointer): EntityNotificationState => ({
+  unreadCount,
+  mentionsCount: 0,
+  readPointer,
+  firstNewMessageRow: undefined,
+})
+
+describe('countOnlyClear', () => {
+  it('reports the cleared badge when the read position held', () => {
+    const pointer = at('m1')
+    expect(countOnlyClear(state(3, pointer), state(0, pointer))).toBe(3)
+  })
+
+  it('stays silent when the pointer advanced with the clear', () => {
+    expect(countOnlyClear(state(3, at('m1')), state(0, at('m2')))).toBeUndefined()
+  })
+
+  it('stays silent when the badge was already zero', () => {
+    const pointer = at('m1')
+    expect(countOnlyClear(state(0, pointer), state(0, pointer))).toBeUndefined()
+  })
+
+  it('reports a pointerless entity whose badge cleared', () => {
+    expect(countOnlyClear(state(2, undefined), state(0, undefined))).toBe(2)
+  })
+
+  it('stays silent when a pointerless entity gained a position', () => {
+    expect(countOnlyClear(state(2, undefined), state(0, at('m1')))).toBeUndefined()
+  })
+
+  // Row identity, not the client message id: a reused MUC nick puts two rows under
+  // one id, so comparing ids alone would call a real advance a count-only clear.
+  it('treats two occupants sharing a message id as different rows', () => {
+    const before = at('m1', { occupantId: 'occ-a' })
+    const after = at('m1', { occupantId: 'occ-b' })
+    expect(countOnlyClear(state(3, before), state(0, after))).toBeUndefined()
+  })
+
+  it('treats the same occupant re-derived as the same row', () => {
+    const before = at('m1', { occupantId: 'occ-a' })
+    const after = at('m1', { occupantId: 'occ-a' })
+    expect(countOnlyClear(state(3, before), state(0, after))).toBe(3)
+  })
+})
+
+describe('recountLedger', () => {
+  let seen: DiagnosticEvent[]
+  let unsubscribe: () => void
+
+  beforeEach(() => {
+    seen = []
+    unsubscribe = subscribeDiagnostics((event) => seen.push(event), { kinds: ['unread-recount'] })
+  })
+  afterEach(() => unsubscribe())
+
+  it('publishes nothing until asked', () => {
+    const ledger = recountLedger('chat', 'alice@example.com', vi.fn())
+    ledger.counted(4, 9)
+    expect(seen).toEqual([])
+  })
+
+  it('publishes the last verdict once', () => {
+    const ledger = recountLedger('chat', 'alice@example.com', vi.fn())
+    ledger.defer('no-meta')
+    ledger.counted(4, 9)
+    ledger.publish()
+
+    expect(seen).toEqual([
+      {
+        kind: 'unread-recount',
+        entityKind: 'chat',
+        entityId: 'alice@example.com',
+        verdict: { status: 'counted', count: 4, previousCount: 9 },
+      },
+    ])
+  })
+
+  it('publishes nothing when the body reached no verdict', () => {
+    recountLedger('room', 'team@conf.example.com', vi.fn()).publish()
+    expect(seen).toEqual([])
+  })
+
+  it('names the entity kind it was built for', () => {
+    const ledger = recountLedger('room', 'team@conf.example.com', vi.fn())
+    ledger.defer('coverage-missing')
+    ledger.publish()
+
+    expect(seen).toEqual([
+      {
+        kind: 'unread-recount',
+        entityKind: 'room',
+        entityId: 'team@conf.example.com',
+        verdict: { status: 'deferred', reason: 'coverage-missing' },
+      },
+    ])
+  })
+
+  it('queues the trailing retry only for an input change', () => {
+    const scheduleRetry = vi.fn()
+    const ledger = recountLedger('chat', 'alice@example.com', scheduleRetry)
+
+    ledger.defer('coverage-missing')
+    expect(scheduleRetry).not.toHaveBeenCalled()
+
+    ledger.defer('input-version-changed')
+    expect(scheduleRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
+++ b/packages/fluux-sdk/src/stores/shared/recountDiagnostics.ts
@@ -12,12 +12,19 @@
  * naming a reason, and a commit cannot be added without reporting the count.
  *
  * `diagnostics/channel.ts` declares the payload, the reason vocabulary, and which of
- * the recount's side effects deliberately stay private. This module only publishes.
+ * the recount's side effects deliberately stay private. This module holds the rules
+ * the two stores would otherwise each restate: the one-verdict ledger, what counts as
+ * a count-only clear, and the publication itself. Chat and room differ only in the
+ * entity kind they name, so the kind is a parameter.
  *
  * @module Stores/Shared/RecountDiagnostics
  */
+import { sameMessageRow } from '../../utils/messageIdentity'
+import type { EntityNotificationState } from './notificationState'
+import { pointerRowRef } from './readPointer'
 import {
   publishDiagnostic,
+  type RecountDeferralReason,
   type RecountEntityKind,
   type UnreadClearedDiagnostic,
   type UnreadRecountDiagnostic,
@@ -78,3 +85,79 @@ const unreadClearedEvent = (source: UnreadClearedSource): UnreadClearedDiagnosti
   entityId: source.entityId,
   previousCount: source.previousCount,
 })
+
+/**
+ * The ledger one recount invocation writes its single verdict into.
+ *
+ * A recount is a chain of about twenty guards, most of which stand down. What makes
+ * the verdict trustworthy is that EVERY exit goes through {@link RecountLedger.defer}
+ * or {@link RecountLedger.counted} and the result is published once — so a new guard
+ * cannot be added without naming a reason, and the commit cannot change without
+ * saying what it committed. Holding that rule here rather than in each store is what
+ * keeps the two recounts from drifting into two different rules.
+ *
+ * `scheduleRetry` stays with the caller: the bounded trailing retry an
+ * `input-version-changed` deferral earns is driven by the store's own retry state and
+ * readiness predicate, which the ledger has no business knowing.
+ */
+export interface RecountLedger {
+  /** Stand down, naming the guard. Queues the trailing retry on an input change. */
+  defer(reason: RecountDeferralReason): void
+  /** Commit a count, paired with the badge it replaced in the same `set` turn. */
+  counted(count: number, previousCount: number): void
+  /**
+   * Publish the verdict the body produced.
+   *
+   * Call it from the recount's outermost `finally`, AFTER the store update: a
+   * subscriber reached mid-update would read a store halfway through committing.
+   * Nothing is published when the body threw, which is not a verdict about anything.
+   */
+  publish(): void
+}
+
+export function recountLedger(
+  entityKind: RecountEntityKind,
+  entityId: string,
+  scheduleRetry: () => void
+): RecountLedger {
+  let verdict: UnreadRecountVerdict | undefined
+  return {
+    defer(reason) {
+      verdict = { status: 'deferred', reason }
+      if (reason === 'input-version-changed') scheduleRetry()
+    },
+    counted(count, previousCount) {
+      verdict = { status: 'counted', count, previousCount }
+    },
+    publish() {
+      if (verdict) reportRecountVerdict(entityKind, entityId, verdict)
+    },
+  }
+}
+
+/**
+ * The badge value a count-only mark-read cleared, or `undefined` when this was not
+ * one.
+ *
+ * A count-only clear is a nonzero badge going to zero while the read position stays
+ * put: above the live edge `markAsRead` cannot know which message the reader reached,
+ * so it deliberately preserves the pointer (#1076). Row identity decides whether the
+ * position moved, not the client message id — a reused MUC nick puts two rows under
+ * one id.
+ *
+ * Pure, so it can be evaluated inside the store's `set` callback where both states
+ * are in hand while {@link reportUnreadCleared} publishes after the update.
+ */
+export function countOnlyClear(
+  before: EntityNotificationState,
+  after: EntityNotificationState
+): number | undefined {
+  const readPositionStayed =
+    after.readPointer && before.readPointer
+      ? sameMessageRow(pointerRowRef(after.readPointer), pointerRowRef(before.readPointer))
+      : after.readPointer === before.readPointer
+  if (before.unreadCount > 0 && after.unreadCount === 0 && readPositionStayed) {
+    return before.unreadCount
+  }
+  return undefined
+}


### PR DESCRIPTION
Third and last of the three changes proposed in #1353: chat/room twins where the
codebase already has an answer.

## What was actually left

The issue proposed one `unreadDiagnostic(kind, id)` and one merge reporter in
`stores/shared/`. Both already existed before this branch: #1355 moved them there, and
#1372 then deleted the pull-based unread diagnostic outright. So the literal proposal
was already delivered, and what remained were twins one level up — the scaffolding each
store wrapped around those shared reporters.

The issue's claim that more than half is identical once the vocabulary is normalised
held for that remainder. Normalising `conversationId`/`roomJid`, the retry schedulers
and the recompute names, the four sites diff clean:

| Twin | Result |
| --- | --- |
| Recount verdict ledger (21 lines) | identical |
| `markAsRead` count-only-clear (19 lines) | identical but for the kind literal |
| Merge tally and report guard (19 lines) | identical but for kind and id |
| `chatReadStateGeneration` / `roomReadStateGeneration` | identical but for the module-scope counters each reads |

## The collapse

- `recountLedger(kind, id, scheduleRetry)` holds the one-verdict-per-invocation rule:
  every exit names a reason or a count, and the recount's outermost `finally` publishes
  once, after the store update. The store keeps only the retry it queues on an input
  change, since that is driven by its own retry state and readiness predicate.
- `countOnlyClear(before, after)` decides what a count-only mark-read is — a nonzero
  badge going to zero with the read position held. Row identity decides whether the
  position moved, not the client message id: a reused MUC nick puts two rows under one
  id.
- `newArchiveMergeTally()` replaces the zeroed accumulator each store declared, and
  `reportArchiveMergeWhenDurable` now owns the "a merge that never counted reports
  nothing" guard instead of each caller repeating it.
- `readStateGeneration(kind, id)` replaces the exported pair. Each store keeps its own
  reader, because both counters are module scope bumped by that store's teardown, but
  the pair is no longer the public surface.

The kind is a parameter and the store-owned work is a callback — the shape
`readPointer`, `transientUnread` and `messageTimeline.mergeArchive` already use.

## What was left alone, and why

The recounts' own gate chains. Their differences are not vocabulary: chat compares the
pointer by `identity.messageId` where room compares it by object reference, and the two
commit into different state shapes (`draftConversationMaps` versus `roomMeta` plus
`rooms`). Folding them would change behaviour rather than shape, so they stay. They also
predate stage 5 and sit outside the issue's claim.

The outbound path is untouched — the only change to `diagnostics/channel.ts` is a
comment. `bench:seam` reports an unsubscribed dispatch at 5.3 ns/stanza against a 5.21
baseline, inside a measured run-to-run band of 5.29–5.47, so the figure is flat rather
than proven unchanged. The kind-aware subscriber check added in #1372 survives: a
subscriber for another kind still costs the same as none, rather than the 269 ns a real
subscriber costs.

Net in the two stores: 134 lines removed, 57 added.

Closes #1353.
