### PR TITLE
feat(anomaly): detect a scrollport shrink nothing gives back

### DIFF
--- a/apps/fluux/src/anomaly/detectors/scrollportShrinkUnreconciled.test.ts
+++ b/apps/fluux/src/anomaly/detectors/scrollportShrinkUnreconciled.test.ts
@@ -1,0 +1,235 @@
+/**
+ * `scroll/scrollport-shrink-unreconciled` — the scrollport lost height under a reader at
+ * the live edge and nothing gave it back.
+ *
+ * The control question for every case here: could a healthy session produce it? A
+ * detector that reports supported behaviour is deleted rather than tuned, so the
+ * exclusions get more cases than the positive does — a reader who was already scrolled
+ * up, a shrink with nothing to reconcile, a decline that was correct, a reader who leaves
+ * during the hold, a window still being dragged, a frozen WebView.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createScrollportShrinkUnreconciledDetector,
+  type ScrollportShrank,
+  type ShrinkSample,
+} from './scrollportShrinkUnreconciled'
+
+const CID = 'carol@example.com'
+const SCOPE = 'me@example.com'
+/** `BOTTOM_PIN_TOLERANCE` as the resize hook reports it. */
+const TOLERANCE = 4
+/** The typing band: `pt-2` 8 + a one-line pill 30 + `pb-0.5` 2. */
+const BAND_PX = 40
+
+const sample = (over: Partial<ShrinkSample> = {}): ShrinkSample => ({
+  active: { kind: 'conversation', id: CID },
+  distFromBottom: BAND_PX,
+  scrollHeight: 1_000,
+  windowAtLiveEdge: true,
+  scopeKey: SCOPE,
+  ...over,
+})
+
+const shrank = (over: Partial<ScrollportShrank> = {}): ScrollportShrank => ({
+  conversationId: CID,
+  shrunkPx: BAND_PX,
+  distFromBottom: BAND_PX,
+  scrollHeight: 1_000,
+  repin: 'ran',
+  tolerancePx: TOLERANCE,
+  ...over,
+})
+
+describe('createScrollportShrinkUnreconciledDetector', () => {
+  it('reports a shortfall the band opened and nothing closed', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+
+    expect(d.observe(sample(), 1500)).toBeNull() // inside the hold window
+    expect(d.observe(sample(), 2100)).toEqual({
+      distFromBottom: BAND_PX,
+      shrunkPx: BAND_PX,
+      repin: 'ran',
+      heldMs: 1100,
+    })
+  })
+
+  it('carries whether the positioning controller refused the re-pin', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ repin: 'refused' }), SCOPE, 1000)
+    expect(d.observe(sample(), 2100)?.repin).toBe('refused')
+  })
+
+  it('keeps the shrink shortfall when a sent row grows beneath it', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+
+    expect(
+      d.observe(sample({ distFromBottom: BAND_PX + 30, scrollHeight: 1_030 }), 2100),
+    ).toEqual({
+      distFromBottom: BAND_PX,
+      shrunkPx: BAND_PX,
+      repin: 'ran',
+      heldMs: 1100,
+    })
+  })
+
+  it('reports at most once per episode', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample(), 2100)).not.toBeNull()
+    expect(d.observe(sample(), 3100)).toBeNull()
+  })
+
+  it('stays silent with nothing armed', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    expect(d.observe(sample(), 2100)).toBeNull()
+  })
+
+  // ── Supported behaviour that must stay silent ──────────────────────────────────
+
+  // The reader chose to be up there. The band takes its 40px from a viewport that was
+  // already 600px from the bottom, and none of that shortfall is the band's doing.
+  it('never arms for a reader who had already scrolled up', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ distFromBottom: 640, repin: null }), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 640 }), 2100)).toBeNull()
+  })
+
+  // The arming guard on its own, isolated from the guard in `observe`: a reader who was
+  // already up when the band mounted, and who then scrolls back to WITHIN the band's
+  // height of the bottom. Every later reading fits what the shrink would account for, so
+  // only refusing to arm in the first place keeps this silent — and it must be silent,
+  // because where they stopped is where they chose to stop.
+  it('never arms for a reader who was up and then returns to near the bottom', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ distFromBottom: 640, repin: null }), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: BAND_PX }), 1500)).toBeNull()
+    expect(d.observe(sample({ distFromBottom: BAND_PX }), 2600)).toBeNull()
+  })
+
+  // Right at the boundary: one pixel more than the shrink accounts for is already
+  // somebody else's shortfall.
+  it('never arms one pixel past what the shrink accounts for', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ distFromBottom: BAND_PX + TOLERANCE + 1 }), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: BAND_PX + TOLERANCE + 1 }), 2100)).toBeNull()
+  })
+
+  it('arms exactly at the boundary the shrink does account for', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ distFromBottom: BAND_PX + TOLERANCE }), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: BAND_PX }), 2100)).not.toBeNull()
+  })
+
+  // The hook declines here too, and it is right to: there is no shortfall to close.
+  it('never arms when the shrink left nothing to reconcile', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ distFromBottom: TOLERANCE, repin: null }), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: TOLERANCE }), 2100)).toBeNull()
+  })
+
+  // The correction arrived. This is the whole point of the re-pin, and by far the most
+  // common outcome — if this case ever reported, the detector would fire constantly.
+  it('disarms when the view comes back to the bottom', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 0 }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2600)).toBeNull()
+  })
+
+  // `live-edge-pin-short` documents that it cannot tell this apart. Here it can: a reader
+  // who leaves is further away than the shrink explains.
+  it('disarms when the reader scrolls away during the hold', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 900 }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2600)).toBeNull()
+  })
+
+  it('disarms on reader movement even when content also grew', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: 130, scrollHeight: 1_030 }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2600)).toBeNull()
+  })
+
+  // A window being dragged smaller delivers a stream of shrinks. Each re-arms with fresh
+  // geometry, so the clock restarts instead of a drag accumulating a hold.
+  it('restarts the clock on every further shrink', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample(), 1800)).toBeNull()
+    d.noteShrank(shrank(), SCOPE, 1900)
+    expect(d.observe(sample(), 2400)).toBeNull() // 500ms into the NEW episode
+    expect(d.observe(sample(), 3100)).not.toBeNull()
+  })
+
+  // A later shrink that lands on a reader who has since moved away also clears whatever
+  // was armed: the older reading is no longer what the reader is looking at.
+  it('drops an armed episode when a later shrink finds the reader elsewhere', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    d.noteShrank(shrank({ distFromBottom: 900, repin: null }), SCOPE, 1100)
+    expect(d.observe(sample(), 2600)).toBeNull()
+  })
+
+  // The rest of the family's shared guard: with the loaded window slid up, the bottom of
+  // what is loaded is not the live edge.
+  it('disarms when the loaded window is not at the live edge', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ windowAtLiveEdge: false }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  it('disarms when the reader moved to another conversation', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(
+      d.observe(sample({ active: { kind: 'conversation', id: 'dave@example.com' } }), 2100),
+    ).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  it('disarms when no conversation is open', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ active: null }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  it('disarms when the store was rebuilt underneath', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ scopeKey: 'other@example.com' }), 2100)).toBeNull()
+    expect(d.observe(sample(), 3200)).toBeNull()
+  })
+
+  // A frozen WebView resumes with a huge apparent hold. Reporting it would turn a
+  // suspension into a fabricated defect.
+  it('disarms rather than report across a sampling gap', () => {
+    const d = createScrollportShrinkUnreconciledDetector({ maxSampleGapMs: 5000 })
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample(), 1500)).toBeNull()
+    expect(d.observe(sample(), 90_000)).toBeNull()
+    expect(d.observe(sample(), 91_000)).toBeNull()
+  })
+
+  it('keeps the episode armed while the distance cannot be measured', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank(), SCOPE, 1000)
+    expect(d.observe(sample({ distFromBottom: null }), 1500)).toBeNull()
+    expect(d.observe(sample(), 2100)?.heldMs).toBe(1100)
+  })
+
+  // A two-line label costs less than a full band. The bound travels with the fact, so the
+  // detector judges each shrink against its own size rather than a constant of its own.
+  it('scales the accounted-for shortfall with the shrink it was given', () => {
+    const d = createScrollportShrinkUnreconciledDetector()
+    d.noteShrank(shrank({ shrunkPx: 16, distFromBottom: 16 }), SCOPE, 1000)
+    // 40px was fine for a 40px band; against a 16px one it is somebody else's.
+    expect(d.observe(sample({ distFromBottom: 40 }), 2100)).toBeNull()
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/scrollportShrinkUnreconciled.ts
+++ b/apps/fluux/src/anomaly/detectors/scrollportShrinkUnreconciled.ts
@@ -1,0 +1,239 @@
+/**
+ * `scroll/scrollport-shrink-unreconciled` — the scrollport lost height under a reader who
+ * was at the live edge, and the distance it opened was still there.
+ *
+ * This is the one direction with no engine backstop. A browser clamps `scrollTop` only
+ * DOWNWARD, so growing the scrollport is self-correcting while shrinking it is not: the
+ * reader is left exactly the lost height short of the bottom, and nothing — no later
+ * render, no repaint, no peer who stopped typing — moves them back. Only the app's own
+ * re-pin does, or the reader scrolling. The typing band mounting is this case, and so is
+ * the composer growing to a second line.
+ *
+ * `live-edge-pin-short` cannot see it. That detector arms on a pin run that reaches
+ * `settled` while short, and the failure here is that **no run happens at all**: no loop,
+ * no write, no settle. The family's silence about a correction that never started is what
+ * this detector exists to break.
+ *
+ * Two halves, the same division `live-edge-pin-short` makes:
+ *
+ * - The resize hook reports a FACT it has already measured — how much height the
+ *   scrollport lost, the distance that left, and whether its re-pin ran. It adds no
+ *   judgement.
+ * - This detector holds the CONFIRMATION, because a single frame short of the bottom is
+ *   ordinary: the re-pin is a frame away, the commit is a frame behind the DOM. The
+ *   shortfall must still be there when the tick looks again.
+ *
+ * WHAT IT MUST NOT FIRE ON. A detector that reports supported behaviour is deleted rather
+ * than tuned, so the exclusions are structural rather than tuned thresholds:
+ *
+ * - **A reader who deliberately scrolled up.** Their distance is not explained by this
+ *   shrink. Arming requires the whole shortfall to fit inside `shrunkPx + tolerancePx`,
+ *   so a reader parked anywhere further up never arms, whatever the band does.
+ * - **A shrink with nothing to reconcile.** A reader already inside the tolerance arms
+ *   nothing: there is no shortfall to report.
+ * - **A correction the hook legitimately did not request.** Both reasons are the two
+ *   cases above, and such an observation cannot arm a confirmable episode.
+ * - **A reader who leaves during the hold.** The confirmation measures the distance to
+ *   the content bottom captured at the shrink, so appended content cannot masquerade as
+ *   reader movement. Only movement away from that original bottom drops the episode.
+ * - **A resize still in progress.** Every shrink re-arms with fresh geometry, so a window
+ *   being dragged smaller keeps resetting the clock instead of accumulating a hold.
+ * - **A frozen WebView.** A sample gap larger than the tick's own budget abandons the
+ *   episode rather than reporting a suspension as a defect.
+ *
+ * What remains, and why the severity is `suspect`: a reader who scrolls DOWN during the
+ * hold window and stops just short of the bottom is indistinguishable from a shortfall
+ * that persisted. `observed` is therefore always the distance measured AT THE SHRINK.
+ *
+ * PURE: every input is passed in, including the clock. The detector retains only the
+ * current episode.
+ *
+ * @module Anomaly/Detectors/ScrollportShrinkUnreconciled
+ */
+
+/** What the resize hook already knows when the scrollport loses height. */
+export interface ScrollportShrank {
+  conversationId: string
+  /** Height the scrollport lost. */
+  shrunkPx: number
+  /** Distance to the content bottom, after the shrink and before any re-pin. */
+  distFromBottom: number
+  /** Content height at the shrink, used to isolate later content growth. */
+  scrollHeight: number
+  /** Whether the requested re-pin ran, was refused, or was not needed. */
+  repin: 'ran' | 'refused' | null
+  /** The hook's own at-bottom tolerance, so the detector never invents one. */
+  tolerancePx: number
+}
+
+/** Everything the confirmation depends on, sampled at one instant. */
+export interface ShrinkSample {
+  /** Active conversation, or null when none is open. */
+  active: { kind: 'conversation' | 'room'; id: string } | null
+  /** Independently measured distance to the content bottom, or null when unmeasurable. */
+  distFromBottom: number | null
+  /** Independently measured content height, or null when unmeasurable. */
+  scrollHeight: number | null
+  /**
+   * Is the loaded message window at the tail of the archive.
+   *
+   * Required for the same reason the rest of the family requires it: with the window slid
+   * up, the bottom of what is loaded is not the live edge, so sitting away from it is not
+   * a failed correction.
+   */
+  windowAtLiveEdge: boolean
+  /** Account / storage scope. A change means the store was rebuilt under us. */
+  scopeKey: string
+}
+
+export interface ShrinkVerdict {
+  /** The shortfall measured AT THE SHRINK, never a later drift the reader caused. */
+  distFromBottom: number
+  /** Height the scrollport lost, so a reader can see the shortfall is the band's. */
+  shrunkPx: number
+  /** Whether the positioning controller accepted or refused the re-pin. */
+  repin: 'ran' | 'refused'
+  heldMs: number
+}
+
+export interface ScrollportShrinkUnreconciledDetector {
+  /**
+   * The scrollport shrank. Arms an episode only when the shortfall it left is both real
+   * and explained by this shrink.
+   *
+   * `scopeKey` is supplied by the caller in the anomaly layer, not by the hook: the hook
+   * ships in release builds and has no business reading a store, and the scope has to be
+   * pinned at ARMING so an account switch between the shrink and the confirmation voids
+   * the episode instead of confirming it against a rebuilt store.
+   */
+  noteShrank(fact: ScrollportShrank, scopeKey: string, now: number): void
+  /** At most one verdict per episode. */
+  observe(sample: ShrinkSample, now: number): ShrinkVerdict | null
+}
+
+/**
+ * How long the shortfall must survive.
+ *
+ * Matches `live-edge-pin-short` and `fab-at-live-edge`: during a normal correction a
+ * fresh measurement and the position the loop is about to write legitimately disagree for
+ * a few frames.
+ */
+const DEFAULT_HOLD_MS = 1000
+
+/** Largest observed interval that still counts as continuous sampling. */
+const DEFAULT_MAX_SAMPLE_GAP_MS = 5000
+
+export interface ScrollportShrinkUnreconciledOptions {
+  holdMs?: number
+  maxSampleGapMs?: number
+}
+
+interface Episode {
+  entityId: string
+  scopeKey: string
+  at: number
+  distFromBottom: number
+  scrollHeight: number
+  shrunkPx: number
+  repin: 'ran' | 'refused'
+  tolerancePx: number
+  lastSeenAt: number
+}
+
+export function createScrollportShrinkUnreconciledDetector(
+  opts: ScrollportShrinkUnreconciledOptions = {},
+): ScrollportShrinkUnreconciledDetector {
+  const holdMs = opts.holdMs ?? DEFAULT_HOLD_MS
+  const maxSampleGapMs = opts.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS
+
+  let episode: Episode | null = null
+
+  /** Is `distance` a shortfall this shrink alone accounts for. */
+  function explainedByShrink(distance: number, shrunkPx: number, tolerancePx: number): boolean {
+    return distance > tolerancePx && distance <= shrunkPx + tolerancePx
+  }
+
+  return {
+    noteShrank(fact: ScrollportShrank, scopeKey: string, now: number): void {
+      if (
+        fact.repin === null ||
+        !explainedByShrink(fact.distFromBottom, fact.shrunkPx, fact.tolerancePx)
+      ) {
+        // Either nothing to reconcile, or a reader who was already elsewhere. Drop any
+        // episode in flight too: this shrink re-measured the same viewport, and the older
+        // reading is no longer what the reader is looking at.
+        episode = null
+        return
+      }
+      episode = {
+        entityId: fact.conversationId,
+        scopeKey,
+        at: now,
+        distFromBottom: fact.distFromBottom,
+        scrollHeight: fact.scrollHeight,
+        shrunkPx: fact.shrunkPx,
+        repin: fact.repin,
+        tolerancePx: fact.tolerancePx,
+        lastSeenAt: now,
+      }
+    },
+
+    observe(sample: ShrinkSample, now: number): ShrinkVerdict | null {
+      const current = episode
+      if (!current) return null
+
+      // A frozen WebView resumes with a huge apparent hold. Reporting it would turn a
+      // suspension into a fabricated defect, so the episode is abandoned instead.
+      const gap = now - current.lastSeenAt
+      if (!Number.isFinite(gap) || gap < 0 || gap > maxSampleGapMs) {
+        episode = null
+        return null
+      }
+      current.lastSeenAt = now
+
+      if (current.scopeKey !== sample.scopeKey) {
+        episode = null
+        return null
+      }
+
+      if (!sample.active || sample.active.id !== current.entityId) {
+        episode = null
+        return null
+      }
+      if (!sample.windowAtLiveEdge) {
+        episode = null
+        return null
+      }
+
+      // Unmeasurable is not evidence either way — an unmounted list, a view we do not
+      // track. Keep waiting rather than guess in either direction.
+      if (sample.distFromBottom === null || sample.scrollHeight === null) return null
+
+      const contentGrowth = sample.scrollHeight - current.scrollHeight
+      const shrinkDistance = sample.distFromBottom - contentGrowth
+
+      // Recovered: something re-pinned, which is the whole point of the correction.
+      if (shrinkDistance <= current.tolerancePx) {
+        episode = null
+        return null
+      }
+      // The reader moved further away than this shrink can account for, so whatever is
+      // being measured now is no longer the shrink's doing.
+      if (shrinkDistance > current.shrunkPx + current.tolerancePx) {
+        episode = null
+        return null
+      }
+
+      const heldMs = now - current.at
+      if (heldMs < holdMs) return null
+
+      episode = null
+      return {
+        distFromBottom: current.distFromBottom,
+        shrunkPx: current.shrunkPx,
+        repin: current.repin,
+        heldMs,
+      }
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
@@ -214,6 +214,13 @@ describe('every fan-out record survives the privacy gate', () => {
       peakUnread: 21,
     },
     { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
+    {
+      name: 'scroll/scrollport-shrink-unreconciled',
+      distFromBottom: 40,
+      shrunkPx: 40,
+      repin: 'ran',
+      heldMs: 1000,
+    },
     { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'msg-1' },
   ]
 
@@ -436,6 +443,43 @@ describe('stage-3 detector mappings', () => {
     expect(record?.ctx?.map(([k, v]) => [k.s, v])).toEqual([['heldMs', 1000]])
   })
 
+  it('maps an unreconciled scrollport shrink to the shortfall it opened', () => {
+    const record = recordForSignal({
+      name: 'scroll/scrollport-shrink-unreconciled',
+      distFromBottom: 40,
+      shrunkPx: 40,
+      repin: 'ran',
+      heldMs: 1000,
+    })
+
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(0)
+    expect(record?.observed).toBe(40)
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['heldMs', 'shrunkPx', 'repin'])
+    expect(record?.ctx?.find(([k]) => k.s === 'shrunkPx')?.[1]).toBe(40)
+  })
+
+  it('distinguishes an accepted re-pin from one the controller refused', () => {
+    const ran = recordForSignal({
+      name: 'scroll/scrollport-shrink-unreconciled',
+      distFromBottom: 40,
+      shrunkPx: 40,
+      repin: 'ran',
+      heldMs: 1000,
+    })
+    const refused = recordForSignal({
+      name: 'scroll/scrollport-shrink-unreconciled',
+      distFromBottom: 40,
+      shrunkPx: 40,
+      repin: 'refused',
+      heldMs: 1000,
+    })
+    const tagOf = (r: typeof ran) =>
+      (r?.ctx?.find(([k]) => k.s === 'repin')?.[1] as { s: string }).s
+    expect(tagOf(ran)).toBe('repin:ran')
+    expect(tagOf(refused)).toBe('repin:refused')
+  })
+
   it('maps a jump-target miss with a message ref and a signed distance', () => {
     const record = recordForSignal({
       name: 'scroll/jump-target-miss',
@@ -505,6 +549,13 @@ describe('FANOUT_IDS', () => {
           },
           { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
           { name: 'scroll/live-edge-pin-short', distFromBottom: 420, heldMs: 1000 },
+          {
+            name: 'scroll/scrollport-shrink-unreconciled',
+            distFromBottom: 40,
+            shrunkPx: 40,
+            repin: 'ran',
+            heldMs: 1000,
+          },
           { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'm' },
         ] as AnomalySignal[]
       ).map((s) => recordForSignal(s)!.id.s),

--- a/apps/fluux/src/anomaly/detectors/signalRecords.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.ts
@@ -228,6 +228,24 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
         ctx: [[CTX.heldMs, signal.heldMs]],
       }
 
+    case 'scroll/scrollport-shrink-unreconciled':
+      // `expected: 0` reads as "nothing left between the reader and the newest message
+      // once the scrollport had finished shrinking". `observed` is the shortfall the
+      // shrink opened; `ctx.shrunkPx` is what it cost, so a reader can see the two are
+      // the same number. `ctx.repin` is the half the rest of the family loses: whether
+      // the positioning controller accepted or refused the correction.
+      return {
+        id: ID.scrollportShrinkUnreconciled,
+        sev: 'suspect',
+        expected: 0,
+        observed: signal.distFromBottom,
+        ctx: [
+          [CTX.heldMs, signal.heldMs],
+          [CTX.shrunkPx, signal.shrunkPx],
+          [CTX.repin, signal.repin === 'ran' ? TAG.repinRan : TAG.repinRefused],
+        ],
+      }
+
     case 'scroll/jump-target-miss': {
       // A session-local ref, not a token: a message id is seen once, so hashing it
       // into the cross-session space would fill the cache with singletons and
@@ -272,6 +290,7 @@ export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
   ID.unreadFocusCleared,
   ID.fabAtLiveEdge,
   ID.liveEdgePinShort,
+  ID.scrollportShrinkUnreconciled,
   ID.jumpTargetMiss,
 ])
 

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -47,6 +47,12 @@ function world(overrides: Partial<TickWorld> = {}): TickWorld {
     fabShown: () => true,
     windowAtLiveEdge: () => true,
     distFromBottom: () => 10,
+    viewportMetrics: () => ({
+      distFromBottom: 10,
+      scrollHeight: 1_000,
+      scrollTop: 490,
+      clientHeight: 500,
+    }),
     now: () => (clock += 1000),
     ...overrides,
   }
@@ -568,6 +574,122 @@ describe('live-edge pin shortfall, end to end through the seams', () => {
       const record = recordForSignal(h.shortfalls()[0])
       expect(record?.id.s).toBe('scroll/live-edge-pin-short')
       expect(record?.observed).toBe(420)
+    } finally {
+      h.stop()
+    }
+  })
+})
+
+/**
+ * The wiring for the other half of the silence.
+ *
+ * `scrollportShrinkUnreconciled.test.ts` covers what the detector decides. What is proved
+ * here is that a shrink measured by the release-shipped resize hook reaches it through
+ * the same seam the pin settle uses, and that the two detectors stay independent — the
+ * shrink observation must not arm the pin detector, or one id would report the other's
+ * failure.
+ */
+describe('scrollport shrink, end to end through the seams', () => {
+  function shrinkHarness(distFromBottom: number, scrollHeight = 1_000) {
+    let clock = 0
+    const tick = startDetectorTick(
+      world({
+        now: () => clock,
+        distFromBottom: () => distFromBottom,
+        viewportMetrics: () => ({
+          distFromBottom,
+          scrollHeight,
+          scrollTop: scrollHeight - distFromBottom - 500,
+          clientHeight: 500,
+        }),
+        fabShown: () => false,
+      }),
+    )
+    setAnomalyObservationHandler((observation) => tick.observeRaw(observation))
+    return {
+      tick,
+      at: (ms: number) => {
+        clock = ms
+      },
+      shrink: (repin: 'ran' | 'refused' | null = 'ran') =>
+        observeAnomaly({
+          kind: 'scrollport-shrank',
+          conversationId: ACTIVE.id,
+          shrunkPx: 40,
+          distFromBottom: 40,
+          scrollHeight: 1_000,
+          repin,
+          tolerancePx: 4,
+        }),
+      unreconciled: () =>
+        seen.filter((s) => s.name === 'scroll/scrollport-shrink-unreconciled'),
+      shortfalls: () => seen.filter((s) => s.name === 'scroll/live-edge-pin-short'),
+      stop: () => {
+        clearAnomalyObservationHandler()
+        tick.stop()
+      },
+    }
+  }
+
+  it('carries a confirmed shortfall from the resize hook to a signal', () => {
+    const h = shrinkHarness(40)
+    try {
+      h.shrink()
+
+      h.at(500)
+      h.tick.sample()
+      expect(h.unreconciled()).toEqual([])
+
+      h.at(1200)
+      h.tick.sample()
+      expect(h.unreconciled()).toEqual([
+        {
+          name: 'scroll/scrollport-shrink-unreconciled',
+          distFromBottom: 40,
+          shrunkPx: 40,
+          repin: 'ran',
+          heldMs: 1200,
+        },
+      ])
+    } finally {
+      h.stop()
+    }
+  })
+
+  it('stays silent when the re-pin brought the view back', () => {
+    const h = shrinkHarness(0)
+    try {
+      h.shrink()
+      h.at(1200)
+      h.tick.sample()
+      expect(h.unreconciled()).toEqual([])
+    } finally {
+      h.stop()
+    }
+  })
+
+  it('does not arm the pin-short detector', () => {
+    const h = shrinkHarness(40)
+    try {
+      h.shrink()
+      h.at(1200)
+      h.tick.sample()
+      expect(h.shortfalls()).toEqual([])
+    } finally {
+      h.stop()
+    }
+  })
+
+  it('produces a record the registry accepts', () => {
+    const h = shrinkHarness(40)
+    try {
+      h.shrink('refused')
+      h.at(1200)
+      h.tick.sample()
+      const record = recordForSignal(h.unreconciled()[0])
+      expect(record?.id.s).toBe('scroll/scrollport-shrink-unreconciled')
+      expect(record?.observed).toBe(40)
+      expect(record?.ctx?.find(([k]) => k.s === 'repin')).toBeDefined()
     } finally {
       h.stop()
     }

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -1,9 +1,10 @@
 /**
  * The sampling clock for the timed detectors.
  *
- * `unread-survives-focus` and `fab-at-live-edge` both ask whether something held
- * CONTINUOUSLY, so both need a clock rather than an event. One interval drives both;
- * `jump-target-miss` is event-driven and does not appear here.
+ * `unread-survives-focus`, `fab-at-live-edge`, `live-edge-pin-short` and
+ * `scrollport-shrink-unreconciled` all ask whether something held CONTINUOUSLY, so each
+ * needs a clock rather than an event. One interval drives them all; `jump-target-miss` is
+ * event-driven and does not appear here.
  *
  * Sampling is deliberately shallow: read the world, hand it to pure functions, forward
  * whatever they return. No decision lives in this file, so a wrong verdict is always a
@@ -21,11 +22,12 @@
 import { signalAnomaly } from '../../utils/anomalySignal'
 import type { AnomalyObservation } from '../../utils/anomalyObservation'
 import { isViewportAtBottom, type ViewportKind } from '../../utils/viewportAtBottom'
-import { measureViewport } from '../../utils/viewportScroller'
+import { measureViewport, type ViewportMetrics } from '../../utils/viewportScroller'
 import { isTokenizerReady } from '../values'
 import { warmConversation, warmRoom } from '../identity'
 import { createFabAtLiveEdgeDetector } from './fabAtLiveEdge'
 import { createLiveEdgePinShortDetector } from './liveEdgePinShort'
+import { createScrollportShrinkUnreconciledDetector } from './scrollportShrinkUnreconciled'
 import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
 
 /** How often the world is sampled. */
@@ -68,6 +70,8 @@ export interface TickWorld {
   windowAtLiveEdge(kind: ViewportKind, id: string): boolean
   /** Independently measured distance to the content bottom, or null. */
   distFromBottom(kind: ViewportKind, id: string): number | null
+  /** Independently measured viewport geometry, or null. */
+  viewportMetrics(kind: ViewportKind, id: string): ViewportMetrics | null
   now(): number
   /**
    * Called once per sample, before any detector runs.
@@ -107,6 +111,7 @@ export function browserWorld(
         (fab) => fab.closest('[inert]') === null,
       ),
     distFromBottom: (kind, id) => measureViewport(kind, id)?.distFromBottom ?? null,
+    viewportMetrics: (kind, id) => measureViewport(kind, id),
     now: () => Date.now(),
   }
 }
@@ -142,6 +147,9 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
   })
   const fab = createFabAtLiveEdgeDetector()
   const pinShort = createLiveEdgePinShortDetector({
+    maxSampleGapMs: intervalMs * MAX_SAMPLE_GAP_TICKS,
+  })
+  const shrink = createScrollportShrinkUnreconciledDetector({
     maxSampleGapMs: intervalMs * MAX_SAMPLE_GAP_TICKS,
   })
 
@@ -292,22 +300,59 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
         heldMs: pinShortVerdict.heldMs,
       })
     }
+
+    const shrinkMetrics = active ? world.viewportMetrics(active.kind, active.id) : null
+    const shrinkVerdict = shrink.observe(
+      {
+        active,
+        distFromBottom: shrinkMetrics?.distFromBottom ?? null,
+        scrollHeight: shrinkMetrics?.scrollHeight ?? null,
+        windowAtLiveEdge: active ? world.windowAtLiveEdge(active.kind, active.id) : false,
+        scopeKey: world.scopeKey(),
+      },
+      now,
+    )
+    if (shrinkVerdict) {
+      signalAnomaly({
+        name: 'scroll/scrollport-shrink-unreconciled',
+        distFromBottom: shrinkVerdict.distFromBottom,
+        shrunkPx: shrinkVerdict.shrunkPx,
+        repin: shrinkVerdict.repin,
+        heldMs: shrinkVerdict.heldMs,
+      })
+    }
   }
 
   const id = setInterval(sample, intervalMs)
   return {
     sample,
     observeRaw: (observation) => {
-      if (observation.kind !== 'live-edge-pin-settled') return
-      pinShort.noteSettledShort(
-        {
-          conversationId: observation.conversationId,
-          distFromBottom: observation.distFromBottom,
-          thresholdPx: observation.thresholdPx,
-        },
-        world.scopeKey(),
-        world.now(),
-      )
+      if (observation.kind === 'live-edge-pin-settled') {
+        pinShort.noteSettledShort(
+          {
+            conversationId: observation.conversationId,
+            distFromBottom: observation.distFromBottom,
+            thresholdPx: observation.thresholdPx,
+          },
+          world.scopeKey(),
+          world.now(),
+        )
+        return
+      }
+      if (observation.kind === 'scrollport-shrank') {
+        shrink.noteShrank(
+          {
+            conversationId: observation.conversationId,
+            shrunkPx: observation.shrunkPx,
+            distFromBottom: observation.distFromBottom,
+            scrollHeight: observation.scrollHeight,
+            repin: observation.repin,
+            tolerancePx: observation.tolerancePx,
+          },
+          world.scopeKey(),
+          world.now(),
+        )
+      }
     },
     warmSettled: () => pendingWarm,
     stop: () => clearInterval(id),

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -134,6 +134,10 @@ export const TAG = Object.freeze({
   qMam: mint('q:mam', 'tag'),
   qRoster: mint('q:roster', 'tag'),
   qOther: mint('q:other', 'tag'),
+  // Whether the positioning controller accepted the shrink reconciliation. Two
+  // constants rather than a boolean, for the reason every other label here is one.
+  repinRan: mint('repin:ran', 'tag'),
+  repinRefused: mint('repin:refused', 'tag'),
 })
 
 /**
@@ -177,6 +181,7 @@ export const ID = Object.freeze({
   unreadFocusCleared: mint('read-state/unread-focus-cleared', 'id'),
   fabAtLiveEdge: mint('scroll/fab-at-live-edge', 'id'),
   liveEdgePinShort: mint('scroll/live-edge-pin-short', 'id'),
+  scrollportShrinkUnreconciled: mint('scroll/scrollport-shrink-unreconciled', 'id'),
   jumpTargetMiss: mint('scroll/jump-target-miss', 'id'),
   redundantQuery: mint('xmpp-traffic/redundant-query', 'id'),
   iqUnanswered: mint('xmpp-traffic/iq-unanswered', 'id'),
@@ -211,6 +216,10 @@ export const CTX = Object.freeze({
   returned: mint('returned', 'ctx'),
   /** How far back a read pointer moved, in milliseconds. */
   behindMs: mint('behindMs', 'ctx'),
+  /** Height a scrollport lost in one resize, in px. */
+  shrunkPx: mint('shrunkPx', 'ctx'),
+  /** Whether a reconciliation was asked for — a TAG constant, never a raw trigger. */
+  repin: mint('repin', 'ctx'),
 })
 
 /**

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -937,9 +937,8 @@ export function useMessageListScroll({
     ports: {
       getScroller: () => scrollerRef.current,
       isAtBottom: () => isAtBottomRef.current,
-      reconcileLiveEdge: (trigger, rearmEligibleFromGeometry) => {
-        reconcileLiveEdgeRef.current(trigger, rearmEligibleFromGeometry)
-      },
+      reconcileLiveEdge: (trigger, rearmEligibleFromGeometry) =>
+        reconcileLiveEdgeRef.current(trigger, rearmEligibleFromGeometry),
     },
     conversationId,
     staticMode,

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.test.ts
@@ -1,6 +1,11 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  clearAnomalyObservationHandler,
+  setAnomalyObservationHandler,
+  type AnomalyObservation,
+} from '@/utils/anomalyObservation'
+import {
   useViewportResizeReconciliation,
   type ViewportResizeReconciliationPorts,
 } from './useViewportResizeReconciliation'
@@ -107,7 +112,7 @@ function scrollerHarness() {
 function mount(staticMode = false) {
   const scroller = scrollerHarness()
   const state = { atBottom: true }
-  const reconcileLiveEdge = vi.fn()
+  const reconcileLiveEdge = vi.fn(() => true)
   const ports: ViewportResizeReconciliationPorts = {
     getScroller: () => scroller.element,
     isAtBottom: () => state.atBottom,
@@ -165,6 +170,113 @@ describe('useViewportResizeReconciliation', () => {
     flushFrames()
     expect(scope.reconcileLiveEdge).toHaveBeenCalledOnce()
     expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink', true)
+  })
+
+  /**
+   * The shrink direction has no engine backstop — a browser clamps `scrollTop` only
+   * downward — so a re-pin that never runs leaves the reader short until they scroll.
+   * `scroll/live-edge-pin-short` cannot see that, because it needs a run that reached
+   * `settled`. These prove the fact leaves the hook at all: a control that never
+   * registered a handler would keep the whole path unproven.
+   */
+  describe('shrink observations', () => {
+    let observed: AnomalyObservation[]
+
+    beforeEach(() => {
+      observed = []
+      setAnomalyObservationHandler((observation) => observed.push(observation))
+    })
+
+    afterEach(() => {
+      clearAnomalyObservationHandler()
+    })
+
+    const shrinks = () => observed.filter((o) => o.kind === 'scrollport-shrank')
+
+    it('reports the shrink it reconciled, with what it cost', () => {
+      const scope = mount()
+      observers[0].fire(600, 800)
+      flushFrames()
+
+      scope.scroller.geometry.clientHeight = 560
+      scope.scroller.geometry.scrollTop = 400
+      observers[0].fire(560, 800)
+      flushFrames()
+
+      expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink', true)
+      expect(shrinks()).toEqual([
+        {
+          kind: 'scrollport-shrank',
+          conversationId: 'room-a',
+          shrunkPx: 40,
+          distFromBottom: 40,
+          scrollHeight: 1000,
+          repin: 'ran',
+          tolerancePx: 4,
+        },
+      ])
+    })
+
+    it('reports when the positioning controller refuses the re-pin', () => {
+      const scope = mount()
+      scope.reconcileLiveEdge.mockReturnValue(false)
+      observers[0].fire(600, 800)
+      flushFrames()
+
+      scope.scroller.geometry.clientHeight = 560
+      scope.scroller.geometry.scrollTop = 400
+      observers[0].fire(560, 800)
+      flushFrames()
+
+      expect(scope.reconcileLiveEdge).toHaveBeenCalledWith('container-shrink', true)
+      expect(shrinks()).toEqual([
+        {
+          kind: 'scrollport-shrank',
+          conversationId: 'room-a',
+          shrunkPx: 40,
+          distFromBottom: 40,
+          scrollHeight: 1000,
+          repin: 'refused',
+          tolerancePx: 4,
+        },
+      ])
+    })
+
+    it('reports when no re-pin was needed', () => {
+      const scope = mount()
+      observers[0].fire(600, 800)
+      flushFrames()
+
+      scope.scroller.geometry.clientHeight = 560
+      scope.scroller.geometry.scrollTop = 0
+      observers[0].fire(560, 800)
+      flushFrames()
+
+      expect(scope.reconcileLiveEdge).not.toHaveBeenCalled()
+      expect(shrinks()).toEqual([
+        {
+          kind: 'scrollport-shrank',
+          conversationId: 'room-a',
+          shrunkPx: 40,
+          distFromBottom: 440,
+          scrollHeight: 1000,
+          repin: null,
+          tolerancePx: 4,
+        },
+      ])
+    })
+
+    it('says nothing about a growth', () => {
+      const scope = mount()
+      observers[0].fire(600, 800)
+      flushFrames()
+
+      scope.scroller.geometry.clientHeight = 640
+      observers[0].fire(640, 800)
+      flushFrames()
+
+      expect(shrinks()).toEqual([])
+    })
   })
 
   it('reconciles a container growth that left the view short of the bottom', () => {

--- a/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
+++ b/apps/fluux/src/components/conversation/useViewportResizeReconciliation.ts
@@ -9,6 +9,7 @@
 import { useEffect, useRef } from 'react'
 import { AT_BOTTOM_THRESHOLD } from '@/utils/scrollStateManager'
 import { signalAnomaly } from '@/utils/anomalySignal'
+import { hasAnomalyObservationHandler, observeAnomaly } from '@/utils/anomalyObservation'
 import { BOTTOM_PIN_TOLERANCE } from './liveEdgeBrowserAdapter'
 import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
 
@@ -24,7 +25,7 @@ export interface ViewportResizeReconciliationPorts {
   reconcileLiveEdge: (
     trigger: ViewportResizeReconciliationTrigger,
     rearmEligibleFromGeometry: boolean,
-  ) => void
+  ) => boolean
 }
 
 export interface UseViewportResizeReconciliationInput {
@@ -95,10 +96,30 @@ export function useViewportResizeReconciliation({
       const liveScroller = active.getScroller()
       const shrunk = lastHeight - newHeight
       if (shrunk > 0 && liveScroller) {
-        const distance = distanceFromBottom(liveScroller)
+        const scrollHeight = liveScroller.scrollHeight
+        const distance = scrollHeight - liveScroller.scrollTop - liveScroller.clientHeight
         const wasNear = distance <= shrunk + AT_BOTTOM_THRESHOLD
-        if (wasNear && distance > BOTTOM_PIN_TOLERANCE) {
-          active.reconcileLiveEdge('container-shrink', wasNear)
+        const shouldRepin = wasNear && distance > BOTTOM_PIN_TOLERANCE
+        const repin = shouldRepin
+          ? active.reconcileLiveEdge('container-shrink', wasNear)
+            ? 'ran'
+            : 'refused'
+          : null
+        // Reported as the measurement it already is, never as a verdict: one frame short
+        // of the bottom after a shrink is ordinary, and only a clock can tell that from a
+        // shortfall nothing came back for. Unlike a pin settling short, this direction has
+        // no run to report itself — in the failing case none starts — so the fact has to
+        // cross here. Reuses `distance` and `shrunk`, adding no layout read.
+        if (hasAnomalyObservationHandler()) {
+          observeAnomaly({
+            kind: 'scrollport-shrank',
+            conversationId,
+            shrunkPx: shrunk,
+            distFromBottom: distance,
+            scrollHeight,
+            repin,
+            tolerancePx: BOTTOM_PIN_TOLERANCE,
+          })
         }
       } else if (
         newWidth !== null &&

--- a/apps/fluux/src/utils/anomalyObservation.ts
+++ b/apps/fluux/src/utils/anomalyObservation.ts
@@ -10,6 +10,10 @@
  * still animating, a commit a frame behind the DOM. Only a dev-only detector holding a
  * clock can tell that apart, so what crosses here is the measurement, not a claim.
  *
+ * A scrollport losing height is the same shape: the resize hook measures the loss and
+ * the distance it left behind, and only a clock can tell a frame of settling from a
+ * shortfall nothing came back for.
+ *
  * Same inversion and same cost as the verdict seam: the executor ships in release
  * builds and must never import anything under `src/anomaly/`, so this module holds a
  * nullable handler that the anomaly runtime installs into. In a release build nothing
@@ -22,17 +26,41 @@
  * One measured fact, as its source measured it.
  *
  * Thresholds travel WITH the fact rather than being restated on the anomaly side: the
- * executor owns what "at the bottom" means, and a detector inventing its own number
- * would judge the executor against a rule the executor does not follow.
+ * source owns what "at the bottom" means, and a detector inventing its own number
+ * would judge it against a rule it does not follow.
  */
-export type AnomalyObservation = {
-  kind: 'live-edge-pin-settled'
-  conversationId: string
-  /** Distance still remaining when the run reached `settled`. */
-  distFromBottom: number
-  /** The executor's own at-bottom threshold. */
-  thresholdPx: number
-}
+export type AnomalyObservation =
+  | {
+      kind: 'live-edge-pin-settled'
+      conversationId: string
+      /** Distance still remaining when the run reached `settled`. */
+      distFromBottom: number
+      /** The executor's own at-bottom threshold. */
+      thresholdPx: number
+    }
+  | {
+      /**
+       * The scrollport lost height — the typing band mounting or wrapping, the composer
+       * growing, the window shrinking.
+       *
+       * This direction has no engine backstop: the browser's clamp only ever LOWERS
+       * `scrollTop`, so a reader who was at the live edge is left exactly this far short
+       * of it and stays there until the app re-pins or the reader scrolls. A settle
+       * cannot report it because in the failing case no run starts at all.
+       */
+      kind: 'scrollport-shrank'
+      conversationId: string
+      /** Height the scrollport lost in this resize. */
+      shrunkPx: number
+      /** Distance to the content bottom, measured after the shrink and before any re-pin. */
+      distFromBottom: number
+      /** Content height at the shrink, used to isolate later content growth. */
+      scrollHeight: number
+      /** Whether the requested re-pin ran, was refused, or was not needed. */
+      repin: 'ran' | 'refused' | null
+      /** The hook's own at-bottom tolerance, so the detector never invents one. */
+      tolerancePx: number
+    }
 
 export type AnomalyObservationHandler = (observation: AnomalyObservation) => void
 

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -113,6 +113,17 @@ export type AnomalySignal =
       heldMs: number
     }
   | {
+      name: 'scroll/scrollport-shrink-unreconciled'
+      /** The shortfall as the shrink measured it, not a later drift. */
+      distFromBottom: number
+      /** Height the scrollport lost, so the shortfall can be attributed to it. */
+      shrunkPx: number
+      /** Whether the positioning controller accepted or refused the re-pin. */
+      repin: 'ran' | 'refused'
+      /** How long it was still there when the tick confirmed it. */
+      heldMs: number
+    }
+  | {
       name: 'scroll/jump-target-miss'
       /** Signed px outside the viewport: negative above, positive below. */
       offBy: number

--- a/apps/fluux/src/utils/viewportScroller.test.ts
+++ b/apps/fluux/src/utils/viewportScroller.test.ts
@@ -32,6 +32,7 @@ describe('viewportScroller', () => {
 
     expect(measureViewport('conversation', 'a@x.tld')).toEqual({
       distFromBottom: 100,
+      scrollHeight: 1000,
       scrollTop: 400,
       clientHeight: 500,
     })

--- a/apps/fluux/src/utils/viewportScroller.ts
+++ b/apps/fluux/src/utils/viewportScroller.ts
@@ -55,6 +55,7 @@ export function registerViewportScroller(
 export interface ViewportMetrics {
   /** Pixels between the viewport bottom and the content bottom. */
   distFromBottom: number
+  scrollHeight: number
   scrollTop: number
   clientHeight: number
 }
@@ -70,10 +71,14 @@ export interface ViewportMetrics {
 export function measureViewport(kind: ViewportKind, id: string): ViewportMetrics | null {
   const element = scrollers.get(key(kind, id))?.current
   if (!element || !element.isConnected) return null
+  const scrollHeight = element.scrollHeight
+  const scrollTop = element.scrollTop
+  const clientHeight = element.clientHeight
   return {
-    distFromBottom: element.scrollHeight - element.scrollTop - element.clientHeight,
-    scrollTop: element.scrollTop,
-    clientHeight: element.clientHeight,
+    distFromBottom: scrollHeight - scrollTop - clientHeight,
+    scrollHeight,
+    scrollTop,
+    clientHeight,
   }
 }
 

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -272,12 +272,13 @@ could not be recorded (overlapping loop labels, the conversation, the scrollHeig
 | `scroll/resize-loop` | suspect | The message-list `ResizeObserver` fired `observed` times in `ctx.elapsedMs` (`expected` is the threshold per window) | Oscillating content (classically a `<video controls>` on WebKitGTK) driving a correction feedback loop. Not itself a failure; a sustained one is   |
 | `scroll/slow-correction` | suspect | A scroll correction took `observed` ms (`expected` is the threshold), with `ctx.rows` rows rendered | Reflow cost scaling with the rendered backlog. Correlate with `ctx.rows`: a high count means virtualization is not engaged |
 
-These two are genuine detectors rather than fan-out, so they have **no** matching
+These are genuine detectors rather than fan-out, so they have **no** matching
 `console.warn`:
 
 | id | sev | Meaning | What to do |
 |---|---|---|---|
 | `scroll/live-edge-pin-short` | suspect | A live-edge pin run reported itself `settled` while the viewport was still `observed` px beyond the executor's own at-bottom threshold, and it was **still** there `ctx.heldMs` later | A correction that was asked for and did not arrive. Classically a resident row that grew in place — a reaction, a link preview, a decrypted attachment, a correction, a retraction — whose growth nothing absorbed. `rowGrowthDecision.ts` skips the re-pin when a pin loop already claims the bottom, on the bet that the running loop absorbs it, and that skip is final. The `PIN completed` and `[PinLoopProbe]` lines in `fluux.log` carry the trigger |
+| `scroll/scrollport-shrink-unreconciled` | suspect | The scrollport lost `ctx.shrunkPx` px of height under a reader who was at the live edge — the typing band mounting or wrapping, the composer growing, the window shrinking — and `observed` px of the shortfall it opened was **still** there `ctx.heldMs` later. `ctx.repin` says whether the positioning controller accepted the reconciliation | The one direction with no engine backstop: a browser clamps `scrollTop` only downward, so growing the scrollport is self-correcting and shrinking it is not. `repin:refused` means no run started; `repin:ran` means an accepted run landed short. Later content growth is removed from the confirmation distance, so a sent row cannot hide a surviving shrink shortfall |
 | `scroll/fab-at-live-edge` | bug | The scroll-to-bottom button was shown for `ctx.heldMs` while an independent measurement put the viewport `observed` px from the content bottom, already at the newest message  | Stale `showScrollToBottom` React state: the scroll handler stopped firing after the list returned to the bottom. Not a fault in `shouldShowScrollToBottomFab`, which cannot produce this state |
 | `scroll/jump-target-miss` | bug | A go-to-message reported that it applied a position, but the target row landed `ctx.offBy` px outside the viewport, negative above, positive below  | The anchor resolved to the wrong offset, or content grew after the jump settled. `ctx.msg` is the session-local ref for the target |
 
@@ -294,10 +295,9 @@ These two are genuine detectors rather than fan-out, so they have **no** matchin
 - `fab-at-live-edge` measures through `utils/viewportScroller.ts`, deliberately not the
   scroll hook's own at-bottom state, a detector reading the suspect value cannot
   disagree with it, and would go silent exactly when the bug is present.
-- `live-edge-pin-short` is the family's only detector of a correction that did **not**
-  happen. The other five all need pathological activity, or an action that completed and
-  landed wrong; a growth nothing absorbs produces no loop, no write, no resize and no
-  slow frame, so it was invisible to all of them.
+- `live-edge-pin-short` and `scrollport-shrink-unreconciled` cover quiet, persistent
+  shortfalls without requiring pathological activity. The former needs a pin run that
+  settled short; the latter arms on the shrink itself and does not require a run.
 - `live-edge-pin-short` takes its threshold FROM the executor rather than declaring one.
   A detector judging the pin against a number the pin does not use would report a
   disagreement about the rule instead of a failure to follow it.
@@ -310,6 +310,26 @@ These two are genuine detectors rather than fan-out, so they have **no** matchin
   from a shortfall that persisted, so its `observed` is the distance measured AT THE
   SETTLE and never the later one. The confirmation is a noise filter, not the claim.
   Reported as `suspect` for that reason.
+- `scrollport-shrink-unreconciled` is the OTHER half of that silence: `live-edge-pin-short`
+  needs a run that reached `settled`, while this detector arms before that outcome. It can
+  therefore see both a refused request with no run and an accepted request whose shrink
+  shortfall survives. Neither subsumes the other.
+- `scrollport-shrink-unreconciled` never arms for a reader who had already scrolled up.
+  Arming requires the whole shortfall to fit inside `ctx.shrunkPx` plus the hook's own
+  at-bottom tolerance, so a reader parked further up is excluded by geometry rather than
+  by a tuned threshold — whatever the band does afterwards.
+- It never arms when the shrink left nothing to reconcile. In that case, or when the
+  reader was already further up, `ctx.repin` is null and no confirmable episode exists.
+  A controller refusal is different: the hook did request a re-pin, the detector can arm,
+  and `ctx.repin` records `repin:refused` if the shortfall survives.
+- It drops the episode when the reader scrolls away during the hold, because leaving puts
+  them further off than the shrink accounts for. This is the half `live-edge-pin-short`
+  documents that it cannot do.
+- Every further shrink re-arms with fresh geometry, so a window being dragged smaller
+  keeps restarting the clock instead of accumulating a hold.
+- What remains, and why it is `suspect` rather than `bug`: a reader who scrolls DOWN
+  during the hold and stops just short of the bottom is indistinguishable from a shortfall
+  that persisted. `observed` is therefore always the distance measured AT THE SHRINK.
 
 ### `perf/`
 

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -299,6 +299,7 @@ test.describe('anomaly runtime', () => {
         'read-state/unread-survives-focus',
         'scroll/fab-at-live-edge',
         'scroll/live-edge-pin-short',
+        'scroll/scrollport-shrink-unreconciled',
         'scroll/jump-target-miss',
         'xmpp-traffic/redundant-query',
         'xmpp-traffic/iq-unanswered',
@@ -637,6 +638,224 @@ test.describe('anomaly runtime', () => {
     // observation rather than a single lucky sample.
     expect(ctx.heldMs).toBeGreaterThanOrEqual(2000)
     expect(record.tokenKeyId).toMatch(/^[0-9a-f]{8}$/)
+  })
+
+  /** Park the live message list at its bottom and report whether it can scroll at all. */
+  async function settleAtBottom(page: Page): Promise<{ scrollable: boolean; clientHeight: number }> {
+    const geometry = await page.evaluate(() => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!scroller) return { scrollable: false, clientHeight: 0 }
+      scroller.scrollTop = scroller.scrollHeight
+      return {
+        scrollable: scroller.scrollHeight > scroller.clientHeight + 80,
+        clientHeight: Math.round(scroller.clientHeight),
+      }
+    })
+    await page.waitForTimeout(600)
+    return geometry
+  }
+
+  /** Raise the typing band on the open room, and wait for it to be laid out. */
+  async function raiseTypingBand(page: Page): Promise<void> {
+    await page.evaluate((jid) => {
+      const scope = window as unknown as {
+        __demoClient: { emitSDK(name: string, payload: unknown): void }
+      }
+      scope.__demoClient.emitSDK('room:typing', { roomJid: jid, nick: 'Ada', isTyping: true })
+    }, DEMO_ROOM_JID)
+    await page.waitForFunction(
+      () => {
+        const pill = document.querySelector('[data-typing-pill]') as HTMLElement | null
+        if (!pill) return false
+        const rect = pill.getBoundingClientRect()
+        return rect.width > 0 && rect.height > 0
+      },
+      undefined,
+      { timeout: 10_000 },
+    )
+  }
+
+  const shrinkRecords = (page: Page) =>
+    page.evaluate(() =>
+      (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .filter((record) => record.id === 'scroll/scrollport-shrink-unreconciled'),
+    )
+
+  /**
+   * The anti-false-positive control for `scrollport-shrink-unreconciled`, at system level.
+   *
+   * The detector's own suite proves it stays quiet on synthetic healthy input, and the
+   * healthy-session control above proves nothing fires on a session that never shrinks the
+   * scrollport. Neither covers the case this detector is actually about: a band that DOES
+   * mount, take height, and get reconciled. This project deletes a detector that reports
+   * supported behaviour rather than tuning it, so the ordinary case needs its own test.
+   */
+  test('a typing band the app reconciles trips no shrink record', async ({ page }) => {
+    await driveFocusRegainInPage(page)
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    await openDemoRoom(page)
+    const before = await settleAtBottom(page)
+    expect(before.scrollable, 'the demo room must be scrollable, or this control is vacuous').toBe(true)
+
+    await raiseTypingBand(page)
+    await page.waitForTimeout(3000) // past the 1s hold, with margin
+
+    const after = await page.evaluate(() => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLElement
+      return {
+        clientHeight: Math.round(scroller.clientHeight),
+        distFromBottom: Math.round(
+          scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
+        ),
+      }
+    })
+
+    // Guard the guard: a band that took no height would leave nothing to reconcile, and
+    // the silence below would mean nothing.
+    expect(
+      before.clientHeight - after.clientHeight,
+      'the typing band took no height from the scrollport — the control is vacuous',
+    ).toBeGreaterThan(10)
+    // And the app DID reconcile it, which is why the detector is right to stay quiet.
+    expect(after.distFromBottom, 'the app did not hold the bottom under the band').toBeLessThanOrEqual(4)
+
+    expect(
+      await shrinkRecords(page),
+      'the shrink detector fired on a band the app reconciled — it would be deleted, not tuned',
+    ).toEqual([])
+  })
+
+  /**
+   * The same band, with the one thing that separates the healthy case from the reported
+   * one removed: the re-pin cannot land.
+   *
+   * `scrollTop` writes are swallowed on the live scroller — the same shape as the badge
+   * test pinning `unreadCount`, and for the same reason. Every other layer stays real: the
+   * resize hook measures its own shrink, the observation seam carries it, the tick holds
+   * the clock, and the recorder and serializer produce the line. A scrollport shrink is
+   * the one direction a browser never clamps back, so with the write swallowed the
+   * shortfall simply stays, which is exactly the field failure.
+   */
+  test('sending while a scrollport shrink is stuck reaches the anomaly log', async ({ page }) => {
+    await driveFocusRegainInPage(page)
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    await openDemoRoom(page)
+    const before = await settleAtBottom(page)
+    expect(before.scrollable, 'the demo room must be scrollable, or this test is vacuous').toBe(true)
+
+    // Swallow the writes, exactly as the badge test swallows the app's unread clear:
+    // assigning to a getter-only property would throw in strict mode and take the app
+    // down instead of the correction.
+    const frozen = await page.evaluate(() => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!scroller) return false
+      // `scrollTop` is defined on Element.prototype, several links up from a div.
+      let proto: object | null = Object.getPrototypeOf(scroller) as object | null
+      let descriptor: PropertyDescriptor | undefined
+      while (proto && !descriptor) {
+        descriptor = Object.getOwnPropertyDescriptor(proto, 'scrollTop')
+        proto = Object.getPrototypeOf(proto) as object | null
+      }
+      if (!descriptor?.get) return false
+      const read = descriptor.get
+      const frozenTop = read.call(scroller) as number
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => frozenTop,
+        set: () => {},
+      })
+      // The virtualized path does not assign `scrollTop`: it re-windows through
+      // `scrollToIndex`, which calls `scrollTo`. Swallowing only the property would leave
+      // the correction free to land and the fault uninjected.
+      Object.defineProperty(scroller, 'scrollTo', { configurable: true, value: () => {} })
+      Object.defineProperty(scroller, 'scrollBy', { configurable: true, value: () => {} })
+      return true
+    })
+    expect(frozen, 'could not swallow scrollTop writes — the fault was never injected').toBe(true)
+
+    await raiseTypingBand(page)
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    )
+    expect(
+      await shrinkRecords(page),
+      'the shrink confirmed before the send-during-typing sequence could run',
+    ).toEqual([])
+
+    const sent = await page.evaluate(async (jid) => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLElement
+      const client = (window as unknown as {
+        __demoClient: { messages: { sendMessage(to: string, body: string): Promise<string> } }
+      }).__demoClient
+      const scrollHeight = scroller.scrollHeight
+      const id = await client.messages.sendMessage(jid, 'sent while Ada is typing')
+      return { id, scrollHeight }
+    }, DEMO_ROOM_JID)
+    await page.waitForSelector(`[data-message-id="${sent.id}"]`, { timeout: 10_000 })
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const scroller = document.querySelector('[data-message-list]') as HTMLElement
+            return scroller.scrollHeight
+          }),
+        { message: 'the sent row did not grow the message content' },
+      )
+      .toBeGreaterThan(sent.scrollHeight)
+
+    await expect
+      .poll(async () => (await shrinkRecords(page)).length, {
+        timeout: 20_000,
+        message:
+          'a scrollport shrink nothing gave back never reached the anomaly log — the seam is blind',
+      })
+      .toBeGreaterThan(0)
+
+    const record = (await shrinkRecords(page))[0]
+    expect(record).toMatchObject({
+      kind: 'anomaly',
+      id: 'scroll/scrollport-shrink-unreconciled',
+      sev: 'suspect',
+      expected: 0,
+    })
+    // The band's height, not an arbitrary number: the shortfall IS what the band took.
+    expect(record.observed as number).toBeGreaterThan(10)
+
+    const ctx = record.ctx as { heldMs?: number; shrunkPx?: number; repin?: string }
+    expect(ctx.shrunkPx).toBe(record.observed)
+    // Past the 1s hold by construction — a sustained observation, not one lucky sample.
+    expect(ctx.heldMs).toBeGreaterThanOrEqual(1000)
+    expect(ctx.repin).toBe('repin:ran')
   })
 
   /**

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2798,6 +2798,104 @@ test.describe('Typing indicator never covers message text', () => {
     expect(probe.worstOverlap, `grown pill covers ${probe.worstRowId}`).toBe(0)
   })
 
+  /**
+   * The demo server echoes EVERY groupchat stanza back as a message, including the
+   * body-less chat states the composer sends while you type. A real MUC creates no row
+   * for those, so without this the case below measures against two phantom empty rows
+   * appended around the send and the sent row is never the tail. Dropped at the transport
+   * seam, the same way the echo already skips reaction stanzas.
+   */
+  async function suppressChatStateEcho(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = (window as any).__demoClient
+      if (!client) throw new Error('no __demoClient')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const original = Object.getPrototypeOf(client).beginStanzaSend as (s: any) => Promise<void>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client.beginStanzaSend = async function (stanza: any) {
+        const groupchat = stanza?.name === 'message' && stanza?.attrs?.type === 'groupchat'
+        if (groupchat && !stanza?.getChildText?.('body')) return
+        return original.call(this, stanza)
+      }
+    })
+  }
+
+  // The gesture the suite had no case for: SENDING while the band is up. The reported
+  // defect is that the sent message ends up under the pill, which has two possible
+  // shapes — the pill being a list item the message is inserted after (DOM order), or the
+  // bottom never being reconciled so the message renders where the pill sits (layout).
+  // They need different fixes, so this asserts both separately rather than one composite
+  // "looks right".
+  test('a message sent while the band is up lands above it, at the live edge', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+    await suppressChatStateEcho(page)
+    await scrollToBottom(page)
+    await setRoomTypers(page, STRESS_ROOM_JID, ['Ada', 'Marcus Chen'])
+
+    const before = await probeBottomAnchor(page)
+    expect(before.distFromBottom, 'precondition: glued to the live edge before the send').toBeLessThanOrEqual(
+      GLUED_TOLERANCE_PX,
+    )
+    expect(await pillHeight(page), 'precondition: the band is mounted with height').toBeGreaterThan(10)
+
+    const marker = `sent-under-pill-${Date.now()}`
+    const composer = page.locator('textarea').first()
+    await composer.click()
+    await composer.fill(`ok ${marker}`)
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(
+      (text) =>
+        Array.from(document.querySelectorAll('[data-message-list] [data-message-row-id]')).some(
+          (row) => (row.textContent ?? '').includes(text),
+        ),
+      marker,
+      { timeout: 10_000 },
+    )
+    await page.waitForTimeout(SETTLE_MS)
+
+    const sent = await page.evaluate((text) => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
+      const pill = scroller?.parentElement?.querySelector('[data-typing-pill]') as HTMLElement | null
+      if (!scroller || !pill) return null
+      const rows = Array.from(scroller.querySelectorAll('[data-message-row-id]')) as HTMLElement[]
+      const matched = rows.filter((row) => (row.textContent ?? '').includes(text))
+      const row = matched[matched.length - 1]
+      if (!row) return null
+      const scrollerRect = scroller.getBoundingClientRect()
+      const rowRect = row.getBoundingClientRect()
+      const position = row.compareDocumentPosition(pill)
+      return {
+        matches: matched.length,
+        pillInsideScroller: scroller.contains(pill),
+        pillFollowsRow: (position & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+        isTail: rows[rows.length - 1] === row,
+        belowFold: Math.round(rowRect.bottom - scrollerRect.bottom),
+        distFromBottom: Math.round(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight),
+      }
+    }, marker)
+
+    expect(sent, 'the sent row and the pill must both be present').not.toBeNull()
+    expect(sent!.matches, 'the sent body must map to exactly one row').toBe(1)
+
+    // ORDER. The band is a sibling below the scrollport, so no message can follow it.
+    expect(sent!.pillInsideScroller, 'the pill must not be a row inside the scroller').toBe(false)
+    expect(sent!.pillFollowsRow, 'the sent row must precede the pill in document order').toBe(true)
+    expect(sent!.isTail, 'the sent row must be the last row in the list').toBe(true)
+
+    // LAYOUT. A shrunk scrollport is never clamped back by the engine, so a missed re-pin
+    // leaves the sent row hanging below the fold with the band immediately under it.
+    expect(sent!.belowFold, `the sent row hangs ${sent!.belowFold}px below the fold`).toBeLessThanOrEqual(0)
+    expect(sent!.distFromBottom, `the view sits ${sent!.distFromBottom}px off the bottom after the send`).toBeLessThanOrEqual(
+      GLUED_TOLERANCE_PX,
+    )
+
+    const overlap = await probeOverlap(page, 0)
+    expect(overlap.pillFound && overlap.visibleRows > 0, 'pill/rows missing after the send').toBe(true)
+    expect(overlap.worstOverlap, `the pill covers ${overlap.worstRowId} after the send`).toBe(0)
+  })
+
   /** React on the newest message through the real store path, so its row genuinely grows. */
   async function reactToNewest(page: Page, jid: string): Promise<string> {
     const lastId = await page.evaluate((j) => {


### PR DESCRIPTION
A browser clamps `scrollTop` only downward, so growing the scrollport is self-correcting while shrinking it is not: the typing band mounting, the composer growing to a second line or the window shrinking leaves a reader who was at the live edge exactly that far short of it, and nothing gives it back until the app re-pins or the reader scrolls.

The `scroll/` detector family could not see that. `live-edge-pin-short` arms on a pin run that reaches `settled` while short, and this failure is that no run happens at all — no loop, no write, no settle — so the log stayed silent while the reader was stuck.

The resize hook now reports every shrink it already measures across the observation seam, carrying the distance it left, the content height at that moment, and whether the reconciliation it asked for ran or was refused. A new `scroll/scrollport-shrink-unreconciled` detector holds the confirmation the way the rest of the family does.

Arming requires the whole shortfall to fit inside the shrink plus the hook's own tolerance, so a reader who had already scrolled up is excluded by geometry rather than by a tuned threshold. The confirmation measures against the content bottom captured at the shrink, so a message arriving afterwards cannot masquerade as the reader moving away — that is the sequence the defect is reported in, and without it the detector would go blind exactly there.

Also adds the send-with-the-band-up case the scroll invariants had no cover for: a message sent while the pill is mounted must precede it in document order and land at the live edge.
