### PR TITLE
fix(contacts): stop the contact suggestion list nesting a scroll area in its dialog (#1281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
       #
       # CI=true is set by GitHub Actions → the config enables retries(2), forbidOnly,
       # and the github + html reporters. Blocks the PR if any invariant regresses.
-      - name: Run scroll + composer invariants (chromium + webkit)
+      - name: Run browser invariants — scroll, composer, popover (chromium + webkit)
         run: npm run test:e2e
 
       - name: Upload Playwright report on failure

--- a/apps/fluux/src/components/ContactSelector.tsx
+++ b/apps/fluux/src/components/ContactSelector.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { TextInput } from './ui/TextInput'
 import { useTranslation } from 'react-i18next'
 import { useRoster, matchNameOrJid, chatStore } from '@fluux/sdk'
 import { useConnectionStore } from '@fluux/sdk/react'
 import { X } from 'lucide-react'
 import { APP_OFFLINE_PRESENCE_COLOR, PRESENCE_COLORS } from '@/constants/ui'
+import { anchorMenuToTrigger } from '@/hooks/useAnchoredMenu'
 
 /**
  * Check if a string looks like a valid JID (user@domain).
@@ -58,9 +60,6 @@ interface UnifiedContact {
  * - Escape: clear search
  * - Backspace (empty input): remove last selected contact
  */
-// Estimated dropdown height (max-h-40 = 160px + hint bar ~30px)
-const DROPDOWN_HEIGHT = 190
-
 export function ContactSelector({
   selectedContacts,
   onSelectionChange,
@@ -77,10 +76,11 @@ export function ContactSelector({
   const forceOffline = connectionStatus !== 'online'
   const [search, setSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
-  const [flipUp, setFlipUp] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Recent-activity ordering is a one-shot nicety for the dropdown. Read it
   // non-reactively (getState, not a subscription) so the picker does NOT re-render
@@ -154,46 +154,108 @@ export function ContactSelector({
     setHighlightedIndex(0)
   }, [search])
 
-  // Calculate if dropdown should flip up based on available space
-  // Use useLayoutEffect to measure synchronously before paint
+  const cancelPendingBlur = () => {
+    if (blurTimerRef.current === null) return
+    clearTimeout(blurTimerRef.current)
+    blurTimerRef.current = null
+  }
+
+  useEffect(() => cancelPendingBlur, [])
+
+  // Whether the search text is a JID the user can add outright.
+  const searchIsValidJid = isValidJid(search)
+  const searchJidNormalized = search.trim().toLowerCase()
+  const canAddAsJid = searchIsValidJid &&
+    !selectedContacts.includes(searchJidNormalized) &&
+    !excludeJids.includes(searchJidNormalized)
+
+  // The popover shows suggestions, an add-this-JID row, or a no-match notice.
+  const isPopoverOpen = isFocused && (filteredContacts.length > 0 || !!search)
+
+  // Place the popover against the input, in viewport coordinates.
+  //
+  // Keep the popover portalled to the document body: modal bodies may use
+  // `overflow-y-auto`, so an absolutely positioned descendant would be clipped
+  // and would enlarge the body's scrollable overflow (#1281). A viewport-anchored
+  // popover has no clipping ancestor, and the modal remains sized to its content.
+  //
+  // Measuring the rendered popover — rather than estimating its height — is also
+  // what makes the flip-up decision honest: it flips when the popover truly does
+  // not fit below the input, and is pinned inside the viewport as a last resort.
   useLayoutEffect(() => {
-    if (filteredContacts.length === 0 || !containerRef.current) {
-      setFlipUp(false)
-      return
+    if (!isPopoverOpen) return
+
+    const place = (): string | null => {
+      const anchor = containerRef.current
+      const menu = popoverRef.current
+      if (!anchor || !menu) return null
+      const anchorRect = anchor.getBoundingClientRect()
+      const menuHeight = menu.getBoundingClientRect().height
+      const { x, y } = anchorMenuToTrigger(
+        { left: anchorRect.left, top: anchorRect.top, bottom: anchorRect.bottom },
+        { width: anchorRect.width, height: menuHeight },
+        { width: window.innerWidth, height: window.innerHeight },
+      )
+      menu.style.left = `${x}px`
+      menu.style.top = `${y}px`
+      menu.style.width = `${anchorRect.width}px`
+      menu.style.visibility = ''
+      return [anchorRect.left, anchorRect.top, anchorRect.bottom, anchorRect.width, menuHeight].join(':')
     }
 
-    const container = containerRef.current
-    const containerRect = container.getBoundingClientRect()
-
-    // Find the closest scrollable parent (modal container)
-    let scrollParent: Element | null = container.parentElement
-    while (scrollParent) {
-      const style = window.getComputedStyle(scrollParent)
-      const overflow = style.overflow + style.overflowY
-      if (overflow.includes('auto') || overflow.includes('scroll')) {
-        break
+    place()
+    let animationFrame: number | null = null
+    let previousGeometry: string | null = null
+    let stableFrames = 0
+    const ancestorIsAnimating = () => {
+      let element: Element | null = containerRef.current
+      while (element) {
+        if (element.getAnimations().some(animation => animation.playState === 'running')) return true
+        element = element.parentElement
       }
-      scrollParent = scrollParent.parentElement
+      return false
     }
-
-    // Calculate available space
-    let spaceBelow: number
-    let spaceAbove: number
-
-    if (scrollParent) {
-      // Use scrollable parent bounds
-      const parentRect = scrollParent.getBoundingClientRect()
-      spaceBelow = parentRect.bottom - containerRect.bottom
-      spaceAbove = containerRect.top - parentRect.top
-    } else {
-      // Fallback to window
-      spaceBelow = window.innerHeight - containerRect.bottom
-      spaceAbove = containerRect.top
+    const trackFrame = () => {
+      animationFrame = null
+      const geometry = place()
+      if (!geometry) return
+      stableFrames = geometry === previousGeometry ? stableFrames + 1 : 0
+      previousGeometry = geometry
+      if (stableFrames < 2 || ancestorIsAnimating()) {
+        animationFrame = window.requestAnimationFrame(trackFrame)
+      }
     }
-
-    // Flip up if not enough space below but more space above
-    setFlipUp(spaceBelow < DROPDOWN_HEIGHT && spaceAbove > spaceBelow)
-  }, [filteredContacts.length, search])
+    const trackAnchor = () => {
+      stableFrames = 0
+      if (animationFrame === null) animationFrame = window.requestAnimationFrame(trackFrame)
+    }
+    trackAnchor()
+    const handleViewportChange = () => {
+      place()
+      trackAnchor()
+    }
+    const resizeObserver = new ResizeObserver(trackAnchor)
+    let observed: Element | null = containerRef.current
+    while (observed) {
+      resizeObserver.observe(observed)
+      observed = observed.parentElement
+    }
+    if (popoverRef.current) resizeObserver.observe(popoverRef.current)
+    // Capture phase: the anchor rides an ancestor's scrollbar (a modal body, the
+    // member list behind an add-member form), and those scrolls do not bubble.
+    window.addEventListener('scroll', handleViewportChange, true)
+    window.addEventListener('resize', handleViewportChange)
+    window.addEventListener('animationstart', trackAnchor, true)
+    window.addEventListener('transitionrun', trackAnchor, true)
+    return () => {
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
+      resizeObserver.disconnect()
+      window.removeEventListener('scroll', handleViewportChange, true)
+      window.removeEventListener('resize', handleViewportChange)
+      window.removeEventListener('animationstart', trackAnchor, true)
+      window.removeEventListener('transitionrun', trackAnchor, true)
+    }
+  }, [isPopoverOpen, filteredContacts.length, search, canAddAsJid, selectedContacts.length])
 
   const selectContact = (jid: string) => {
     if (onPick) {
@@ -213,13 +275,6 @@ export function ContactSelector({
   const removeContact = (jid: string) => {
     onSelectionChange(selectedContacts.filter(j => j !== jid))
   }
-
-  // Check if current search input is a valid JID that can be added directly
-  const searchIsValidJid = isValidJid(search)
-  const searchJidNormalized = search.trim().toLowerCase()
-  const canAddAsJid = searchIsValidJid &&
-    !selectedContacts.includes(searchJidNormalized) &&
-    !excludeJids.includes(searchJidNormalized)
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // Backspace removes last selected contact when input is empty
@@ -316,15 +371,25 @@ export function ContactSelector({
       )}
 
       {/* Contact search with keyboard navigation */}
-      <div ref={containerRef} className="relative">
+      <div ref={containerRef}>
         <TextInput
           ref={inputRef}
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setTimeout(() => setIsFocused(false), 150)} // Delay to allow click on dropdown
+          onFocus={() => { cancelPendingBlur(); setIsFocused(true) }}
+          // Closing is deferred so a click can land on the popover before it goes
+          // away — but the pending close MUST be cancelled when focus comes back,
+          // or a blur immediately followed by a refocus closes the list 150ms
+          // later while the field still holds focus.
+          onBlur={() => {
+            cancelPendingBlur()
+            blurTimerRef.current = setTimeout(() => {
+              blurTimerRef.current = null
+              setIsFocused(false)
+            }, 150)
+          }}
           placeholder={selectedContacts.length > 0
             ? (addMorePlaceholder || defaultAddMorePlaceholder)
             : (placeholder || defaultPlaceholder)}
@@ -334,72 +399,81 @@ export function ContactSelector({
                      placeholder:text-fluux-muted disabled:opacity-50"
         />
 
-        {/* Dropdown with keyboard-highlighted contacts - flips up when near bottom */}
-        {isFocused && filteredContacts.length > 0 && (
-          <div className={`absolute inset-x-0 max-h-40 overflow-y-auto fluux-popover rounded z-10 ${
-            flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}>
-            {filteredContacts.map((contact, index) => {
-              const presenceColor = contact.isExtra
-                ? 'bg-fluux-muted/50'
-                : forceOffline
-                  ? APP_OFFLINE_PRESENCE_COLOR
-                  : PRESENCE_COLORS[contact.presence as keyof typeof PRESENCE_COLORS]
-              return (
-                <div
-                  key={contact.jid}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => selectContact(contact.jid)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectContact(contact.jid) } }}
-                  className={`flex items-center gap-2 px-3 py-2 cursor-pointer ${
-                    index === highlightedIndex
-                      ? 'bg-fluux-brand/20 text-fluux-text'
-                      : 'hover:bg-fluux-hover text-fluux-text'
-                  }`}
-                >
-                  <span className={`size-2 rounded-full flex-shrink-0 ${presenceColor}`} />
-                  <span className="text-sm truncate flex-1">{contact.name}</span>
-                  <span className="text-xs text-fluux-muted truncate">{contact.jid}</span>
-                  {index === highlightedIndex && (
-                    <span className="text-xs text-fluux-muted ms-1">↵</span>
-                  )}
+        {isPopoverOpen && createPortal(
+          <div
+            ref={popoverRef}
+            data-testid="contact-suggestions"
+            // `fixed`, and outside the modal tree, so no ancestor scroll container
+            // can clip it. Hidden until the layout effect has measured it, which
+            // happens before the first paint.
+            className="fixed max-h-40 overflow-y-auto fluux-popover rounded z-[60]"
+            style={{
+              left: 0,
+              top: 0,
+              visibility: 'hidden',
+            }}
+          >
+            {/* Keyboard-highlighted contacts */}
+            {filteredContacts.length > 0 && (
+              <>
+                {filteredContacts.map((contact, index) => {
+                  const presenceColor = contact.isExtra
+                    ? 'bg-fluux-muted/50'
+                    : forceOffline
+                      ? APP_OFFLINE_PRESENCE_COLOR
+                      : PRESENCE_COLORS[contact.presence as keyof typeof PRESENCE_COLORS]
+                  return (
+                    <div
+                      key={contact.jid}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => selectContact(contact.jid)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectContact(contact.jid) } }}
+                      className={`flex items-center gap-2 px-3 py-2 cursor-pointer ${
+                        index === highlightedIndex
+                          ? 'bg-fluux-brand/20 text-fluux-text'
+                          : 'hover:bg-fluux-hover text-fluux-text'
+                      }`}
+                    >
+                      <span className={`size-2 rounded-full flex-shrink-0 ${presenceColor}`} />
+                      <span className="text-sm truncate flex-1">{contact.name}</span>
+                      <span className="text-xs text-fluux-muted truncate">{contact.jid}</span>
+                      {index === highlightedIndex && (
+                        <span className="text-xs text-fluux-muted ms-1">↵</span>
+                      )}
+                    </div>
+                  )
+                })}
+                <div className="px-3 py-1.5 text-xs text-fluux-muted border-t border-fluux-hover bg-fluux-sidebar">
+                  {t('contacts.keyboardHint')}
                 </div>
-              )
-            })}
-            <div className="px-3 py-1.5 text-xs text-fluux-muted border-t border-fluux-hover bg-fluux-sidebar">
-              {t('contacts.keyboardHint')}
-            </div>
-          </div>
-        )}
+              </>
+            )}
 
-        {/* Hint when input is a valid JID but no contacts match */}
-        {isFocused && filteredContacts.length === 0 && canAddAsJid && (
-          <div className={`absolute inset-x-0 fluux-popover rounded z-10 ${
-            flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}>
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={() => selectContact(searchJidNormalized)}
-              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectContact(searchJidNormalized) } }}
-              className="flex items-center gap-2 px-3 py-2 cursor-pointer bg-fluux-brand/20 text-fluux-text"
-            >
-              <span className="size-2 rounded-full flex-shrink-0 bg-fluux-muted" />
-              <span className="text-sm truncate flex-1">{searchJidNormalized}</span>
-              <span className="text-xs text-fluux-muted">{t('contacts.pressEnterToAdd')}</span>
-              <span className="text-xs text-fluux-muted">↵</span>
-            </div>
-          </div>
-        )}
+            {/* Hint when input is a valid JID but no contacts match */}
+            {filteredContacts.length === 0 && canAddAsJid && (
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => selectContact(searchJidNormalized)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectContact(searchJidNormalized) } }}
+                className="flex items-center gap-2 px-3 py-2 cursor-pointer bg-fluux-brand/20 text-fluux-text"
+              >
+                <span className="size-2 rounded-full flex-shrink-0 bg-fluux-muted" />
+                <span className="text-sm truncate flex-1">{searchJidNormalized}</span>
+                <span className="text-xs text-fluux-muted">{t('contacts.pressEnterToAdd')}</span>
+                <span className="text-xs text-fluux-muted">↵</span>
+              </div>
+            )}
 
-        {/* No contacts found hint */}
-        {isFocused && filteredContacts.length === 0 && search && !canAddAsJid && (
-          <div className={`absolute inset-x-0 fluux-popover rounded z-10 px-3 py-2 text-sm text-fluux-muted ${
-            flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}>
-            {t('contacts.noContactsFound')}
-          </div>
+            {/* No contacts found hint */}
+            {filteredContacts.length === 0 && !canAddAsJid && search && (
+              <div className="px-3 py-2 text-sm text-fluux-muted">
+                {t('contacts.noContactsFound')}
+              </div>
+            )}
+          </div>,
+          document.body,
         )}
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e": "npx playwright test --config playwright.e2e.config.ts",
     "test:scroll": "npx playwright test --config playwright.e2e.config.ts --project=scroll-chromium --project=scroll-webkit",
     "test:composer": "npx playwright test --config playwright.e2e.config.ts --project=composer-chromium --project=composer-webkit",
+    "test:popover": "npx playwright test --config playwright.e2e.config.ts --project=popover-chromium --project=popover-webkit",
     "pretypecheck": "npm run guard:sdk-link",
     "typecheck": "npm run typecheck --workspaces --if-present && npm run typecheck:scripts",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -19,18 +19,16 @@ const useDevServer = process.env.FLUUX_E2E_DEV_SERVER === '1'
 const BASE_URL = useDevServer ? 'http://localhost:5173' : 'http://localhost:4173'
 
 /**
- * The browser-level invariant gates: scroll positioning and composer geometry.
- *
- * Both suites were previously separate configs, each spawning its own `npm run dev`.
- * That paid vite's cold transform of the demo bundle twice per CI job and left the two
- * runs unable to share workers — the composer suite sat idle while scroll finished, and
- * vice versa. One config, four projects, one dev server.
+ * Browser-level invariant gates for scroll positioning, composer geometry, and
+ * anchored popovers. The shared configuration creates one project per suite and
+ * browser engine, backed by one demo server.
  *
  * Each suite is still runnable and diagnosable on its own, which is why the projects are
  * named per suite rather than per engine:
  *
  *   npm run test:scroll                        # both engines, scroll only
  *   npm run test:composer                      # both engines, composer only
+ *   npm run test:popover                       # both engines, popover only
  *   npm run test:e2e                           # everything (what CI runs)
  *   npx playwright test --config playwright.e2e.config.ts --project=scroll-webkit
  *
@@ -41,6 +39,7 @@ const BASE_URL = useDevServer ? 'http://localhost:5173' : 'http://localhost:4173
 const SUITES = [
   { name: 'scroll', testMatch: 'scroll-invariants.ts' },
   { name: 'composer', testMatch: 'composer-geometry.ts' },
+  { name: 'popover', testMatch: 'popover-geometry.ts' },
 ] as const
 
 /**
@@ -72,8 +71,8 @@ export default defineConfig({
   // ~3s, and the measurements themselves are sub-second.
   timeout: 180_000,
 
-  // Tests within a file share a worker and run in declaration order. With four projects
-  // the two workers stay fed across both suites instead of draining one then the other.
+  // Tests within a file share a worker and run in declaration order. With six projects,
+  // the two workers stay fed across suites instead of draining one before the next.
   fullyParallel: false,
 
   // CI: retry twice to absorb timing noise on slower runners (the suites gate on async

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -105,7 +105,7 @@ async function driveFocusRegainInPage(page: Page): Promise<void> {
  *
  * Chromium only, deliberately: the assertions read a JavaScript global and are
  * engine-independent, so a second engine would double the cost for no signal. The
- * scroll and composer suites run on both because they measure layout, which is
+ * browser-geometry suites run on both because they measure layout, which is
  * exactly where the engines differ.
  */
 test.describe('anomaly runtime', () => {

--- a/scripts/ci-changed-scopes.sh
+++ b/scripts/ci-changed-scopes.sh
@@ -72,8 +72,10 @@ while IFS= read -r path || [ -n "$path" ]; do
         # --- Rule 4: TypeScript / JavaScript ----------------------------------
         # The scripts named explicitly are the bodies of the Playwright suites run
         # by the e2e job, their shared harness in scripts/e2e/, and the build that
-        # produces the bundle those suites load.
-        packages/* | apps/fluux/* | playwright*.config.ts | scripts/scroll-invariants.ts | scripts/composer-geometry.ts | scripts/e2e/* | scripts/build-e2e.mjs)
+        # produces the bundle those suites load. Every other path under scripts/
+        # falls through to the fail-safe catch-all below, so a new suite must be
+        # listed here or it needlessly runs the Rust job too.
+        packages/* | apps/fluux/* | playwright*.config.ts | scripts/scroll-invariants.ts | scripts/composer-geometry.ts | scripts/popover-geometry.ts | scripts/e2e/* | scripts/build-e2e.mjs)
             js=true
             ;;
 

--- a/scripts/e2e/demoBoot.ts
+++ b/scripts/e2e/demoBoot.ts
@@ -1,8 +1,8 @@
 /**
  * Shared demo boot for the Playwright suites.
  *
- * Both the scroll and the composer harness need the same three things before they can
- * measure anything: the demo loaded, React mounted, and the stress seeding finished.
+ * Each browser-invariant harness needs the same three things before it can measure
+ * anything: the demo loaded, React mounted, and the stress seeding finished.
  * Keeping that here gives the readiness contract with demo.tsx a single owner.
  *
  * The boot is instrumented because it has an open, intermittent failure: the first webkit

--- a/scripts/popover-geometry.ts
+++ b/scripts/popover-geometry.ts
@@ -1,0 +1,214 @@
+/**
+ * Playwright popover-geometry harness.
+ *
+ * These real-box-model invariants cannot be expressed in jsdom. The suggestion
+ * list must remain outside the dialog's scroll tree, stay fully painted within
+ * the viewport, and follow its input while the dialog moves. The dialog must
+ * remain content-sized whether the list is open or closed (#1281).
+ *
+ * The last two invariants are counterweights, not restatements: the report asked
+ * for a taller dialog, and a dialog sized to hold the list at all times would
+ * satisfy every invariant above while standing mostly empty whenever the list is
+ * closed. Do not drop them as redundant.
+ *
+ * Run:
+ *   npm run test:popover
+ *   npx playwright test --config=playwright.e2e.config.ts --project=popover-webkit
+ */
+
+import { test, expect, type Page, type Locator } from '@playwright/test'
+import { bootDemo } from './e2e/demoBoot'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const DEMO_URL = '/demo.html?tutorial=false'
+
+/** Accessible name of the sidebar button that opens the dialog under test. */
+const NEW_MESSAGE = 'New message'
+
+/** Sub-pixel slack: engines round fractional box metrics differently. */
+const EPSILON = 1
+
+/** The dialog body's own bottom padding (`p-4`), the only gap it may legitimately keep. */
+const BODY_PADDING_PX = 16
+
+/** Gap the popover keeps below its input. Must match MENU_TRIGGER_GAP in useAnchoredMenu. */
+const TRIGGER_GAP_PX = 4
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** The dialog's glass panel, and the scrolling body inside it. */
+const panelOf = (page: Page): Locator => page.locator('[data-modal="true"] .fluux-glass')
+
+/** Open the "New message" dialog and return its panel, with the list explicitly closed. */
+async function openNewMessageDialog(
+  page: Page,
+): Promise<Locator> {
+  await bootDemo(page, DEMO_URL)
+  await page.getByRole('button', { name: NEW_MESSAGE, exact: true }).first().click()
+  const panel = panelOf(page)
+  await expect(panel).toBeVisible()
+  await page.getByRole('heading', { name: NEW_MESSAGE }).click({ force: true })
+  await expect(page.getByTestId('contact-suggestions')).toHaveCount(0)
+  await panel.evaluate((el) => Promise.all(el.getAnimations().map(animation => animation.finished)))
+  return panel
+}
+
+/**
+ * Open the suggestion list from the helper's explicit blurred state.
+ */
+async function openSuggestions(page: Page): Promise<Locator> {
+  await page.locator('[data-modal="true"] input[type="text"]').first().focus()
+  const suggestions = page.getByTestId('contact-suggestions')
+  await expect(suggestions).toBeVisible()
+  return suggestions
+}
+
+/**
+ * Every descendant of `root` that both declares a scrolling overflow and actually
+ * has content to scroll, named by its class list so a failure says which box.
+ */
+async function scrollingDescendantsOf(root: Locator): Promise<string[]> {
+  return root.evaluate((el) => {
+    const scrolling: string[] = []
+    for (const node of [el, ...el.querySelectorAll('*')]) {
+      const overflowY = getComputedStyle(node).overflowY
+      if (overflowY !== 'auto' && overflowY !== 'scroll') continue
+      if (node.scrollHeight > node.clientHeight + 1) scrolling.push(node.className.toString())
+    }
+    return scrolling
+  })
+}
+
+// ── Invariants ───────────────────────────────────────────────────────────────
+
+test.describe('contact suggestion popover geometry', () => {
+  /**
+   * The suggestion list may scroll, but the dialog around it must not become a
+   * second scroll area.
+   */
+  test('opens the contact list without nesting a second scroll area', async ({ page }) => {
+    const panel = await openNewMessageDialog(page)
+    await openSuggestions(page)
+
+    expect(
+      await scrollingDescendantsOf(panel),
+      'no box inside the dialog may scroll while the suggestion list is open',
+    ).toEqual([])
+  })
+
+  /**
+   * Hit-test the box rather than trusting its rect: a clipped element still
+   * reports its full rect, while `elementFromPoint` reports what is painted.
+   */
+  test('paints the whole contact list, clipped by nothing', async ({ page }) => {
+    await openNewMessageDialog(page)
+    const suggestions = await openSuggestions(page)
+
+    const painted = await suggestions.evaluate((el) => {
+      const box = el.getBoundingClientRect()
+      const withinViewport =
+        box.top >= 0 && box.left >= 0 &&
+        box.bottom <= window.innerHeight && box.right <= window.innerWidth
+      // A pixel just inside each vertical edge: the top one is normally safe, the
+      // bottom one is where a dialog-clipped list stops being painted.
+      const hits = [box.top + 2, box.bottom - 2].map((y) =>
+        el.contains(document.elementFromPoint(box.left + box.width / 2, y)),
+      )
+      return { withinViewport, topEdgePainted: hits[0], bottomEdgePainted: hits[1] }
+    })
+
+    expect(painted, 'the suggestion list must be on screen and painted edge to edge').toEqual({
+      withinViewport: true,
+      topEdgePainted: true,
+      bottomEdgePainted: true,
+    })
+  })
+
+  /**
+   * The dialog opens with a 200ms `scale(0.97)` enter animation, and a focused
+   * field opens the list immediately — so the popover is placed against an anchor
+   * whose box is still moving. Placing it once leaves it misaligned for the rest
+   * of the dialog's life. The animation is slowed to 2s so the mid-flight state
+   * can be observed rather than raced.
+   */
+  test('stays anchored while the dialog finishes opening', async ({ page }) => {
+    await bootDemo(page, DEMO_URL)
+    await page.addStyleTag({
+      content: '.modal-panel-in { animation-duration: 2000ms !important; }',
+    })
+    await page.getByRole('button', { name: NEW_MESSAGE, exact: true }).first().click()
+    const panel = panelOf(page)
+    await expect(panel).toBeVisible()
+    await page.getByRole('heading', { name: NEW_MESSAGE }).click({ force: true })
+    await expect(page.getByTestId('contact-suggestions')).toHaveCount(0)
+    await openSuggestions(page)
+
+    expect(await panel.evaluate((el) =>
+      el.getAnimations().some(animation => animation.playState === 'running'),
+    )).toBe(true)
+    await page.waitForFunction(() => document.querySelector('.fluux-glass')?.getAnimations().some(
+      animation => animation.playState === 'running' && Number(animation.currentTime) >= 1000,
+    ))
+
+    // The gap is passed in, not closed over: this body is serialized and evaluated
+    // in the page, where module-scope constants do not exist.
+    await expect.poll(async () => page.evaluate((gap) => {
+      const menu = document.querySelector('[data-testid="contact-suggestions"]')
+      const input = document.querySelector('[data-modal="true"] input[type="text"]')
+      if (!menu || !input) return null
+      const menuBox = menu.getBoundingClientRect()
+      const inputBox = input.getBoundingClientRect()
+      return Math.max(
+        Math.abs(menuBox.left - inputBox.left),
+        Math.abs(menuBox.width - inputBox.width),
+        Math.abs(menuBox.top - inputBox.bottom - gap),
+      )
+    }, TRIGGER_GAP_PX)).toBeLessThanOrEqual(EPSILON)
+  })
+
+  /**
+   * The dialog stays content-sized while the list is closed. Any gap beyond the
+   * body padding would reserve layout space for a popover that is not rendered.
+   */
+  test('reserves no empty space while the list is closed', async ({ page }) => {
+    const panel = await openNewMessageDialog(page)
+
+    const slack = await panel.evaluate((el) => {
+      const body = [...el.children].find((child) => {
+        const overflowY = getComputedStyle(child).overflowY
+        return overflowY === 'auto' || overflowY === 'scroll'
+      })
+      const last = body?.lastElementChild
+      // Negative reports a dialog that no longer has the shape this measures,
+      // which must fail rather than silently pass.
+      if (!body || !last) return -1
+      return body.getBoundingClientRect().bottom - last.getBoundingClientRect().bottom
+    })
+
+    expect(slack, 'the dialog body must end where its content ends').toBeGreaterThanOrEqual(0)
+    expect(
+      slack,
+      'with the list closed the dialog must be sized on its content, not on the list it may show',
+    ).toBeLessThanOrEqual(BODY_PADDING_PX + EPSILON)
+  })
+
+  /**
+   * The dialog must also come back to that compact size once the list closes, so
+   * the first invariant cannot be met by a dialog that grows and stays grown.
+   */
+  test('returns to its closed height after the list is dismissed', async ({ page }) => {
+    const panel = await openNewMessageDialog(page)
+    const heightOf = async () => (await panel.boundingBox())!.height
+
+    const closed = await heightOf()
+    await openSuggestions(page)
+    // Click off the field rather than pressing Escape: Escape reaches the dialog's
+    // own handler and would close the whole thing, not just the list.
+    await page.getByRole('heading', { name: NEW_MESSAGE }).click()
+    await expect(page.getByTestId('contact-suggestions')).toHaveCount(0)
+
+    expect(await heightOf(), 'the dialog height must not depend on the list having been open')
+      .toBeCloseTo(closed, 0)
+  })
+})


### PR DESCRIPTION
Fixes #1281.

## The defect

The suggestion list was an absolutely positioned child of the dialog body, and every modal
embedding `ContactSelector` lays that body out as an `overflow-y-auto` scroll container. An
absolute child adds nothing to its ancestor's layout height but does add to its scrollable
overflow — so the dialog stayed sized on its own short content, cut the list off at its bottom
edge, and grew a scrollbar of its own. The report called it nested scrolling; measured on the
demo at 1280x800 with the list open, it was two scroll areas:

| | before | after |
|---|---|---|
| dialog panel height | 226px, of 720px allowed by `max-h-[90vh]` | 226px |
| dialog body | scrollHeight 222 / clientHeight 171 | 171 / 171 |
| suggestion list rect | 403..563, dialog ends at 513 (cut off) | fully painted |
| suggestion list | scrollHeight 281 / clientHeight 158 | unchanged — its own scroll |

The list is meant to scroll; the fault was that the dialog around it scrolled too, so one
gesture meant two different things depending on which box the pointer was over.

This affected every dialog embedding the selector, not only "New message" — Invite to room and
Create quick chat put it in a scrolling body as well.

## The fix

The list is portalled to the document body and anchored to the search field in viewport
coordinates, reusing the existing `anchorMenuToTrigger`, with the anchor tracked while it moves
so the placement survives the dialog's 200ms enter animation.

The issue asked for a taller dialog. That was the reporter's description of a remedy, and taken
literally it trades a visible defect for a quiet one — a dialog standing mostly empty whenever
the list is closed. Portalling removes that failure mode by construction rather than guarding
against it: the list contributes no layout to the dialog at all, so there is no height to
reserve and nothing to give back when it closes.

It also replaces a hardcoded 190px height estimate with the list's measured height, and decides
the flip-up against real viewport space instead of the bounds of the box that was doing the
clipping. In the "New message" dialog that estimate never fired at any viewport height tested
(800/560/420), because it compared space *inside* the clipping body — roughly 16px above the
field and 116px below — rather than space on screen. Flip-up still works where it is actually
needed: verified in Manage Membership, where the field sits at the bottom of a tall dialog.

## Tests

`scripts/popover-geometry.ts`, a third suite in the existing browser-invariant config
(`npm run test:popover`), on Chromium and WebKit. These cannot be unit tests: jsdom has no
layout, so it cannot report that a box was clipped or that the clipped overflow turned an
ancestor into a scroll container.

Each assertion has a demonstrated failing baseline:

- *no second scroll area* and *painted edge to edge* — fail against the previous component
  (4 scrolling boxes instead of 0; the bottom edge hit-tests to the scrim, not the list).
- *stays anchored while the dialog finishes opening* — fails at 9.5px of drift against a
  portalled list that is placed once instead of tracked.
- *reserves no empty space while the list is closed* — fails at 209.9px against a
  `min-h-[420px]` dialog, i.e. against the issue's literal remedy.
