### PR TITLE
fix(fluux-sdk): prevent off-slice floor read-pointer regression

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
@@ -110,23 +110,11 @@ describe('chatStore — a floor pointer naming the newest message', () => {
   })
 })
 
-/**
- * The other floor population: one naming a message the archive does NOT hold.
- *
- * The sibling above names the newest message, so the slice can resolve it. Here
- * the named message is absent — the archive stops behind the floor — and
- * activation's load-around finds nothing to bring in. What is left resident is
- * older than the read position, while the latest-N load has cleared the slid
- * flag, so the window reads as the live edge and `onMessageSeen`'s off-slice
- * hatch is armed against a row that is not the maximum it assumes.
- *
- * Field record for the shape and the number: issue #1381, `behindMs` 947243 on
- * a 1:1 conversation, seconds after the window regained focus and the
- * conversation was activated.
- */
+// An absent floor can be ahead of every resident row at the live edge. A
+// viewport report must preserve the forward-only pointer invariant (#1381).
 describe('chatStore — a floor pointer naming a message the archive does not hold', () => {
   const ARCHIVE_TOP = new Date('2026-09-04T06:54:00.000Z').getTime()
-  /** The gap the field record carries, to the millisecond. */
+  // Regression input from #1381, expressed in milliseconds.
   const BEHIND_MS = 947_243
 
   const ABSENT_FLOOR: ReadPointer = {

--- a/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.floorResolution.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { chatStore } from './chatStore'
 import { connectionStore } from './connectionStore'
 import type { Message, Conversation } from '../core'
-import type { ReadPointer } from './shared/readPointer'
+import { isAhead, type ReadPointer } from './shared/readPointer'
 import { _clearAllTransientForTesting } from './shared/transientUnread'
 
 vi.mock('../utils/messageCache', async (importOriginal) => {
@@ -25,6 +25,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     getMessagesAround: vi.fn().mockResolvedValue([]),
   }
 })
+import * as messageCache from '../utils/messageCache'
 
 const CID = 'alice@example.com'
 
@@ -106,5 +107,101 @@ describe('chatStore — a floor pointer naming the newest message', () => {
     const settled = chatStore.getState().conversationMeta.get(CID)?.readPointer
     chatStore.getState().advanceReadPointer(CID, { id: 'm2' })
     expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).toBe(settled)
+  })
+})
+
+/**
+ * The other floor population: one naming a message the archive does NOT hold.
+ *
+ * The sibling above names the newest message, so the slice can resolve it. Here
+ * the named message is absent — the archive stops behind the floor — and
+ * activation's load-around finds nothing to bring in. What is left resident is
+ * older than the read position, while the latest-N load has cleared the slid
+ * flag, so the window reads as the live edge and `onMessageSeen`'s off-slice
+ * hatch is armed against a row that is not the maximum it assumes.
+ *
+ * Field record for the shape and the number: issue #1381, `behindMs` 947243 on
+ * a 1:1 conversation, seconds after the window regained focus and the
+ * conversation was activated.
+ */
+describe('chatStore — a floor pointer naming a message the archive does not hold', () => {
+  const ARCHIVE_TOP = new Date('2026-09-04T06:54:00.000Z').getTime()
+  /** The gap the field record carries, to the millisecond. */
+  const BEHIND_MS = 947_243
+
+  const ABSENT_FLOOR: ReadPointer = {
+    order: { role: 'floor', timestamp: ARCHIVE_TOP + BEHIND_MS },
+    identity: { state: 'local', messageId: 'never-archived' },
+  }
+
+  /** 50 archived messages, one per second, newest at ARCHIVE_TOP. */
+  const ARCHIVED: Message[] = Array.from({ length: 50 }, (_, i) => ({
+    type: 'chat',
+    id: `arch-${49 - i}`,
+    conversationId: CID,
+    from: CID,
+    body: `archived ${49 - i}`,
+    timestamp: new Date(ARCHIVE_TOP - (49 - i) * 1000),
+    isOutgoing: false,
+  }))
+
+  beforeEach(() => {
+    _clearAllTransientForTesting()
+    connectionStore.setState({ windowVisible: true })
+    const conversation: Conversation = { id: CID, name: 'alice', type: 'chat', unreadCount: 0 }
+    chatStore.setState({
+      conversations: new Map([[CID, conversation]]),
+      conversationMeta: new Map([[CID, { unreadCount: 0, readPointer: ABSENT_FLOOR }]]),
+      messages: new Map(),
+      firstNewMessageMarkers: new Map(),
+      windowAtLiveEdge: new Map(),
+      activeConversationId: null,
+    })
+    vi.mocked(messageCache.getMessages).mockResolvedValue(ARCHIVED)
+    vi.mocked(messageCache.getMessagesAround).mockResolvedValue([])
+  })
+
+  it('does not walk the pointer back onto the newest archived message', async () => {
+    await chatStore.getState().activateConversation(CID)
+
+    // The preconditions the hatch would otherwise fire under, asserted rather
+    // than assumed: the pointer's own row is absent, the resident tail is older
+    // than the read position, and the latest-N load left the window at the edge.
+    const resident = chatStore.getState().messages.get(CID) ?? []
+    expect(resident.map((m) => m.id)).not.toContain('never-archived')
+    expect(resident[resident.length - 1].id).toBe('arch-0')
+    expect(chatStore.getState().windowAtLiveEdge.get(CID)).toBeUndefined()
+    // Activation itself never writes a read position.
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer).toBe(ABSENT_FLOOR)
+
+    // What the viewport observer reports once the list has painted: the
+    // bottom-most row, which here is the newest message the archive holds.
+    chatStore.getState().advanceReadPointer(CID, { id: 'arch-0' })
+
+    const after = chatStore.getState().conversationMeta.get(CID)?.readPointer
+    expect(after).toBe(ABSENT_FLOOR)
+    expect(isAhead(ABSENT_FLOOR, after)).toBe(false)
+  })
+
+  // The hatch still has to do its job: it exists so a floor whose named row is
+  // gone is not stuck for good. One message newer than the floor unsticks it.
+  it('still advances once a message newer than the floor is resident', async () => {
+    const newer: Message = {
+      type: 'chat',
+      id: 'arch-newer',
+      conversationId: CID,
+      from: CID,
+      body: 'newer',
+      timestamp: new Date(ABSENT_FLOOR.order.timestamp + 1),
+      isOutgoing: false,
+    }
+    vi.mocked(messageCache.getMessages).mockResolvedValue([...ARCHIVED, newer])
+
+    await chatStore.getState().activateConversation(CID)
+    chatStore.getState().advanceReadPointer(CID, { id: 'arch-newer' })
+
+    const after = chatStore.getState().conversationMeta.get(CID)?.readPointer
+    expect(after?.identity.messageId).toBe('arch-newer')
+    expect(after?.order.role).toBe('exact')
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
@@ -110,6 +110,24 @@ afterEach(() => {
 })
 
 describe('room read state persistence', () => {
+  it('does not move an off-slice floor backwards at the live edge', () => {
+    const archiveTop = new Date('2026-09-04T06:54:00.000Z').getTime()
+    const floor = {
+      order: { role: 'floor' as const, timestamp: archiveTop + 947_243 },
+      identity: { state: 'local' as const, messageId: 'never-archived' },
+    }
+
+    roomStore.getState().addRoom(
+      { ...makeRoom(ROOM), readPointer: floor },
+      [rmsg('archived-tail', archiveTop)]
+    )
+    const before = roomStore.getState().roomMeta.get(ROOM)?.readPointer
+
+    roomStore.getState().advanceReadPointer(ROOM, { id: 'archived-tail' })
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(before)
+  })
+
   it('stamps historyFloor when a room is first added', () => {
     roomStore.getState().addRoom({ jid: ROOM, name: 'Room', nickname: 'me', joined: true } as never)
     expect(roomStore.getState().roomMeta.get(ROOM)?.historyFloor).toBeInstanceOf(Date)

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -2109,25 +2109,16 @@ describe('onMessageSeen — resolves a floor onto the message it names', () => {
     expect(onMessageSeen(offSlice, { id: 'm1' }, messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
   })
 
-  // The hatch rests on "the newest resident row is an unambiguous maximum". That
-  // holds only while the floor sits behind that row. A floor naming a message the
-  // archive does not hold sits AHEAD of every resident row, and the hatch then
-  // walks a forward-only position backwards — read messages come back unread and
-  // nothing downstream can tell them from new mail (#1381, #1076). The resolution
-  // branch above refuses exactly this ("refuses when the floor sits AHEAD of the
-  // message it names"); the hatch asks `mayAdvanceTo` and refuses it too.
+  // An absent floor can lie ahead of every resident row. The live-edge hatch
+  // must preserve the same forward-only rule as every other advance.
   it('refuses the off-slice hatch when the newest resident row sits BEHIND the floor', () => {
     const messages = [src('m1', 1000), src('m2', 2000)]
     const offSlice = stateWith(floorAt('never-archived', 3000))
     expect(onMessageSeen(offSlice, { id: 'm2' }, messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
   })
 
-  // The same rule, one millisecond wide. A floor cannot prove where it sits
-  // inside its own millisecond, so `mayAdvanceTo` never overtakes there — the
-  // keyed branch is pinned for this by "does NOT move a KEYED, OFF-SLICE pointer
-  // back onto a same-millisecond sibling that sorts before it", and the hatch
-  // answers it the same way rather than resolving the tie in the unrecoverable
-  // direction.
+  // A floor has no tie-break, so it cannot prove an advance within its own
+  // millisecond.
   it('refuses the off-slice hatch on a row sharing the floor’s millisecond', () => {
     const messages = [src('m1', 1000), src('m2', 2000)]
     const offSlice = stateWith(floorAt('never-archived', 2000))

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -2109,6 +2109,31 @@ describe('onMessageSeen — resolves a floor onto the message it names', () => {
     expect(onMessageSeen(offSlice, { id: 'm1' }, messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
   })
 
+  // The hatch rests on "the newest resident row is an unambiguous maximum". That
+  // holds only while the floor sits behind that row. A floor naming a message the
+  // archive does not hold sits AHEAD of every resident row, and the hatch then
+  // walks a forward-only position backwards — read messages come back unread and
+  // nothing downstream can tell them from new mail (#1381, #1076). The resolution
+  // branch above refuses exactly this ("refuses when the floor sits AHEAD of the
+  // message it names"); the hatch asks `mayAdvanceTo` and refuses it too.
+  it('refuses the off-slice hatch when the newest resident row sits BEHIND the floor', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const offSlice = stateWith(floorAt('never-archived', 3000))
+    expect(onMessageSeen(offSlice, { id: 'm2' }, messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
+  })
+
+  // The same rule, one millisecond wide. A floor cannot prove where it sits
+  // inside its own millisecond, so `mayAdvanceTo` never overtakes there — the
+  // keyed branch is pinned for this by "does NOT move a KEYED, OFF-SLICE pointer
+  // back onto a same-millisecond sibling that sorts before it", and the hatch
+  // answers it the same way rather than resolving the tie in the unrecoverable
+  // direction.
+  it('refuses the off-slice hatch on a row sharing the floor’s millisecond', () => {
+    const messages = [src('m1', 1000), src('m2', 2000)]
+    const offSlice = stateWith(floorAt('never-archived', 2000))
+    expect(onMessageSeen(offSlice, { id: 'm2' }, messages, 'chat', { atLiveEdge: true })).toBe(offSlice)
+  })
+
   // Idempotence: the resolved pointer is exact, so the next viewport report of
   // the same message goes down the exact branch and hands the state back by
   // reference. Both stores commit on a reference check, so a pointer that kept

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -520,11 +520,26 @@ export function onMessageSeen(
   }
 
   // FLOOR (migrated) pointer: its timestamp proves nothing about its position,
-  // so keep ordering by index — including the off-slice guard and the live-edge
-  // escape hatch that stops it getting stuck.
+  // so order by index within the slice — including the off-slice guard and the
+  // live-edge escape hatch that stops it getting stuck.
   const currentIdx = findMessageRowIndex(messages, pointerRowRef(state.readPointer))
   if (currentIdx === -1) {
-    if (options?.atLiveEdge && newIdx === messages.length - 1) return advanced()
+    // Off the slice there is no index to order by, and the hatch takes the
+    // newest resident row for the maximum. It is only the maximum while the
+    // floor sits behind it: a floor naming a message the archive does not hold
+    // sits AHEAD of every resident row, and advancing there walks a forward-only
+    // position backwards (#1381). So the hatch asks the ADVANCE question too —
+    // the same one the exact branch above asks. With a floor on one side
+    // `mayAdvanceTo` also refuses a shared millisecond, because a floor cannot
+    // prove where it sits inside its own; `hasFloorResolutionEvidence` refuses
+    // that same move on the resolution path below.
+    if (
+      options?.atLiveEdge &&
+      newIdx === messages.length - 1 &&
+      mayAdvanceTo(exactPosition(messages[newIdx], kind), current)
+    ) {
+      return advanced()
+    }
     return state
   }
   if (newIdx > currentIdx) return advanced()

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -519,20 +519,13 @@ export function onMessageSeen(
     return mayAdvanceTo(exactPosition(messages[newIdx], kind), current) ? advanced() : state
   }
 
-  // FLOOR (migrated) pointer: its timestamp proves nothing about its position,
-  // so order by index within the slice — including the off-slice guard and the
-  // live-edge escape hatch that stops it getting stuck.
+  // FLOOR (migrated) pointer: order by index within the resident slice. Off
+  // the slice, a reported tail can replace it only when the position advances.
   const currentIdx = findMessageRowIndex(messages, pointerRowRef(state.readPointer))
   if (currentIdx === -1) {
-    // Off the slice there is no index to order by, and the hatch takes the
-    // newest resident row for the maximum. It is only the maximum while the
-    // floor sits behind it: a floor naming a message the archive does not hold
-    // sits AHEAD of every resident row, and advancing there walks a forward-only
-    // position backwards (#1381). So the hatch asks the ADVANCE question too —
-    // the same one the exact branch above asks. With a floor on one side
-    // `mayAdvanceTo` also refuses a shared millisecond, because a floor cannot
-    // prove where it sits inside its own; `hasFloorResolutionEvidence` refuses
-    // that same move on the resolution path below.
+    // The tail is safe only when it is ahead of the floor. `mayAdvanceTo` also
+    // refuses a shared millisecond: a floor has no tie-break to prove its place
+    // within that millisecond.
     if (
       options?.atLiveEdge &&
       newIdx === messages.length - 1 &&


### PR DESCRIPTION
## Intent

Investigate issue 1381 before deciding whether to publish 0.17.3. The captain's words, 2026-09-07: "Lance d abord une investigation sur l issue 1381." Read-position synchronisation is the central theme of 0.17.3, and this anomaly arrived on the day we were about to publish, so the diagnosis governs that publication decision.

The anomaly as recorded: on 2026-09-04 at 07:19:58Z, build 0.17.2+f59381ba, macOS/WebKit, the detector read-state/pointer-regression fired for a one-to-one conversation with behindMs 947243, about 15 min 47 s. The breadcrumbs are narrow: the window regained focus, that same conversation was activated about 34 ms later, and the read position moved backwards about 5 seconds after that. The read position is forward-only and a backward move is unrecoverable: messages already read are marked unread again, and nothing downstream distinguishes that from genuine new mail (issue 1076). The detector had been silent for five weeks of daily use.

After the diagnosis the captain decided, 2026-09-07, his words: "Corrige ce garde et prevoit ensuite sur une autre PR d enchainer avec les autres."

The guard he means, in substance. In onMessageSeen, packages/fluux-sdk/src/stores/shared/notificationState.ts, a read pointer of role floor whose named row is not in the resident slice falls into an off-slice live-edge escape hatch. That hatch exists so such a pointer does not get stuck, and it advances the pointer onto the newest resident row with no position comparison at all. It must refuse to advance onto a reported row that is not ahead of the floor's own position: the guard its neighbouring branch in the same module already has, hasFloorResolutionEvidence in packages/fluux-sdk/src/stores/shared/readPointer.ts, which refuses a reported message whose timestamp sits behind the floor. One condition, at that one place. Both stores, conversations and rooms, share onMessageSeen, so rooms are repaired by the same line.

The cause, stated plainly: the hatch takes the newest resident row for an unambiguous maximum. That premise held for the pre-0.17.3 read-state model, where the read position was a message id with no position of its own. It is false under the 0.17.3 model, where the pointer carries a timestamp and tie-break order and a floor can hold a position that no resident row matches. A floor naming a message the local archive does not hold sits ahead of every resident row, and the hatch then walks a forward-only position backwards.

The masking condition, which is why it stayed silent for five weeks: it needs a floor pointer, and 0.17.3 mints exact pointers, so only migrated or pre-tie-break persisted pointers are floors; that floor's named message must be absent from the local archive; and the window must count as at the live edge. On the machine that recorded the anomaly, 12 of 28 persisted conversation pointers are floors, and 0 of 8 room pointers are.

The reservation, which must not be oversold: that this path produced THAT precise record remains an inference by elimination. No log line survives from the 200 ms before the record, so nothing directly observes which writer ran. What is reproducible is the backward move itself, at 947243 ms exactly, along the recorded path.

The field reproduction becomes the regression test, at 947243 ms exactly rather than an approximation: the conversation activated while the row named by its pointer is absent from the archive, then one viewport report on the bottom row.

Explicitly out of scope at the captain's request, tracked separately and destined for a different pull request so that a reviewer does not rediscover them as oversights: the four unguarded read-pointer writers, namely onMarkAsRead, markReadToNewest, and addConversation's wholesale replacement in both its forms; and the stuck pendingRemoteDisplayedStanzaId that freezes one conversation's unread recount. Do not fix them here.

## What Changed

- Guard off-slice floor-pointer resolution at the live edge so it advances only to a position ahead of the existing floor.
- Preserve legitimate advancement when a newer resident message is reported.
- Add conversation, room, and shared-state regressions for absent floor rows, including the recorded 947243 ms case.

## Risk Assessment

✅ Low: The shared off-slice live-edge path now admits only a strictly later exact position, preserving the intended escape hatch while preventing the documented backward transition for chats and rooms.

## Testing

The activation-plus-bottom-row viewport path preserves an off-slice floor pointer at the recorded 947243 ms gap, while the counterfactual demonstrably moves it backward in both stores. No visual artifact applies: this is a headless SDK store transition with no rendered UI surface.

<details>
<summary>Evidence: Conversation regression counterfactual</summary>

<code>Counterfactual trace: old hatch rewrites floor `never-archived` at `1788505787243` to older resident `arch-0` at `1788504840000` — exactly 947243 ms backward.</code>

```text

 RUN  v5.0.0 ~/.no-mistakes/worktrees/b2ebbbea8565/01M1YA293DQYQ41GF4DTX5WX65/packages/fluux-sdk

 ↓ src/stores/chatStore.floorResolution.test.ts > chatStore — a floor pointer naming the newest message > stops re-showing the divider once the named message has been read
 ↓ src/stores/chatStore.floorResolution.test.ts > chatStore — a floor pointer naming the newest message > leaves the pointer on the message it named — never on another one
 × src/stores/chatStore.floorResolution.test.ts > chatStore — a floor pointer naming a message the archive does not hold > does not walk the pointer back onto the newest archived message 13ms
   → expected { Object (order, identity) } to be { Object (order, identity) } // Object.is equality
 ↓ src/stores/chatStore.floorResolution.test.ts > chatStore — a floor pointer naming a message the archive does not hold > still advances once a message newer than the floor is resident

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/stores/chatStore.floorResolution.test.ts > chatStore — a floor pointer naming a message the archive does not hold > does not walk the pointer back onto the newest archived message
AssertionError: expected { Object (order, identity) } to be { Object (order, identity) } // Object.is equality

- Expected
+ Received

  {
    "identity": {
-     "messageId": "never-archived",
+     "messageId": "arch-0",
      "state": "local",
    },
    "order": {
-     "role": "floor",
-     "timestamp": 1788505787243,
+     "role": "exact",
+     "tiebreak": {
+       "id": "arch-0",
+       "kind": "chat",
+     },
+     "timestamp": 1788504840000,
    },
  }

 ❯ src/stores/chatStore.floorResolution.test.ts:182:19
    180|
    181|     const after = chatStore.getState().conversationMeta.get(CID)?.read…
    182|     expect(after).toBe(ABSENT_FLOOR)
       |                   ^
    183|     expect(isAhead(ABSENT_FLOOR, after)).toBe(false)
    184|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 3 skipped (4)
   Start at  18:13:30
   Duration  836ms (environment 43%, transform 40%, import 13%, tests 2%, setup 1%, worker 1%)
```
</details>
<details>
<summary>Evidence: Room regression counterfactual</summary>

<code>Counterfactual trace: old hatch rewrites the room floor to older resident `archived-tail`, also exactly 947243 ms backward.</code>

```text

 RUN  v5.0.0 ~/.no-mistakes/worktrees/b2ebbbea8565/01M1YA293DQYQ41GF4DTX5WX65/packages/fluux-sdk

 × src/stores/roomStore.readState.test.ts > room read state persistence > does not move an off-slice floor backwards at the live edge 10ms
   → expected { Object (order, identity) } to be { Object (order, identity) } // Object.is equality
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > stamps historyFloor when a room is first added
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > does NOT restamp historyFloor when an existing room is re-added
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > persists the pointer so it survives a store reset + rehydrate
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > loads read state from disk on switchAccount
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > rehydrates the persisted pointer into roomMeta on the next session
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > keeps the original historyFloor across a restart
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > persists a pointer advanced through commitRoomUpdate (markReadToNewest)
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > keeps the row of a room that has not been re-added this session
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > stamps and restores read state for a room born from a bookmark
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > keeps the durable pointer when the snapshot Room carries a staler one
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > takes the snapshot pointer when it is ahead of the durable row
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > drops a removed room from the durable copy
 ↓ src/stores/roomStore.readState.test.ts > room read state persistence > does not persist unreadCount

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/stores/roomStore.readState.test.ts > room read state persistence > does not move an off-slice floor backwards at the live edge
AssertionError: expected { Object (order, identity) } to be { Object (order, identity) } // Object.is equality

- Expected
+ Received

  {
    "identity": {
-     "messageId": "never-archived",
-     "state": "local",
+     "archiveId": "s-archived-tail",
+     "messageId": "archived-tail",
+     "state": "addressable",
    },
    "order": {
-     "role": "floor",
-     "timestamp": 1788505787243,
+     "role": "exact",
+     "tiebreak": {
+       "from": "room@conf.example.com/alice",
+       "id": "archived-tail",
+       "kind": "room",
+     },
+     "timestamp": 1788504840000,
    },
  }

 ❯ src/stores/roomStore.readState.test.ts:128:66
    126|     roomStore.getState().advanceReadPointer(ROOM, { id: 'archived-tail…
    127|
    128|     expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(…
       |                                                                  ^
    129|   })
    130|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 13 skipped (14)
   Start at  18:15:45
   Duration  950ms (transform 42%, environment 42%, import 13%, tests 1%, worker 1%, setup 1%)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"16e74c036437dcb804f4b23e1bff3f9a08d9d1cd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial focused Vitest run was blocked because the isolated worktree lacked project dependencies; installed lockfile dependencies locally with `npm ci --ignore-scripts` and removed transient `node_modules` afterward.</code>
- `cd packages/fluux-sdk && npx vitest run src/stores/shared/notificationState.test.ts src/stores/chatStore.floorResolution.test.ts --reporter=verbose`
- <code>Counterfactual: temporarily reverted only the target predicate; `npx vitest run src/stores/chatStore.floorResolution.test.ts --reporter=verbose -t &#39;does not walk the pointer back onto the newest archived message&#39;` failed at the intended assertion; restored target code.</code>
- <code>Counterfactual: temporarily reverted only the target predicate; `npx vitest run src/stores/roomStore.readState.test.ts --reporter=verbose -t &#39;does not move an off-slice floor backwards at the live edge&#39;` failed at the intended assertion; restored target code.</code>
- `cd packages/fluux-sdk && npx vitest run src/stores/shared/notificationState.test.ts src/stores/chatStore.floorResolution.test.ts src/stores/roomStore.readState.test.ts --reporter=dot`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
