### PR TITLE
fix(sdk): key the 1:1 chat cache on a canonical identity, not the client id

### DIFF
--- a/apps/fluux/src/hooks/useReactionNotifications.test.tsx
+++ b/apps/fluux/src/hooks/useReactionNotifications.test.tsx
@@ -110,7 +110,7 @@ describe('useReactionNotifications — chat reaction resolution', () => {
       isLive: true,
     })
 
-    expect(mockGetCachedMessage).toHaveBeenCalledWith('m1')
+    expect(mockGetCachedMessage).toHaveBeenCalledWith('peer@example.com', 'm1')
     expect(mockAddToast).toHaveBeenCalledTimes(1)
     expect(mockAddToast).toHaveBeenCalledWith('info', expect.stringContaining('reactions.mention'), 6000, expect.any(Function))
     expect(mockAddMention).not.toHaveBeenCalled()
@@ -136,7 +136,7 @@ describe('useReactionNotifications — chat reaction resolution', () => {
       isLive: true,
     })
 
-    expect(mockGetCachedMessageByStanzaId).toHaveBeenCalledWith('stanza-1')
+    expect(mockGetCachedMessageByStanzaId).toHaveBeenCalledWith('peer@example.com', 'stanza-1')
     expect(mockAddToast).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -85,7 +85,12 @@ export function useReactionNotifications(): void {
       const residentMessages = chatStore.getState().messages.get(conversationId)
       let message = residentMessages ? findMessageById([...residentMessages], messageId) : undefined
       if (!message) {
-        message = (await getCachedMessage(messageId)) ?? (await getCachedMessageByStanzaId(messageId)) ?? undefined
+        // Both lookups are conversation-scoped: a client id names a message in ONE
+        // stream and repeats across them, so an unscoped read can answer with another
+        // conversation's row (see docs/MESSAGE_IDENTIFIERS.md).
+        message = (await getCachedMessage(conversationId, messageId))
+          ?? (await getCachedMessageByStanzaId(conversationId, messageId))
+          ?? undefined
       }
       if (!message?.isOutgoing) return
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -255,17 +255,10 @@ lower edge, backward pagination shrinks it as pages reach into or across it.
 
 One logical message arrives several times — the optimistic local echo, the MUC reflection, the MAM
 copy — with no single field stable across all three. Identity is therefore a three-tier ladder:
-`stanzaId`, then `originId`, then `from` + `id`. Two copies are the same message if they share a
-tier and do not carry conflicting XEP-0421 occupant ids; the **canonical key** is the highest tier
-present. A room fallback canonical key also carries a known occupant id so conflicting occupants
-can coexist, while legacy ambiguous rows remain unchanged. Every room tier key is **scoped by room
-JID**. Reference resolution explicitly chooses
-`archive-first` or `client-id-first`: the former treats an origin-id as an XEP-0359 identity claim,
-while the latter tries real id and stanza-id matches before that sender-controlled value. A set of
-copies may be coalesced only when it contains at most one known occupant-id; an occupant-less copy
-cannot bridge two conflicting known occupants. For retractions, the full ladder expands a durable
-target through `canonicalReference`, while the outgoing stanza deliberately uses
-`archiveReference` (archive id, then client id).
+`stanzaId`, then `originId`, then `from` + `id`; the **canonical key** is the highest tier present.
+A room fallback key also carries a known occupant id so conflicting occupants remain separate.
+`identityKeys` retains every tier for lookup. The complete matching, row-discriminator and
+retraction rules live in [Message Identifiers](MESSAGE_IDENTIFIERS.md).
 
 **Standard notion:** a composite or fallback deduplication key. The tiering is what is unusual, and
 it exists because tier 3 is the only identity a legacy sender or bridge provides.

--- a/docs/MESSAGE_IDENTIFIERS.md
+++ b/docs/MESSAGE_IDENTIFIERS.md
@@ -64,11 +64,14 @@ deduplication, caches, reference lookups, retractions and search. The order, mos
 2. `originId`
 3. `from` + `id`
 
-Two copies are the same logical message **iff they share a tier and do not carry conflicting
-XEP-0421 occupant ids** (`sameLogicalMessage`). The canonical key is the highest tier present
-(`canonicalKey`). For room messages on tier 3 only, a known occupant id also qualifies the durable
-canonical key, while the searchable `identityKeys` strings remain unchanged. Tier 3 exists because
-legacy senders and bridges emit neither XEP-0359 element —
+Two copies are candidate logical matches **iff they share a tier and do not carry conflicting
+XEP-0421 occupant ids** (`sameLogicalMessage`). At the non-unique `from` + `id` rung, the chat
+cache and retraction ledger also reject copies whose known `stanzaId` or `originId` values disagree
+(`archiveIdentityConflict`): a disagreement is evidence that they are different messages, while a
+missing id is not. The canonical key is the highest tier present (`canonicalKey`). For room messages
+on tier 3 only, a known occupant id also qualifies the durable canonical key, while the searchable
+`identityKeys` strings remain unchanged. Tier 3 exists because legacy senders and bridges emit
+neither XEP-0359 element —
 without it those messages would have no identity at all. An absent occupant id does not separate
 copies; two present, different occupant ids do, even when a nick and client id were reused.
 
@@ -82,7 +85,7 @@ Every room tier key is **scoped by room JID** (`scoped`, same file). `stanzaId` 
 assigned per archive and can repeat across rooms, while the `identityKeys` index spans the whole
 store; an unscoped key would let the finder merge messages from different rooms. The room cache
 carries the same rule: no unscoped `stanzaId`/`originId` index exists, and every such lookup goes
-through the room-scoped alias — `packages/fluux-sdk/src/utils/messageCache.ts:202-210`.
+through the room-scoped alias — `packages/fluux-sdk/src/utils/messageCache.ts`.
 
 The same boundary derives the equivalent unscoped keys for 1:1 chats. Scope is an explicit
 parameter rather than a second ladder implementation.
@@ -110,18 +113,20 @@ is this?" — has a different answer, and conflating them is what a reused MUC n
 
 XEP-0421 lets a room reassign a nick once its owner leaves. Two occupants can then produce rows
 sharing a room, a `from` and a client id, and only the occupant-id separates them. Anything that
-points AT A ROW must therefore carry both halves:
+points AT A ROW therefore starts with the row's client id and carries every available discriminator:
 
 - a saved scroll anchor and the load-around request that restores it,
 - the new-message divider,
 - the viewport report that advances the read pointer, and the pointer itself.
 
-`MessageRowRef` (`utils/messageIdentity.ts`) is that currency: a client `id` plus the optional
-occupant-id. It is deliberately **not** a wire reference. Its `id` is always the row's own client
-id — read off a rendered row, or off a pointer's local name — never a stanza-id or an origin-id, so
-resolving one (`findMessageRowIndex`) walks no tier ladder and takes no `ResolutionPolicy`.
-Admitting stanza-id matches there would let a read pointer advance onto a message no viewport ever
-reported.
+`MessageRowRef` (`utils/messageIdentity.ts`) is that currency: a client `id`, the optional
+occupant-id, and — when the resolved row already supplied them — optional `stanzaId`/`originId`
+discriminators. It is deliberately **not** a wire reference. Its `id` is always the row's own client
+id — read off a rendered row, or off a pointer's local name — never replaced by a stanza-id or an
+origin-id. Resolving one (`findMessageRowIndex`) walks no tier ladder and takes no
+`ResolutionPolicy`: archive fields only reject a candidate whose known archive identity conflicts.
+They never create a match. A DOM handle has only the client and occupant halves, so it retains the
+compatible bare-id fallback when no archive discriminator is available.
 
 Two selection rules coexist, and they are not interchangeable:
 
@@ -244,7 +249,8 @@ What a caller should do with a missing archive id:
 
 - **Do not treat a client `id` as an identity.** It is a name in one stream, reusable across a
   restart, and the lowest identity tier only in combination with `from` (`messageIdentity.ts`).
-  **No durable store may key on it** — that is what the v5 chat migration exists to undo (§5).
+  **No durable message-cache row may key on it** — that is what the v5 chat migration exists to
+  undo (§5).
 - **Do not name a row with a client id alone.** After a nick reassignment it names two of them, and
   a bare-id lookup silently takes the first. Scroll anchors, the divider, the viewport report and
   the read pointer all speak `MessageRowRef` (§4).

--- a/docs/MESSAGE_IDENTIFIERS.md
+++ b/docs/MESSAGE_IDENTIFIERS.md
@@ -145,11 +145,19 @@ possible client id. `messageRowRefFromRowId` decodes it back before it crosses i
 
 ## 5. Why rooms and 1:1 conversations differ
 
-The cache stores them under different primary keys:
+Both stores are keyed by a **canonical identity key**, never by a client id:
 
-- chat messages: `keyPath: 'id'` — the **client** id (`utils/messageCache.ts:181`)
-- room messages: `keyPath: 'cacheKey'` — the **canonical identity key** above
-  (`utils/messageCache.ts:202`)
+- chat messages: `keyPath: 'cacheKey'` — the canonical key qualified by
+  `conversationId`, because chat identity keys are themselves unscoped (§3)
+- room messages: `keyPath: 'cacheKey'` — the canonical key, already namespaced by room
+
+A client id was the chat store's primary key until v5, and that is the shape of defect it
+produces: a client that restarts and re-issues an id had its later message overwrite the
+earlier one's row, then inherit its retraction tombstone. Both bodies were destroyed. Keying
+alone was not enough — see `archiveIdentityConflict` in `messageIdentity.ts` for the second
+half, at the `from+id` rung.
+
+What still differs between the two is ORDER, not identity.
 
 `CacheOrderKey` (`packages/fluux-sdk/src/core/types/readState.ts:14-59`) is discriminated by kind
 for the same reason, and states why an archive id could never serve here: XEP-0313 §6.2 makes
@@ -234,16 +242,20 @@ What a caller should do with a missing archive id:
 
 ## 7. Do not
 
-- **Do not treat a client `id` as an identity.** It is a name in one stream. It is the chat cache's
-  primary key (`messageCache.ts:181`) and the lowest identity tier only in combination with `from`
-  (`messageIdentity.ts`).
+- **Do not treat a client `id` as an identity.** It is a name in one stream, reusable across a
+  restart, and the lowest identity tier only in combination with `from` (`messageIdentity.ts`).
+  **No durable store may key on it** — that is what the v5 chat migration exists to undo (§5).
 - **Do not name a row with a client id alone.** After a nick reassignment it names two of them, and
   a bare-id lookup silently takes the first. Scroll anchors, the divider, the viewport report and
   the read pointer all speak `MessageRowRef` (§4).
 - **Do not compare archive ids from different archives.** A message can carry several
   `<stanza-id>`; only the one stamped `by` the archive you are addressing is meaningful there
   (`messagingUtils.ts:239-276`). Comparing across archives, or across rooms, is what the room
-  scoping exists to prevent (`messageIdentity.ts`, `messageCache.ts:202-210`).
+  scoping exists to prevent (`messageIdentity.ts`, `messageCache.ts`).
+- **Do not separate two copies by a clock.** What tells two messages apart is what the archive
+  says about them — a stanza-id or origin-id disagreement (`archiveIdentityConflict`), the room's
+  occupant-id disagreement (`occupantConflict`) — never when either was written or received. Only
+  a disagreement is evidence; an absent id must never separate two copies of one message.
 - **Do not read stability as identity.** `originId` is stable and sender-assigned, which makes it a
   good echo-dedup key — but two rows can share one, which is why `withArchiveId` forbids binding
   through it (`readPointer.ts:207-243`) and why references resolve it last

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -415,8 +415,10 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(count).toBe(1)
       // Written back to the DURABLE cache with plaintext + cleared stash.
       expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        'carol@example.com',
         'durable-1',
-        expect.objectContaining({ body: 'hello', encryptedPayload: undefined })
+        expect.objectContaining({ body: 'hello', encryptedPayload: undefined }),
+        'carol@example.com'
       )
     })
 

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -25,6 +25,9 @@ vi.mock('../utils/messageCache', () => ({
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),
   getMessagesWithEncryptedPayload: vi.fn().mockResolvedValue([]),
+  chatCacheKey: vi.fn((message: { cacheKey?: string; conversationId: string; id: string }) =>
+    message.cacheKey ?? `${message.conversationId}\u0000${message.id}`
+  ),
   getMessage: vi.fn().mockResolvedValue(null),
   getMessageByStanzaId: vi.fn().mockResolvedValue(null),
   // recomputeUnreadForConversation's coverage
@@ -407,6 +410,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
           timestamp: new Date(),
           isOutgoing: false,
           encryptedPayload: DUMMY_PAYLOAD_XML,
+          cacheKey: 'carol@example.com\u0000durable-1',
         },
       ])
 
@@ -418,7 +422,9 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
         'carol@example.com',
         'durable-1',
         expect.objectContaining({ body: 'hello', encryptedPayload: undefined }),
-        'carol@example.com'
+        'carol@example.com',
+        undefined,
+        'carol@example.com\u0000durable-1'
       )
     })
 
@@ -457,6 +463,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
           timestamp: new Date(),
           isOutgoing: false,
           encryptedPayload: DUMMY_PAYLOAD_XML,
+          cacheKey: 'dave@example.com\u0000dup-1',
         },
       ])
 
@@ -499,7 +506,9 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
         lastMessage: encryptedPreview,
         unreadCount: 1,
       })
-      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([encryptedPreview])
+      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([
+        { ...encryptedPreview, cacheKey: 'carol@example.com\u0000durable-preview-1' },
+      ])
 
       await xmppClient.retryPendingDecrypts()
 

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
@@ -13,7 +13,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
-import { DeferredDecryptEngine } from './deferredDecrypt'
+import { DeferredDecryptEngine, type DeferredDecryptCache } from './deferredDecrypt'
 import {
   E2EEManager,
   InMemoryStorageBackend,
@@ -60,7 +60,9 @@ const makeCache = () => ({
 describe('DeferredDecryptEngine', () => {
   let manager: E2EEManager
   let stores: MockStoreBindings
-  let cache: ReturnType<typeof makeCache>
+  // The PORT, not the mock factory's shape: tests bind either the vi.fn stubs or the
+  // real messageCache functions here, and only the port covers both.
+  let cache: DeferredDecryptCache
   let engine: DeferredDecryptEngine
 
   beforeEach(async () => {

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
@@ -11,6 +11,8 @@
  * decrypt here and fail.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
 import { DeferredDecryptEngine } from './deferredDecrypt'
 import {
   E2EEManager,
@@ -21,6 +23,8 @@ import { DummyPlaintextPlugin } from './DummyPlaintextPlugin'
 import { createMockStores, type MockStoreBindings } from '../test-utils'
 import type { StoreBindings } from '../types'
 import type { Message } from '../types/chat'
+import * as messageCache from '../../utils/messageCache'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from '../../utils/storageScope'
 
 function stubXmppPrimitives(): XMPPPrimitives {
   return {
@@ -60,6 +64,10 @@ describe('DeferredDecryptEngine', () => {
   let engine: DeferredDecryptEngine
 
   beforeEach(async () => {
+    globalThis.indexedDB = new IDBFactory()
+    _resetStorageScopeForTesting()
+    messageCache._resetDBForTesting()
+    setStorageScopeJid('deferred-decrypt@example.com')
     manager = await makeManagerWithDummyPlugin('me@example.com')
     stores = createMockStores()
     cache = makeCache()
@@ -206,6 +214,65 @@ describe('DeferredDecryptEngine', () => {
 
     expect(stores.chat.updateMessage).toHaveBeenCalledTimes(1)
     expect(stores.chat.refreshLastMessageContent).not.toHaveBeenCalled()
+  })
+
+  it('repairs each archive-distinct durable row that reuses a client id', async () => {
+    vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+      plaintext: new TextEncoder().encode('hello'),
+      senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+      securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+    })
+
+    const conversationId = 'bob@example.com'
+    const first: Message = {
+      type: 'chat',
+      id: 'reused-client-id',
+      stanzaId: 'z',
+      conversationId,
+      from: conversationId,
+      body: '[encrypted first]',
+      timestamp: new Date(1_700_000_000_000),
+      isOutgoing: false,
+      encryptedPayload: DUMMY_PAYLOAD_XML,
+    }
+    const second: Message = {
+      ...first,
+      stanzaId: 'a', // Sorts before z, so a bare id lookup must not select it for both writes.
+      body: '[encrypted second]',
+      timestamp: new Date(1_700_000_001_000),
+    }
+    await messageCache.saveMessages([first, second])
+
+    cache = {
+      getMessagesWithEncryptedPayload: messageCache.getMessagesWithEncryptedPayload,
+      updateMessage: messageCache.updateMessage,
+      deleteMessage: messageCache.deleteMessage,
+    }
+    engine = new DeferredDecryptEngine({
+      getManager: () => manager,
+      getStores: () => stores as unknown as StoreBindings,
+      getOwnBareJid: () => 'me@example.com',
+      cache,
+    })
+    stores.chat.getAllStoredMessages.mockReturnValue([])
+    stores.chat.getEncryptedPreviews.mockReturnValue([])
+
+    const repairedCount = await engine.retryPending()
+    const repaired = await messageCache.getMessages(conversationId, { limit: 10 })
+    expect({
+      repairedCount,
+      rows: repaired.map((message) => ({
+        stanzaId: message.stanzaId,
+        body: message.body,
+        encryptedPayload: message.encryptedPayload,
+      })),
+    }).toEqual({
+      repairedCount: 2,
+      rows: [
+        { stanzaId: 'z', body: 'hello', encryptedPayload: undefined },
+        { stanzaId: 'a', body: 'hello', encryptedPayload: undefined },
+      ],
+    })
   })
 
   it('is a no-op when no E2EE manager is available', async () => {

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
@@ -62,8 +62,8 @@ type RetryOutcome =
  */
 export interface DeferredDecryptCache {
   getMessagesWithEncryptedPayload: () => Promise<Message[]>
-  updateMessage: (id: string, updates: Partial<Message>) => Promise<void>
-  deleteMessage: (id: string) => Promise<void>
+  updateMessage: (conversationId: string, id: string, updates: Partial<Message>, from: string) => Promise<void>
+  deleteMessage: (conversationId: string, id: string, from: string) => Promise<void>
 }
 
 /**
@@ -245,7 +245,7 @@ export class DeferredDecryptEngine {
             ...(outcome.attachment && { attachment: outcome.attachment }),
             encryptedPayload: undefined,
           }
-          await this.deps.cache.updateMessage(msg.id, updates)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
           // The conversation's messages aren't loaded (durable path), so the
           // in-memory sidebar preview would keep the "[OpenPGP-encrypted
           // message]" fallback. Heal it when this message IS the preview.
@@ -260,7 +260,7 @@ export class DeferredDecryptEngine {
           // the signal is reconciled on the next MAM catch-up, when the
           // now-unlocked key decrypts it inline.
           this.applyChatModification(conversationId, msg, outcome.modification, stores.chat)
-          await this.deps.cache.deleteMessage(msg.id)
+          await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from)
           // Never-opened conversation: its unread badge was hydrated from the
           // durable cache during catch-up and still counts this placeholder.
           // Recompute now that the row is gone from the cache (deleted above),
@@ -270,14 +270,14 @@ export class DeferredDecryptEngine {
         } else if (outcome.kind === 'rejected') {
           if (msg.body === COULD_NOT_DECRYPT_BODY) {
             // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
-            await this.deps.cache.deleteMessage(msg.id)
+            await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from)
           } else {
             const updates = {
               body: MESSAGE_REJECTED_BODY,
               ...(outcome.securityContext && { securityContext: outcome.securityContext }),
               encryptedPayload: undefined,
             }
-            await this.deps.cache.updateMessage(msg.id, updates)
+            await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
             stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
           }
         } else if (outcome.kind === 'unsupported') {
@@ -285,7 +285,7 @@ export class DeferredDecryptEngine {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
           }
-          await this.deps.cache.updateMessage(msg.id, updates)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
           stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
         }
       }

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
@@ -25,6 +25,7 @@ import { parseMessageContent, applyRetraction, parseReactionsSignal, parseRetrac
 import { getBareJid, getDomain } from '../jid'
 import { logDebug, logInfo, logWarn } from '../logger'
 import type { StoreBindings, MessageSecurityContext, FileAttachment, Message } from '../types'
+import { chatCacheKey, type CachedChatMessage } from '../../utils/messageCache'
 
 /**
  * A bodiless signal stanza recovered from a deferred decrypt. The whole
@@ -61,9 +62,22 @@ type RetryOutcome =
  * direct module-global dependency and is unit-testable in isolation.
  */
 export interface DeferredDecryptCache {
-  getMessagesWithEncryptedPayload: () => Promise<Message[]>
-  updateMessage: (conversationId: string, id: string, updates: Partial<Message>, from: string) => Promise<void>
-  deleteMessage: (conversationId: string, id: string, from: string) => Promise<void>
+  getMessagesWithEncryptedPayload: () => Promise<CachedChatMessage[]>
+  updateMessage: (
+    conversationId: string,
+    id: string,
+    updates: Partial<Message>,
+    from: string,
+    scopeJid?: string | null,
+    expectedCacheKey?: string
+  ) => Promise<void>
+  deleteMessage: (
+    conversationId: string,
+    id: string,
+    from: string,
+    scopeJid?: string | null,
+    expectedCacheKey?: string
+  ) => Promise<void>
 }
 
 /**
@@ -139,7 +153,7 @@ export class DeferredDecryptEngine {
       for (const { id: conversationId, messages } of chatBindings.getAllStoredMessages()) {
         for (const msg of messages) {
           if (!msg.encryptedPayload) continue
-          handledChatKeys.add(`${conversationId} ${msg.id}`)
+          handledChatKeys.add(chatCacheKey(msg))
           const outcome = await this.decryptSingle(
             manager, msg.encryptedPayload, msg.from, conversationId,
           )
@@ -231,10 +245,10 @@ export class DeferredDecryptEngine {
       for (const msg of await this.deps.cache.getMessagesWithEncryptedPayload()) {
         const conversationId = msg.conversationId
         if (!msg.encryptedPayload || !conversationId) continue
-        if (handledChatKeys.has(`${conversationId} ${msg.id}`)) continue
+        if (handledChatKeys.has(msg.cacheKey)) continue
         // Record so the preview-heal pass below skips a message this pass
         // already repaired (it heals the preview via refreshLastMessageContent).
-        handledChatKeys.add(`${conversationId} ${msg.id}`)
+        handledChatKeys.add(msg.cacheKey)
         const outcome = await this.decryptSingle(
           manager, msg.encryptedPayload, msg.from, conversationId,
         )
@@ -245,7 +259,7 @@ export class DeferredDecryptEngine {
             ...(outcome.attachment && { attachment: outcome.attachment }),
             encryptedPayload: undefined,
           }
-          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
           // The conversation's messages aren't loaded (durable path), so the
           // in-memory sidebar preview would keep the "[OpenPGP-encrypted
           // message]" fallback. Heal it when this message IS the preview.
@@ -260,7 +274,7 @@ export class DeferredDecryptEngine {
           // the signal is reconciled on the next MAM catch-up, when the
           // now-unlocked key decrypts it inline.
           this.applyChatModification(conversationId, msg, outcome.modification, stores.chat)
-          await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from)
+          await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, undefined, msg.cacheKey)
           // Never-opened conversation: its unread badge was hydrated from the
           // durable cache during catch-up and still counts this placeholder.
           // Recompute now that the row is gone from the cache (deleted above),
@@ -270,14 +284,14 @@ export class DeferredDecryptEngine {
         } else if (outcome.kind === 'rejected') {
           if (msg.body === COULD_NOT_DECRYPT_BODY) {
             // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
-            await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from)
+            await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, undefined, msg.cacheKey)
           } else {
             const updates = {
               body: MESSAGE_REJECTED_BODY,
               ...(outcome.securityContext && { securityContext: outcome.securityContext }),
               encryptedPayload: undefined,
             }
-            await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
+            await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
             stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
           }
         } else if (outcome.kind === 'unsupported') {
@@ -285,7 +299,7 @@ export class DeferredDecryptEngine {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
           }
-          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
           stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
         }
       }
@@ -306,7 +320,7 @@ export class DeferredDecryptEngine {
         // Skip a preview whose message a store pass already repaired — that pass
         // heals the preview in place (updateMessage / refreshLastMessageContent),
         // so re-decrypting here would be redundant work.
-        if (handledChatKeys.has(`${conversationId} ${lastMessage.id}`)) continue
+        if (handledChatKeys.has(chatCacheKey(lastMessage))) continue
         const outcome = await this.decryptSingle(
           manager, lastMessage.encryptedPayload, lastMessage.from, conversationId,
         )

--- a/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
@@ -22,7 +22,9 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/messageCache')>()
   return {
     ...actual,
-    getMessage: (id: string) => (getMessageGate ? getMessageGate(id) : actual.getMessage(id)),
+    getMessage: (conversationId: string, id: string) => (
+      getMessageGate ? getMessageGate(id) : actual.getMessage(conversationId, id)
+    ),
   }
 })
 
@@ -57,7 +59,7 @@ describe('read pointer migration', () => {
   })
 
   it('keeps the archive identity when the cached row is resolved by id', async () => {
-    await messageCache.updateMessage('m2', { stanzaId: 'archive-m2' })
+    await messageCache.updateMessage(CONV, 'm2', { stanzaId: 'archive-m2' }, CONV)
     const p = await migrateReadPointer(CONV, { lastSeenMessageId: 'm2' })
     expect(p).toEqual({
       order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } },
@@ -69,7 +71,7 @@ describe('read pointer migration', () => {
   // here. That is ahead of where the user was, and the pointer is forward-only,
   // so it would destroy the position unrecoverably.
   it('keeps a timestamp-resolved cached row local without moving its order', async () => {
-    await messageCache.updateMessage('m2', { stanzaId: 'archive-m2' })
+    await messageCache.updateMessage(CONV, 'm2', { stanzaId: 'archive-m2' }, CONV)
     const p = await migrateReadPointer(CONV, { lastReadAt: at(2500) })
     expect(p).toEqual({
       order: { role: 'exact', timestamp: 2000, tiebreak: { kind: 'chat', id: 'm2' } },

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1927,7 +1927,12 @@ describe('chatStore', () => {
       chatStore.getState().clearMessageStanzaId('alice@example.com', 'uuid-sent')
 
       expect(chatStore.getState().getMessage('alice@example.com', msg.id)?.stanzaId).toBeUndefined()
-      expect(messageCache.updateMessage).toHaveBeenCalledWith(msg.id, { stanzaId: undefined })
+      expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        'alice@example.com',
+        msg.id,
+        { stanzaId: undefined },
+        msg.from
+      )
     })
 
     it('heals the lastMessage preview when the cleared message was the preview', () => {
@@ -3359,8 +3364,10 @@ describe('chatStore', () => {
         expect(messages?.length).toBe(1)
         expect(messages?.[0].stanzaId).toBe('archive-carbon')
         expect(messageCache.updateMessage).toHaveBeenCalledWith(
+          'alice@example.com',
           'uuid-2',
-          expect.objectContaining({ stanzaId: 'archive-carbon' })
+          expect.objectContaining({ stanzaId: 'archive-carbon' }),
+          sent.from
         )
       })
     })
@@ -4978,11 +4985,11 @@ describe('chatStore', () => {
       // microtasks after the synchronous store update.
       await flushRetractionStorage()
       expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        convId,
         'msg-1',
         expect.objectContaining({ isRetracted: true }),
-        // The account scope captured before the first await; none is set here.
+        convId,
         null,
-        expect.objectContaining({ conversationId: convId })
       )
     })
 
@@ -5006,11 +5013,11 @@ describe('chatStore', () => {
       // Written through, so the tombstone survives a reload without the record.
       await flushRetractionStorage()
       expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        convId,
         'msg-1',
         expect.objectContaining({ isRetracted: true }),
-        // The account scope captured before the first await; none is set here.
+        convId,
         null,
-        expect.objectContaining({ conversationId: convId })
       )
     })
 

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -4990,6 +4990,8 @@ describe('chatStore', () => {
         expect.objectContaining({ isRetracted: true }),
         convId,
         null,
+        // No exact cache key: the target is resident but has no cached row to pin.
+        undefined,
       )
     })
 
@@ -5018,6 +5020,8 @@ describe('chatStore', () => {
         expect.objectContaining({ isRetracted: true }),
         convId,
         null,
+        // No exact cache key: the target is resident but has no cached row to pin.
+        undefined,
       )
     })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -858,7 +858,7 @@ export async function migrateReadPointer(
     // is" is earned: the row's own archive id may ride along, and this pointer
     // mints `addressable` when the cached row carries one. Contrast the
     // timestamp-resolved branch below, which cannot make that claim.
-    const cached = await messageCache.getMessage(lastSeenMessageId)
+    const cached = await messageCache.getMessage(conversationId, lastSeenMessageId)
     if (cached) return makeReadPointer(cached, 'chat')
     return undefined
   }
@@ -1812,7 +1812,12 @@ export const chatStore = createStore<ChatState>()(
           if (append.kind === 'duplicate-backfilled') {
             // Persist the backfilled archive ids so pagination cursors survive a reload.
             for (const p of append.patched) {
-              void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+              void messageCache.updateMessage(
+                p.conversationId,
+                p.id,
+                { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) },
+                p.from
+              )
             }
             const patchedMap = new Map(state.messages)
             patchedMap.set(msg.conversationId, append.messages)
@@ -2490,7 +2495,12 @@ export const chatStore = createStore<ChatState>()(
           }
 
           // Update in IndexedDB asynchronously
-          void messageCache.updateMessage(message.id, { reactions: updatedMessage.reactions })
+          void messageCache.updateMessage(
+            message.conversationId,
+            message.id,
+            { reactions: updatedMessage.reactions },
+            message.from
+          )
 
           const newMessages = new Map(state.messages)
           const updatedConvMessages = [...convMessages]
@@ -2545,7 +2555,12 @@ export const chatStore = createStore<ChatState>()(
               retractionReference ?? messageId
             )
           } else {
-            void messageCache.updateMessage(convMessages[messageIndex].id, updates)
+            void messageCache.updateMessage(
+              conversationId,
+              convMessages[messageIndex].id,
+              updates,
+              convMessages[messageIndex].from
+            )
             if (updates.body) void searchIndex.updateMessage(updatedMessage)
           }
 
@@ -2599,7 +2614,12 @@ export const chatStore = createStore<ChatState>()(
           updatedConvMessages[messageIndex] = updatedMessage
           newMessages.set(conversationId, updatedConvMessages)
 
-          void messageCache.updateMessage(convMessages[messageIndex].id, { stanzaId: undefined })
+          void messageCache.updateMessage(
+            conversationId,
+            convMessages[messageIndex].id,
+            { stanzaId: undefined },
+            convMessages[messageIndex].from
+          )
 
           // Against the PRE-update copy: `updatedMessage` has just lost the
           // stanza-id tier the preview may be known under.
@@ -2719,7 +2739,7 @@ export const chatStore = createStore<ChatState>()(
           // Mirror updateMessage: keep the search index and durable cache in
           // sync, using the message's real id (not the lookup id).
           void searchIndex.removeMessage(removed)
-          void messageCache.deleteMessage(removed.id)
+          void messageCache.deleteMessage(conversationId, removed.id, removed.from)
 
           // This may be dropping a noted `noLocalStore` message (a
           // bodiless placeholder never resolves to noLocalStore in practice,

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -1412,3 +1412,200 @@ describe('retraction propagates to the cache and the search index', () => {
     })
   })
 })
+
+// =============================================================================
+// A retraction must not reach across a REUSED client id (#1381)
+// =============================================================================
+
+/**
+ * A client id names a stanza, not a message: a peer that restarts may re-issue
+ * one it already used. When the earlier message under that id was retracted,
+ * nothing about the later message may inherit that tombstone — not the cache
+ * key, not the identity ladder, not the session ledger. Scrubbing it destroys
+ * content the user never deleted, durably and with no way back.
+ */
+describe('a reused client id after a retraction', () => {
+  const REUSED_ID = 'client-42'
+  const T0 = 1_700_000_000_000
+  const TWENTY_MINUTES = 20 * 60 * 1000
+
+  beforeEach(async () => {
+    globalThis.indexedDB = new IDBFactory()
+    _resetStorageScopeForTesting()
+    messageCache._resetDBForTesting()
+    searchIndex._resetDBForTesting()
+    _clearRetractedIdentitiesForTesting()
+    localStorage.clear()
+    setStorageScopeJid(SCOPE)
+    await searchIndex.initSearchIndex(SCOPE)
+    chatStore.setState({ messages: new Map(), pendingRetractions: new Map() })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await searchIndex.closeSearchIndex()
+  })
+
+  /** The rows of CHAT as a reader would see them, oldest first. */
+  async function storedChat(): Promise<Message[]> {
+    return (await messageCache.getMessages(CHAT, { limit: 50 })).slice().sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime()
+    )
+  }
+
+  it('keeps the later message intact when both copies carry an archive id', async () => {
+    const retracted = chatMessage({ id: REUSED_ID, stanzaId: 'archive-first', timestamp: new Date(T0) })
+    await messageCache.saveMessage(retracted)
+    await searchIndex.indexMessage(retracted)
+
+    await retractChatMessageInStorage(CHAT, retracted)
+    await settle()
+    await expectNoTraceOf(SECRET)
+
+    // The peer's client restarted and re-issued the same client id.
+    const innocent = chatMessage({
+      id: REUSED_ID,
+      stanzaId: 'archive-second',
+      body: 'an innocent later message',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+    })
+    await messageCache.saveMessage(innocent)
+    await settle()
+
+    const rows = await storedChat()
+    expect(rows).toHaveLength(2)
+    expect(rows[0].isRetracted).toBe(true)
+    expect(rows[0].body).toBe('')
+    expect(rows[1].isRetracted).toBeFalsy()
+    expect(rows[1].body).toBe('an innocent later message')
+    expect(rows[1].stanzaId).toBe('archive-second')
+  })
+
+  /**
+   * The residual, asserted so it cannot change unnoticed.
+   *
+   * With no stanza-id and no origin-id on either copy, `from+id` is the ONLY
+   * identity either one has: both derive the same canonical key, so the cache
+   * cannot hold them as two rows and no evidence exists that would separate
+   * them. Reachable only where the server stamps no XEP-0359 stanza-id AND the
+   * sender sends no origin-id — Fluux itself stamps one on every live 1:1
+   * message it receives.
+   *
+   * One key leaves only the question of which message survives, and XEP-0424 is
+   * monotonic: the tombstone wins. Showing a body the user deleted is the worse
+   * failure, and the opposite choice was already tried and reverted.
+   */
+  it('collapses onto the tombstone when neither copy carries an archive id', async () => {
+    const retracted = chatMessage({ id: REUSED_ID, timestamp: new Date(T0) })
+    await messageCache.saveMessage(retracted)
+    await searchIndex.indexMessage(retracted)
+
+    await retractChatMessageInStorage(CHAT, retracted)
+    await settle()
+    await expectNoTraceOf(SECRET)
+
+    const innocent = chatMessage({
+      id: REUSED_ID,
+      body: 'an innocent later message',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+    })
+    await messageCache.saveMessage(innocent)
+    await settle()
+
+    const rows = await storedChat()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].isRetracted).toBe(true)
+    expect(rows[0].body).toBe('')
+    // An archive id on EITHER copy is enough to separate them.
+    expect(retracted.stanzaId).toBeUndefined()
+    expect(innocent.stanzaId).toBeUndefined()
+  })
+
+  it('erases the index document of a copy the cache merged away', async () => {
+    // Two archive copies of ONE message under different client ids. The cache
+    // holds them as a single row, but the search index keys chat documents by
+    // client id and so still holds two — the retraction has to reach both.
+    const live = chatMessage({ id: 'live-id', originId: 'O', body: `the ${SECRET} plan` })
+    const archived = chatMessage({ id: 'mam-id', originId: 'O', body: `the ${SECRET} plan` })
+    await messageCache.saveMessages([live, archived])
+    await searchIndex.indexMessages([live, archived])
+    expect(await searchIndex.search(SECRET)).toHaveLength(2)
+
+    await retractChatMessageInStorage(CHAT, live)
+    await settle()
+
+    expect(await storedChat()).toHaveLength(1)
+    await expectNoTraceOf(SECRET)
+  })
+
+  it('erases the index document of a message whose own save has not landed', async () => {
+    // Indexed but not cached — its save is still in flight — while a sibling copy
+    // IS cached. The sibling must not shadow it out of the removal.
+    const pending = chatMessage({ id: 'pending-id', originId: 'O', body: `the ${SECRET} plan` })
+    const cached = chatMessage({ id: 'cached-id', originId: 'O', body: `the ${SECRET} plan` })
+    await messageCache.saveMessage(cached)
+    await searchIndex.indexMessages([pending, cached])
+
+    await retractChatMessageInStorage(CHAT, pending)
+    await settle()
+
+    await expectNoTraceOf(SECRET)
+  })
+
+  /**
+   * The other half of the residual: separating two copies needs evidence on BOTH
+   * sides. An archive id the later copy does not carry cannot disagree with
+   * anything, and the same shape is how a copy that predates its archive stamp is
+   * legitimately recognised — so absence stays non-evidence, exactly as it does
+   * for a room's XEP-0421 occupant-id.
+   *
+   * Not reachable where a server stamps XEP-0359 stanza-ids, which it does for
+   * every incoming 1:1 message or for none.
+   */
+  it('collapses onto the tombstone when only the earlier copy carries an archive id', async () => {
+    const retracted = chatMessage({ id: REUSED_ID, stanzaId: 'archive-first', timestamp: new Date(T0) })
+    await messageCache.saveMessage(retracted)
+    await retractChatMessageInStorage(CHAT, retracted)
+    await settle()
+
+    const innocent = chatMessage({
+      id: REUSED_ID,
+      body: 'an innocent later message',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+    })
+    await messageCache.saveMessage(innocent)
+    await settle()
+
+    const rows = await storedChat()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].isRetracted).toBe(true)
+    expect(innocent.stanzaId).toBeUndefined()
+  })
+
+  it('keeps an attachment and a poll on the later message', async () => {
+    const retracted = chatMessage({ id: REUSED_ID, stanzaId: 'archive-first', timestamp: new Date(T0) })
+    await messageCache.saveMessage(retracted)
+    await retractChatMessageInStorage(CHAT, retracted)
+    await settle()
+
+    const innocent = chatMessage({
+      id: REUSED_ID,
+      stanzaId: 'archive-second',
+      body: 'see the plan',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+      attachment: { url: 'https://files.example/plan.pdf', mediaType: 'application/pdf' },
+      poll: {
+        title: 'ship it?',
+        options: [{ emoji: '1️⃣', label: 'yes' }],
+        settings: { allowMultiple: false, hideResultsBeforeVote: false },
+      },
+    })
+    await messageCache.saveMessage(innocent)
+    await settle()
+
+    const survivor = (await storedChat()).find((row) => row.stanzaId === 'archive-second')
+    expect(survivor?.attachment).toBeDefined()
+    expect(survivor?.poll).toBeDefined()
+    expect(survivor?.isRetracted).toBeFalsy()
+  })
+})

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -1523,10 +1523,11 @@ describe('a reused client id after a retraction', () => {
     await retractChatMessageInStorage(CHAT, first)
 
     const rows = await storedChat()
-    expect(rows.find((row) => row.stanzaId === 'a')).toMatchObject({
+    const innocent = rows.find((row) => row.stanzaId === 'a')
+    expect(innocent).toMatchObject({
       body: 'innocent archive-distinct sibling',
-      isRetracted: undefined,
     })
+    expect(innocent?.isRetracted).toBeFalsy()
     expect(rows.find((row) => row.stanzaId === 'z')).toMatchObject({
       body: '',
       isRetracted: true,

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -180,7 +180,7 @@ describe('retraction propagates to the cache and the search index', () => {
       chatStore.getState().recordPendingRetraction(CHAT, message.id, CHAT)
       await settle()
 
-      const stored = await messageCache.getMessage(message.id)
+      const stored = await messageCache.getMessage(CHAT, message.id)
       expect(stored?.isRetracted).toBe(true)
       expect(stored?.body).toBe('')
       await expectNoTraceOf(SECRET)
@@ -195,8 +195,8 @@ describe('retraction propagates to the cache and the search index', () => {
       chatStore.getState().recordPendingRetraction(CHAT, 'shared-archive', CHAT)
       await settle()
 
-      expect((await messageCache.getMessage(first.id))?.isRetracted).toBe(true)
-      expect((await messageCache.getMessage(second.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, first.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, second.id))?.isRetracted).toBe(true)
       expect(await searchIndex.search('holmium')).toEqual([])
       expect(await searchIndex.search('thulium')).toEqual([])
     })
@@ -221,8 +221,8 @@ describe('retraction propagates to the cache and the search index', () => {
       chatStore.getState().recordPendingRetraction(CHAT, first.originId!, first.from)
       await settle()
 
-      expect((await messageCache.getMessage(first.id))?.isRetracted).toBe(true)
-      expect((await messageCache.getMessage(second.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, first.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, second.id))?.isRetracted).toBe(true)
       expect(await searchIndex.search('holmium')).toEqual([])
       expect(await searchIndex.search('thulium')).toEqual([])
     })
@@ -271,12 +271,12 @@ describe('retraction propagates to the cache and the search index', () => {
 
       await retractChatMessageInStorage(CHAT, target, { retractedAt: new Date() })
 
-      expect(await messageCache.getMessage(target.id)).toMatchObject({
+      expect(await messageCache.getMessage(OTHER_CHAT, target.id)).toMatchObject({
         conversationId: OTHER_CHAT,
         from: target.from,
         body: 'other-conversation terbium',
       })
-      expect((await messageCache.getMessage(target.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(OTHER_CHAT, target.id))?.isRetracted).toBeFalsy()
       expect(await searchIndex.search('terbium')).toHaveLength(1)
 
       const otherSender = chatMessage({
@@ -293,12 +293,12 @@ describe('retraction propagates to the cache and the search index', () => {
         { retractedAt: new Date() }
       )
 
-      expect(await messageCache.getMessage(otherSender.id)).toMatchObject({
+      expect(await messageCache.getMessage(CHAT, otherSender.id)).toMatchObject({
         conversationId: CHAT,
         from: otherSender.from,
         body: 'other-sender ytterbium',
       })
-      expect((await messageCache.getMessage(otherSender.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, otherSender.id))?.isRetracted).toBeFalsy()
       expect(await searchIndex.search('ytterbium')).toHaveLength(1)
     })
 
@@ -365,7 +365,7 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
 
-      expect((await messageCache.getMessage(message.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBeFalsy()
       expect(await searchIndex.search(SECRET)).toHaveLength(1)
     })
 
@@ -373,7 +373,12 @@ describe('retraction propagates to the cache and the search index', () => {
       const message = chatMessage()
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
-      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt: new Date() })
+      await messageCache.updateMessage(
+        CHAT,
+        message.id,
+        { isRetracted: true, retractedAt: new Date() },
+        message.from
+      )
 
       chatStore.getState().recordPendingRetraction(CHAT, message.id, message.from)
       await settle()
@@ -408,7 +413,7 @@ describe('retraction propagates to the cache and the search index', () => {
       const retractedAt = new Date('2026-07-22T03:53:00Z')
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
-      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt })
+      await messageCache.updateMessage(CHAT, message.id, { isRetracted: true, retractedAt }, message.from)
       chatStore.setState({
         messages: new Map([[CHAT, [{ ...message, isRetracted: true, retractedAt }]]]),
       })
@@ -416,7 +421,7 @@ describe('retraction propagates to the cache and the search index', () => {
       chatStore.getState().recordPendingRetraction(CHAT, message.id, message.from)
       await settle()
 
-      expect((await messageCache.getMessage(message.id))?.retractedAt).toEqual(retractedAt)
+      expect((await messageCache.getMessage(CHAT, message.id))?.retractedAt).toEqual(retractedAt)
       expect(chatStore.getState().messages.get(CHAT)?.[0].retractedAt).toEqual(retractedAt)
       expect(await searchIndex.search(SECRET)).toEqual([])
     })
@@ -452,7 +457,7 @@ describe('retraction propagates to the cache and the search index', () => {
       const retractedAt = new Date()
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
-      await messageCache.updateMessage(message.id, { isRetracted: true, retractedAt })
+      await messageCache.updateMessage(CHAT, message.id, { isRetracted: true, retractedAt }, message.from)
       _clearRetractedIdentitiesForTesting()
       chatStore.setState({
         messages: new Map(),
@@ -554,8 +559,8 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(early)
       await searchIndex.indexMessage(early)
 
-      await messageCache.updateMessage(early.id, { stanzaId: 'archive-late' })
-      expect((await messageCache.getMessage(early.id))?.stanzaId).toBe('archive-late')
+      await messageCache.updateMessage(CHAT, early.id, { stanzaId: 'archive-late' }, early.from)
+      expect((await messageCache.getMessage(CHAT, early.id))?.stanzaId).toBe('archive-late')
 
       chatStore.getState().recordPendingRetraction(CHAT, 'archive-late', CHAT)
       await settle()
@@ -781,9 +786,9 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(lowerTier)
 
       expect(chatStore.getState().pendingRetractions.get(CHAT)).toBeUndefined()
-      expect((await messageCache.getMessage(authoritative.id))?.isRetracted).toBeFalsy()
-      expect((await messageCache.getMessage(lowerTier.id))?.isRetracted).toBeFalsy()
-      expect((await messageCache.getMessage(lowerTier.id))?.body).toBe('lower tier body')
+      expect((await messageCache.getMessage(CHAT, authoritative.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, lowerTier.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, lowerTier.id))?.body).toBe('lower tier body')
       expect(await searchIndex.search('lower tier')).toHaveLength(1)
     })
 
@@ -856,7 +861,7 @@ describe('retraction propagates to the cache and the search index', () => {
       await Promise.all([retraction, save, index])
       await settle()
 
-      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBe(true)
       await expectNoTraceOf(SECRET)
     })
 
@@ -884,7 +889,7 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessages([message])
       await searchIndex.indexMessages([message])
 
-      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBe(true)
       await expectNoTraceOf(SECRET)
     })
 
@@ -983,8 +988,8 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(target)
       await searchIndex.indexMessage(target)
 
-      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('innocent niobium')
-      expect((await messageCache.getMessage(target.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, unrelated.id))?.body).toBe('innocent niobium')
+      expect((await messageCache.getMessage(CHAT, target.id))?.isRetracted).toBe(true)
       expect(await searchIndex.search('niobium')).toHaveLength(1)
       await expectNoTraceOf(SECRET)
     })
@@ -1001,7 +1006,7 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
 
-      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBe(true)
       await expectNoTraceOf(SECRET)
     })
 
@@ -1081,8 +1086,8 @@ describe('retraction propagates to the cache and the search index', () => {
       })
       await messageCache.saveMessage(unrelated)
 
-      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('unrelated hafnium')
-      expect((await messageCache.getMessage(unrelated.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, unrelated.id))?.body).toBe('unrelated hafnium')
+      expect((await messageCache.getMessage(CHAT, unrelated.id))?.isRetracted).toBeFalsy()
     })
 
     it('does not apply a verified stanza alias to an unrelated room client id', async () => {
@@ -1117,7 +1122,7 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessage(message)
       await searchIndex.indexMessage(message)
 
-      expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBe(true)
       await expectNoTraceOf(SECRET)
     })
 
@@ -1148,8 +1153,8 @@ describe('retraction propagates to the cache and the search index', () => {
       await messageCache.saveMessages([stanzaCopy, originCopy])
       await searchIndex.indexMessages([stanzaCopy, originCopy])
 
-      expect((await messageCache.getMessage(stanzaCopy.id))?.isRetracted).toBe(true)
-      expect((await messageCache.getMessage(originCopy.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, stanzaCopy.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, originCopy.id))?.isRetracted).toBe(true)
       expect(await searchIndex.search('dysprosium')).toEqual([])
       expect(await searchIndex.search('erbium')).toEqual([])
     })
@@ -1182,8 +1187,8 @@ describe('retraction propagates to the cache and the search index', () => {
       )
 
       for (const message of [first, bridge, last]) {
-        expect((await messageCache.getMessage(message.id))?.body).toBe('')
-        expect((await messageCache.getMessage(message.id))?.isRetracted).toBe(true)
+        expect((await messageCache.getMessage(CHAT, message.id))?.body).toBe('')
+        expect((await messageCache.getMessage(CHAT, message.id))?.isRetracted).toBe(true)
       }
       await expectNoTraceOf(SECRET)
     })
@@ -1202,8 +1207,8 @@ describe('retraction propagates to the cache and the search index', () => {
         body: 'unrelated rhenium',
       })
       await messageCache.saveMessage(unrelated)
-      expect((await messageCache.getMessage(unrelated.id))?.body).toBe('unrelated rhenium')
-      expect((await messageCache.getMessage(unrelated.id))?.isRetracted).toBeFalsy()
+      expect((await messageCache.getMessage(CHAT, unrelated.id))?.body).toBe('unrelated rhenium')
+      expect((await messageCache.getMessage(CHAT, unrelated.id))?.isRetracted).toBeFalsy()
     })
 
     it('removes resolved room pending state before a lower-tier id can reuse it', async () => {
@@ -1346,7 +1351,7 @@ describe('retraction propagates to the cache and the search index', () => {
       )
       setStorageScopeJid(SCOPE)
 
-      expect((await messageCache.getMessage(chat.id))?.isRetracted).toBe(true)
+      expect((await messageCache.getMessage(CHAT, chat.id))?.isRetracted).toBe(true)
       expect((await messageCache.getRoomMessage(ROOM, roomTarget.id))?.isRetracted).toBe(true)
       await expectNoTraceOf(SECRET)
     })
@@ -1479,6 +1484,25 @@ describe('a reused client id after a retraction', () => {
     expect(rows[1].isRetracted).toBeFalsy()
     expect(rows[1].body).toBe('an innocent later message')
     expect(rows[1].stanzaId).toBe('archive-second')
+  })
+
+  it('keeps the later archive-distinct message searchable', async () => {
+    const retracted = chatMessage({ id: REUSED_ID, stanzaId: 'archive-first', timestamp: new Date(T0) })
+    await messageCache.saveMessage(retracted)
+    await searchIndex.indexMessage(retracted)
+    await retractChatMessageInStorage(CHAT, retracted)
+
+    const innocent = chatMessage({
+      id: REUSED_ID,
+      stanzaId: 'archive-second',
+      body: 'searchable innocent later message',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+    })
+    await messageCache.saveMessage(innocent)
+    await searchIndex.indexMessage(innocent)
+
+    expect((await searchIndex.search('searchable innocent')).map((message) => message.body))
+      .toEqual(['searchable innocent later message'])
   })
 
   /**

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -1505,6 +1505,34 @@ describe('a reused client id after a retraction', () => {
       .toEqual(['searchable innocent later message'])
   })
 
+  it('tombstones the resolved archive row, not its same-id sibling', async () => {
+    const first = chatMessage({
+      id: REUSED_ID,
+      stanzaId: 'z',
+      body: 'first message to retract',
+      timestamp: new Date(T0),
+    })
+    const second = chatMessage({
+      id: REUSED_ID,
+      stanzaId: 'a',
+      body: 'innocent archive-distinct sibling',
+      timestamp: new Date(T0 + TWENTY_MINUTES),
+    })
+    await messageCache.saveMessages([first, second])
+
+    await retractChatMessageInStorage(CHAT, first)
+
+    const rows = await storedChat()
+    expect(rows.find((row) => row.stanzaId === 'a')).toMatchObject({
+      body: 'innocent archive-distinct sibling',
+      isRetracted: undefined,
+    })
+    expect(rows.find((row) => row.stanzaId === 'z')).toMatchObject({
+      body: '',
+      isRetracted: true,
+    })
+  })
+
   /**
    * The residual, asserted so it cannot change unnoticed.
    *

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -194,9 +194,11 @@ export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): 
  * after a MUC nick reassignment that is not enough to pick a row.
  */
 export function pointerRowRef(pointer: ReadPointer): MessageRowRef {
-  return pointer.identity.occupantId
-    ? { id: pointer.identity.messageId, occupantId: pointer.identity.occupantId }
-    : { id: pointer.identity.messageId }
+  return {
+    id: pointer.identity.messageId,
+    ...(pointer.identity.occupantId ? { occupantId: pointer.identity.occupantId } : {}),
+    ...(pointer.identity.state === 'addressable' ? { stanzaId: pointer.identity.archiveId } : {}),
+  }
 }
 
 /** {@link pointerRowRef} for a position that may not exist yet. */

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -194,11 +194,9 @@ export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): 
  * after a MUC nick reassignment that is not enough to pick a row.
  */
 export function pointerRowRef(pointer: ReadPointer): MessageRowRef {
-  return {
-    id: pointer.identity.messageId,
-    ...(pointer.identity.occupantId ? { occupantId: pointer.identity.occupantId } : {}),
-    ...(pointer.identity.state === 'addressable' ? { stanzaId: pointer.identity.archiveId } : {}),
-  }
+  return pointer.identity.occupantId
+    ? { id: pointer.identity.messageId, occupantId: pointer.identity.occupantId }
+    : { id: pointer.identity.messageId }
 }
 
 /** {@link pointerRowRef} for a position that may not exist yet. */

--- a/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
+++ b/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
@@ -91,7 +91,7 @@ export async function retractChatMessageInStorage(
       message,
     })
   }
-  for (const { message: target, ids } of targets.values()) {
+  for (const { cacheKey, message: target, ids } of targets.values()) {
     const targetRetractedAt = target.retractedAt ?? retractedAt
     noteRetractedIdentity(
       scope,
@@ -104,7 +104,8 @@ export async function retractChatMessageInStorage(
       target.id,
       { ...updates, isRetracted: true, retractedAt: targetRetractedAt },
       target.from,
-      storageScope
+      storageScope,
+      cacheKey || undefined
     )
     await searchIndex.removeMessage(target, storageScope, { ids })
   }

--- a/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
+++ b/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
@@ -63,25 +63,35 @@ export async function retractChatMessageInStorage(
     storageScope
   )
   const actor = { actorJid: message.from }
-  const targets = new Map<string, Message>([[message.id, message]])
-  for (const candidate of resolution?.candidates ?? []) {
-    if (chatMessageAuthor(candidate, actor)) targets.set(candidate.id, candidate)
-  }
-  const queue = [...targets.values()]
-  for (let index = 0; index < queue.length; index++) {
-    const target = queue[index]
+  const seeds = [message, ...(resolution?.candidates ?? [])].filter((candidate) =>
+    chatMessageAuthor(candidate, actor)
+  )
+  const targets = new Map<string, messageCache.ChatMessageCopy>()
+  for (const seed of seeds) {
     const copies = await messageCache.findChatMessageCopies(
       conversationId,
-      target,
+      seed,
       storageScope
     )
-    for (const candidate of copies) {
-      if (targets.has(candidate.id) || !chatMessageAuthor(candidate, actor)) continue
-      targets.set(candidate.id, candidate)
-      queue.push(candidate)
+    for (const copy of copies) {
+      if (targets.has(copy.cacheKey) || !chatMessageAuthor(copy.message, actor)) continue
+      targets.set(copy.cacheKey, copy)
     }
   }
-  for (const target of targets.values()) {
+  // The retraction can land before its target's own save does, so the message may
+  // have a search document and no cached row at all. The ledger note above is what
+  // stops the pending save from keeping the body; this keeps the message itself a
+  // target so that document is removed too — unless a resolved copy already
+  // absorbed its client id, in which case it is covered.
+  if (![...targets.values()].some(({ ids }) => ids.includes(message.id))) {
+    targets.set(`self\u0000${message.id}`, {
+      cacheKey: '',
+      identityKeys: chatRetractionAliases(message),
+      ids: [message.id],
+      message,
+    })
+  }
+  for (const { message: target, ids } of targets.values()) {
     const targetRetractedAt = target.retractedAt ?? retractedAt
     noteRetractedIdentity(
       scope,
@@ -95,7 +105,7 @@ export async function retractChatMessageInStorage(
       storageScope,
       { conversationId: target.conversationId, from: target.from }
     )
-    await searchIndex.removeMessage(target, storageScope)
+    await searchIndex.removeMessage(target, storageScope, { ids })
   }
 }
 

--- a/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
+++ b/packages/fluux-sdk/src/stores/shared/retractionStorage.ts
@@ -100,10 +100,11 @@ export async function retractChatMessageInStorage(
       targetRetractedAt.getTime()
     )
     await messageCache.updateMessage(
+      target.conversationId,
       target.id,
       { ...updates, isRetracted: true, retractedAt: targetRetractedAt },
-      storageScope,
-      { conversationId: target.conversationId, from: target.from }
+      target.from,
+      storageScope
     )
     await searchIndex.removeMessage(target, storageScope, { ids })
   }

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -181,7 +181,7 @@ describe('messageCache', () => {
     })
 
     await messageCache.getRoomMessages(roomJid)
-    const db = await openDB('fluux-message-cache', 4)
+    const db = await openDB('fluux-message-cache', 5)
     const tx = db.transaction('room-messages-canonical', 'readwrite')
     for (const message of [departed, target, compatible]) {
       await tx.store.put(rrow({
@@ -2191,5 +2191,212 @@ describe('cursor ranges stay scoped to one entity', () => {
       before: new Date(BASE + 10 * 60_000),
     })
     expectScopedTo(ranges[0], FIRST)
+  })
+})
+
+/**
+ * The v5 chat-store canonicalization, on the rows a user already has.
+ *
+ * The upgrade rewrites the whole 1:1 archive under a new primary key, and a badly
+ * scoped pass would merge or drop real messages with no way back once it has run
+ * on a device. These cover both shapes it can start from — a v3 database, whose
+ * ROOM store is still legacy too, and a v4 one, whose room store is already
+ * canonical — and assert on the rows, not on the fact that it completed.
+ */
+describe('v5 migration — chat-store canonicalization', () => {
+  const JID = 'me@example.com'
+  const dbName = `fluux-message-cache:${JID}`
+  const ALICE = 'alice@example.com'
+  const BOB = 'bob@example.com'
+  const ROOM = 'r@c'
+
+  const CHAT_INDEXES = [
+    ['conversationId', 'conversationId'],
+    ['stanzaId', 'stanzaId'],
+    ['timestamp', 'timestamp'],
+    ['conv_timestamp', ['conversationId', 'timestamp']],
+    ['encryptedPayload', 'encryptedPayload'],
+  ] as const
+
+  /** A legacy chat row: keyPath 'id', no cacheKey/identityKeys/ids. */
+  function legacyChat(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      type: 'chat', id: 'c1', conversationId: ALICE, from: ALICE,
+      body: 'hello', timestamp: 1000, isOutgoing: false, ...over,
+    }
+  }
+
+  async function seedV3(chat: Array<Record<string, unknown>>, room: Array<Record<string, unknown>> = []) {
+    const db = await openDB(dbName, 3, {
+      upgrade(d) {
+        const s = d.createObjectStore('messages', { keyPath: 'id' })
+        for (const [n, kp] of CHAT_INDEXES) s.createIndex(n, kp as never)
+        const r = d.createObjectStore('room-messages', { keyPath: 'cacheKey' })
+        for (const [n, kp] of [['roomJid','roomJid'],['stanzaId','stanzaId'],['timestamp','timestamp'],['room_timestamp',['roomJid','timestamp']],['id','id']] as const) r.createIndex(n, kp as never)
+      },
+    })
+    const tx = db.transaction(['messages', 'room-messages'], 'readwrite')
+    for (const row of chat) await tx.objectStore('messages').put(row as never)
+    for (const row of room) await tx.objectStore('room-messages').put(row as never)
+    await tx.done; db.close()
+  }
+
+  async function seedV4(chat: Array<Record<string, unknown>>, room: Array<Record<string, unknown>> = []) {
+    const db = await openDB(dbName, 4, {
+      upgrade(d) {
+        const s = d.createObjectStore('messages', { keyPath: 'id' })
+        for (const [n, kp] of CHAT_INDEXES) s.createIndex(n, kp as never)
+        const r = d.createObjectStore('room-messages-canonical', { keyPath: 'cacheKey' })
+        r.createIndex('roomJid', 'roomJid')
+        r.createIndex('identityKeys', 'identityKeys', { multiEntry: true })
+        r.createIndex('ids', 'ids', { multiEntry: true })
+        r.createIndex('timestamp', 'timestamp')
+        r.createIndex('room_timestamp', ['roomJid', 'timestamp'] as never)
+        r.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'] as never)
+      },
+    })
+    const tx = db.transaction(['messages', 'room-messages-canonical'], 'readwrite')
+    for (const row of chat) await tx.objectStore('messages').put(row as never)
+    for (const row of room) await tx.objectStore('room-messages-canonical').put(row as never)
+    await tx.done; db.close()
+  }
+
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory()
+    messageCache._resetDBForTesting()
+    _resetStorageScopeForTesting()
+    _clearRetractedIdentitiesForTesting()
+    setStorageScopeJid(JID)
+  })
+
+  it('carries every distinct row across, from a v4 database', async () => {
+    await seedV4([
+      legacyChat({ id: 'c1', stanzaId: 'S1', body: 'first', timestamp: 1000 }),
+      legacyChat({ id: 'c2', stanzaId: 'S2', body: 'second', timestamp: 2000 }),
+      legacyChat({ id: 'c3', body: 'no archive id', timestamp: 3000 }),
+      legacyChat({ id: 'c4', conversationId: BOB, from: BOB, body: 'other peer', timestamp: 4000 }),
+    ])
+
+    const alice = await messageCache.getMessages(ALICE, {})
+    const bob = await messageCache.getMessages(BOB, {})
+    expect(alice.map((m) => m.body).sort()).toEqual(['first', 'no archive id', 'second'])
+    expect(bob.map((m) => m.body)).toEqual(['other peer'])
+    // Every row stays addressable by the client id it was stored under.
+    for (const id of ['c1', 'c2', 'c3', 'c4']) {
+      expect((await messageCache.getMessage(id))?.id).toBe(id)
+    }
+    expect(await messageCache.getTotalMessageCount()).toBe(4)
+  })
+
+  it('drains BOTH legacy stores in one upgrade, from a v3 database', async () => {
+    await seedV3(
+      [legacyChat({ id: 'c1', stanzaId: 'S1', body: 'chat survives' })],
+      [{ cacheKey: 'k1', type: 'groupchat', id: 'r1', roomJid: ROOM, from: `${ROOM}/alice`, body: 'room survives', timestamp: 1000, isOutgoing: false }]
+    )
+
+    expect((await messageCache.getMessages(ALICE, {})).map((m) => m.body)).toEqual(['chat survives'])
+    expect((await messageCache.getRoomMessages(ROOM, {})).map((m) => m.body)).toEqual(['room survives'])
+
+    const raw = await openDB(dbName)
+    expect(raw.version).toBe(5)
+    // Both legacy stores are emptied, not merely bypassed.
+    expect(await raw.count('messages' as never)).toBe(0)
+    expect(await raw.count('room-messages' as never)).toBe(0)
+    raw.close()
+  })
+
+  it('holds two conversations that share a client id', async () => {
+    // Not reachable from a legacy seed: `keyPath: 'id'` meant only ONE of these
+    // could be stored at all, which is the wider half of the same defect. Driven
+    // through the live write path, where it is reachable.
+    await messageCache.saveMessages([
+      { type: 'chat', id: 'shared', conversationId: ALICE, from: JID, body: 'to alice', timestamp: new Date(1000), isOutgoing: true },
+      { type: 'chat', id: 'shared', conversationId: BOB, from: JID, body: 'to bob', timestamp: new Date(2000), isOutgoing: true },
+    ])
+    expect((await messageCache.getMessages(ALICE, {})).map((m) => m.body)).toEqual(['to alice'])
+    expect((await messageCache.getMessages(BOB, {})).map((m) => m.body)).toEqual(['to bob'])
+  })
+
+  it('does not merge two senders that share a client id in one conversation', async () => {
+    // A 1:1 conversation holds both directions: our own outgoing copy and the
+    // peer's. `from` separates them, and it is part of the fallback rung.
+    await seedV4([
+      legacyChat({ id: 'mine', from: JID, isOutgoing: true, body: 'mine' }),
+      legacyChat({ id: 'theirs', from: ALICE, body: 'theirs' }),
+    ])
+    expect((await messageCache.getMessages(ALICE, {})).map((m) => m.body).sort()).toEqual(['mine', 'theirs'])
+  })
+
+  it('collapses copies that agree on an archive id, keeping every id resolvable', async () => {
+    await seedV4([
+      legacyChat({ id: 'live', stanzaId: 'S', body: 'one message', timestamp: 1000 }),
+      legacyChat({ id: 'mam', stanzaId: 'S', body: 'one message', timestamp: 2000 }),
+      legacyChat({ id: 'echo', originId: 'O', body: 'another', timestamp: 3000 }),
+      legacyChat({ id: 'archived', originId: 'O', body: 'another', timestamp: 4000 }),
+    ])
+    const rows = await messageCache.getMessages(ALICE, {})
+    expect(rows).toHaveLength(2)
+    for (const id of ['live', 'mam', 'echo', 'archived']) {
+      expect(await messageCache.getMessage(id)).not.toBeNull()
+    }
+    expect(await messageCache.getMessageByStanzaId('S')).not.toBeNull()
+  })
+
+  it('keeps two messages apart when their archive ids disagree', async () => {
+    // The defect this keying closes, as it survives IN the cache: a client that
+    // restarted and re-issued a client id. Under keyPath 'id' only one of these
+    // could ever have been stored; seeded here as the archive delivers them.
+    await seedV4([
+      legacyChat({ id: 'reused', stanzaId: 'S1', body: 'first', timestamp: 1000, isRetracted: true, retractedAt: 1500 }),
+      legacyChat({ id: 'reused-later', stanzaId: 'S2', body: 'second', timestamp: 9000 }),
+    ])
+    const rows = (await messageCache.getMessages(ALICE, {})).slice().sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+    expect(rows).toHaveLength(2)
+    expect(rows[1].body).toBe('second')
+    expect(rows[1].isRetracted).toBeFalsy()
+  })
+
+  it('does not downgrade a decrypted body during migration', async () => {
+    await seedV4([
+      legacyChat({ id: 'cipher', stanzaId: 'S9', body: '', unsupportedEncryption: { kind: 'x' }, timestamp: 1000 }),
+      legacyChat({ id: 'clear', stanzaId: 'S9', body: 'decrypted', timestamp: 1000 }),
+    ])
+    const rows = await messageCache.getMessages(ALICE, {})
+    expect(rows).toHaveLength(1)
+    expect(rows[0].body).toBe('decrypted')
+  })
+
+  it('preserves a tombstone and never resurrects a retracted body', async () => {
+    await seedV4([
+      legacyChat({ id: 'gone', stanzaId: 'S3', body: '', isRetracted: true, retractedAt: 500, timestamp: 1000 }),
+      legacyChat({ id: 'gone-mam', stanzaId: 'S3', body: 'the original text', timestamp: 1000 }),
+    ])
+    const rows = await messageCache.getMessages(ALICE, {})
+    expect(rows).toHaveLength(1)
+    expect(rows[0].isRetracted).toBe(true)
+    expect(rows[0].body).toBe('')
+    expect(JSON.stringify(rows)).not.toContain('the original text')
+  })
+
+  it('aborts the whole upgrade if the migration throws — nothing is lost', async () => {
+    await seedV4(
+      [legacyChat({ id: 'c1', stanzaId: 'S1', body: 'still here' })],
+      [{ cacheKey: 'k1', identityKeys: ['x'], ids: ['r1'], type: 'groupchat', id: 'r1', roomJid: ROOM, from: `${ROOM}/a`, body: 'room row', timestamp: 1000, isOutgoing: false }]
+    )
+    messageCache._setMigrationFaultForTesting(true)
+    await expect(messageCache.getMessages(ALICE, {})).resolves.toEqual([])
+
+    messageCache._setMigrationFaultForTesting(false)
+    messageCache._resetDBForTesting()
+    const raw = await openDB(dbName)
+    expect(raw.version).toBe(4)
+    expect(raw.objectStoreNames.contains('messages-canonical' as never)).toBe(false)
+    expect(await raw.get('messages' as never, 'c1')).toBeTruthy()
+    expect(await raw.get('room-messages-canonical' as never, 'k1')).toBeTruthy()
+    raw.close()
+
+    // And the retry after the fault clears completes normally.
+    messageCache._resetDBForTesting()
+    expect((await messageCache.getMessages(ALICE, {})).map((m) => m.body)).toEqual(['still here'])
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -106,7 +106,10 @@ describe('messageCache', () => {
     ])
 
     const result = await messageCache.getMessagesByReferences(
-      ['chat-found', 'chat-missing'],
+      [
+        { conversationId: 'alice@example.com', id: 'chat-found' },
+        { conversationId: 'alice@example.com', id: 'chat-missing' },
+      ],
       [
         { roomJid, id: 'shared-id', from: `${roomJid}/Alice` },
         { roomJid, id: 'shared-id', from: `${roomJid}/Bob` },
@@ -120,6 +123,40 @@ describe('messageCache', () => {
       'Bob body',
       null,
     ])
+  })
+
+  it('resolves repeated chat ids inside their own conversations', async () => {
+    const alpha = 'alpha@example.com'
+    const beta = 'beta@example.com'
+    const id = 'reused-client-id'
+    const alphaMessage = createMockMessage(alpha, {
+      id,
+      body: 'alpha original',
+      timestamp: new Date(1000),
+    })
+    const betaMessage = createMockMessage(beta, {
+      id,
+      body: 'beta original',
+      timestamp: new Date(2000),
+    })
+    await messageCache.saveMessages([alphaMessage, betaMessage])
+
+    expect((await messageCache.getMessage(alpha, id))?.body).toBe('alpha original')
+    expect((await messageCache.getMessage(beta, id))?.body).toBe('beta original')
+    expect((await messageCache.getMessagesByReferences(
+      [{ conversationId: alpha, id }, { conversationId: beta, id }],
+      []
+    )).chatMessages.map((message) => message?.body)).toEqual(['alpha original', 'beta original'])
+    expect((await messageCache.getMessagesAround(beta, { id }, { before: 0, after: 0 }))
+      .map((message) => message.body)).toEqual(['beta original'])
+
+    await messageCache.updateMessage(beta, id, { body: 'beta updated' }, betaMessage.from)
+    expect((await messageCache.getMessage(alpha, id))?.body).toBe('alpha original')
+    expect((await messageCache.getMessage(beta, id))?.body).toBe('beta updated')
+
+    await messageCache.deleteMessage(beta, id, betaMessage.from)
+    expect((await messageCache.getMessage(alpha, id))?.body).toBe('alpha original')
+    expect(await messageCache.getMessage(beta, id)).toBeNull()
   })
 
   // fluux-room-nick-reuse-false-deletion: a departed occupant's row and a new
@@ -308,11 +345,11 @@ describe('messageCache', () => {
       await messageCache.saveMessage(createMockMessage(conversationId, { id: 'shared-id', body: 'Bob message' }))
 
       setStorageScopeJid('alice@example.com')
-      const aliceMessage = await messageCache.getMessage('shared-id')
+      const aliceMessage = await messageCache.getMessage(conversationId, 'shared-id')
       expect(aliceMessage?.body).toBe('Alice message')
 
       setStorageScopeJid('bob@example.com')
-      const bobMessage = await messageCache.getMessage('shared-id')
+      const bobMessage = await messageCache.getMessage(conversationId, 'shared-id')
       expect(bobMessage?.body).toBe('Bob message')
     })
 
@@ -322,7 +359,7 @@ describe('messageCache', () => {
 
         await expect(messageCache.saveMessage(message)).resolves.toBeUndefined()
 
-        const retrieved = await messageCache.getMessage('msg-1')
+        const retrieved = await messageCache.getMessage(conversationId, 'msg-1')
         expect(retrieved).not.toBeNull()
         expect(retrieved?.id).toBe('msg-1')
         expect(retrieved?.body).toBe('Test message')
@@ -336,7 +373,7 @@ describe('messageCache', () => {
 
         await expect(messageCache.saveMessage(message)).resolves.toBeUndefined()
 
-        const byStanzaId = await messageCache.getMessageByStanzaId('stanza-123')
+        const byStanzaId = await messageCache.getMessageByStanzaId(conversationId, 'stanza-123')
         expect(byStanzaId).not.toBeNull()
         expect(byStanzaId?.id).toBe('msg-2')
       })
@@ -350,7 +387,7 @@ describe('messageCache', () => {
 
         await messageCache.saveMessage(message)
 
-        const retrieved = await messageCache.getMessage('msg-date')
+        const retrieved = await messageCache.getMessage(conversationId, 'msg-date')
         expect(retrieved?.timestamp).toBeInstanceOf(Date)
         expect(retrieved?.timestamp.getTime()).toBe(timestamp.getTime())
       })
@@ -363,7 +400,7 @@ describe('messageCache', () => {
 
         await messageCache.saveMessage(message)
 
-        const retrieved = await messageCache.getMessage('msg-reactions')
+        const retrieved = await messageCache.getMessage(conversationId, 'msg-reactions')
         expect(retrieved?.reactions).toEqual({
           '👍': ['alice@example.com'],
           '❤️': ['bob@example.com'],
@@ -383,7 +420,7 @@ describe('messageCache', () => {
 
         await messageCache.saveMessage(message)
 
-        const retrieved = await messageCache.getMessage('msg-attachment')
+        const retrieved = await messageCache.getMessage(conversationId, 'msg-attachment')
         expect(retrieved?.attachment).toBeDefined()
         expect(retrieved?.attachment?.url).toBe('https://example.com/file.jpg')
       })
@@ -521,12 +558,12 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'update-1', body: 'Original' })
         await messageCache.saveMessage(message)
 
-        await messageCache.updateMessage('update-1', {
+        await messageCache.updateMessage(conversationId, 'update-1', {
           body: 'Updated',
           isEdited: true,
-        })
+        }, message.from)
 
-        const retrieved = await messageCache.getMessage('update-1')
+        const retrieved = await messageCache.getMessage(conversationId, 'update-1')
         expect(retrieved?.body).toBe('Updated')
         expect(retrieved?.isEdited).toBe(true)
       })
@@ -535,18 +572,18 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'react-update' })
         await messageCache.saveMessage(message)
 
-        await messageCache.updateMessage('react-update', {
+        await messageCache.updateMessage(conversationId, 'react-update', {
           reactions: { '🎉': ['user@example.com'] },
-        })
+        }, message.from)
 
-        const retrieved = await messageCache.getMessage('react-update')
+        const retrieved = await messageCache.getMessage(conversationId, 'react-update')
         expect(retrieved?.reactions).toEqual({ '🎉': ['user@example.com'] })
       })
 
       it('should handle updating non-existent message gracefully', async () => {
         // Should not throw
         await expect(
-          messageCache.updateMessage('nonexistent', { body: 'Test' })
+          messageCache.updateMessage(conversationId, 'nonexistent', { body: 'Test' }, 'user@example.com')
         ).resolves.not.toThrow()
       })
     })
@@ -559,7 +596,7 @@ describe('messageCache', () => {
         const found = await messageCache.updateMessageReactions(conversationId, 'react-1', 'bob@example.com', ['👍'])
 
         expect(found).toBe(true)
-        const retrieved = await messageCache.getMessage('react-1')
+        const retrieved = await messageCache.getMessage(conversationId, 'react-1')
         expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
       })
 
@@ -570,7 +607,7 @@ describe('messageCache', () => {
         const found = await messageCache.updateMessageReactions(conversationId, 'server-stanza-id-1', 'bob@example.com', ['👍'])
 
         expect(found).toBe(true)
-        const retrieved = await messageCache.getMessage('react-2')
+        const retrieved = await messageCache.getMessage(conversationId, 'react-2')
         expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
       })
 
@@ -581,7 +618,7 @@ describe('messageCache', () => {
         const found = await messageCache.updateMessageReactions(conversationId, 'origin-reaction-id', 'bob@example.com', ['👍'])
 
         expect(found).toBe(true)
-        const retrieved = await messageCache.getMessage(message.id)
+        const retrieved = await messageCache.getMessage(conversationId, message.id)
         expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
       })
 
@@ -591,7 +628,7 @@ describe('messageCache', () => {
 
         await messageCache.updateMessageReactions(conversationId, 'react-3', 'bob@example.com', ['❤️'])
 
-        const retrieved = await messageCache.getMessage('react-3')
+        const retrieved = await messageCache.getMessage(conversationId, 'react-3')
         expect(retrieved?.reactions).toEqual({ '❤️': ['bob@example.com'] })
       })
 
@@ -604,7 +641,7 @@ describe('messageCache', () => {
 
         await messageCache.updateMessageReactions(conversationId, 'react-4', 'bob@example.com', [])
 
-        const retrieved = await messageCache.getMessage('react-4')
+        const retrieved = await messageCache.getMessage(conversationId, 'react-4')
         expect(retrieved?.reactions).toEqual({ '👍': ['carol@example.com'] })
       })
 
@@ -619,9 +656,9 @@ describe('messageCache', () => {
         const message = createMockMessage(conversationId, { id: 'delete-1' })
         await messageCache.saveMessage(message)
 
-        await messageCache.deleteMessage('delete-1')
+        await messageCache.deleteMessage(conversationId, 'delete-1', message.from)
 
-        const retrieved = await messageCache.getMessage('delete-1')
+        const retrieved = await messageCache.getMessage(conversationId, 'delete-1')
         expect(retrieved).toBeNull()
       })
     })
@@ -1084,7 +1121,7 @@ describe('messageCache', () => {
         }),
       ])
 
-      const stored = await messageCache.getMessage('m1')
+      const stored = await messageCache.getMessage(conversationId, 'm1')
       expect(stored?.body).toBe('Bonjour en clair')
       expect(stored?.encryptedPayload).toBeUndefined()
     })
@@ -1109,7 +1146,7 @@ describe('messageCache', () => {
         })
       )
 
-      const stored = await messageCache.getMessage('m2')
+      const stored = await messageCache.getMessage(conversationId, 'm2')
       expect(stored?.body).toBe('Coucou déchiffré')
       expect(stored?.encryptedPayload).toBeUndefined()
     })
@@ -1132,7 +1169,7 @@ describe('messageCache', () => {
         })
       )
 
-      const stored = await messageCache.getMessage('m3')
+      const stored = await messageCache.getMessage(conversationId, 'm3')
       expect(stored?.encryptedPayload).toContain('NEW')
     })
 
@@ -1151,7 +1188,7 @@ describe('messageCache', () => {
         })
       )
 
-      const stored = await messageCache.getMessage('u1')
+      const stored = await messageCache.getMessage(conversationId, 'u1')
       expect(stored?.body).toBe('Texte clair')
       expect(stored?.unsupportedEncryption).toBeUndefined()
     })
@@ -1174,7 +1211,7 @@ describe('messageCache', () => {
         })
       )
 
-      const stored = await messageCache.getMessage('u2')
+      const stored = await messageCache.getMessage(conversationId, 'u2')
       expect(stored?.encryptedPayload).toContain('CIPHER')
       expect(stored?.unsupportedEncryption).toBeUndefined()
     })
@@ -1198,7 +1235,7 @@ describe('messageCache', () => {
         })
       )
 
-      const stored = await messageCache.getMessage('u3')
+      const stored = await messageCache.getMessage(conversationId, 'u3')
       expect(stored?.encryptedPayload).toContain('C3')
       expect(stored?.unsupportedEncryption).toBeUndefined()
     })
@@ -1248,7 +1285,7 @@ describe('messageCache', () => {
     })
 
     it('should handle getMessage for non-existent ID', async () => {
-      const message = await messageCache.getMessage('nonexistent-id')
+      const message = await messageCache.getMessage('nonexistent@example.com', 'nonexistent-id')
       expect(message).toBeNull()
     })
   })
@@ -2283,7 +2320,7 @@ describe('v5 migration — chat-store canonicalization', () => {
     expect(bob.map((m) => m.body)).toEqual(['other peer'])
     // Every row stays addressable by the client id it was stored under.
     for (const id of ['c1', 'c2', 'c3', 'c4']) {
-      expect((await messageCache.getMessage(id))?.id).toBe(id)
+      expect((await messageCache.getMessage(id === 'c4' ? BOB : ALICE, id))?.id).toBe(id)
     }
     expect(await messageCache.getTotalMessageCount()).toBe(4)
   })
@@ -2337,9 +2374,9 @@ describe('v5 migration — chat-store canonicalization', () => {
     const rows = await messageCache.getMessages(ALICE, {})
     expect(rows).toHaveLength(2)
     for (const id of ['live', 'mam', 'echo', 'archived']) {
-      expect(await messageCache.getMessage(id)).not.toBeNull()
+      expect(await messageCache.getMessage(ALICE, id)).not.toBeNull()
     }
-    expect(await messageCache.getMessageByStanzaId('S')).not.toBeNull()
+    expect(await messageCache.getMessageByStanzaId(ALICE, 'S')).not.toBeNull()
   })
 
   it('keeps two messages apart when their archive ids disagree', async () => {

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -289,7 +289,7 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
  * two OUTGOING messages to different peers share `from` — our own JID — and would
  * collide on a reused client id, which is the defect this keying closes.
  */
-function chatCacheKey(m: Pick<Message, 'conversationId' | 'from' | 'id' | 'stanzaId' | 'originId'>): string {
+export function chatCacheKey(m: Pick<Message, 'conversationId' | 'from' | 'id' | 'stanzaId' | 'originId'>): string {
   return `${m.conversationId}\u0000${canonicalKey(CHAT_SCOPE, m)}`
 }
 
@@ -1092,7 +1092,9 @@ export async function saveMessages(messages: Message[]): Promise<boolean> {
  * conversations the user has not opened are otherwise left permanently showing
  * "could not be decrypted". Scoped to the active account.
  */
-export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
+export type CachedChatMessage = Message & { cacheKey: string }
+
+export async function getMessagesWithEncryptedPayload(): Promise<CachedChatMessage[]> {
   try {
     const db = await getDB(getStorageScopeJid())
     // Sparse index: this reads ONLY the messages still carrying an
@@ -1100,7 +1102,7 @@ export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
     // every plugin-register / key-unlock, and is near-free when none are
     // pending (the steady state).
     const pending = await db.getAllFromIndex(MESSAGES_STORE, 'encryptedPayload')
-    return pending.map(deserializeMessage)
+    return pending.map((message) => ({ ...deserializeMessage(message), cacheKey: message.cacheKey }))
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to read pending-decrypt messages:', error)

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -671,9 +671,14 @@ type ChatIdentityStore = {
   index(name: 'ids'): { getAll(key: string): Promise<StoredMessage[]> }
 }
 
-/** Minimal structural view of the idb chat-message object store. */
-type ChatMessageStore = ChatIdentityStore & {
+/** The read-only chat-store surface a lookup needs. A readonly idb transaction
+ * satisfies this, which a write-capable view would reject. */
+type ChatMessageReader = ChatIdentityStore & {
   get(key: string): Promise<StoredMessage | undefined>
+}
+
+/** Minimal structural view of the idb chat-message object store. */
+type ChatMessageStore = ChatMessageReader & {
   put(value: StoredMessage): Promise<unknown>
   delete(key: string): Promise<void>
 }
@@ -716,7 +721,7 @@ async function findChatRowsForTier(
  * findable by every id it absorbed.
  */
 async function findChatRowById(
-  store: ChatMessageStore,
+  store: ChatMessageReader,
   id: string,
   conversationId: string,
   from?: string,

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1112,7 +1112,8 @@ export async function getMessagesWithEncryptedPayload(): Promise<CachedChatMessa
 }
 
 /**
- * Get a message by its client-generated ID.
+ * Get a conversation-scoped message by its client-generated ID. An
+ * `expectedCacheKey` preserves a previously resolved archive-distinct row.
  */
 export async function getMessage(
   conversationId: string,
@@ -1144,12 +1145,14 @@ export interface RoomMessageReference {
   occupantId?: string
 }
 
+/** A conversation-scoped chat reference, optionally pinned to one cached row. */
 export interface ChatMessageReference {
   conversationId: string
   id: string
   cacheKey?: string
 }
 
+/** Resolve ordered chat and room references without allowing chat ids across conversations to collide. */
 export async function getMessagesByReferences(
   chatReferences: readonly ChatMessageReference[],
   roomReferences: readonly RoomMessageReference[]
@@ -1190,7 +1193,7 @@ export async function getMessagesByReferences(
 }
 
 /**
- * Get a message by its server-assigned stanzaId (for MAM deduplication).
+ * Get a conversation-scoped message by its server-assigned stanzaId (for MAM deduplication).
  */
 export async function getMessageByStanzaId(
   conversationId: string,
@@ -1368,10 +1371,11 @@ export interface GetMessagesAroundOptions {
  * existing content-anchor restore land correctly. The same primitive serves search/activity jumps
  * to a message that isn't in the recent slice.
  *
- * @param anchor - The anchor ROW. Its `id` is a client id (`message.id`, as carried by
- *   `data-message-id`); the stanza-id index is a fallback so a server stanza id (e.g. a navigation
- *   target) also resolves. 1:1 messages have no XEP-0421 occupant, so `occupantId` is not consulted
- *   here — the ref is taken whole so chat and room share one anchor contract.
+ * @param anchor - The anchor ROW. Its `id` is always a client id (`message.id`, as carried by
+ *   `data-message-id`); an attached stanza-id or origin-id narrows a reused id to the resolved
+ *   archive row before the client-id fallback. 1:1 messages have no XEP-0421 occupant, so
+ *   `occupantId` is not consulted here — the ref is taken whole so chat and room share one anchor
+ *   contract.
  */
 export async function getMessagesAround(
   conversationId: string,
@@ -1573,8 +1577,10 @@ export async function getTotalRoomMessageCount(): Promise<number> {
 }
 
 /**
- * Update specific fields of a message, resolving the row through the `ids` alias
- * so a caller holding a pre-merge id still finds it.
+ * Update specific fields of a message, resolving its conversation- and
+ * sender-scoped row through the `ids` alias so a caller holding a pre-merge id
+ * still finds it. `expectedCacheKey` selects a previously resolved row exactly
+ * when a same-sender client id has several archive-distinct rows.
  *
  * Chat twin of {@link updateRoomMessage}, and it splits the same two ways when an
  * update carries an identity FIELD:
@@ -1933,7 +1939,8 @@ export async function areRetractedInCache(
 }
 
 /**
- * Delete a message by ID.
+ * Delete a conversation- and sender-scoped message by client ID. An
+ * `expectedCacheKey` preserves an already-resolved archive-distinct row.
  */
 export async function deleteMessage(
   conversationId: string,

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -718,12 +718,12 @@ async function findChatRowsForTier(
 async function findChatRowById(
   idsIndex: { getAll(key: string): Promise<StoredMessage[]> },
   id: string,
-  owner?: Pick<StoredMessage, 'conversationId' | 'from'>
+  conversationId: string,
+  from?: string
 ): Promise<StoredMessage | undefined> {
   const matches = await idsIndex.getAll(id)
-  if (!owner) return matches[0]
   return matches.find(
-    (row) => row.conversationId === owner.conversationId && row.from === owner.from
+    (row) => row.conversationId === conversationId && (from === undefined || row.from === from)
   )
 }
 
@@ -1103,10 +1103,14 @@ export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
 /**
  * Get a message by its client-generated ID.
  */
-export async function getMessage(id: string): Promise<Message | null> {
+export async function getMessage(conversationId: string, id: string): Promise<Message | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    const stored = await findChatRowById(db.transaction(MESSAGES_STORE).store.index('ids'), id)
+    const stored = await findChatRowById(
+      db.transaction(MESSAGES_STORE).store.index('ids'),
+      id,
+      conversationId
+    )
     return stored ? deserializeMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -1123,8 +1127,13 @@ export interface RoomMessageReference {
   occupantId?: string
 }
 
+export interface ChatMessageReference {
+  conversationId: string
+  id: string
+}
+
 export async function getMessagesByReferences(
-  chatIds: readonly string[],
+  chatReferences: readonly ChatMessageReference[],
   roomReferences: readonly RoomMessageReference[]
 ): Promise<{ chatMessages: Array<Message | null>; roomMessages: Array<RoomMessage | null> }> {
   try {
@@ -1133,7 +1142,9 @@ export async function getMessagesByReferences(
     const chatIdsIndex = tx.objectStore(MESSAGES_STORE).index('ids')
     const roomIds = tx.objectStore(ROOM_MESSAGES_STORE).index('ids')
     const [storedChatMessages, storedRoomMessages] = await Promise.all([
-      Promise.all(chatIds.map(id => findChatRowById(chatIdsIndex, id))),
+      Promise.all(chatReferences.map(({ conversationId, id }) =>
+        findChatRowById(chatIdsIndex, id, conversationId)
+      )),
       Promise.all(roomReferences.map(reference =>
         findRoomRowById(
           roomIds,
@@ -1154,7 +1165,7 @@ export async function getMessagesByReferences(
       console.warn('Failed to get messages by references:', error)
     }
     return {
-      chatMessages: chatIds.map(() => null),
+      chatMessages: chatReferences.map(() => null),
       roomMessages: roomReferences.map(() => null),
     }
   }
@@ -1163,13 +1174,17 @@ export async function getMessagesByReferences(
 /**
  * Get a message by its server-assigned stanzaId (for MAM deduplication).
  */
-export async function getMessageByStanzaId(stanzaId: string): Promise<Message | null> {
+export async function getMessageByStanzaId(
+  conversationId: string,
+  stanzaId: string
+): Promise<Message | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    const stored = await db.getFromIndex(
-      MESSAGES_STORE,
-      'identityKeys',
-      tierKey(CHAT_SCOPE, 'stanzaId', stanzaId)
+    const [stored] = await findChatRowsForTier(
+      db.transaction(MESSAGES_STORE).store,
+      conversationId,
+      'stanzaId',
+      stanzaId
     )
     return stored ? deserializeMessage(stored) : null
   } catch (error) {
@@ -1326,8 +1341,8 @@ export async function getMessagesAround(
 ): Promise<Message[]> {
   const { before = 50, after } = options
 
-  let anchor = await getMessage(anchorRow.id)
-  if (!anchor) anchor = await getMessageByStanzaId(anchorRow.id)
+  let anchor = await getMessage(conversationId, anchorRow.id)
+  if (!anchor) anchor = await getMessageByStanzaId(conversationId, anchorRow.id)
   if (!anchor) return []
 
   const t = anchor.timestamp.getTime()
@@ -1528,16 +1543,17 @@ export async function getTotalRoomMessageCount(): Promise<number> {
  *     no longer resolves to this row and is not wrongly merged into it.
  */
 export async function updateMessage(
+  conversationId: string,
   id: string,
   updates: Partial<Message>,
-  scopeJid: string | null = getStorageScopeJid(),
-  expectedOwner?: Pick<Message, 'conversationId' | 'from'>
+  from: string,
+  scopeJid: string | null = getStorageScopeJid()
 ): Promise<void> {
   try {
     const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(MESSAGES_STORE)
-    const existing = await findChatRowById(store.index('ids'), id, expectedOwner)
+    const existing = await findChatRowById(store.index('ids'), id, conversationId, from)
     if (!existing) { await tx.done; return }
 
     const updated = { ...deserializeMessage(existing), ...updates } as Message
@@ -1875,11 +1891,16 @@ export async function areRetractedInCache(
 /**
  * Delete a message by ID.
  */
-export async function deleteMessage(id: string): Promise<void> {
+export async function deleteMessage(
+  conversationId: string,
+  id: string,
+  from: string,
+  scopeJid: string | null = getStorageScopeJid()
+): Promise<void> {
   try {
-    const db = await getDB(getStorageScopeJid())
+    const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
-    const existing = await findChatRowById(tx.store.index('ids'), id)
+    const existing = await findChatRowById(tx.store.index('ids'), id, conversationId, from)
     if (existing) await tx.store.delete(existing.cacheKey)
     await tx.done
   } catch (error) {
@@ -2211,8 +2232,8 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
  * `id`. Rooms reuse their own per-archive id sequence, so a bare `stanzaId`
  * index lookup could return a DIFFERENT room's row — {@link
  * getRoomMessageByStanzaId} confines it to `entityId` (room-scoping
- * footgun, see that function's doc). Chat's single per-account archive makes
- * a plain `getMessageByStanzaId` lookup unambiguous.
+ * footgun, see that function's doc). The chat lookup is likewise confined to
+ * `entityId`.
  *
  * Returns `null` when the id is not cached (evicted, or the coverage record
  * is stale) — the caller (`resolveCoverageBottom`) turns that into
@@ -2225,7 +2246,7 @@ export async function resolveArchivePosition(
 ): Promise<ExactPosition | null> {
   const message = isRoom
     ? await getRoomMessageByStanzaId(entityId, archiveId)
-    : await getMessageByStanzaId(archiveId)
+    : await getMessageByStanzaId(entityId, archiveId)
   if (!message) return null
   return exactPosition(message, isRoom ? 'room' : 'chat')
 }

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -16,8 +16,10 @@ import type { Message } from '../core/types/chat'
 import type { RoomMessage } from '../core/types/room'
 import { getStorageScopeJid } from './storageScope'
 import {
+  archiveIdentityConflict,
   canMergeOccupantSet,
   canonicalKey,
+  CHAT_SCOPE,
   chatMessageAuthor,
   extendOccupantComponent,
   identityKeys,
@@ -31,11 +33,11 @@ import {
   sameLogicalMessage,
   tierKey,
   type MessageRowRef,
-  type IdentityProbe,
   type IdentityTier,
 } from './messageIdentity'
 import {
   adoptPendingRetraction,
+  type PendingRetractionIdentity,
   chatPendingRetractionAliases,
   chatRetractionAliases,
   noteRetractedIdentity,
@@ -61,8 +63,18 @@ const DB_NAME = 'fluux-message-cache'
 // canonically-keyed store (identityKeys[]/ids[] multiEntry + room_ts_from_id order
 // index) replaces the old room store; the v4 upgrade streams every legacy row
 // through the identity-resolving upsert into it and aborts atomically on failure.
-const DB_VERSION = 4
-const MESSAGES_STORE = 'messages'
+// v5: canonicalize the 1:1 chat archive on the same pattern. A client id names a
+// stanza, not a message — a client that restarts may re-issue one it already used —
+// so the pre-v5 `keyPath: 'id'` let a later message OVERWRITE an earlier one and
+// inherit its retraction tombstone, destroying both bodies durably. A fresh
+// canonically-keyed store (identityKeys[]/ids[] multiEntry) replaces it; the v5
+// upgrade streams every legacy row through the identity-resolving upsert into it
+// and aborts atomically on failure.
+const DB_VERSION = 5
+// The canonical chat store (v5+). Keyed by the conversation-qualified canonical key.
+const MESSAGES_STORE = 'messages-canonical'
+// The pre-v5 chat store. Read + cleared by the v5 migration only; never written live.
+const LEGACY_MESSAGES_STORE = 'messages'
 // The canonical room store (v4+). Keyed by the canonical durable identity key.
 const ROOM_MESSAGES_STORE = 'room-messages-canonical'
 // The pre-v4 room store. Read + cleared by the v4 migration only; never written live.
@@ -71,11 +83,20 @@ const LEGACY_ROOM_MESSAGES_STORE = 'room-messages'
 /**
  * Stored message format with timestamps as numbers for efficient indexing.
  */
-interface StoredMessage extends Omit<Message, 'timestamp' | 'retractedAt' | 'replyTo'> {
+export interface StoredMessage
+  extends Omit<Message, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'> {
+  /** Cache key used as the primary key in IndexedDB. See {@link chatCacheKey}. */
+  cacheKey: string
+  /** Every chat-scoped identity tier this row is known under (see {@link identityKeys}). */
+  identityKeys: string[]
+  /** Every client-generated `id` this row has absorbed (a merged row may carry more than one). */
+  ids: string[]
   /** Timestamp as milliseconds since epoch for indexing */
   timestamp: number
   /** Retracted timestamp as milliseconds if message was retracted */
   retractedAt?: number
+  /** Poll closed timestamp as milliseconds */
+  pollClosedAt?: number
   /** Reply info with nested dates serialized */
   replyTo?: Message['replyTo']
 }
@@ -106,11 +127,14 @@ export interface StoredRoomMessage
  */
 interface MessageCacheSchema extends DBSchema {
   [MESSAGES_STORE]: {
-    key: string // message id
+    key: string // cacheKey — the conversation-qualified canonical identity key
     value: StoredMessage
     indexes: {
       conversationId: string
-      stanzaId: string
+      // multiEntry over identityKeys[] — the finder resolves every identity tier here.
+      identityKeys: string
+      // multiEntry over ids[] — a merged row is findable by EVERY absorbed client id.
+      ids: string
       timestamp: number
       conv_timestamp: [string, number]
       // Sparse: only messages awaiting deferred decryption are indexed here.
@@ -175,24 +199,30 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
 
   dbNameForPromise = targetDbName
   dbPromise = openDB<MessageCacheSchema>(targetDbName, DB_VERSION, {
-    upgrade(db, oldVersion, _newVersion, transaction) {
-      // Chat messages store
+    upgrade(db, _oldVersion, _newVersion, transaction) {
+      // Which legacy stores this upgrade has to drain. Both migrations stream through
+      // the SAME version-change transaction, so they are fired once, sequentially,
+      // below: two concurrent cursor walks over one transaction would interleave
+      // their reads and writes.
+      const drain = { chat: false, room: false }
+
+      // Chat messages store (v5 canonical). Same shape and same reasoning as the v4
+      // room store below.
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
-        const msgStore = db.createObjectStore(MESSAGES_STORE, { keyPath: 'id' })
+        const msgStore = db.createObjectStore(MESSAGES_STORE, { keyPath: 'cacheKey' })
         msgStore.createIndex('conversationId', 'conversationId', { unique: false })
-        msgStore.createIndex('stanzaId', 'stanzaId', { unique: false })
+        msgStore.createIndex('identityKeys', 'identityKeys', { unique: false, multiEntry: true })
+        msgStore.createIndex('ids', 'ids', { unique: false, multiEntry: true })
         msgStore.createIndex('timestamp', 'timestamp', { unique: false })
         msgStore.createIndex('conv_timestamp', ['conversationId', 'timestamp'], {
           unique: false,
         })
         // Sparse index — records without `encryptedPayload` are excluded.
         msgStore.createIndex('encryptedPayload', 'encryptedPayload', { unique: false })
-      } else if (oldVersion < 3) {
-        // v3 migration for existing DBs: add the sparse encryptedPayload index.
-        const msgStore = transaction.objectStore(MESSAGES_STORE)
-        if (!msgStore.indexNames.contains('encryptedPayload')) {
-          msgStore.createIndex('encryptedPayload', 'encryptedPayload', { unique: false })
-        }
+        // `as never`: the legacy store is not in the v5 schema, so idb's typed
+        // objectStoreNames.contains() would reject its name — but it can still be
+        // present in an upgrading DB, which is exactly what we test for here.
+        drain.chat = db.objectStoreNames.contains(LEGACY_MESSAGES_STORE as never)
       }
 
       // Room messages store (v4 canonical). A fresh canonically-keyed store replaces
@@ -213,29 +243,30 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
         s.createIndex('room_timestamp', ['roomJid', 'timestamp'], { unique: false })
         s.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'], { unique: false })
 
-        // `as never`: the legacy store is not in the v4 schema, so idb's typed
-        // objectStoreNames.contains() would reject its name — but it can still be
-        // present in an upgrading DB, which is exactly what we test for here.
-        if (db.objectStoreNames.contains(LEGACY_ROOM_MESSAGES_STORE as never)) {
-          // idb does NOT await this callback, and rethrowing would be an unhandled
-          // rejection. Fire the migration and, on ANY failure, explicitly abort the
-          // version-change transaction (which rejects openDB). The transaction stays
-          // alive meanwhile via the migration's chained requests, and openDB resolves
-          // only after it commits. Do not deleteObjectStore here (illegal from the
-          // async continuation) — the migration clear()s the legacy store instead.
-          migrateRoomStoreToCanonical(transaction, scopeJid).catch((err) => {
-            // Log before aborting: this streaming rewrite of the whole room archive
-            // is the riskiest path in the upgrade, and the abort otherwise swallows
-            // the cause silently. Then: aborting rejects openDB (getDB's caller
-            // handles that) AND rejects transaction.done with AbortError; nothing
-            // awaits `done`, so attach a no-op catch first to keep the abort from
-            // surfacing as an unhandled rejection, then abort.
-            console.error('v4 room-store migration aborted:', err)
-            transaction.done.catch(() => {})
-            transaction.abort()
-          })
-        }
+        // See the chat store above for the `as never` cast.
+        drain.room = db.objectStoreNames.contains(LEGACY_ROOM_MESSAGES_STORE as never)
       }
+
+      if (drain.chat || drain.room) {
+        // idb does NOT await this callback, and rethrowing would be an unhandled
+        // rejection. Fire the migration and, on ANY failure, explicitly abort the
+        // version-change transaction (which rejects openDB). The transaction stays
+        // alive meanwhile via the migration's chained requests, and openDB resolves
+        // only after it commits. Do not deleteObjectStore here (illegal from the
+        // async continuation) — the migration clear()s the legacy stores instead.
+        migrateStoresToCanonical(transaction, scopeJid, drain).catch((err) => {
+          // Log before aborting: this streaming rewrite of the whole archive is the
+          // riskiest path in the upgrade, and the abort otherwise swallows the cause
+          // silently. Then: aborting rejects openDB (getDB's caller handles that) AND
+          // rejects transaction.done with AbortError; nothing awaits `done`, so attach
+          // a no-op catch first to keep the abort from surfacing as an unhandled
+          // rejection, then abort.
+          console.error('canonical-store migration aborted:', err)
+          transaction.done.catch(() => {})
+          transaction.abort()
+        })
+      }
+
     },
   })
 
@@ -247,13 +278,33 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
 // =============================================================================
 
 /**
+ * The primary key of a stored chat row: its canonical identity key, qualified by
+ * the conversation.
+ *
+ * The room store gets that qualification for free — `roomScope` puts the room JID
+ * in every key it derives. Chat identity keys are deliberately unscoped (see the
+ * module note in `messageIdentity.ts`: they are also the retraction ledger's
+ * aliases and the unread overlay's, a spelling that cannot move), so the
+ * conversation is added HERE, at the store boundary, and nowhere else. Without it
+ * two OUTGOING messages to different peers share `from` — our own JID — and would
+ * collide on a reused client id, which is the defect this keying closes.
+ */
+function chatCacheKey(m: Pick<Message, 'conversationId' | 'from' | 'id' | 'stanzaId' | 'originId'>): string {
+  return `${m.conversationId}\u0000${canonicalKey(CHAT_SCOPE, m)}`
+}
+
+/**
  * Convert a Message to storage format (Date -> number).
  */
 function serializeMessage(message: Message): StoredMessage {
   return {
     ...message,
+    cacheKey: chatCacheKey(message),
+    identityKeys: identityKeys(CHAT_SCOPE, message),
+    ids: [message.id],
     timestamp: message.timestamp.getTime(),
     retractedAt: message.retractedAt?.getTime(),
+    pollClosedAt: message.pollClosedAt?.getTime(),
   }
 }
 
@@ -265,6 +316,7 @@ function deserializeMessage(stored: StoredMessage): Message {
     ...stored,
     timestamp: new Date(stored.timestamp),
     retractedAt: stored.retractedAt ? new Date(stored.retractedAt) : undefined,
+    pollClosedAt: stored.pollClosedAt ? new Date(stored.pollClosedAt) : undefined,
   }
 }
 
@@ -355,21 +407,22 @@ function enforceRetraction(
       scope.kind === 'room'
         ? roomRetractionAliases(next as StoredRoomMessage)
         : chatRetractionAliases(next)
+    // A chat record reached through the non-unique `from+id` alias must also be
+    // about THIS message: the room path has the XEP-0421 occupant-id for that,
+    // 1:1 has the archive id. Without it a retraction filed under a client id
+    // tombstones whatever message next carries that id.
+    const isThisMessagesRetraction = (record: PendingRetractionIdentity) =>
+      scope.kind === 'room'
+        ? roomMessageAuthor(next as StoredRoomMessage, record)
+        : chatMessageAuthor(next, record) && !archiveIdentityConflict(next, record)
     const retractedAt =
-      retractedAtForIdentity(scope, verifiedAliases, (record) =>
-        scope.kind === 'room'
-          ? roomMessageAuthor(next as StoredRoomMessage, record)
-          : chatMessageAuthor(next, record)
-      ) ??
+      retractedAtForIdentity(scope, verifiedAliases, isThisMessagesRetraction) ??
       adoptPendingRetraction(
         scope,
         scope.kind === 'room'
           ? roomPendingRetractionAliases(next as StoredRoomMessage)
           : chatPendingRetractionAliases(next),
-        (record) =>
-          scope.kind === 'room'
-            ? roomMessageAuthor(next as StoredRoomMessage, record)
-            : chatMessageAuthor(next, record)
+        isThisMessagesRetraction
       )
     if (retractedAt !== undefined) {
       noteRetractedIdentity(scope, verifiedAliases, next, retractedAt)
@@ -557,64 +610,130 @@ async function upsertRoomRowByIdentity(
   await upsertStoredRoomRow(store, serializeRoomMessage(message), undefined, scopeJid)
 }
 
-/** Minimal cursor view over the legacy room store during migration. */
-type LegacyRoomCursor = { value: StoredRoomMessage; continue(): Promise<LegacyRoomCursor | null> }
+/** Minimal cursor view over a legacy store during migration. */
+type LegacyCursor<T> = { value: T; continue(): Promise<LegacyCursor<T> | null> }
 /** Minimal legacy-store view: stream every row out, then empty. */
-type LegacyRoomStore = { openCursor(): Promise<LegacyRoomCursor | null>; clear(): Promise<void> }
+type LegacyStore<T> = { openCursor(): Promise<LegacyCursor<T> | null>; clear(): Promise<void> }
 /** Minimal version-change transaction view the streaming migration needs. */
 type MigrationTransaction = { objectStore(name: string): unknown }
 
 /**
- * Stream every legacy room row through the identity-resolving upsert into the
+ * Stream every legacy row through the identity-resolving upsert into its
  * canonical store, one cursor step at a time (never `getAll()` the whole archive
- * into memory), then empty the legacy store. Runs inside the v4 version-change
- * transaction; any throw is caught by the caller, which aborts that transaction
- * atomically — so a partial rewrite can never be observed.
+ * into memory), then empty the legacy store.
+ *
+ * Runs inside the version-change transaction; any throw is caught by the caller,
+ * which aborts that transaction atomically — so a partial rewrite can never be
+ * observed. The two stores are drained SEQUENTIALLY on purpose: they share one
+ * transaction, and two concurrent cursor walks over it would interleave.
+ *
+ * Migrating cannot lose a row, and merges only rows the ladder already treated as
+ * one message: the legacy chat store was keyed by `id`, so it held at most one row
+ * per client id, and two rows collapse only when they agree on a stanza-id or an
+ * origin-id. What it cannot do is UNDO a collision — a row the pre-v5 `keyPath:
+ * 'id'` already overwrote is gone before the upgrade runs.
  */
-async function migrateRoomStoreToCanonical(
+async function migrateStoresToCanonical(
   transaction: MigrationTransaction,
-  scopeJid: string | null
+  scopeJid: string | null,
+  drain: { chat: boolean; room: boolean }
 ): Promise<void> {
-  const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE) as LegacyRoomStore
-  const dest = transaction.objectStore(ROOM_MESSAGES_STORE) as RoomStoreLike
-  let cursor = await legacy.openCursor()
-  while (cursor) {
-    if (migrationFaultForTesting) throw new Error('migration fault (test)')
-    await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value), scopeJid)
-    cursor = await cursor.continue()
+  if (drain.room) {
+    const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE) as LegacyStore<StoredRoomMessage>
+    const dest = transaction.objectStore(ROOM_MESSAGES_STORE) as RoomStoreLike
+    let cursor = await legacy.openCursor()
+    while (cursor) {
+      if (migrationFaultForTesting) throw new Error('migration fault (test)')
+      await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value), scopeJid)
+      cursor = await cursor.continue()
+    }
+    await legacy.clear() // now empty; a future version bump can drop it synchronously
   }
-  await legacy.clear() // legacy store now empty; a future version bump can drop it synchronously
+  if (drain.chat) {
+    const legacy = transaction.objectStore(LEGACY_MESSAGES_STORE) as LegacyStore<StoredMessage>
+    const dest = transaction.objectStore(MESSAGES_STORE) as ChatMessageStore
+    let cursor = await legacy.openCursor()
+    while (cursor) {
+      if (migrationFaultForTesting) throw new Error('migration fault (test)')
+      await upsertChatRowByIdentity(dest, deserializeMessage(cursor.value), scopeJid)
+      cursor = await cursor.continue()
+    }
+    await legacy.clear()
+  }
 }
 
 // =============================================================================
 // Chat Message Operations
 // =============================================================================
 
-type StoredMessageCursor = {
-  value: StoredMessage
-  continue(): Promise<StoredMessageCursor | null>
-}
-
-type ChatMessageReader = {
-  get(key: string): Promise<StoredMessage | undefined>
-  index(name: 'stanzaId'): { getAll(key: string): Promise<StoredMessage[]> }
-  index(name: 'conv_timestamp'): {
-    openCursor(range: IDBKeyRange): Promise<StoredMessageCursor | null>
-  }
+type ChatIdentityStore = {
+  index(name: 'identityKeys'): { getAll(key: string): Promise<StoredMessage[]> }
+  index(name: 'ids'): { getAll(key: string): Promise<StoredMessage[]> }
 }
 
 /** Minimal structural view of the idb chat-message object store. */
-type ChatMessageStore = ChatMessageReader & {
+type ChatMessageStore = ChatIdentityStore & {
+  get(key: string): Promise<StoredMessage | undefined>
   put(value: StoredMessage): Promise<unknown>
+  delete(key: string): Promise<void>
+}
+
+/** The identity fields a chat lookup reads off a message or an already-stored row. */
+type ChatIdentityFields = Pick<
+  StoredMessage,
+  'conversationId' | 'from' | 'id' | 'stanzaId' | 'originId'
+>
+
+/**
+ * Every row of `conversationId` that one ladder tier of `reference` matches.
+ *
+ * The room twin's shape: an authoritative tier resolves through the scoped
+ * `identityKeys` alias, the fallback tier through `ids` — never through the row's
+ * own `id` field, because a merged row keeps ONE `id` but stays findable by every
+ * id it absorbed. Chat keys are not namespaced (see `messageIdentity`'s module
+ * note), so both indexes span the store and every lookup is filtered back to its
+ * conversation: a client id is a name in one stream and repeats across them.
+ */
+async function findChatRowsForTier(
+  store: ChatIdentityStore,
+  conversationId: string,
+  tier: IdentityTier,
+  reference: string
+): Promise<StoredMessage[]> {
+  const matches = tier === 'stanzaId' || tier === 'originId'
+    ? await store.index('identityKeys').getAll(tierKey(CHAT_SCOPE, tier, reference))
+    : await store.index('ids').getAll(reference)
+  return matches.filter((row) => row.conversationId === conversationId)
+}
+
+/**
+ * The row carrying client `id`, optionally narrowed to its owner.
+ *
+ * A bare client id names no single row — it repeats across conversations, and a
+ * restarted client may re-issue one — so without an `owner` this can only answer
+ * "a row known by this id", exactly as the pre-v5 primary-key lookup did. The
+ * `ids` index is used rather than the row's own `id` field so a merged row stays
+ * findable by every id it absorbed.
+ */
+async function findChatRowById(
+  idsIndex: { getAll(key: string): Promise<StoredMessage[]> },
+  id: string,
+  owner?: Pick<StoredMessage, 'conversationId' | 'from'>
+): Promise<StoredMessage | undefined> {
+  const matches = await idsIndex.getAll(id)
+  if (!owner) return matches[0]
+  return matches.find(
+    (row) => row.conversationId === owner.conversationId && row.from === owner.from
+  )
 }
 
 async function findChatRowsByReference(
-  store: ChatMessageReader,
+  store: ChatIdentityStore,
   conversationId: string,
   reference: string
 ): Promise<{ tier: IdentityTier; authoritative: boolean; candidates: StoredMessage[] } | undefined> {
   for (const probe of referenceProbes<StoredMessage>(reference, 'archive-first')) {
-    const candidates = await findChatRowsForProbe(store, conversationId, reference, probe)
+    const candidates = await findChatRowsForTier(store, conversationId, probe.tier, reference)
     if (candidates.length > 0) {
       return { tier: probe.tier, authoritative: probe.authoritative, candidates }
     }
@@ -622,45 +741,36 @@ async function findChatRowsByReference(
   return undefined
 }
 
-async function findChatRowsForProbe(
-  store: ChatMessageReader,
-  conversationId: string,
-  reference: string,
-  probe: IdentityProbe<StoredMessage>
-): Promise<StoredMessage[]> {
-  let matches: StoredMessage[] = []
-  if (probe.tier === 'stanzaId') {
-    matches = await store.index('stanzaId').getAll(reference)
-  } else if (probe.tier === 'originId') {
-    let cursor = await store.index('conv_timestamp').openCursor(
-      entityTimestampRange(conversationId)
-    )
-    while (cursor) {
-      if (probe.matches(cursor.value)) matches.push(cursor.value)
-      cursor = await cursor.continue()
-    }
-  } else {
-    const clientMatch = await store.get(reference)
-    if (clientMatch) matches = [clientMatch]
-  }
-  return matches.filter(
-    (row) => row.conversationId === conversationId && probe.matches(row)
-  )
-}
-
+/**
+ * The rows that are the same logical message as `message`, at the highest tier
+ * that matches any.
+ *
+ * Deliberately NOT the room finder's identity-COMPONENT union across tiers: that
+ * one is held together by the XEP-0421 occupant-id, which 1:1 has no equivalent
+ * of, so unioning tiers here would only widen what a `from+id` collision folds
+ * together. Stopping at the first matching tier is what the chat path already
+ * did; the change here is which index answers it.
+ */
 async function findChatRowsByIdentity(
-  store: ChatMessageReader,
-  message: Message
+  store: ChatIdentityStore,
+  message: ChatIdentityFields
 ): Promise<StoredMessage[]> {
   for (const probe of identityProbes<StoredMessage>(message, 'archive-first')) {
-    const matches = await findChatRowsForProbe(
+    const matches = await findChatRowsForTier(
       store,
       message.conversationId,
-      probe.reference,
-      probe
+      probe.tier,
+      probe.reference
     )
+    // `ids` is not keyed by sender, but the fallback rung is `from`+`id`. Pin it,
+    // or an incoming message would match a row the ladder never named. Then drop
+    // any row the archive already proves is a DIFFERENT message: this rung has no
+    // uniqueness guarantee, and folding two of them together is what lets a
+    // re-issued client id inherit an earlier message's tombstone.
     const candidates = probe.tier === 'fallback'
-      ? matches.filter((row) => row.from === message.from)
+      ? matches.filter(
+          (row) => row.from === message.from && !archiveIdentityConflict(row, message)
+        )
       : matches
     if (candidates.length > 0) return candidates
   }
@@ -710,6 +820,23 @@ function stableStringify(v: unknown): string {
 }
 
 /**
+ * The storage fields a canonically-keyed row carries, chat and room alike.
+ *
+ * The room-only fields (`occupantId`, `isMention`) are optional, so a chat row
+ * satisfies this too — which is what lets ONE merge serve both stores. Absent is
+ * not false: the merge's monotonic operators treat a missing field exactly as a
+ * room row missing it, so nothing chat-side depends on their absence.
+ */
+type CanonicalRow = Pick<
+  StoredRoomMessage,
+  | 'cacheKey' | 'identityKeys' | 'ids' | 'timestamp' | 'from' | 'id' | 'body'
+  | 'stanzaId' | 'originId' | 'occupantId' | 'reactions' | 'isEdited'
+  | 'isRetracted' | 'retractedAt' | 'isModerated' | 'moderatedBy' | 'moderationReason'
+  | 'isMention' | 'pollClosed' | 'pollClosedAt' | 'deliveryError'
+  | 'encryptedPayload' | 'unsupportedEncryption'
+>
+
+/**
  * The IMMUTABLE content projection — everything EXCEPT the fields merged
  * separately (aliases, timestamp, reactions, retraction, moderation, poll
  * closure, delivery error, cacheKey). The tiebreak must serialize only this,
@@ -720,7 +847,7 @@ function stableStringify(v: unknown): string {
  * is identical between a merged row and its content-winner, so max over it is
  * genuinely associative.
  */
-function contentProjection(m: StoredRoomMessage): unknown {
+function contentProjection(m: CanonicalRow): unknown {
   const {
     stanzaId: _s, originId: _o, occupantId: _oi, timestamp: _t, reactions: _r,
     identityKeys: _ik, ids: _ids,
@@ -742,7 +869,7 @@ function contentProjection(m: StoredRoomMessage): unknown {
  * moderation, poll closure, delivery error) CHANGE during a merge, so a whole-row
  * serialization would make the winner grouping-dependent (see contentProjection).
  */
-function contentOwner(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+function contentOwner<T extends CanonicalRow>(a: T, b: T): T {
   const ra: number[] = [decryptionRank(a), a.isEdited ? 1 : 0, a.body ? 1 : 0]
   const rb: number[] = [decryptionRank(b), b.isEdited ? 1 : 0, b.body ? 1 : 0]
   for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) return ra[i] > rb[i] ? a : b
@@ -751,13 +878,20 @@ function contentOwner(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMes
 }
 
 /**
- * Merge two stored rows that are the same logical room message into one.
- * COMMUTATIVE and ASSOCIATIVE. The correlated content block comes from
- * {@link contentOwner} (total order); every other field uses a symmetric operator,
- * so no edit, poll closure, retraction, reaction, moderation, mention, or alias
- * is lost.
+ * Merge two stored rows that are the same logical message into one. COMMUTATIVE
+ * and ASSOCIATIVE. The correlated content block comes from {@link contentOwner}
+ * (total order); every other field uses a symmetric operator, so no edit, poll
+ * closure, retraction, reaction, moderation, mention, or alias is lost.
+ *
+ * `rekey` supplies the scope-dependent half — the primary key and the row's own
+ * identity aliases — because that is the ONLY thing that differs between the two
+ * stores: room keys are namespaced by room JID, chat keys by conversation.
  */
-export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+function mergeCanonicalRows<T extends CanonicalRow>(
+  a: T,
+  b: T,
+  rekey: (row: T) => Pick<CanonicalRow, 'cacheKey' | 'identityKeys'>
+): T {
   const owner = contentOwner(a, b)
   const aSid = a.stanzaId != null, bSid = b.stanzaId != null
   const timestamp = aSid !== bSid ? (aSid ? a.timestamp : b.timestamp) : Math.min(a.timestamp, b.timestamp)
@@ -775,7 +909,9 @@ export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): Store
     ? (stableStringify(a.pollClosed) <= stableStringify(b.pollClosed) ? a.pollClosed : b.pollClosed)
     : (a.pollClosed ?? b.pollClosed)
 
-  const merged: StoredRoomMessage = {
+  // `as T`: the literal below carries every CanonicalRow field plus, through
+  // `...owner`, whichever store's remaining fields T actually has.
+  const merged = {
     ...owner,
     stanzaId: minStr(a.stanzaId, b.stanzaId),
     originId: minStr(a.originId, b.originId),
@@ -789,10 +925,65 @@ export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): Store
     ...(moderated ? { isModerated: true, moderatedBy: minStr(a.moderatedBy, b.moderatedBy), moderationReason: minStr(a.moderationReason, b.moderationReason) } : {}),
     ...(pollClosed ? { pollClosed, pollClosedAt: minNum(a.pollClosedAt, b.pollClosedAt) } : {}),
     ...(mentioned ? { isMention: true } : {}),
+  } as T
+  return { ...merged, ...rekey(merged) }
+}
+
+/** {@link mergeCanonicalRows} bound to the room store's namespaced keys. */
+export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+  return mergeCanonicalRows(a, b, (row) => ({
+    cacheKey: canonicalKey(roomScope(row.roomJid), row),
+    identityKeys: unionSorted(row.identityKeys, identityKeys(roomScope(row.roomJid), row)),
+  }))
+}
+
+/** {@link mergeCanonicalRows} bound to the chat store's conversation-scoped keys. */
+export function mergeChatRows(a: StoredMessage, b: StoredMessage): StoredMessage {
+  return mergeCanonicalRows(a, b, (row) => ({
+    cacheKey: chatCacheKey(row),
+    identityKeys: unionSorted(row.identityKeys, identityKeys(CHAT_SCOPE, row)),
+  }))
+}
+
+/**
+ * Core: merge `incoming` with every row already resolved as the same logical
+ * message, delete the losers, put the survivor. The chat twin of
+ * {@link upsertStoredRoomRow}.
+ *
+ * The merge is what carries XEP-0424 forward: a re-delivered copy of a retracted
+ * message (MAM re-ingestion, a carbon) arrives with its original body, and
+ * {@link mergeCanonicalRows}' retraction OR tombstones it again before
+ * {@link enforceRetraction} scrubs it.
+ */
+async function upsertStoredChatRow(
+  store: ChatMessageStore,
+  incoming: StoredMessage,
+  matches: readonly StoredMessage[],
+  scopeJid?: string | null,
+  excludeKey?: string
+): Promise<void> {
+  let merged = incoming
+  for (const row of matches) merged = mergeChatRows(merged, row)
+  if (excludeKey && excludeKey !== merged.cacheKey) await store.delete(excludeKey)
+  for (const row of matches) {
+    if (row.cacheKey !== merged.cacheKey) await store.delete(row.cacheKey)
   }
-  merged.cacheKey = canonicalKey(roomScope(merged.roomJid), merged)
-  merged.identityKeys = unionSorted(merged.identityKeys, identityKeys(roomScope(merged.roomJid), merged))
-  return merged
+  await store.put(enforceRetraction(merged, chatScopeOf(merged, scopeJid)))
+}
+
+/** Insert or merge a message by identity (migration + live/archive write path). */
+async function upsertChatRowByIdentity(
+  store: ChatMessageStore,
+  message: Message,
+  scopeJid?: string | null
+): Promise<void> {
+  const incoming = serializeMessage(message)
+  await upsertStoredChatRow(
+    store,
+    incoming,
+    await findChatRowsByIdentity(store, incoming),
+    scopeJid
+  )
 }
 
 /**
@@ -802,7 +993,7 @@ export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): Store
  * runs the background MAM catch-up while the OpenPGP key may still be locked,
  * and a peer toggling their encryption makes history re-arrive as an
  * unsupported fallback. Either way the re-fetched copy is less recoverable
- * than what we already stored, and a blind `put` would overwrite our decrypted
+ * than what we already stored, and a blind write would overwrite our decrypted
  * plaintext (or our retriable ciphertext) with a placeholder — leaving the
  * message permanently showing "could not be decrypted" / "not supported".
  *
@@ -816,20 +1007,14 @@ async function putChatMessageGuarded(
   message: Message,
   scopeJid: string | null
 ): Promise<void> {
-  const existing = (await findChatRowsByIdentity(store, message))[0]
+  const incoming = serializeMessage(message)
+  const matches = await findChatRowsByIdentity(store, incoming)
   const incomingRank = decryptionRank(message)
-  if (existing && incomingRank < 2 && decryptionRank(existing) > incomingRank) {
+  if (matches[0] && incomingRank < 2 && decryptionRank(matches[0]) > incomingRank) {
     // Existing entry is more recoverable — don't degrade it.
     return
   }
-  // XEP-0424 is monotonic: a re-delivered copy of a retracted message (MAM
-  // re-ingestion, a carbon) carries its original body and would otherwise
-  // resurrect it. The chat twin of mergeRoomRows' retraction OR.
-  const incoming =
-    existing?.isRetracted
-      ? { ...serializeMessage(message), isRetracted: true, retractedAt: existing.retractedAt }
-      : serializeMessage(message)
-  await store.put(enforceRetraction(incoming, chatScopeOf(incoming, scopeJid)))
+  await upsertStoredChatRow(store, incoming, matches, scopeJid)
 }
 
 /**
@@ -921,7 +1106,7 @@ export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
 export async function getMessage(id: string): Promise<Message | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    const stored = await db.get(MESSAGES_STORE, id)
+    const stored = await findChatRowById(db.transaction(MESSAGES_STORE).store.index('ids'), id)
     return stored ? deserializeMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -945,10 +1130,10 @@ export async function getMessagesByReferences(
   try {
     const db = await getDB(getStorageScopeJid())
     const tx = db.transaction([MESSAGES_STORE, ROOM_MESSAGES_STORE], 'readonly')
-    const chatStore = tx.objectStore(MESSAGES_STORE)
+    const chatIdsIndex = tx.objectStore(MESSAGES_STORE).index('ids')
     const roomIds = tx.objectStore(ROOM_MESSAGES_STORE).index('ids')
     const [storedChatMessages, storedRoomMessages] = await Promise.all([
-      Promise.all(chatIds.map(id => chatStore.get(id))),
+      Promise.all(chatIds.map(id => findChatRowById(chatIdsIndex, id))),
       Promise.all(roomReferences.map(reference =>
         findRoomRowById(
           roomIds,
@@ -981,7 +1166,11 @@ export async function getMessagesByReferences(
 export async function getMessageByStanzaId(stanzaId: string): Promise<Message | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    const stored = await db.getFromIndex(MESSAGES_STORE, 'stanzaId', stanzaId)
+    const stored = await db.getFromIndex(
+      MESSAGES_STORE,
+      'identityKeys',
+      tierKey(CHAT_SCOPE, 'stanzaId', stanzaId)
+    )
     return stored ? deserializeMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -1326,7 +1515,17 @@ export async function getTotalRoomMessageCount(): Promise<number> {
 }
 
 /**
- * Update specific fields of a message.
+ * Update specific fields of a message, resolving the row through the `ids` alias
+ * so a caller holding a pre-merge id still finds it.
+ *
+ * Chat twin of {@link updateRoomMessage}, and it splits the same two ways when an
+ * update carries an identity FIELD:
+ *   - Expansion (a stanza-id landing on a local echo, as `confirmSentMessage`
+ *     sends) — the existing row's accumulated aliases are unioned into the updated
+ *     row, then it is re-keyed and any OTHER row already at the new tier merged in.
+ *   - Revocation ({ stanzaId: undefined }, as `clearMessageStanzaId` sends) — the
+ *     cleared tier's alias is REMOVED, so a later message carrying that stanza-id
+ *     no longer resolves to this row and is not wrongly merged into it.
  */
 export async function updateMessage(
   id: string,
@@ -1336,28 +1535,48 @@ export async function updateMessage(
 ): Promise<void> {
   try {
     const db = await getDB(scopeJid)
-    const existing = await db.get(MESSAGES_STORE, id)
-    if (!existing) return
-    if (expectedOwner && (
-      existing.conversationId !== expectedOwner.conversationId ||
-      existing.from !== expectedOwner.from
-    )) return
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+    const store = tx.objectStore(MESSAGES_STORE)
+    const existing = await findChatRowById(store.index('ids'), id, expectedOwner)
+    if (!existing) { await tx.done; return }
 
-    const updated = {
-      ...existing,
-      ...updates,
-      // Handle Date fields
-      timestamp:
-        updates.timestamp instanceof Date
-          ? updates.timestamp.getTime()
-          : existing.timestamp,
-      retractedAt:
-        updates.retractedAt instanceof Date
-          ? updates.retractedAt.getTime()
-          : updates.retractedAt ?? existing.retractedAt,
+    const updated = { ...deserializeMessage(existing), ...updates } as Message
+    const serialized = serializeMessage(updated)
+    // Dates the caller may have passed as epoch millis rather than Date objects.
+    serialized.timestamp =
+      updates.timestamp instanceof Date ? updates.timestamp.getTime() : existing.timestamp
+    serialized.retractedAt =
+      updates.retractedAt instanceof Date
+        ? updates.retractedAt.getTime()
+        : (updates.retractedAt as number | undefined) ?? existing.retractedAt
+
+    // The in-place path requires both unchanged identity fields and an unchanged
+    // serialized key. Either kind of change needs the merge/re-key path below.
+    if (identityFieldsEqual(updated, existing) && serialized.cacheKey === existing.cacheKey) {
+      serialized.identityKeys = existing.identityKeys // unchanged
+      serialized.ids = existing.ids
+      await store.put(enforceRetraction(serialized, chatScopeOf(serialized, scopeJid)))
+    } else {
+      // Do NOT delete-then-upsert: a deleted row cannot be rediscovered, and
+      // re-serialization resets ids/identityKeys. Union the accumulated aliases in,
+      // minus any tier this update explicitly cleared.
+      const revoked: string[] = []
+      if ('stanzaId' in updates && updated.stanzaId == null && existing.stanzaId) {
+        revoked.push(tierKey(CHAT_SCOPE, 'stanzaId', existing.stanzaId))
+      }
+      if ('originId' in updates && updated.originId == null && existing.originId) {
+        revoked.push(tierKey(CHAT_SCOPE, 'originId', existing.originId))
+      }
+      serialized.ids = unionSorted(existing.ids, serialized.ids)
+      serialized.identityKeys = unionSorted(existing.identityKeys, serialized.identityKeys)
+        .filter((key) => !revoked.includes(key))
+      // excludeKey = the old cacheKey: the pre-update copy must not be merged back
+      // in, and its row is dropped when the key moved.
+      const matches = (await findChatRowsByIdentity(store, serialized))
+        .filter((row) => row.cacheKey !== existing.cacheKey)
+      await upsertStoredChatRow(store, serialized, matches, scopeJid, existing.cacheKey)
     }
-
-    await db.put(MESSAGES_STORE, enforceRetraction(updated, chatScopeOf(updated, scopeJid)))
+    await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to update message:', error)
@@ -1406,11 +1625,12 @@ export async function updateMessageReactions(
       newReactions[emoji].push(reactorJid)
     }
 
-    const updated = {
+    const updated: StoredMessage = {
       ...existing,
       reactions: Object.keys(newReactions).length > 0 ? newReactions : undefined,
     }
 
+    // Reactions carry no identity, so the row keeps its key and its aliases.
     await tx.store.put(enforceRetraction(updated, chatScopeOf(updated, scopeJid)))
     await tx.done
     return true
@@ -1462,35 +1682,67 @@ export async function findChatRetractionTargets(
   }
 }
 
+/** A cached chat row, with the aliases and client ids it has absorbed. */
+export interface ChatMessageCopy {
+  cacheKey: string
+  identityKeys: string[]
+  ids: string[]
+  message: Message
+}
+
 /**
- * Every cached chat row sharing any identity tier with `message`.
+ * Every cached chat row sharing any identity tier with `message`, transitively.
  *
- * Unlike reference resolution, this probes the complete ladder because a
- * resolved target can bridge several archive copies through different aliases.
- * The caller repeats this expansion for newly discovered authorized copies.
+ * Unlike reference resolution, this probes the complete ladder because a resolved
+ * target can bridge several archive copies through different aliases, and it
+ * re-expands from each row it discovers.
+ *
+ * The absorbed `ids` come back with each row because the SEARCH INDEX keys chat
+ * documents by client id: once the cache merges two rows, a document written
+ * under the id that lost is reachable only through this list. Chat twin of
+ * {@link findRoomMessageCopies}.
  */
 export async function findChatMessageCopies(
   conversationId: string,
   message: Message,
   scopeJid: string | null = getStorageScopeJid()
-): Promise<Message[]> {
+): Promise<ChatMessageCopy[]> {
   try {
     const db = await getDB(scopeJid)
     const store = db.transaction(MESSAGES_STORE).store
     const found = new Map<string, StoredMessage>()
-    for (const probe of identityProbes<StoredMessage>(message, 'archive-first')) {
-      const matches = await findChatRowsForProbe(
-        store,
-        conversationId,
-        probe.reference,
-        probe
-      )
-      const candidates = probe.tier === 'fallback'
-        ? matches.filter((row) => row.from === message.from)
-        : matches
-      for (const candidate of candidates) found.set(candidate.id, candidate)
+    const queue: ChatIdentityFields[] = [serializeMessage(message)]
+    for (let index = 0; index < queue.length; index++) {
+      const probed = queue[index]
+      for (const probe of identityProbes<StoredMessage>(probed, 'archive-first')) {
+        const matches = await findChatRowsForTier(
+          store,
+          conversationId,
+          probe.tier,
+          probe.reference
+        )
+        // See findChatRowsByIdentity: `ids` is not keyed by sender, and the rung
+        // must not bridge two messages the archive separates.
+        const candidates = probe.tier === 'fallback'
+          ? matches.filter(
+              (row) => row.from === probed.from && !archiveIdentityConflict(row, probed)
+            )
+          : matches
+        // Keyed by cacheKey, not id: a merged row carries several ids, and two
+        // rows can legitimately share one.
+        for (const row of candidates) {
+          if (row.conversationId !== conversationId || found.has(row.cacheKey)) continue
+          found.set(row.cacheKey, row)
+          queue.push(row)
+        }
+      }
     }
-    return [...found.values()].map(deserializeMessage)
+    return [...found.values()].map((row) => ({
+      cacheKey: row.cacheKey,
+      identityKeys: row.identityKeys,
+      ids: row.ids,
+      message: deserializeMessage(row),
+    }))
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to expand chat message copies:', error)
@@ -1626,7 +1878,10 @@ export async function areRetractedInCache(
 export async function deleteMessage(id: string): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
-    await db.delete(MESSAGES_STORE, id)
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+    const existing = await findChatRowById(tx.store.index('ids'), id)
+    if (existing) await tx.store.delete(existing.cacheKey)
+    await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to delete message:', error)
@@ -2321,6 +2576,6 @@ export function _resetDBForTesting(): void {
  * through {@link mergeRoomRows}. For testing only.
  * @internal
  */
-export function _contentProjectionForTesting(m: StoredRoomMessage): unknown {
+export function _contentProjectionForTesting(m: CanonicalRow): unknown {
   return contentProjection(m)
 }

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1221,26 +1221,6 @@ export async function getMessageByStanzaId(
   }
 }
 
-async function getMessageByOriginId(
-  conversationId: string,
-  originId: string
-): Promise<Message | null> {
-  try {
-    const db = await getDB(getStorageScopeJid())
-    const [stored] = await findChatRowsForTier(
-      db.transaction(MESSAGES_STORE).store,
-      conversationId,
-      'originId',
-      originId
-    )
-    return stored ? deserializeMessage(stored) : null
-  } catch (error) {
-    if (isIndexedDBAvailable()) {
-      console.warn('Failed to get message by originId:', error)
-    }
-    return null
-  }
-}
 
 /**
  * Options for querying messages.
@@ -1376,11 +1356,10 @@ export interface GetMessagesAroundOptions {
  * existing content-anchor restore land correctly. The same primitive serves search/activity jumps
  * to a message that isn't in the recent slice.
  *
- * @param anchor - The anchor ROW. Its `id` is always a client id (`message.id`, as carried by
- *   `data-message-id`); an attached stanza-id or origin-id narrows a reused id to the resolved
- *   archive row before the client-id fallback. 1:1 messages have no XEP-0421 occupant, so
- *   `occupantId` is not consulted here — the ref is taken whole so chat and room share one anchor
- *   contract.
+ * @param anchor - The anchor ROW. Its `id` is a client id (`message.id`, as carried by
+ *   `data-message-id`); the stanza-id index is a fallback so a server stanza id (e.g. a navigation
+ *   target) also resolves. 1:1 messages have no XEP-0421 occupant, so `occupantId` is not consulted
+ *   here — the ref is taken whole so chat and room share one anchor contract.
  */
 export async function getMessagesAround(
   conversationId: string,
@@ -1389,11 +1368,7 @@ export async function getMessagesAround(
 ): Promise<Message[]> {
   const { before = 50, after } = options
 
-  let anchor = anchorRow.stanzaId
-    ? await getMessageByStanzaId(conversationId, anchorRow.stanzaId)
-    : anchorRow.originId
-      ? await getMessageByOriginId(conversationId, anchorRow.originId)
-      : await getMessage(conversationId, anchorRow.id)
+  let anchor = await getMessage(conversationId, anchorRow.id)
   if (!anchor) anchor = await getMessageByStanzaId(conversationId, anchorRow.id)
   if (!anchor) return []
 

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -716,12 +716,21 @@ async function findChatRowsForTier(
  * findable by every id it absorbed.
  */
 async function findChatRowById(
-  idsIndex: { getAll(key: string): Promise<StoredMessage[]> },
+  store: ChatMessageStore,
   id: string,
   conversationId: string,
-  from?: string
+  from?: string,
+  expectedCacheKey?: string
 ): Promise<StoredMessage | undefined> {
-  const matches = await idsIndex.getAll(id)
+  if (expectedCacheKey) {
+    const exact = await store.get(expectedCacheKey)
+    return exact?.conversationId === conversationId &&
+      (from === undefined || exact.from === from) &&
+      exact.ids.includes(id)
+      ? exact
+      : undefined
+  }
+  const matches = await store.index('ids').getAll(id)
   return matches.find(
     (row) => row.conversationId === conversationId && (from === undefined || row.from === from)
   )
@@ -1103,13 +1112,19 @@ export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
 /**
  * Get a message by its client-generated ID.
  */
-export async function getMessage(conversationId: string, id: string): Promise<Message | null> {
+export async function getMessage(
+  conversationId: string,
+  id: string,
+  expectedCacheKey?: string
+): Promise<Message | null> {
   try {
     const db = await getDB(getStorageScopeJid())
     const stored = await findChatRowById(
-      db.transaction(MESSAGES_STORE).store.index('ids'),
+      db.transaction(MESSAGES_STORE).store,
       id,
-      conversationId
+      conversationId,
+      undefined,
+      expectedCacheKey
     )
     return stored ? deserializeMessage(stored) : null
   } catch (error) {
@@ -1130,6 +1145,7 @@ export interface RoomMessageReference {
 export interface ChatMessageReference {
   conversationId: string
   id: string
+  cacheKey?: string
 }
 
 export async function getMessagesByReferences(
@@ -1139,11 +1155,11 @@ export async function getMessagesByReferences(
   try {
     const db = await getDB(getStorageScopeJid())
     const tx = db.transaction([MESSAGES_STORE, ROOM_MESSAGES_STORE], 'readonly')
-    const chatIdsIndex = tx.objectStore(MESSAGES_STORE).index('ids')
+    const chatStore = tx.objectStore(MESSAGES_STORE)
     const roomIds = tx.objectStore(ROOM_MESSAGES_STORE).index('ids')
     const [storedChatMessages, storedRoomMessages] = await Promise.all([
-      Promise.all(chatReferences.map(({ conversationId, id }) =>
-        findChatRowById(chatIdsIndex, id, conversationId)
+      Promise.all(chatReferences.map(({ conversationId, id, cacheKey }) =>
+        findChatRowById(chatStore, id, conversationId, undefined, cacheKey)
       )),
       Promise.all(roomReferences.map(reference =>
         findRoomRowById(
@@ -1190,6 +1206,27 @@ export async function getMessageByStanzaId(
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to get message by stanzaId:', error)
+    }
+    return null
+  }
+}
+
+async function getMessageByOriginId(
+  conversationId: string,
+  originId: string
+): Promise<Message | null> {
+  try {
+    const db = await getDB(getStorageScopeJid())
+    const [stored] = await findChatRowsForTier(
+      db.transaction(MESSAGES_STORE).store,
+      conversationId,
+      'originId',
+      originId
+    )
+    return stored ? deserializeMessage(stored) : null
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to get message by originId:', error)
     }
     return null
   }
@@ -1341,7 +1378,11 @@ export async function getMessagesAround(
 ): Promise<Message[]> {
   const { before = 50, after } = options
 
-  let anchor = await getMessage(conversationId, anchorRow.id)
+  let anchor = anchorRow.stanzaId
+    ? await getMessageByStanzaId(conversationId, anchorRow.stanzaId)
+    : anchorRow.originId
+      ? await getMessageByOriginId(conversationId, anchorRow.originId)
+      : await getMessage(conversationId, anchorRow.id)
   if (!anchor) anchor = await getMessageByStanzaId(conversationId, anchorRow.id)
   if (!anchor) return []
 
@@ -1547,13 +1588,14 @@ export async function updateMessage(
   id: string,
   updates: Partial<Message>,
   from: string,
-  scopeJid: string | null = getStorageScopeJid()
+  scopeJid: string | null = getStorageScopeJid(),
+  expectedCacheKey?: string
 ): Promise<void> {
   try {
     const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(MESSAGES_STORE)
-    const existing = await findChatRowById(store.index('ids'), id, conversationId, from)
+    const existing = await findChatRowById(store, id, conversationId, from, expectedCacheKey)
     if (!existing) { await tx.done; return }
 
     const updated = { ...deserializeMessage(existing), ...updates } as Message
@@ -1895,12 +1937,13 @@ export async function deleteMessage(
   conversationId: string,
   id: string,
   from: string,
-  scopeJid: string | null = getStorageScopeJid()
+  scopeJid: string | null = getStorageScopeJid(),
+  expectedCacheKey?: string
 ): Promise<void> {
   try {
     const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
-    const existing = await findChatRowById(tx.store.index('ids'), id, conversationId, from)
+    const existing = await findChatRowById(tx.store, id, conversationId, from, expectedCacheKey)
     if (existing) await tx.store.delete(existing.cacheKey)
     await tx.done
   } catch (error) {

--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -372,11 +372,10 @@ export function archiveIdentityConflict(
  * Whether two copies are the same logical message: they share a tier AND no
  * occupant-id disagreement separates them.
  *
- * This is the shared baseline for identity operations with no stricter row or
- * storage evidence. Spelling it per call site is how a site ends up matching on a
- * tier subset, or forgetting the occupant guard and merging a new occupant's
- * message into a departed one's row. The chat cache additionally applies
- * {@link archiveIdentityConflict} at the non-unique fallback rung.
+ * This is the predicate every "is this the same message?" site must use — cache
+ * merges, preview invalidation, index ownership. Spelling it per call site is how
+ * a site ends up matching on a tier subset, or forgetting the occupant guard and
+ * merging a new occupant's message into a departed one's row.
  */
 export function sameLogicalMessage(
   scope: IdentityScope,
@@ -419,37 +418,23 @@ export function identityFieldsEqual(a: IdentityFields, b: IdentityFields): boole
  * A client `id` names a logical message and carries no uniqueness guarantee (see
  * `docs/MESSAGE_IDENTIFIERS.md`). Once a MUC nick is reassigned, two occupants
  * can legitimately produce rows sharing a room, a `from` and an `id`, and the
- * XEP-0421 occupant-id tells them apart. A restarted 1:1 sender can also leave
- * archive-distinct rows under one client id. Anything that points AT A ROW — a
- * scroll anchor, the new-message divider, a viewport report, a read pointer —
- * carries the client id plus every available discriminator.
+ * XEP-0421 occupant-id is the only thing that tells them apart. Anything that
+ * points AT A ROW — a scroll anchor, the new-message divider, a viewport report,
+ * a read pointer — must carry both halves or it names an ambiguity.
  *
  * This is deliberately NOT a wire reference. `id` is always the row's own client
- * id, never a stanza-id or an origin-id. Optional archive fields only reject a
- * conflicting candidate; they do not create a tier lookup. Resolving one still
- * walks no tier ladder and takes no {@link ResolutionPolicy} — see
- * {@link findMessageRowIndex}.
+ * id, never a stanza-id or an origin-id, so resolving one walks no tier ladder
+ * and takes no {@link ResolutionPolicy} — see {@link findMessageRowIndex}.
  */
 export interface MessageRowRef {
   readonly id: string
   /** XEP-0421 occupant-id. Absent for 1:1, a local echo, or a pre-XEP-0421 room. */
   readonly occupantId?: string
-  /** Archive identity that narrows a reused client id; never an alternate row id. */
-  readonly stanzaId?: string
-  /** Sender archive identity that narrows a reused client id; never an alternate row id. */
-  readonly originId?: string
 }
 
 /** The row ref naming `message`. */
-export function messageRowRef(
-  message: Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>
-): MessageRowRef {
-  return {
-    id: message.id,
-    ...(message.occupantId ? { occupantId: message.occupantId } : {}),
-    ...(message.stanzaId ? { stanzaId: message.stanzaId } : {}),
-    ...(message.originId ? { originId: message.originId } : {}),
-  }
+export function messageRowRef(message: Pick<IdentityFields, 'id' | 'occupantId'>): MessageRowRef {
+  return message.occupantId ? { id: message.id, occupantId: message.occupantId } : { id: message.id }
 }
 
 /**
@@ -487,24 +472,20 @@ export function selectOccupantRow<T extends Pick<IdentityFields, 'occupantId'>>(
 /**
  * The index of the row `ref` names, or -1.
  *
- * Matches `id` EXACTLY, rejects a conflicting known archive identity, then narrows
- * by occupant through {@link selectOccupantRow}. It walks no tier ladder on
- * purpose: a row ref's `id` is read off a rendered row or off a read pointer's
- * local name, so it is always a client id. The optional archive fields only
- * narrow candidates; admitting them as alternate matches would let a read pointer
- * advance onto a message no viewport ever reported. Use
- * {@link resolveMessageReference} — which requires a policy — when the input
- * really is a wire reference.
+ * Matches `id` EXACTLY and narrows by occupant through {@link selectOccupantRow}.
+ * It walks no tier ladder on purpose: a row ref's `id` is read off a rendered row
+ * or off a read pointer's local name, so it is always a client id, and admitting
+ * stanza-id or origin-id matches here would let a read pointer advance onto a
+ * message no viewport ever reported. Use {@link resolveMessageReference} — which
+ * requires a policy — when the input really is a wire reference.
  */
-export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>>(
+export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occupantId'>>(
   messages: readonly T[],
   ref: MessageRowRef
 ): number {
   const candidates: Array<{ occupantId?: string; index: number }> = []
   messages.forEach((message, index) => {
-    if (message.id === ref.id && !archiveIdentityConflict(message, ref)) {
-      candidates.push({ occupantId: message.occupantId, index })
-    }
+    if (message.id === ref.id) candidates.push({ occupantId: message.occupantId, index })
   })
   return selectOccupantRow(ref, candidates)?.index ?? -1
 }
@@ -516,16 +497,16 @@ export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occup
  * has no array to index into.
  */
 export function isMessageRow(
-  message: Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>,
+  message: Pick<IdentityFields, 'id' | 'occupantId'>,
   ref: MessageRowRef
 ): boolean {
-  return message.id === ref.id && !occupantConflict(message, ref) && !archiveIdentityConflict(message, ref)
+  return message.id === ref.id && !occupantConflict(message, ref)
 }
 
 /** Whether two row refs name the same row. */
 export function sameMessageRow(a: MessageRowRef | undefined, b: MessageRowRef | undefined): boolean {
   if (!a || !b) return a === b
-  return a.id === b.id && a.occupantId === b.occupantId && !archiveIdentityConflict(a, b)
+  return a.id === b.id && a.occupantId === b.occupantId
 }
 
 // =============================================================================

--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -430,11 +430,20 @@ export interface MessageRowRef {
   readonly id: string
   /** XEP-0421 occupant-id. Absent for 1:1, a local echo, or a pre-XEP-0421 room. */
   readonly occupantId?: string
+  readonly stanzaId?: string
+  readonly originId?: string
 }
 
 /** The row ref naming `message`. */
-export function messageRowRef(message: Pick<IdentityFields, 'id' | 'occupantId'>): MessageRowRef {
-  return message.occupantId ? { id: message.id, occupantId: message.occupantId } : { id: message.id }
+export function messageRowRef(
+  message: Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>
+): MessageRowRef {
+  return {
+    id: message.id,
+    ...(message.occupantId ? { occupantId: message.occupantId } : {}),
+    ...(message.stanzaId ? { stanzaId: message.stanzaId } : {}),
+    ...(message.originId ? { originId: message.originId } : {}),
+  }
 }
 
 /**
@@ -479,13 +488,15 @@ export function selectOccupantRow<T extends Pick<IdentityFields, 'occupantId'>>(
  * message no viewport ever reported. Use {@link resolveMessageReference} — which
  * requires a policy — when the input really is a wire reference.
  */
-export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occupantId'>>(
+export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>>(
   messages: readonly T[],
   ref: MessageRowRef
 ): number {
   const candidates: Array<{ occupantId?: string; index: number }> = []
   messages.forEach((message, index) => {
-    if (message.id === ref.id) candidates.push({ occupantId: message.occupantId, index })
+    if (message.id === ref.id && !archiveIdentityConflict(message, ref)) {
+      candidates.push({ occupantId: message.occupantId, index })
+    }
   })
   return selectOccupantRow(ref, candidates)?.index ?? -1
 }
@@ -497,16 +508,16 @@ export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occup
  * has no array to index into.
  */
 export function isMessageRow(
-  message: Pick<IdentityFields, 'id' | 'occupantId'>,
+  message: Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>,
   ref: MessageRowRef
 ): boolean {
-  return message.id === ref.id && !occupantConflict(message, ref)
+  return message.id === ref.id && !occupantConflict(message, ref) && !archiveIdentityConflict(message, ref)
 }
 
 /** Whether two row refs name the same row. */
 export function sameMessageRow(a: MessageRowRef | undefined, b: MessageRowRef | undefined): boolean {
   if (!a || !b) return a === b
-  return a.id === b.id && a.occupantId === b.occupantId
+  return a.id === b.id && a.occupantId === b.occupantId && !archiveIdentityConflict(a, b)
 }
 
 // =============================================================================

--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -339,6 +339,36 @@ export function occupantConflict(
 }
 
 /**
+ * Whether two copies carry ARCHIVE identities that prove they are different
+ * messages.
+ *
+ * A stanza-id names one entry in one archive; an origin-id names one stanza from
+ * one sender. Two KNOWN values that disagree at the same tier therefore cannot be
+ * two copies of a single message. Only a disagreement is evidence — a live copy
+ * before the archive stamped it, a legacy row, a peer that sends no origin-id all
+ * carry none, and an absent id must never separate two copies. That is
+ * {@link occupantConflict}'s rule, applied to the archive tiers instead of the
+ * XEP-0421 occupant.
+ *
+ * What it protects is the `from+id` rung, which carries NO uniqueness guarantee: a
+ * client that restarts may re-issue a client id it already used (see
+ * `docs/MESSAGE_IDENTIFIERS.md`). Without this, the ladder folds that new message
+ * into the old one's row and it inherits a retraction the user never asked for.
+ *
+ * Deliberately not a clock comparison. Two messages are separated by what the
+ * archive says about them, never by when either was written or received.
+ */
+export function archiveIdentityConflict(
+  a: Pick<IdentityFields, 'stanzaId' | 'originId'>,
+  b: Pick<IdentityFields, 'stanzaId' | 'originId'>
+): boolean {
+  return (
+    (!!a.stanzaId && !!b.stanzaId && a.stanzaId !== b.stanzaId) ||
+    (!!a.originId && !!b.originId && a.originId !== b.originId)
+  )
+}
+
+/**
  * Whether two copies are the same logical message: they share a tier AND no
  * occupant-id disagreement separates them.
  *

--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -372,10 +372,11 @@ export function archiveIdentityConflict(
  * Whether two copies are the same logical message: they share a tier AND no
  * occupant-id disagreement separates them.
  *
- * This is the predicate every "is this the same message?" site must use — cache
- * merges, preview invalidation, index ownership. Spelling it per call site is how
- * a site ends up matching on a tier subset, or forgetting the occupant guard and
- * merging a new occupant's message into a departed one's row.
+ * This is the shared baseline for identity operations with no stricter row or
+ * storage evidence. Spelling it per call site is how a site ends up matching on a
+ * tier subset, or forgetting the occupant guard and merging a new occupant's
+ * message into a departed one's row. The chat cache additionally applies
+ * {@link archiveIdentityConflict} at the non-unique fallback rung.
  */
 export function sameLogicalMessage(
   scope: IdentityScope,
@@ -418,19 +419,24 @@ export function identityFieldsEqual(a: IdentityFields, b: IdentityFields): boole
  * A client `id` names a logical message and carries no uniqueness guarantee (see
  * `docs/MESSAGE_IDENTIFIERS.md`). Once a MUC nick is reassigned, two occupants
  * can legitimately produce rows sharing a room, a `from` and an `id`, and the
- * XEP-0421 occupant-id is the only thing that tells them apart. Anything that
- * points AT A ROW — a scroll anchor, the new-message divider, a viewport report,
- * a read pointer — must carry both halves or it names an ambiguity.
+ * XEP-0421 occupant-id tells them apart. A restarted 1:1 sender can also leave
+ * archive-distinct rows under one client id. Anything that points AT A ROW — a
+ * scroll anchor, the new-message divider, a viewport report, a read pointer —
+ * carries the client id plus every available discriminator.
  *
  * This is deliberately NOT a wire reference. `id` is always the row's own client
- * id, never a stanza-id or an origin-id, so resolving one walks no tier ladder
- * and takes no {@link ResolutionPolicy} — see {@link findMessageRowIndex}.
+ * id, never a stanza-id or an origin-id. Optional archive fields only reject a
+ * conflicting candidate; they do not create a tier lookup. Resolving one still
+ * walks no tier ladder and takes no {@link ResolutionPolicy} — see
+ * {@link findMessageRowIndex}.
  */
 export interface MessageRowRef {
   readonly id: string
   /** XEP-0421 occupant-id. Absent for 1:1, a local echo, or a pre-XEP-0421 room. */
   readonly occupantId?: string
+  /** Archive identity that narrows a reused client id; never an alternate row id. */
   readonly stanzaId?: string
+  /** Sender archive identity that narrows a reused client id; never an alternate row id. */
   readonly originId?: string
 }
 
@@ -481,12 +487,14 @@ export function selectOccupantRow<T extends Pick<IdentityFields, 'occupantId'>>(
 /**
  * The index of the row `ref` names, or -1.
  *
- * Matches `id` EXACTLY and narrows by occupant through {@link selectOccupantRow}.
- * It walks no tier ladder on purpose: a row ref's `id` is read off a rendered row
- * or off a read pointer's local name, so it is always a client id, and admitting
- * stanza-id or origin-id matches here would let a read pointer advance onto a
- * message no viewport ever reported. Use {@link resolveMessageReference} — which
- * requires a policy — when the input really is a wire reference.
+ * Matches `id` EXACTLY, rejects a conflicting known archive identity, then narrows
+ * by occupant through {@link selectOccupantRow}. It walks no tier ladder on
+ * purpose: a row ref's `id` is read off a rendered row or off a read pointer's
+ * local name, so it is always a client id. The optional archive fields only
+ * narrow candidates; admitting them as alternate matches would let a read pointer
+ * advance onto a message no viewport ever reported. Use
+ * {@link resolveMessageReference} — which requires a policy — when the input
+ * really is a wire reference.
  */
 export function findMessageRowIndex<T extends Pick<IdentityFields, 'id' | 'occupantId' | 'stanzaId' | 'originId'>>(
   messages: readonly T[],

--- a/packages/fluux-sdk/src/utils/retractedIdentities.ts
+++ b/packages/fluux-sdk/src/utils/retractedIdentities.ts
@@ -29,6 +29,7 @@
 
 import { getStorageScopeJid } from './storageScope'
 import {
+  archiveIdentityConflict,
   CHAT_SCOPE,
   identityKeys,
   roomScope,
@@ -47,6 +48,16 @@ export interface RetractionScope {
 export interface PendingRetractionIdentity {
   actorJid: string
   actorOccupantId?: string
+  /**
+   * The archive identity of the message that was retracted, when it had one.
+   *
+   * The `from+id` alias a record is filed under is not unique — a restarted
+   * client re-issues client ids — so a lookup arriving through that rung needs to
+   * corroborate WHICH message the record is about, exactly as `actorJid`
+   * corroborates who retracted it. See {@link archiveIdentityConflict}.
+   */
+  stanzaId?: string
+  originId?: string
   retractedAt: number
 }
 
@@ -69,11 +80,24 @@ const pending = new Map<string, PendingRetractionIdentity[]>()
 let retractedCount = 0
 let pendingCount = 0
 
+/**
+ * Whether two records are about the same retraction — same actor, and no archive
+ * identity separating their targets.
+ *
+ * Both halves matter under one alias: an actor who retracts a message and later
+ * re-uses its client id files two records under the same `from+id` key, and
+ * collapsing them would let the first one's tombstone answer for the second
+ * message.
+ */
 function sameActor(
   left: PendingRetractionIdentity,
-  right: Pick<PendingRetractionIdentity, 'actorJid' | 'actorOccupantId'>
+  right: Pick<PendingRetractionIdentity, 'actorJid' | 'actorOccupantId' | 'stanzaId' | 'originId'>
 ): boolean {
-  return left.actorJid === right.actorJid && left.actorOccupantId === right.actorOccupantId
+  return (
+    left.actorJid === right.actorJid &&
+    left.actorOccupantId === right.actorOccupantId &&
+    !archiveIdentityConflict(left, right)
+  )
 }
 
 function scopePrefix(scope: RetractionScope): string {
@@ -224,13 +248,15 @@ export function adoptPendingRetraction(
 export function noteRetractedIdentity(
   scope: RetractionScope,
   aliases: readonly string[],
-  actor: Pick<IdentityFields, 'from' | 'occupantId'>,
+  actor: Pick<IdentityFields, 'from' | 'occupantId' | 'stanzaId' | 'originId'>,
   retractedAt: number
 ): void {
   const prefix = scopePrefix(scope)
   const record: PendingRetractionIdentity = {
     actorJid: actor.from,
     ...(actor.occupantId ? { actorOccupantId: actor.occupantId } : {}),
+    ...(actor.stanzaId ? { stanzaId: actor.stanzaId } : {}),
+    ...(actor.originId ? { originId: actor.originId } : {}),
     retractedAt,
   }
   for (const alias of aliases) {

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -317,6 +317,18 @@ export interface RoomIdentityClosure {
   ids: readonly string[]
 }
 
+/**
+ * The client ids one cached CHAT row has absorbed.
+ *
+ * Chat documents are keyed by client id (`chat:<id>`), and the cache merges rows
+ * that share an archive identity — so a document written under an id that lost
+ * the merge is unreachable from the surviving row's own id. Removal takes the
+ * whole list, the same job {@link RoomIdentityClosure} does for a room.
+ */
+export interface ChatIdentityClosure {
+  ids: readonly string[]
+}
+
 const ROOM_OWNER_CAP = 2000
 const roomDocumentOwners = new Map<string, RoomDocumentOwner>()
 
@@ -428,8 +440,20 @@ function roomOwnerNamesMessage(owner: RoomDocumentOwner, message: RoomMessage): 
 }
 
 function docBelongsToChat(doc: DocEntry, message: Message): boolean {
+  return docSharesChatOwner(doc, message) && doc.messageId === message.id
+}
+
+/**
+ * Whether a chat document belongs to the same conversation AND sender as
+ * `message`, saying nothing about which message it names.
+ *
+ * The ownership half of {@link docBelongsToChat}, for a document found under an
+ * id the cache row ABSORBED rather than under the row's own id — where the
+ * messageId is expected to differ, but a document from another conversation or
+ * another sender must still not be dropped.
+ */
+function docSharesChatOwner(doc: DocEntry, message: Message): boolean {
   return !doc.isRoom &&
-    doc.messageId === message.id &&
     doc.conversationId === message.conversationId &&
     doc.from === message.from
 }
@@ -688,7 +712,7 @@ async function indexBatch(
 export async function removeMessage(
   message: Message | RoomMessage,
   scopeJid: string | null = getStorageScopeJid(),
-  roomIdentityClosure?: RoomIdentityClosure
+  identityClosure?: RoomIdentityClosure | ChatIdentityClosure
 ): Promise<void> {
   if (!isIndexedDBAvailable()) return
 
@@ -696,16 +720,24 @@ export async function removeMessage(
   const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
   const tokensStore = tx.objectStore(TOKENS_STORE)
   const docsStore = tx.objectStore(DOCS_STORE)
+  const roomIdentityClosure =
+    identityClosure && 'identityKeys' in identityClosure ? identityClosure : undefined
   const closureKeys = new Set(roomIdentityClosure?.identityKeys ?? [])
   const closureIds = new Set(roomIdentityClosure?.ids ?? [])
 
   const drop = async (
     indexId: string,
-    verification: 'chat' | 'room' | 'room-identity' | 'room-closure'
+    verification: 'chat' | 'chat-closure' | 'room' | 'room-identity' | 'room-closure'
   ): Promise<void> => {
     const doc = await docsStore.get(indexId)
     if (!doc) return
     if (verification === 'chat' && (message.type === 'groupchat' || !docBelongsToChat(doc, message))) return
+    // A closure document was written under an id the surviving row absorbed, so
+    // its messageId is NOT the survivor's — verify the owner instead.
+    if (
+      verification === 'chat-closure' &&
+      (message.type === 'groupchat' || !docSharesChatOwner(doc, message))
+    ) return
     if (verification === 'room' && (message.type !== 'groupchat' || !docBelongsToRoom(doc, message))) return
     if (verification === 'room-identity' && !fallbackDocNamesMessage(doc, message, indexId, scopeJid)) return
     if (
@@ -742,6 +774,14 @@ export async function removeMessage(
     getIndexId(message),
     message.type !== 'groupchat' ? 'chat' : message.stanzaId ? 'room' : 'room-identity'
   )
+  if (message.type !== 'groupchat' && identityClosure) {
+    // Every id this row absorbed. `docBelongsToChat` still verifies conversation
+    // and sender per document, so an id that repeats in another conversation is
+    // not dropped with it.
+    for (const id of identityClosure.ids) {
+      if (id !== message.id) await drop(`chat:${id}`, 'chat-closure')
+    }
+  }
   for (const fallbackId of getFallbackIndexIds(message)) {
     await drop(fallbackId, 'room-identity')
   }

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -26,6 +26,7 @@ import {
 import * as messageCache from './messageCache'
 
 import {
+  archiveIdentityConflict,
   chatMessageAuthor,
   identityKeys,
   occupantConflict,
@@ -517,7 +518,7 @@ function isKnownRetracted(message: Message | RoomMessage, scopeJid: string | nul
     (record) =>
       message.type === 'groupchat'
         ? roomMessageAuthor(message, record)
-        : chatMessageAuthor(message, record)
+        : chatMessageAuthor(message, record) && !archiveIdentityConflict(message, record)
   ) !== undefined
 }
 


### PR DESCRIPTION
A client id names a stanza, not a message: a client that restarts may re-issue one it
already used. The 1:1 chat cache was created with `keyPath: 'id'`, so a later message
written under a re-issued id **overwrote** the earlier one's row, and the identity ladder
then folded it into that row's retraction tombstone — emptying its body, attachment and
poll. Both messages' content was destroyed, durably.

The room store already had the answer: since v4 it is keyed by `canonicalKey` with
`identityKeys[]` / `ids[]` multiEntry indexes. This extends that to chat.

## What changed

- **v5 canonicalizes the chat store**, keyed by the canonical identity qualified by
  conversation. Chat identity keys are deliberately unscoped — they are also the retraction
  ledger's aliases — so the conversation is added at the store boundary only. Without it two
  outgoing messages to different peers share `from` and collide on a reused client id.
- **The v5 upgrade** streams every legacy row through the identity-resolving upsert and
  aborts the whole version-change transaction on any failure, so a partial rewrite cannot be
  observed. It drains a v3 database's room store in the same transaction, sequentially.
- **One merge serves both stores**, so a re-delivered copy of a retracted message is
  tombstoned by the same commutative merge the room uses.
- **`archiveIdentityConflict`** — canonical keying alone did not close the defect: the ladder
  still bridged the two messages at the `from+id` rung, which carries no uniqueness
  guarantee. The ladder's own rule already says two copies are the same message only if no
  stronger evidence separates them; `occupantConflict` applies that to a MUC's occupant-id,
  and this applies it to the archive tiers, in the cache finder and in the session ledger,
  which now records *which* message a retraction was about rather than only who made it.
  Only a disagreement is evidence, and no clock is consulted anywhere.
- Search documents are keyed by client id, so a row the cache merges away leaves a document
  reachable only through the ids the survivor absorbed. Retraction now carries that closure.

## Acceptance criterion, stated honestly

> A retraction never marks an innocent message as deleted **whenever the archive supplies
> something that tells the two copies apart.**

The "whenever" clause is load-bearing and is not a hedge. See below.

## What this does NOT close

**Two copies that carry no archive identity remain indistinguishable, and an archive id on
only one of them is not enough either.** Both derive the same canonical key: the cache
structurally cannot hold two rows and no evidence exists that would separate them. With one
key the only question is which message survives, and XEP-0424 is monotonic, so the tombstone
wins. Absence is deliberately kept non-evidence — the same shape is how a copy predating its
archive stamp is legitimately recognised. Both cases are pinned by tests so they cannot
change unnoticed. Reachable where a server stamps no XEP-0359 stanza-id and the sender sends
no origin-id. Tracked as **fluux-retraction-collision-without-archive-id**, which also carries
a third case: a retraction referencing a bare client id whose target was never cached leaves
a pending record with no archive identity to corroborate, for the rest of the session.

## The wider family, which is NOT closed

**This change makes two rows sharing a client id coexist, while other paths in the SDK still
address a row by that client id alone.** Six such sites are known:

| Site | State |
| --- | --- |
| Chat cache by-id lookup, unscoped | fixed |
| Chat cache by-id lookup ambiguous within one conversation | fixed — the resolved row's cache key is threaded through |
| Pending retraction ledger keyed by a bare client id | **open** |
| Search document key `chat:<id>` | **open** |
| `getMessagesAround` window de-duplication by bare client id | **open — deliberately left so** |
| Deferred-decrypt handled-set keyed by `(conversation, client id)` | closed, but by the validation pipeline's test step rather than by design here |

Four remain open. A reader should not take this list as complete: each review round of this
change surfaced further sites, which is why the inventory is being produced as separate work
rather than pursued case by case here. The search-key site is tracked as
**fluux-search-index-key-collides-on-client-id**; its open question is whether any document
exists in the search index but not in the message cache, since the existing rebuild takes the
cache as its source of truth.

## An invariant change that was attempted and reverted

The validation pipeline widened `MessageRowRef` to carry `stanzaId` and `originId`, taught the
row-ref constructors and comparators to populate and compare them, made `getMessagesAround`
resolve its anchor through them, and rewrote the module documentation to describe that as the
contract. It left 26 read-state tests asserting the previous shape.

That was reverted. A row ref names a rendered row: its id is read off a row or off a read
pointer's local name, so it is always a client id, and the occupant-id is the one
discriminator a row genuinely carries. Archive ids belong to the identity ladder, which
resolves messages rather than rows, and a read pointer that admits archive evidence can
advance onto a message no viewport ever reported. The documentation was restored with it — a
module comment that blesses a change is not a review of it.

The chat cache keeps `archiveIdentityConflict` at its `from+id` rung, where the evidence is
about which stored row a *write* may merge or tombstone. That is the storage question, and it
is unaffected.

## Effect on the retraction findings this replaces

Of the nine findings raised while attempting a temporal guard on the read paths, **three no
longer exist** (the archive copy re-overwriting an innocent row; the ledger tombstoning a
message that did not exist; the retraction OR inheriting a tombstone through the fallback
rung), and **two more are moot** unless that approach returns, since they describe clock
comparisons this change does not make. Four survive, untouched here: two are in-memory
pending-retraction bookkeeping, one is the room merge path, and one is half-settled — its
chat half now inherits the conflict rule, its room half does not.

Notably, the guard's own worst failure — refusing a genuine retraction at an authoritative
tier when the local clock is behind — is now structurally unavailable: nothing compares a
clock, so no skew can refuse anything.

https://claude.ai/code/session_013sUfjLBTJtsUZDZU6fW4AM
