### PR TITLE
fix(composer): preserve chat position while deleting text

### DIFF
--- a/apps/fluux/src/components/MessageComposer.autosize.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.autosize.test.tsx
@@ -305,6 +305,26 @@ describe('MessageComposer autosize', () => {
     expect(onInputResize).not.toHaveBeenCalled()
   })
 
+  it('does not report a resize when deleting characters leaves the same number of lines', () => {
+    const onInputResize = vi.fn()
+    mockScrollHeight = 120
+    const { container, rerender } = renderWithResize('one\ntwo\nthree\nfour\nexample.', onInputResize)
+    onInputResize.mockClear()
+
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value={'one\ntwo\nthree\nfour\nex'}
+        onValueChange={() => {}}
+        onInputResize={onInputResize}
+      />
+    )
+
+    expect(container.querySelector('textarea')!.style.height).toBe('120px')
+    expect(onInputResize).not.toHaveBeenCalled()
+  })
+
   it('fires onInputResize and grows when an append wraps to a new line', () => {
     const onInputResize = vi.fn()
     mockScrollHeight = 48

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -441,12 +441,10 @@ export function MessageComposer({
   // below doesn't re-subscribe on parent re-renders.
   const onInputResizeRef = useRef(onInputResize)
   onInputResizeRef.current = onInputResize
-  // Autosize bookkeeping. The previous textarea value and the height we last
-  // set let us skip the layout-disturbing work on keystrokes that cannot
-  // change the composer's height (the common case). Resetting to height:auto
-  // is what dirties the flex column — and therefore relayouts the entire,
-  // non-virtualized message list — so a plain append must avoid it. See
-  // MessageComposer.autosize.test.tsx for the regression guard.
+  // Appends can be measured at the current height. Deletions need an intrinsic
+  // measurement, with the input frame holding its space until the final height
+  // is known so the browser cannot clamp the adjacent message list's scrollTop.
+  const inputFrameRef = useRef<HTMLDivElement>(null)
   const prevValueRef = useRef('')
   const lastSetHeightRef = useRef(0)
   const lastOverflowRef = useRef('')
@@ -491,6 +489,11 @@ export function MessageComposer({
     const mayShrink = forceRemeasure || (couldShrink && lastSetHeightRef.current > minHeight)
 
     const savedScrollTop = textarea.scrollTop
+    const measuringFrame = mayShrink ? inputFrameRef.current : null
+    const previousMinHeight = measuringFrame?.style.minHeight ?? ''
+    if (measuringFrame) {
+      measuringFrame.style.minHeight = `${measuringFrame.getBoundingClientRect().height}px`
+    }
     // Only collapse to `auto` when a shrink is possible. Even with overflow-y
     // hidden, scrollHeight still reflects the full content height without the
     // reset, so growth is still detected — without dirtying the surrounding
@@ -515,8 +518,10 @@ export function MessageComposer({
     // no scrollbar.
     if (!mayShrink && newHeight === lastSetHeightRef.current && nextOverflow === lastOverflowRef.current) return
 
+    const heightChanged = newHeight !== lastSetHeightRef.current
     textarea.style.overflowY = nextOverflow
     textarea.style.height = `${newHeight}px`
+    if (measuringFrame) measuringFrame.style.minHeight = previousMinHeight
     lastSetHeightRef.current = newHeight
     lastOverflowRef.current = nextOverflow
 
@@ -529,7 +534,7 @@ export function MessageComposer({
       textarea.scrollTop = savedScrollTop
     }
 
-    onInputResizeRef.current?.()
+    if (heightChanged) onInputResizeRef.current?.()
   }, [])
 
   useEffect(() => {
@@ -1159,7 +1164,7 @@ export function MessageComposer({
         {/* Text input — either custom or default. The frame owns the block
             padding so the textarea stays padding-free and its scrollport is a
             whole number of lines (see MESSAGE_INPUT_BASE_CLASSES). */}
-        <div className={`[grid-area:input] ${MESSAGE_INPUT_FRAME_CLASSES}`}>
+        <div ref={inputFrameRef} className={`[grid-area:input] ${MESSAGE_INPUT_FRAME_CLASSES}`}>
           {renderInput ? (
             // An inner box that hugs the textarea exactly. A `renderInput` that
             // stacks an overlay on the textarea positions it against this box,

--- a/scripts/composer-geometry.ts
+++ b/scripts/composer-geometry.ts
@@ -260,12 +260,28 @@ test.describe('composer geometry', () => {
           }
           await page.waitForTimeout(700)
 
-          const read = () => scroller.evaluate((el) => {
+          const read = (anchorIndex: string | null = null) => scroller.evaluate((el, expectedAnchorIndex) => {
             const ta = document.querySelector('textarea')!
             const badge = el.parentElement!.querySelector('[data-typing-pill]')
             const rect = el.getBoundingClientRect()
             const rows = Array.from(el.querySelectorAll('.message-row[data-message-id]'))
             const tail = rows.at(-1)!.getBoundingClientRect()
+            const virtualRows = Array.from(
+              el.querySelectorAll<HTMLElement>('[data-virtualizer-spacer] > [data-index]')
+            ).filter(row => row.querySelector('.message-row[data-message-id]'))
+            const anchorRow = expectedAnchorIndex === null
+              ? virtualRows.reduce<HTMLElement | null>((closest, row) => {
+                const rowRect = row.getBoundingClientRect()
+                if (rowRect.bottom <= rect.top || rowRect.top >= rect.bottom) return closest
+                if (!closest) return row
+                const viewportMiddle = rect.top + rect.height / 2
+                const closestMiddle = closest.getBoundingClientRect().top + closest.getBoundingClientRect().height / 2
+                const rowMiddle = rowRect.top + rowRect.height / 2
+                return Math.abs(rowMiddle - viewportMiddle) < Math.abs(closestMiddle - viewportMiddle)
+                  ? row
+                  : closest
+              }, null)
+              : virtualRows.find(row => row.dataset.index === expectedAnchorIndex) ?? null
             return {
               composerHeight: ta.clientHeight,
               viewportHeight: el.clientHeight,
@@ -274,8 +290,10 @@ test.describe('composer geometry', () => {
               bottomGap: el.scrollHeight - el.clientHeight - el.scrollTop,
               tailVisible: tail.bottom <= rect.bottom + 1,
               badgeOverlapsMessages: badge ? badge.getBoundingClientRect().top < rect.bottom : false,
+              anchorIndex: anchorRow?.dataset.index ?? null,
+              anchorTop: anchorRow ? anchorRow.getBoundingClientRect().top - rect.top : null,
             }
-          })
+          }, anchorIndex)
           const before = await read()
           expect(before.composerHeight).toBe(5 * LINE_HEIGHT)
           if (gap === 0) expect(before.bottomGap).toBeLessThanOrEqual(EPSILON)
@@ -288,10 +306,9 @@ test.describe('composer geometry', () => {
           await textarea.press('Backspace')
           await expect(pill).toHaveCount(typing === 'disappearing' ? 0 : 1)
           await page.waitForTimeout(700)
-          const after = await read()
+          const after = await read(before.anchorIndex)
           console.log('composer and typing geometry', { view, typing, gap, before, after })
           expect(after.composerHeight).toBe(before.composerHeight)
-          expect(after.scrollHeight).toBe(before.scrollHeight)
           expect(after.badgeOverlapsMessages).toBe(false)
           if (typing === 'appearing') expect(after.viewportHeight).toBeLessThan(before.viewportHeight)
           else if (typing === 'disappearing') expect(after.viewportHeight).toBeGreaterThan(before.viewportHeight)
@@ -300,7 +317,11 @@ test.describe('composer geometry', () => {
             expect(after.bottomGap).toBeLessThanOrEqual(EPSILON)
             expect(after.tailVisible).toBe(true)
           } else {
-            expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(EPSILON)
+            expect(before.anchorIndex, 'the reading viewport must contain a message anchor').not.toBeNull()
+            expect(after.anchorIndex, 'the same message anchor must remain mounted').toBe(before.anchorIndex)
+            expect(after.anchorTop).not.toBeNull()
+            expect(before.anchorTop).not.toBeNull()
+            expect(Math.abs(after.anchorTop! - before.anchorTop!)).toBeLessThanOrEqual(EPSILON)
           }
         }
       })

--- a/scripts/composer-geometry.ts
+++ b/scripts/composer-geometry.ts
@@ -145,9 +145,168 @@ async function measure(textarea: Locator): Promise<Geometry> {
 
 const linesOf = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join('\n')
 
+async function openStableComposer(page: Page, view: 'chat' | 'room'): Promise<Locator> {
+  let textarea: Locator
+  if (view === 'room') {
+    textarea = await openRoomComposer(page)
+  } else {
+    await bootDemo(page, DEMO_URL)
+    textarea = page.locator('textarea').first()
+    await textarea.waitFor({ state: 'visible' })
+  }
+  // Keep history fixed: the demo timeline adds messages, and its transport
+  // echoes body-less room chat states as empty rows (a real MUC does not).
+  await page.evaluate(() => {
+    const client = (window as Window & {
+      __demoClient?: { stopAnimation(): void; messages: { sendChatState: () => Promise<void> } }
+    }).__demoClient
+    if (!client) throw new Error('demo client missing')
+    client.stopAnimation()
+    client.messages.sendChatState = async () => {}
+  })
+  return textarea
+}
+
+async function setRemoteTyping(page: Page, view: 'chat' | 'room', isTyping: boolean): Promise<void> {
+  await page.evaluate(({ view, isTyping }) => {
+    const demo = window as Window & {
+      __demoClient?: { emitSDK(event: string, payload: unknown): void }
+      __chatStore?: { getState(): { activeConversationId: string } }
+      __roomStore?: { getState(): { activeRoomJid: string } }
+    }
+    if (view === 'chat') {
+      const jid = demo.__chatStore!.getState().activeConversationId
+      demo.__demoClient!.emitSDK('chat:typing', { conversationId: jid, jid, isTyping })
+    } else {
+      const roomJid = demo.__roomStore!.getState().activeRoomJid
+      demo.__demoClient!.emitSDK('room:typing', { roomJid, nick: 'Emma', isTyping })
+    }
+  }, { view, isTyping })
+}
+
 // ── Invariants ───────────────────────────────────────────────────────────────
 
 test.describe('composer geometry', () => {
+  for (const view of ['chat', 'room'] as const) {
+    test(`deleting within a line preserves the ${view} viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: 1298, height: 950 })
+      const textarea = await openStableComposer(page, view)
+
+      const draft = 'First line\nSecond line\nThird line\nFourth line\nLast line example.'
+      const scroller = page.locator('[data-message-list]').first()
+      const snapshot = async () => scroller.evaluate((el) => {
+        const ta = document.querySelector('textarea')!
+        return {
+          composerHeight: ta.clientHeight,
+          viewportHeight: el.clientHeight,
+          scrollHeight: el.scrollHeight,
+          scrollTop: el.scrollTop,
+          bottomGap: el.scrollHeight - el.clientHeight - el.scrollTop,
+        }
+      })
+
+      // Cover both a reader following the latest message and one reading just above it.
+      for (const gap of [0, 40]) {
+        await setDraft(textarea, draft)
+        await textarea.focus()
+        await textarea.evaluate((el) => {
+          const ta = el as HTMLTextAreaElement
+          ta.setSelectionRange(ta.value.length, ta.value.length)
+        })
+        await page.waitForTimeout(700)
+        await scroller.evaluate((el, offset) => {
+          el.scrollTop = el.scrollHeight - el.clientHeight - offset
+        }, gap)
+        await page.waitForTimeout(700)
+        const before = await snapshot()
+        expect(before.composerHeight).toBe(5 * LINE_HEIGHT)
+        expect(before.scrollTop, 'fixture must have scrollable chat history').toBeGreaterThan(100)
+        expect(Math.abs(before.bottomGap - gap)).toBeLessThanOrEqual(EPSILON)
+
+        for (let i = 0; i < 5; i++) await textarea.press('Backspace')
+        await page.waitForTimeout(700)
+        const after = await snapshot()
+        console.log('composer deletion geometry', { view, gap, before, after })
+        expect(after.composerHeight).toBe(before.composerHeight)
+        expect(after.viewportHeight).toBe(before.viewportHeight)
+        expect(after.scrollHeight).toBe(before.scrollHeight)
+        expect.soft(Math.abs(after.scrollTop - before.scrollTop),
+          `deletion moved the chat by ${after.scrollTop - before.scrollTop}px at bottom gap ${gap}`,
+        ).toBeLessThanOrEqual(EPSILON)
+      }
+    })
+
+    for (const typing of ['visible', 'appearing', 'disappearing'] as const) {
+      test(`deleting with typing ${typing} preserves the ${view} reading position`, async ({ page }) => {
+        await page.setViewportSize({ width: 1298, height: 950 })
+        const textarea = await openStableComposer(page, view)
+        const scroller = page.locator('[data-message-list]').first()
+        const pill = page.locator('[data-typing-pill]')
+
+        for (const gap of [0, 400]) {
+          await setDraft(textarea, `${linesOf(4)}\nLast line example.`)
+          await textarea.focus()
+          await textarea.evaluate((el) => {
+            const ta = el as HTMLTextAreaElement
+            ta.setSelectionRange(ta.value.length, ta.value.length)
+          })
+          await setRemoteTyping(page, view, typing !== 'appearing')
+          await expect(pill).toHaveCount(typing === 'appearing' ? 0 : 1)
+          await page.waitForTimeout(700)
+          await scroller.evaluate((el) => { el.scrollTop = el.scrollHeight })
+          if (gap > 0) {
+            await scroller.hover()
+            await page.mouse.wheel(0, -gap)
+          }
+          await page.waitForTimeout(700)
+
+          const read = () => scroller.evaluate((el) => {
+            const ta = document.querySelector('textarea')!
+            const badge = el.parentElement!.querySelector('[data-typing-pill]')
+            const rect = el.getBoundingClientRect()
+            const rows = Array.from(el.querySelectorAll('.message-row[data-message-id]'))
+            const tail = rows.at(-1)!.getBoundingClientRect()
+            return {
+              composerHeight: ta.clientHeight,
+              viewportHeight: el.clientHeight,
+              scrollHeight: el.scrollHeight,
+              scrollTop: el.scrollTop,
+              bottomGap: el.scrollHeight - el.clientHeight - el.scrollTop,
+              tailVisible: tail.bottom <= rect.bottom + 1,
+              badgeOverlapsMessages: badge ? badge.getBoundingClientRect().top < rect.bottom : false,
+            }
+          })
+          const before = await read()
+          expect(before.composerHeight).toBe(5 * LINE_HEIGHT)
+          if (gap === 0) expect(before.bottomGap).toBeLessThanOrEqual(EPSILON)
+          else expect(before.bottomGap).toBeGreaterThan(300)
+
+          // Change the badge between real Backspace events, without a settling
+          // delay: its resize and the composer's measurement can share a frame.
+          await textarea.press('Backspace')
+          if (typing !== 'visible') await setRemoteTyping(page, view, typing === 'appearing')
+          await textarea.press('Backspace')
+          await expect(pill).toHaveCount(typing === 'disappearing' ? 0 : 1)
+          await page.waitForTimeout(700)
+          const after = await read()
+          console.log('composer and typing geometry', { view, typing, gap, before, after })
+          expect(after.composerHeight).toBe(before.composerHeight)
+          expect(after.scrollHeight).toBe(before.scrollHeight)
+          expect(after.badgeOverlapsMessages).toBe(false)
+          if (typing === 'appearing') expect(after.viewportHeight).toBeLessThan(before.viewportHeight)
+          else if (typing === 'disappearing') expect(after.viewportHeight).toBeGreaterThan(before.viewportHeight)
+          else expect(after.viewportHeight).toBe(before.viewportHeight)
+          if (gap === 0) {
+            expect(after.bottomGap).toBeLessThanOrEqual(EPSILON)
+            expect(after.tailVisible).toBe(true)
+          } else {
+            expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(EPSILON)
+          }
+        }
+      })
+    }
+  }
+
   /**
    * The reported bug, stated as an invariant: content may be cut off only when a
    * scrollbar exists to explain the cut. A clipped line inside an overflow:hidden

--- a/scripts/composer-geometry.ts
+++ b/scripts/composer-geometry.ts
@@ -184,6 +184,53 @@ async function setRemoteTyping(page: Page, view: 'chat' | 'room', isTyping: bool
   }, { view, isTyping })
 }
 
+async function waitForMessageLayoutSettled(scroller: Locator): Promise<void> {
+  await scroller.evaluate((el) => new Promise<void>((resolve, reject) => {
+    const stableFramesRequired = 30
+    const timeoutMs = 15_000
+    const startedAt = performance.now()
+    let lastSignature = ''
+    let stableFrames = 0
+
+    const readSignature = () => {
+      const viewport = el.getBoundingClientRect()
+      const rows = Array.from(
+        el.querySelectorAll<HTMLElement>('[data-virtualizer-spacer] > [data-index]')
+      ).map(row => {
+        const rect = row.getBoundingClientRect()
+        return [row.dataset.index, Math.round(rect.top - viewport.top), Math.round(rect.height)]
+      })
+      return JSON.stringify([
+        Math.round(el.scrollTop),
+        el.scrollHeight,
+        el.clientHeight,
+        rows,
+      ])
+    }
+
+    const tick = () => {
+      const signature = readSignature()
+      if (signature === lastSignature) stableFrames += 1
+      else {
+        lastSignature = signature
+        stableFrames = 0
+      }
+
+      if (stableFrames >= stableFramesRequired) {
+        resolve()
+        return
+      }
+      if (performance.now() - startedAt >= timeoutMs) {
+        reject(new Error('message layout did not settle before the composer measurement'))
+        return
+      }
+      requestAnimationFrame(tick)
+    }
+
+    requestAnimationFrame(tick)
+  }))
+}
+
 // ── Invariants ───────────────────────────────────────────────────────────────
 
 test.describe('composer geometry', () => {
@@ -258,7 +305,7 @@ test.describe('composer geometry', () => {
             await scroller.hover()
             await page.mouse.wheel(0, -gap)
           }
-          await page.waitForTimeout(700)
+          await waitForMessageLayoutSettled(scroller)
 
           const read = (anchorIndex: string | null = null) => scroller.evaluate((el, expectedAnchorIndex) => {
             const ta = document.querySelector('textarea')!
@@ -305,7 +352,7 @@ test.describe('composer geometry', () => {
           if (typing !== 'visible') await setRemoteTyping(page, view, typing === 'appearing')
           await textarea.press('Backspace')
           await expect(pill).toHaveCount(typing === 'disappearing' ? 0 : 1)
-          await page.waitForTimeout(700)
+          await waitForMessageLayoutSettled(scroller)
           const after = await read(before.anchorIndex)
           console.log('composer and typing geometry', { view, typing, gap, before, after })
           expect(after.composerHeight).toBe(before.composerHeight)


### PR DESCRIPTION
Deleting characters in a multiline draft could shift the conversation and hide its latest lines even when the composer stayed the same height. Preserve the input frame's space during autosize measurement and notify resize listeners only when the final height changes.

Keep the reading position stable in chat and room composers, including while typing indicators are visible, appear, or disappear.
