### PR TITLE
fix(sdk): preserve message edits across history and cache reloads

### DIFF
--- a/docs/MAM_CATCHUP.md
+++ b/docs/MAM_CATCHUP.md
@@ -22,6 +22,85 @@ The SDK uses a **hybrid lazy + background** approach organized into five layers:
 
 Additionally, once per day, archived conversations are checked for new activity and auto-unarchived if new incoming messages are found.
 
+## Message Corrections
+
+Corrections cross the SDK event boundary before history rows are deduplicated. The store checks
+the target's author and applies the revision to the resident message or directly to its cached
+row. This also covers background catch-up that only peeks at the cache. The original message's
+timestamp and identity remain unchanged; reference aliases follow
+[Message Identifiers](MESSAGE_IDENTIFIERS.md#3-canonical-identity-is-a-tiered-ladder-not-a-single-field).
+Resident updates replay pending retractions when new aliases make their targets resolvable. Live
+chat and room corrections also try the scoped cache handoff before creating a message for an unknown target.
+Cache completions match the canonical target and author before copying correction content into a
+resident row or preview. A source revision/payload precondition prevents a delayed completion from
+replacing an intervening edit, while known predecessor evidence permits updating an older activation
+snapshot; search indexing reconciles against the current cached row before atomically replacing
+the document and its token postings. Both room preview projections change together. Account and
+store-session changes cancel completion updates to resident state, including an account switch
+away and back to the same JID.
+Outgoing corrections select their predecessors at the current store/cache boundary after sending,
+including when another device's edit arrived while encryption was pending. Genuine live mutations
+also incorporate the current durable predecessor when the resident window is an older snapshot.
+Their operation provenance is transient: history, decryption, and completion updates cannot reuse it.
+
+Revision ordering uses archive chronology, known predecessor identities, and comparable live
+observations within one receipt session. Receipt sequence is captured before asynchronous
+decryption; counters from different sessions never order revisions. An archive echo can add aliases
+and a date to the same revision without replacing its earliest live observation. Retained live and
+archive observations are merged before content selection, including when the revision is an
+alternative. Known archive provenance survives reloads, so a later live replay cannot gain fresh
+ordering authority from its receipt alone.
+
+An undated edit with evidence that it follows the held revision records that predecessor and the
+archive chronology already observed. The signed content date retains its provenance separately,
+including after deferred decryption; local wall clocks and signed device clocks do not order
+revisions. Legacy rows without revision metadata have unknown chronology; a replay identified by
+their known correction aliases cannot replace their saved text, while a genuinely new correction can. Selecting
+legacy content also preserves its unknown revision identity; an older fetched revision cannot label it.
+
+Equal-date room edits share their archive-order group across nickname changes when a stable
+occupant ID identifies the author. Known target aliases share that group as well, including aliases
+resolved by indexed, author-checked cache lookups when the original is outside the fetched page.
+Conflicting archive revision IDs distinguish edits even when a sender reuses its client ID.
+Predecessor identities retain their revision grouping; older flat predecessor metadata is read
+conservatively so weak aliases cannot override conflicting archive identities.
+
+Only observed predecessor relationships are retained. When two revisions cannot be ordered, the
+unselected content and its metadata remain cached as an alternative. A provisional content choice
+creates no predecessor proof; later archive evidence can resolve it. Distinct corrections sharing
+an archive timestamp retain their observed entry order through predecessor identities, including
+across contiguous query pages. Archive IDs and page positions are never converted into globally
+sortable clocks.
+
+When an incoming live correction leaves alternatives unresolved and MAM is supported or has
+responded in the current session, its store/cache completion queues automatic archive reconciliation.
+`MAM.reconcileCorrectionBatch` bounds each request and batch, first checking recent archive entries
+and then walking forward from a known correction or original-message cursor. The walk retains its
+cursor and observed order across batches up to a captured archive endpoint; a batch limit does not
+discard unresolved work. It stops on resolution or retraction, that endpoint, archive completion,
+missing or repeated cursors, request failure, or account/session/target invalidation. If evidence
+remains unavailable, the alternatives survive for later evidence. Returned modifications must
+resolve through the scoped, author-checked reference lookup to the queued canonical target,
+including original IDs absorbed by an earlier cache merge.
+
+Before emitting or returning history, queries reconcile their rows through read-only store/cache
+bindings using the same revision selection as persistence. Reconciliation copies correction content
+and identity/retraction metadata, preserving the fetched page's reactions and other history fields.
+Bounded search-context queries retain a newer cached edit even when its correction lies outside the
+requested window. Failed cache reads fall back to fetched history and resident revisions. Queries
+cancel when their initiating account or session changes, without emitting stale history or status.
+Cache hydration refreshes correction state after its initial read and reconciles duplicates with
+the current resident rows and previews, including latest and around-message loads. It preserves
+resident reactions and rejects obsolete account, store, or entity generations.
+Deferred recovery carries a write precondition naming the source payload, revision, author,
+occupant and account. Resident messages, cached rows and sidebar previews independently check
+that precondition before accepting recovered content or clearing the payload. A selected encrypted
+correction is queued for recovery even when its original is outside the resident window.
+
+Revision selection is implemented in `packages/fluux-sdk/src/core/types/message-internal.ts`;
+the store/cache integration regressions are in
+`packages/fluux-sdk/src/utils/messageCache.corrections.test.ts`.
+
 ## Detailed Flow
 
 ### 1. Preview Refresh (fast, sidebar)
@@ -135,8 +214,9 @@ by the [confirmed-join design](superpowers/specs/2026-07-27-room-mam-after-join-
 
 ## Deduplication
 
-The store layer still deduplicates returned messages by ID. In addition, the
-foreground and delayed room paths coordinate ownership: the background pass
+The store layer deduplicates returned messages through the
+[message-identity boundary](MESSAGE_IDENTIFIERS.md#3-canonical-identity-is-a-tiered-ladder-not-a-single-field).
+In addition, the foreground and delayed room paths coordinate ownership: the background pass
 excludes the active room, observes foreground coverage for the current
 membership, and accepts a released attempt only after the room becomes
 inactive. This prevents duplicate room archive queries instead of relying on
@@ -144,7 +224,8 @@ store deduplication alone.
 
 ## Concurrency
 
-All background queries use `executeWithConcurrency()` from `utils/concurrencyUtils.ts` to limit parallel MAM requests:
+Preview, catch-up, and roster-discovery passes use `executeWithConcurrency()` from
+`utils/concurrencyUtils.ts` to limit parallel MAM requests:
 
 | Operation | Concurrency |
 |-----------|-------------|

--- a/docs/MESSAGE_IDENTIFIERS.md
+++ b/docs/MESSAGE_IDENTIFIERS.md
@@ -19,12 +19,12 @@ part of XEP-0359 or XEP-0313, this document says so instead of restating the spe
 | `originId` | the sender (XEP-0359 `<origin-id>`) | Recognising the echo of one's own message before an archive id exists. |
 
 `originId` is written on every outgoing stanza through `createOriginIdElement`
-(`packages/fluux-sdk/src/core/modules/messagingUtils.ts:292`), and read back with `parseOriginId`
-(same file, `:282`).
+(`packages/fluux-sdk/src/core/modules/messagingUtils.ts`), and read back with `parseOriginId`
+in the same file.
 
 There is a fourth source of an archive id: the `<result id="…">` wrapper of a MAM page. The SDK
 prefers the message's own `<stanza-id>` and falls back to the wrapper id —
-`packages/fluux-sdk/src/core/modules/MAM.ts:2313` and `:2402`.
+`parseArchiveMessage` and `parseRoomArchiveMessage` in `packages/fluux-sdk/src/core/modules/MAM.ts`.
 
 ## 2. `stanzaId` is authoritative only relative to an archive
 
@@ -33,25 +33,28 @@ through (the user's own server *and* a MUC service). They are different values n
 message in different archives, and they are **not interchangeable**: using the wrong one as a MAM
 RSM cursor makes the server answer `item-not-found`. `parseStanzaId` therefore selects by the `by`
 attribute, compared on a bare-JID basis —
-`packages/fluux-sdk/src/core/modules/messagingUtils.ts:239-276`.
+`packages/fluux-sdk/src/core/modules/messagingUtils.ts`.
 
 The expected archive is fixed per conversation kind by the call sites:
 
-- 1:1 chat → the user's own bare JID (`core/modules/MAM.ts:2297`, `core/modules/Chat.ts:2143`)
-- MUC → the room's bare JID (`core/modules/MAM.ts:2383`, `core/modules/Chat.ts:2227`)
+- 1:1 chat → the user's own bare JID (`MAM.parseArchiveMessage`, `Chat.processChatMessage`)
+- MUC → the room's bare JID (`MAM.parseRoomArchiveMessage`, `Chat.processRoomMessage`)
 
 **The fallback matters to callers.** When `expectedBy` is omitted, or when no `<stanza-id>` matches
 it, `parseStanzaId` returns the *first* id present — commented as preserved single-archive
-behaviour (`messagingUtils.ts:269`). So a `stanzaId` obtained without an `expectedBy` may belong to
+behaviour (`parseStanzaId` in `messagingUtils.ts`). So a `stanzaId` obtained via this fallback may belong to
 an archive you are not querying. It is still a usable dedup key against other copies of the same
 message, but it is not a safe pagination cursor and not a safe cross-client reference. If the id
-must address an archive, pass `expectedBy`.
+must address an archive, use `parseArchiveStanzaId(messageEl, expectedBy)`: it returns only an ID
+stamped by that archive. Correction revision identity uses this strict lookup, falling back to
+the MAM wrapper's result ID when available. A legacy fallback alias can remain usable as a
+reference without becoming authoritative revision identity.
 
 An archive id can also be *revoked* after the fact: when an `after:`-anchored query hits
 `item-not-found`, the stale id is stripped from the message and from the persisted gap anchor,
-keeping the timestamp so catch-up can resume by time — `stores/chatStore.ts:2588-2602` and
-`:3414-3418`, `stores/roomStore.ts:2527-2547` and `:4472-4478`. Treat a stored archive id as
-revocable, not permanent.
+keeping the timestamp so catch-up can resume by time. The `chat:history-anchor-purged` and
+`room:history-anchor-purged` bindings in `packages/fluux-sdk/src/bindings/storeBindings.ts` route
+this cleanup to the stores. Treat a stored archive id as revocable, not permanent.
 
 ## 3. Canonical identity is a tiered ladder, not a single field
 
@@ -94,6 +97,15 @@ Reference resolution has two named policies over this one ladder. `archive-first
 explicit XEP-0359 `originId` above the bare client id, while `client-id-first` tries the real id and
 stanza-id matches before the sender-controlled, spoofable `originId`. Callers must choose a policy
 explicitly; there is no default.
+
+Correction stanza IDs form a reference-only tier immediately after the message's own stanza ID
+under `archive-first`. The cache indexes these aliases for replies and retractions, including when
+the target is absent from RAM. They never participate in canonical-row merging or change the
+message's primary key. Lookups remain scoped to the conversation or room and mutations still
+check the author and, for rooms, occupant identity. IndexedDB version 6 backfills correction
+aliases into the existing identity index in the same atomic upgrade transaction as the older
+canonical-store migrations. The alias backfill preserves existing canonical rows, primary keys
+and aliases; normal reference lookups use indexes without scanning conversation history.
 
 The full ladder also resolves a retraction target at the cache and search-index boundary —
 `packages/fluux-sdk/src/stores/shared/retractionStorage.ts`. `canonicalReference` chooses the
@@ -207,14 +219,14 @@ no occupant identity and cannot acquire one, so a pair already ordered wrong sta
 Nothing recovers an occupant-id that was never stored.
 
 Protocol references follow the same split. `getMessageReferenceId`
-(`packages/fluux-sdk/src/core/modules/Chat.ts:1873-1880`) returns the `stanzaId` for a groupchat
+(`packages/fluux-sdk/src/core/modules/Chat.ts`) returns the `stanzaId` for a groupchat
 message when one is known, and the message id otherwise — per XEP-0461, only groupchat references
-use a stanza-id. Retractions (`Chat.ts:1417`), reactions (`Chat.ts:1177`) and replies
-(`Chat.ts:867`) all use this archive-first wire rule. MUC whispers are the exception: they are
-`<no-store>`, so the reference is the `originId` (`Chat.ts:1865`).
+use a stanza-id. `sendRetraction`, `sendReaction` and replies in `sendMessage` use this wire rule.
+MUC whispers are the exception: they are `<no-store>`, so the reference is the `originId`
+(see `resolveWhisperRouting`).
 
-On the receiving side, an incoming reference is resolved by `id`/`stanzaId` first and only then by
-`originId` — `stores/chatStore.ts:2457` and `:2518`.
+On the receiving side, callers select a reference-resolution policy from §3 according to the
+operation's trust requirements.
 
 ## 6. When the archive id is missing
 
@@ -256,7 +268,7 @@ What a caller should do with a missing archive id:
   the read pointer all speak `MessageRowRef` (§4).
 - **Do not compare archive ids from different archives.** A message can carry several
   `<stanza-id>`; only the one stamped `by` the archive you are addressing is meaningful there
-  (`messagingUtils.ts:239-276`). Comparing across archives, or across rooms, is what the room
+  (`messagingUtils.ts`). Comparing across archives, or across rooms, is what the room
   scoping exists to prevent (`messageIdentity.ts`, `messageCache.ts`).
 - **Do not separate two copies by a clock.** What tells two messages apart is what the archive
   says about them — a stanza-id or origin-id disagreement (`archiveIdentityConflict`), the room's
@@ -264,10 +276,9 @@ What a caller should do with a missing archive id:
   a disagreement is evidence; an absent id must never separate two copies of one message.
 - **Do not read stability as identity.** `originId` is stable and sender-assigned, which makes it a
   good echo-dedup key — but two rows can share one, which is why `withArchiveId` forbids binding
-  through it (`readPointer.ts:207-243`) and why references resolve it last
-  (`chatStore.ts:2457`, `:2518`).
+  through it (`readPointer.ts:207-243`). Reference lookup follows the explicit policies in §3.
 - **Do not assume an archive id, once seen, is permanent.** It can be revoked when the archive
-  purges it (`chatStore.ts:2588-2602`, `roomStore.ts:2527-2547`).
+  purges it (see §2).
 - **Do not use an archive id for ordering.** It carries none (`core/types/readState.ts:14-25`).
 
 ## Related

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -203,9 +203,11 @@ export function createStoreBindings(
     stores.chat.updateReactions(conversationId, messageId, reactorJid, emojis)
   })
 
-  on('chat:message-updated', ({ conversationId, messageId, updates }) => {
+  on('chat:message-updated', ({ conversationId, messageId, updates, correctionActor, onCorrectionMissing, onCorrectionResolved }) => {
     const stores = getStores()
-    stores.chat.updateMessage(conversationId, messageId, updates)
+    if (correctionActor && (onCorrectionMissing || onCorrectionResolved)) stores.chat.updateMessage(conversationId, messageId, updates, undefined, correctionActor, onCorrectionMissing, onCorrectionResolved)
+    else if (correctionActor) stores.chat.updateMessage(conversationId, messageId, updates, undefined, correctionActor)
+    else stores.chat.updateMessage(conversationId, messageId, updates)
   })
 
   on('chat:retraction-pending', ({ conversationId, targetId, actorJid }) => {
@@ -276,14 +278,14 @@ export function createStoreBindings(
     }
   })
 
-  on('chat:history-loading', ({ conversationId, isLoading }) => {
+  on('chat:history-loading', ({ conversationId, isLoading, requestId }) => {
     const stores = getStores()
-    stores.chat.setMAMLoading(conversationId, isLoading)
+    stores.chat.setMAMLoading(conversationId, isLoading, requestId)
   })
 
-  on('chat:history-error', ({ conversationId, error }) => {
+  on('chat:history-error', ({ conversationId, error, requestId }) => {
     const stores = getStores()
-    stores.chat.setMAMError(conversationId, error)
+    stores.chat.setMAMError(conversationId, error, requestId)
   })
 
   on('chat:history-messages', ({ conversationId, messages, page, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId }) => {
@@ -433,9 +435,11 @@ export function createStoreBindings(
     })
   })
 
-  on('room:message-updated', ({ roomJid, messageId, updates }) => {
+  on('room:message-updated', ({ roomJid, messageId, updates, correctionActor, onCorrectionMissing, onCorrectionResolved }) => {
     const stores = getStores()
-    stores.room.updateMessage(roomJid, messageId, updates)
+    if (correctionActor && (onCorrectionMissing || onCorrectionResolved)) stores.room.updateMessage(roomJid, messageId, updates, undefined, undefined, correctionActor, onCorrectionMissing, onCorrectionResolved)
+    else if (correctionActor) stores.room.updateMessage(roomJid, messageId, updates, undefined, undefined, correctionActor)
+    else stores.room.updateMessage(roomJid, messageId, updates)
   })
 
   on('room:reactions', ({ roomJid, messageId, reactorNick, emojis }) => {
@@ -469,14 +473,14 @@ export function createStoreBindings(
     }
   })
 
-  on('room:history-loading', ({ roomJid, isLoading }) => {
+  on('room:history-loading', ({ roomJid, isLoading, requestId }) => {
     const stores = getStores()
-    stores.room.setRoomMAMLoading(roomJid, isLoading)
+    stores.room.setRoomMAMLoading(roomJid, isLoading, requestId)
   })
 
-  on('room:history-error', ({ roomJid, error }) => {
+  on('room:history-error', ({ roomJid, error, requestId }) => {
     const stores = getStores()
-    stores.room.setRoomMAMError(roomJid, error)
+    stores.room.setRoomMAMError(roomJid, error, requestId)
   })
 
   on('room:history-messages', ({ roomJid, messages, page, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter, walkOldestId }) => {

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -423,7 +423,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
         'durable-1',
         expect.objectContaining({ body: 'hello', encryptedPayload: undefined }),
         'carol@example.com',
-        undefined,
+        null,
         'carol@example.com\u0000durable-1'
       )
     })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -131,7 +131,7 @@ import {
 import { NS_MAM } from './namespaces'
 import { createDefaultStoreBindings } from './defaultStoreBindings'
 import { createPresenceReader, type PresenceReader } from './presenceReader'
-import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
+import { initSearchIndex, backfillFromMessageCache, updateMessage as updateSearchIndex } from '../utils/searchIndex'
 import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, deleteMessage as cacheDeleteMessage } from '../utils/messageCache'
 import { queryPepNodeSymbol } from './rawXmppAccess'
 
@@ -678,6 +678,7 @@ export class XMPPClient {
     // Deferred-decrypt engine reads/writes through getters so it always sees
     // the current manager, stores, and identity — never a captured snapshot.
     this.deferredDecrypt = new DeferredDecryptEngine({
+      updateSearchIndex,
       getManager: () => this.e2ee,
       getStores: () => this.stores,
       getOwnBareJid: () => (this.currentJid ? getBareJid(this.currentJid) : ''),
@@ -709,6 +710,7 @@ export class XMPPClient {
       registerMAMCollector: (queryId: string, collector: (stanza: Element) => void) => this.registerMAMCollector(queryId, collector),
       privacyOptions: this.privacyOptions,
       getE2EEManager: () => this.e2ee,
+      recoverCorrection: (...args: Parameters<DeferredDecryptEngine['recoverCorrection']>) => this.deferredDecrypt?.recoverCorrection(...args),
       shouldAutoReconnect: this.shouldAutoReconnect,
     }
 

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
@@ -1,3 +1,4 @@
+import type { StoredRoomMessage } from '../types/message-internal'
 /**
  * DeferredDecryptEngine unit tests.
  *
@@ -74,6 +75,7 @@ describe('DeferredDecryptEngine', () => {
     stores = createMockStores()
     cache = makeCache()
     engine = new DeferredDecryptEngine({
+      updateSearchIndex: vi.fn().mockResolvedValue(undefined),
       getManager: () => manager,
       getStores: () => stores as unknown as StoreBindings,
       getOwnBareJid: () => 'me@example.com',
@@ -251,6 +253,7 @@ describe('DeferredDecryptEngine', () => {
       deleteMessage: messageCache.deleteMessage,
     }
     engine = new DeferredDecryptEngine({
+      updateSearchIndex: vi.fn().mockResolvedValue(undefined),
       getManager: () => manager,
       getStores: () => stores as unknown as StoreBindings,
       getOwnBareJid: () => 'me@example.com',
@@ -277,8 +280,28 @@ describe('DeferredDecryptEngine', () => {
     })
   })
 
+  it('repairs another room row with the same client ID while a promoted correction recovers', async () => {
+    vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+      plaintext: new TextEncoder().encode('hello'),
+      senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+      securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+    })
+    const first: StoredRoomMessage = { type: 'groupchat', roomJid: 'room@example.com', from: 'room@example.com/Bob',
+      nick: 'Bob', occupantId: 'bob', id: 'reused', stanzaId: 'archive-one', body: 'encrypted',
+      timestamp: new Date(), isOutgoing: false, isEdited: true, encryptedPayload: DUMMY_PAYLOAD_XML,
+      correctionRevision: { ids: ['id:correction'], supersedes: [] } }
+    const second: StoredRoomMessage = { ...first, stanzaId: 'archive-two' }
+    stores.room.getAllRoomMessages.mockReturnValue([{ jid: first.roomJid, messages: [first, second] }])
+    const apply = vi.fn()
+    engine.recoverCorrection(first, () => true, apply)
+    await vi.waitFor(() => expect(stores.room.updateMessage).toHaveBeenCalledTimes(1))
+    expect(apply).toHaveBeenCalledWith(expect.objectContaining({ body: 'hello', encryptedPayload: undefined }))
+    expect(manager.decryptArchive).toHaveBeenCalledTimes(2)
+  })
+
   it('is a no-op when no E2EE manager is available', async () => {
     engine = new DeferredDecryptEngine({
+      updateSearchIndex: vi.fn().mockResolvedValue(undefined),
       getManager: () => null,
       getStores: () => stores as unknown as StoreBindings,
       getOwnBareJid: () => 'me@example.com',

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
@@ -25,6 +25,8 @@ import { parseMessageContent, applyRetraction, parseReactionsSignal, parseRetrac
 import { getBareJid, getDomain } from '../jid'
 import { logDebug, logInfo, logWarn } from '../logger'
 import type { StoreBindings, MessageSecurityContext, FileAttachment, Message } from '../types'
+import { compareCorrectionRevisions, sameCorrection, type MessageImplState, type CorrectionUpdates, type StoredMessage, type StoredRoomMessage } from '../types/message-internal'
+import { captureStorageScope } from '../../utils/storageScope'
 import { chatCacheKey, type CachedChatMessage } from '../../utils/messageCache'
 
 /**
@@ -50,7 +52,7 @@ type RetryModification =
  * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
  */
 type RetryOutcome =
-  | { kind: 'decrypted'; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
+  | { kind: 'decrypted'; authoredAt?: Date; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
   | { kind: 'modification'; modification: RetryModification }
   | { kind: 'unsupported'; info: { namespace: string; name: string } }
   | { kind: 'rejected'; securityContext?: MessageSecurityContext }
@@ -90,9 +92,62 @@ export interface DeferredDecryptDeps {
   getStores: () => StoreBindings | null
   getOwnBareJid: () => string
   cache: DeferredDecryptCache
+  updateSearchIndex: (message: Message, scopeJid: string | null) => Promise<void>
+}
+
+function guardedUpdates<T>(message: CorrectionUpdates & { from: string }, updates: T, accountScope: string | null) {
+  return {
+    ...updates,
+    contentRecovery: {
+      encryptedPayload: message.encryptedPayload,
+      revisionIds: message.correctionRevision?.ids ?? [],
+      isEdited: !!message.isEdited,
+      from: message.from,
+      occupantId: message.occupantId,
+      accountScope,
+    },
+  }
+}
+
+function recoveredUpdates(
+  message: MessageImplState & { isEdited?: boolean; from: string; encryptedPayload?: string; occupantId?: string },
+  outcome: Extract<RetryOutcome, { kind: 'decrypted' }>,
+  accountScope: string | null,
+) {
+  return guardedUpdates(message, {
+    body: outcome.body,
+    ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+    ...(outcome.attachment && { attachment: outcome.attachment }),
+    ...(message.isEdited && {
+      isEdited: true,
+      correctionRevision: message.correctionRevision,
+      ...(outcome.authoredAt && { correctionTimestamp: outcome.authoredAt.getTime(), correctionTimestampSource: 'authored' as const }),
+    }),
+    encryptedPayload: undefined,
+  }, accountScope)
+}
+
+export interface CorrectionRecovery {
+  message: StoredMessage | StoredRoomMessage
+  isCurrent: () => boolean
+  apply: (updates: CorrectionUpdates) => void
 }
 
 export class DeferredDecryptEngine {
+  private correctionRecoveries = new Map<string, CorrectionRecovery>()
+
+  recoverCorrection(message: StoredMessage | StoredRoomMessage, isCurrent: () => boolean, apply: CorrectionRecovery['apply']): void {
+    const key = JSON.stringify([message.type, 'roomJid' in message ? message.roomJid : message.conversationId,
+      message.stanzaId ?? message.id, message.from, 'occupantId' in message ? message.occupantId : undefined])
+    if (!isCurrent()) return
+    const pending = this.correctionRecoveries.get(key)
+    if (pending?.isCurrent() && !message.isRetracted && !sameCorrection(pending.message, message) &&
+        compareCorrectionRevisions(message, pending.message) <= 0) return
+    if (!message.encryptedPayload || message.isRetracted) { this.correctionRecoveries.delete(key); return }
+    this.correctionRecoveries.set(key, { message, isCurrent, apply })
+    void this.retryPending().catch(error => logWarn(`Failed to recover correction: ${String(error)}`))
+  }
+
   /**
    * Guard flag for {@link retryPending}. Prevents concurrent retry loops when
    * multiple triggers (plugin-registered, key-unlocked) fire close together.
@@ -136,6 +191,10 @@ export class DeferredDecryptEngine {
     const stores = this.deps.getStores()
     if (!stores) return 0
 
+    const storageScope = captureStorageScope()
+    const accountScope = storageScope.jid
+    const ownJid = this.deps.getOwnBareJid()
+    const accountChanged = () => !storageScope.isCurrent() || this.deps.getOwnBareJid() !== ownJid || this.deps.getManager() !== manager || this.deps.getStores() !== stores
     this.isRetrying = true
     let decryptedCount = 0
     // Chat messages handled by the in-memory pass below, so the durable-cache
@@ -145,6 +204,31 @@ export class DeferredDecryptEngine {
     try {
       const chatBindings = stores.chat
       const roomBindings = stores.room
+      const handledRoomKeys = new Set<string>()
+      for (const [key, request] of this.correctionRecoveries) {
+        if (!request.isCurrent()) { this.correctionRecoveries.delete(key); continue }
+        const { message } = request
+        const room = 'roomJid' in message
+        const conversationId = room ? message.roomJid : message.conversationId
+        if (room) handledRoomKeys.add(JSON.stringify([message.roomJid, message.stanzaId ?? message.id, message.from, message.occupantId]))
+        else handledChatKeys.add(chatCacheKey(message))
+        const outcome = await this.decryptSingle(manager, message.encryptedPayload!, message.from, conversationId, room ? 'room' : 'chat')
+        if (accountChanged()) return decryptedCount
+        if (this.correctionRecoveries.get(key) !== request) continue
+        if (!request.isCurrent()) { this.correctionRecoveries.delete(key); continue }
+        if (outcome.kind === 'pending') continue
+        this.correctionRecoveries.delete(key)
+        if (outcome.kind === 'decrypted') {
+          request.apply(recoveredUpdates(message, outcome, accountScope))
+          decryptedCount++
+        } else if (outcome.kind === 'unsupported') {
+          request.apply(guardedUpdates(message, { encryptedPayload: undefined, unsupportedEncryption: outcome.info }, accountScope))
+        } else {
+          request.apply(guardedUpdates(message, { encryptedPayload: undefined, body: MESSAGE_REJECTED_BODY,
+            ...(outcome.kind === 'rejected' && { securityContext: outcome.securityContext }) }, accountScope))
+        }
+      }
+
 
       // --- 1:1 chat messages ---
       // Read the full in-memory set (archived included) through the store
@@ -152,18 +236,14 @@ export class DeferredDecryptEngine {
       // honoured for custom-store consumers.
       for (const { id: conversationId, messages } of chatBindings.getAllStoredMessages()) {
         for (const msg of messages) {
-          if (!msg.encryptedPayload) continue
+          if (!msg.encryptedPayload || handledChatKeys.has(chatCacheKey(msg))) continue
           handledChatKeys.add(chatCacheKey(msg))
           const outcome = await this.decryptSingle(
             manager, msg.encryptedPayload, msg.from, conversationId,
           )
+          if (accountChanged()) return decryptedCount
           if (outcome.kind === 'decrypted') {
-            chatBindings.updateMessage(conversationId, msg.id, {
-              body: outcome.body,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              ...(outcome.attachment && { attachment: outcome.attachment }),
-              encryptedPayload: undefined,
-            })
+            chatBindings.updateMessage(conversationId, msg.id, recoveredUpdates(msg, outcome, accountScope))
             decryptedCount++
           } else if (outcome.kind === 'modification') {
             this.applyChatModification(conversationId, msg, outcome.modification, chatBindings)
@@ -171,16 +251,18 @@ export class DeferredDecryptEngine {
             // must clear that phantom badge. removeMessage above has already
             // pruned the resident window, so this recount reads a clean slice.
             await chatBindings.recomputeUnreadForConversation?.(conversationId)
+            if (accountChanged()) return decryptedCount
             decryptedCount++
           } else if (outcome.kind === 'rejected') {
-            if (this.resolveRejectedPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)) {
+            if (this.resolveRejectedPlaceholder(conversationId, msg, outcome.securityContext, chatBindings, accountScope)) {
               await chatBindings.recomputeUnreadForConversation?.(conversationId)
+              if (accountChanged()) return decryptedCount
             }
           } else if (outcome.kind === 'unsupported') {
-            chatBindings.updateMessage(conversationId, msg.id, {
+            chatBindings.updateMessage(conversationId, msg.id, guardedUpdates(msg, {
               encryptedPayload: undefined,
               unsupportedEncryption: outcome.info,
-            })
+            }, accountScope))
           }
         }
       }
@@ -191,33 +273,29 @@ export class DeferredDecryptEngine {
       const roomsToRecount = new Set<string>()
       for (const { jid: roomJid, messages } of roomBindings.getAllRoomMessages()) {
         for (const msg of messages) {
-          if (!msg.encryptedPayload) continue
+          if (!msg.encryptedPayload || handledRoomKeys.has(JSON.stringify([roomJid, msg.stanzaId ?? msg.id, msg.from, msg.occupantId]))) continue
           const outcome = await this.decryptSingle(
             manager, msg.encryptedPayload, msg.from, roomJid, 'room',
           )
+          if (accountChanged()) return decryptedCount
           if (outcome.kind === 'decrypted') {
-            roomBindings.updateMessage(roomJid, msg.id, {
-              body: outcome.body,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              ...(outcome.attachment && { attachment: outcome.attachment }),
-              encryptedPayload: undefined,
-            })
+            roomBindings.updateMessage(roomJid, msg.id, recoveredUpdates(msg, outcome, accountScope))
             decryptedCount++
             roomsToRecount.add(roomJid)
           } else if (outcome.kind === 'rejected') {
             // MUC carries no encrypted bodiless signals, so a rejected room
             // message always has real content — warn the user and clear the stash.
-            roomBindings.updateMessage(roomJid, msg.id, {
+            roomBindings.updateMessage(roomJid, msg.id, guardedUpdates(msg, {
               body: MESSAGE_REJECTED_BODY,
               ...(outcome.securityContext && { securityContext: outcome.securityContext }),
               encryptedPayload: undefined,
-            })
+            }, accountScope))
             roomsToRecount.add(roomJid)
           } else if (outcome.kind === 'unsupported') {
-            roomBindings.updateMessage(roomJid, msg.id, {
+            roomBindings.updateMessage(roomJid, msg.id, guardedUpdates(msg, {
               encryptedPayload: undefined,
               unsupportedEncryption: outcome.info,
-            })
+            }, accountScope))
             roomsToRecount.add(roomJid)
           }
         }
@@ -233,6 +311,7 @@ export class DeferredDecryptEngine {
       // call unconditionally — an entity not yet caught up simply defers.
       for (const roomJid of roomsToRecount) {
         await roomBindings.recomputeUnreadForRoom?.(roomJid)
+        if (accountChanged()) return decryptedCount
       }
 
       // --- Durable cache (web fresh-session reload) ---
@@ -242,7 +321,10 @@ export class DeferredDecryptEngine {
       // them straight in IndexedDB. The sparse `encryptedPayload` index makes
       // this O(pending), not a full-archive scan, and near-free when nothing
       // is pending (the steady state).
-      for (const msg of await this.deps.cache.getMessagesWithEncryptedPayload()) {
+      const pendingMessages = await this.deps.cache.getMessagesWithEncryptedPayload()
+      if (accountChanged()) return decryptedCount
+      for (const msg of pendingMessages) {
+        if (accountChanged()) return decryptedCount
         const conversationId = msg.conversationId
         if (!msg.encryptedPayload || !conversationId) continue
         if (handledChatKeys.has(msg.cacheKey)) continue
@@ -252,14 +334,14 @@ export class DeferredDecryptEngine {
         const outcome = await this.decryptSingle(
           manager, msg.encryptedPayload, msg.from, conversationId,
         )
+        if (accountChanged()) return decryptedCount
         if (outcome.kind === 'decrypted') {
-          const updates = {
-            body: outcome.body,
-            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-            ...(outcome.attachment && { attachment: outcome.attachment }),
-            encryptedPayload: undefined,
-          }
-          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
+          const updates = recoveredUpdates(msg, outcome, accountScope)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, accountScope, msg.cacheKey)
+          if (accountChanged()) return decryptedCount
+          await this.deps.updateSearchIndex({ ...msg, ...updates }, accountScope)
+            .catch(error => logWarn(`Failed to index recovered message: ${String(error)}`))
+          if (accountChanged()) return decryptedCount
           // The conversation's messages aren't loaded (durable path), so the
           // in-memory sidebar preview would keep the "[OpenPGP-encrypted
           // message]" fallback. Heal it when this message IS the preview.
@@ -274,32 +356,40 @@ export class DeferredDecryptEngine {
           // the signal is reconciled on the next MAM catch-up, when the
           // now-unlocked key decrypts it inline.
           this.applyChatModification(conversationId, msg, outcome.modification, stores.chat)
-          await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, undefined, msg.cacheKey)
+          await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, accountScope, msg.cacheKey)
+          if (accountChanged()) return decryptedCount
           // Never-opened conversation: its unread badge was hydrated from the
           // durable cache during catch-up and still counts this placeholder.
           // Recompute now that the row is gone from the cache (deleted above),
           // so the phantom badge clears without waiting for the user to open it.
           await stores.chat.recomputeUnreadForConversation?.(conversationId)
+          if (accountChanged()) return decryptedCount
           decryptedCount++
         } else if (outcome.kind === 'rejected') {
           if (msg.body === COULD_NOT_DECRYPT_BODY) {
             // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
-            await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, undefined, msg.cacheKey)
+            await this.deps.cache.deleteMessage(conversationId, msg.id, msg.from, accountScope, msg.cacheKey)
+            if (accountChanged()) return decryptedCount
           } else {
-            const updates = {
+            const updates = guardedUpdates(msg, {
               body: MESSAGE_REJECTED_BODY,
               ...(outcome.securityContext && { securityContext: outcome.securityContext }),
               encryptedPayload: undefined,
-            }
-            await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
+            }, accountScope)
+            await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, accountScope, msg.cacheKey)
+            if (accountChanged()) return decryptedCount
+            await this.deps.updateSearchIndex({ ...msg, ...updates }, accountScope)
+              .catch(error => logWarn(`Failed to index recovered message: ${String(error)}`))
+            if (accountChanged()) return decryptedCount
             stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
           }
         } else if (outcome.kind === 'unsupported') {
-          const updates = {
+          const updates = guardedUpdates(msg, {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
-          }
-          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, undefined, msg.cacheKey)
+          }, accountScope)
+          await this.deps.cache.updateMessage(conversationId, msg.id, updates, msg.from, accountScope, msg.cacheKey)
+          if (accountChanged()) return decryptedCount
           stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
         }
       }
@@ -324,27 +414,23 @@ export class DeferredDecryptEngine {
         const outcome = await this.decryptSingle(
           manager, lastMessage.encryptedPayload, lastMessage.from, conversationId,
         )
+        if (accountChanged()) return decryptedCount
         if (outcome.kind === 'decrypted') {
-          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, {
-            body: outcome.body,
-            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-            ...(outcome.attachment && { attachment: outcome.attachment }),
-            encryptedPayload: undefined,
-          })
+          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, recoveredUpdates(lastMessage, outcome, accountScope))
           decryptedCount++
         } else if (outcome.kind === 'unsupported') {
-          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, {
+          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, guardedUpdates(lastMessage, {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
-          })
+          }, accountScope))
         } else if (outcome.kind === 'rejected') {
           // A preview is always a real previewable message (bodiless-signal
           // placeholders are never previewable), so warn with the rejected body.
-          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, {
+          chatBindings.refreshLastMessageContent?.(conversationId, lastMessage.id, guardedUpdates(lastMessage, {
             body: MESSAGE_REJECTED_BODY,
             ...(outcome.securityContext && { securityContext: outcome.securityContext }),
             encryptedPayload: undefined,
-          })
+          }, accountScope))
         }
         // 'modification' (reaction/retraction) can't be a preview, and 'pending'
         // means the key is still locked — leave the stash for a later pass.
@@ -355,13 +441,10 @@ export class DeferredDecryptEngine {
       }
     } finally {
       this.isRetrying = false
-    }
-
-    // A trigger that arrived mid-pass was coalesced — run once more so its
-    // newly-available state (e.g. a just-unlocked key) is applied.
-    if (this.retryRequested) {
-      this.retryRequested = false
-      decryptedCount += await this.retryPending()
+      if (this.retryRequested) {
+        this.retryRequested = false
+        decryptedCount += await this.retryPending()
+      }
     }
 
     return decryptedCount
@@ -417,9 +500,10 @@ export class DeferredDecryptEngine {
    */
   private resolveRejectedPlaceholder(
     conversationId: string,
-    placeholder: { id: string; body: string },
+    placeholder: Message & MessageImplState,
     securityContext: MessageSecurityContext | undefined,
     chatBindings: StoreBindings['chat'],
+    accountScope: string | null,
   ): boolean {
     if (placeholder.body === COULD_NOT_DECRYPT_BODY) {
       // Dropped a bodiless-signal placeholder that had been counted as unread —
@@ -427,11 +511,11 @@ export class DeferredDecryptEngine {
       chatBindings.removeMessage(conversationId, placeholder.id)
       return true
     }
-    chatBindings.updateMessage(conversationId, placeholder.id, {
+    chatBindings.updateMessage(conversationId, placeholder.id, guardedUpdates(placeholder, {
       body: MESSAGE_REJECTED_BODY,
       ...(securityContext && { securityContext }),
       encryptedPayload: undefined,
-    })
+    }, accountScope))
     return false
   }
 
@@ -530,7 +614,7 @@ export class DeferredDecryptEngine {
       // (aesgcm:// URI, XEP-0446 file metadata, XEP-0264 thumbnails).
       // Legacy bare-element stashes carry no outer <fallback>, so their
       // body passes through unchanged.
-      const parsed = parseMessageContent({ messageEl: stanza, body, messageContext })
+      const parsed = parseMessageContent({ messageEl: stanza, body, messageContext, authoredAt: result.authoredAt })
       const processedBody = parsed.processedBody
       const attachment = parsed.attachment
       if (attachment) {
@@ -554,6 +638,7 @@ export class DeferredDecryptEngine {
 
       return {
         kind: 'decrypted',
+        ...(parsed.timestampSource === 'authored' && { authoredAt: parsed.timestamp }),
         body: processedBody,
         ...(securityContext && { securityContext }),
         ...(attachment && { attachment }),
@@ -587,6 +672,9 @@ export class DeferredDecryptEngine {
     const stores = this.deps.getStores()
     if (!stores) return
 
+    const storageScope = captureStorageScope()
+    const accountScope = storageScope.jid
+    const ownJid = this.deps.getOwnBareJid()
     const chatBindings = stores.chat
     const peerMessages = chatBindings.getConversationMessages(peer)
     if (peerMessages.length === 0) return
@@ -597,19 +685,15 @@ export class DeferredDecryptEngine {
         const outcome = await this.decryptSingle(
           manager, msg.encryptedPayload, msg.from, peer,
         )
+        if (!storageScope.isCurrent() || this.deps.getOwnBareJid() !== ownJid) return
         if (outcome.kind === 'decrypted') {
-          chatBindings.updateMessage(peer, msg.id, {
-            body: outcome.body,
-            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-            ...(outcome.attachment && { attachment: outcome.attachment }),
-            encryptedPayload: undefined,
-          })
+          chatBindings.updateMessage(peer, msg.id, recoveredUpdates(msg, outcome, accountScope))
           updated++
         } else if (outcome.kind === 'unsupported') {
-          chatBindings.updateMessage(peer, msg.id, {
+          chatBindings.updateMessage(peer, msg.id, guardedUpdates(msg, {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
-          })
+          }, accountScope))
           updated++
         }
         continue

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -1,3 +1,5 @@
+import type { DeferredDecryptEngine } from '../e2ee/deferredDecrypt'
+import { captureStorageScope } from '../../utils/storageScope'
 import type { Client, Element } from '@xmpp/client'
 import type { StoreBindings, ClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
 import type { E2EEManager } from '../e2ee'
@@ -68,6 +70,7 @@ export interface ModuleDependencies {
    * which case messages simply flow in cleartext.
    */
   getE2EEManager?: () => E2EEManager | null
+  recoverCorrection?: DeferredDecryptEngine['recoverCorrection']
   /**
    * Pull-based predicate: "is automatic reconnection currently allowed?"
    * Evaluated live at the single reconnect funnel (Connection.attemptReconnect).
@@ -111,6 +114,22 @@ export interface ModuleDependencies {
  */
 export abstract class BaseModule {
   protected deps: ModuleDependencies
+
+  protected captureQuery() {
+    const scope = captureStorageScope()
+    const jid = this.deps.getCurrentJid()
+    const xmpp = this.deps.getXmpp()
+    const manager = this.deps.getE2EEManager?.()
+    const isAccountCurrent = () => scope.isCurrent() && jid === this.deps.getCurrentJid()
+    const isCurrent = () => isAccountCurrent() && xmpp === this.deps.getXmpp() && manager === this.deps.getE2EEManager?.()
+    return {
+      isCurrent,
+      isAccountCurrent,
+      assertCurrent() {
+        if (!isCurrent()) throw new DOMException('History query cancelled', 'AbortError')
+      },
+    }
+  }
 
   constructor(deps: ModuleDependencies) {
     this.deps = deps

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -10,7 +10,7 @@ import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Chat } from './Chat'
-import type { MAM } from './MAM'
+import { MAM } from './MAM'
 import type { ModuleDependencies } from './BaseModule'
 import {
   E2EEEncryptionRequiredError,
@@ -125,12 +125,6 @@ function stubXmppPrimitives(sendStanza: (el: Element) => Promise<void>): XMPPPri
   }
 }
 
-function stubMAM(): MAM {
-  // Chat only calls .markDequeued / event collectors defensively in the paths we
-  // exercise here. An empty object cast is enough for the happy path.
-  return {} as unknown as MAM
-}
-
 /** Build a minimal ModuleDependencies wired to capture sendStanza calls. */
 function makeDeps(options: {
   jid: string
@@ -199,7 +193,7 @@ describe('Chat E2EE wiring', () => {
       captureStanza: (el) => captured.push(el),
     })
     sdkEmitted = built.sdkEmitted
-    chat = new Chat(built.deps, stubMAM())
+    chat = new Chat(built.deps, new MAM(built.deps))
   })
 
   describe('outbound encryption', () => {
@@ -240,7 +234,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendMessage('bob@example.com', 'Hello plaintext')
 
@@ -258,7 +252,7 @@ describe('Chat E2EE wiring', () => {
         captureStanza: (el) => captured.push(el),
         rooms: ['room@muc.example.com'],
       })
-      await new Chat(roomBuilt.deps, stubMAM()).sendMessage('room@muc.example.com', 'hi room')
+      await new Chat(roomBuilt.deps, new MAM(roomBuilt.deps)).sendMessage('room@muc.example.com', 'hi room')
 
       const sent = captured[0]
       expect(sent.getChild('body')?.text()).toBe('hi room')
@@ -335,7 +329,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendMessage('bob@example.com', 'Check this', { attachment: {
         url: 'https://upload.example.com/plain.jpg',
@@ -369,7 +363,7 @@ describe('Chat E2EE wiring', () => {
         manager: strictManager,
         captureStanza: (el) => captured.push(el),
       })
-      const strictChat = new Chat(deps, stubMAM())
+      const strictChat = new Chat(deps, new MAM(deps))
 
       await expect(
         strictChat.sendMessage('bob@example.com', 'secret'),
@@ -420,7 +414,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const guardedChat = new Chat(deps, stubMAM())
+      const guardedChat = new Chat(deps, new MAM(deps))
 
       await expect(
         guardedChat.sendMessage('bob@example.com', 'secret photo', { attachment: {
@@ -450,7 +444,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendMessage('bob@example.com', 'here is the file', { attachment: {
         url: 'https://upload.example.com/plain.jpg',
@@ -491,7 +485,7 @@ describe('Chat E2EE wiring', () => {
       deps.emit = (event, ...args) => {
         if (event === 'message') emittedMessages.push(args[0] as { body: string })
       }
-      const rxChat = new Chat(deps, stubMAM())
+      const rxChat = new Chat(deps, new MAM(deps))
 
       const handled = rxChat.handle(inbound)
       expect(handled).toBe(true)
@@ -520,7 +514,7 @@ describe('Chat E2EE wiring', () => {
       deps.emit = (event, ...args) => {
         if (event === 'message') emittedMessages.push(args[0] as { body: string })
       }
-      const rxChat = new Chat(deps, stubMAM())
+      const rxChat = new Chat(deps, new MAM(deps))
 
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
@@ -686,7 +680,7 @@ describe('Chat E2EE wiring', () => {
       deps.emitSDK = (event, payload) => {
         sdkEvents.push({ event, payload })
       }
-      const rxChat = new Chat(deps, stubMAM())
+      const rxChat = new Chat(deps, new MAM(deps))
 
       const handled = rxChat.handle(carbon)
       expect(handled).toBe(true)
@@ -737,7 +731,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: () => {},
       })
-      const plainChat = new Chat(built.deps, stubMAM())
+      const plainChat = new Chat(built.deps, new MAM(built.deps))
       await plainChat.sendMessage('bob@example.com', 'Hi')
 
       const chatMessageEvent = built.sdkEmitted.find(
@@ -766,7 +760,7 @@ describe('Chat E2EE wiring', () => {
       // Need a conversation so processChatMessage emits (stranger path would bail).
       // In this test setup deps.stores is null, so hasConversation/hasContact aren't
       // hit — the message goes straight through.
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
@@ -796,7 +790,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
@@ -862,7 +856,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = buildEncryptedInbound({
         from: 'bob@example.com/r',
@@ -892,7 +886,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = buildEncryptedInbound({
         from: 'bob@example.com/r',
@@ -917,7 +911,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = buildEncryptedInbound({
         from: 'bob@example.com/r',
@@ -946,7 +940,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = buildEncryptedInbound({
         from: 'bob@example.com/r',
@@ -982,7 +976,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
@@ -1070,7 +1064,7 @@ describe('Chat E2EE wiring', () => {
 
     it('sets encryptedPayload when EME hint is present but no plugin claims', async () => {
       const built = makeDepsNoManager('me@example.com')
-      const noManagerChat = new Chat(built.deps, stubMAM())
+      const noManagerChat = new Chat(built.deps, new MAM(built.deps))
 
       const inbound = xml(
         'message',
@@ -1095,7 +1089,7 @@ describe('Chat E2EE wiring', () => {
 
     it('does not set encryptedPayload on a plain message without EME', async () => {
       const built = makeDepsNoManager('me@example.com')
-      const noManagerChat = new Chat(built.deps, stubMAM())
+      const noManagerChat = new Chat(built.deps, new MAM(built.deps))
 
       const inbound = xml(
         'message',
@@ -1125,7 +1119,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = xml(
         'message',
@@ -1188,7 +1182,7 @@ describe('Chat E2EE wiring', () => {
         },
       } as unknown as import('../types').StoreBindings
 
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = xml(
         'message',
@@ -1250,7 +1244,7 @@ describe('Chat E2EE wiring', () => {
         manager: openpgpManager,
         captureStanza: () => {},
       })
-      const rxChat = new Chat(built.deps, stubMAM())
+      const rxChat = new Chat(built.deps, new MAM(built.deps))
 
       const plaintext = 'Hello from OpenPGP'
       const encoded = Buffer.from(plaintext).toString('base64')
@@ -1309,7 +1303,7 @@ describe('Chat E2EE wiring', () => {
         manager: strictManager,
         captureStanza: (el) => captured.push(el),
       })
-      const strictChat = new Chat(deps, stubMAM())
+      const strictChat = new Chat(deps, new MAM(deps))
 
       await expect(
         strictChat.resendMessage('bob@example.com', 'leaky retry', 'msg-retry-2'),
@@ -1342,7 +1336,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const guardedChat = new Chat(deps, stubMAM())
+      const guardedChat = new Chat(deps, new MAM(deps))
 
       await expect(
         guardedChat.resendMessage('bob@example.com', 'retry photo', 'msg-retry-3', {
@@ -1397,7 +1391,7 @@ describe('Chat E2EE wiring', () => {
         manager: strictManager,
         captureStanza: (el) => captured.push(el),
       })
-      const strictChat = new Chat(deps, stubMAM())
+      const strictChat = new Chat(deps, new MAM(deps))
 
       await expect(
         strictChat.sendCorrection('bob@example.com', 'orig-id', 'leaky edit'),
@@ -1430,7 +1424,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const guardedChat = new Chat(deps, stubMAM())
+      const guardedChat = new Chat(deps, new MAM(deps))
 
       await expect(
         guardedChat.sendCorrection('bob@example.com', 'orig-id', 'updated caption', {
@@ -1480,7 +1474,7 @@ describe('Chat E2EE wiring', () => {
         captureStanza: (el) => captured.push(el),
         rooms: ['room@conf.example.com'],
       })
-      await new Chat(roomBuilt.deps, stubMAM()).sendCorrection('room@conf.example.com', 'orig-id', 'fixed text')
+      await new Chat(roomBuilt.deps, new MAM(roomBuilt.deps)).sendCorrection('room@conf.example.com', 'orig-id', 'fixed text')
 
       expect(captured).toHaveLength(1)
       const sent = captured[0]
@@ -1534,7 +1528,7 @@ describe('Chat E2EE wiring', () => {
         manager,
         originalBody: 'super secret original message',
       })
-      const reactingChat = new Chat(built.deps, stubMAM())
+      const reactingChat = new Chat(built.deps, new MAM(built.deps))
 
       await reactingChat.sendReaction('bob@example.com', 'orig-id', ['👍'])
 
@@ -1567,7 +1561,7 @@ describe('Chat E2EE wiring', () => {
       )
 
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
 
@@ -1591,7 +1585,7 @@ describe('Chat E2EE wiring', () => {
         manager: strictManager,
         originalBody: 'must stay encrypted',
       })
-      const strictChat = new Chat(built.deps, stubMAM())
+      const strictChat = new Chat(built.deps, new MAM(built.deps))
 
       await expect(
         strictChat.sendReaction('bob@example.com', 'orig-id', ['🔥']),
@@ -1613,7 +1607,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         originalBody: 'legacy chat — already plaintext anyway',
       })
-      const plainChat = new Chat(built.deps, stubMAM())
+      const plainChat = new Chat(built.deps, new MAM(built.deps))
 
       await plainChat.sendReaction('bob@example.com', 'orig-id', ['🎉'])
 
@@ -1649,7 +1643,7 @@ describe('Chat E2EE wiring', () => {
         manager: rejectingManager,
         captureStanza: () => {},
       })
-      return { chat: new Chat(built.deps, stubMAM()), sdkEmitted: built.sdkEmitted }
+      return { chat: new Chat(built.deps, new MAM(built.deps)), sdkEmitted: built.sdkEmitted }
     }
 
     it('drops a forged (rejected-signature) bodiless reaction instead of showing a ghost message', async () => {
@@ -1729,7 +1723,7 @@ describe('Chat E2EE wiring', () => {
         // person, so the lookup finds nothing.
         room: { getRoom: () => undefined },
       } as unknown as import('../types').StoreBindings
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
 
@@ -1753,7 +1747,7 @@ describe('Chat E2EE wiring', () => {
         manager: strictManager,
         captureStanza: (el) => captured.push(el),
       })
-      const strictChat = new Chat(deps, stubMAM())
+      const strictChat = new Chat(deps, new MAM(deps))
 
       await expect(
         strictChat.sendRetraction('bob@example.com', 'orig-id'),
@@ -1772,7 +1766,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendRetraction('bob@example.com', 'orig-id')
 
@@ -1820,7 +1814,7 @@ describe('Chat E2EE wiring', () => {
       )
 
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
 
@@ -1843,7 +1837,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendLinkPreview('bob@example.com', 'orig-id', preview)
 
@@ -1874,7 +1868,7 @@ describe('Chat E2EE wiring', () => {
         captureStanza: (el) => localCaptured.push(el),
         rooms,
       })
-      return { chat: new Chat(deps, stubMAM()), captured: localCaptured }
+      return { chat: new Chat(deps, new MAM(deps)), captured: localCaptured }
     }
 
     // Collapse the OGP <meta> children of <apply-to> into a { property: content } map.
@@ -1935,7 +1929,7 @@ describe('Chat E2EE wiring', () => {
 
     it('renders a foreign (mod_ogp / Gajim) preview: meta direct under apply-to, no <external>', () => {
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       // Shape emitted by Prosody mod_ogp: OGP <meta> as direct children of
       // <apply-to>, from the room, applying to the message's id/origin-id.
@@ -1965,7 +1959,7 @@ describe('Chat E2EE wiring', () => {
 
     it('renders a foreign 1:1 preview (direct-meta apply-to on a chat stanza)', () => {
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = xml(
         'message',
@@ -1991,7 +1985,7 @@ describe('Chat E2EE wiring', () => {
 
     it('still renders an inbound legacy <external>-wrapped preview (older Fluux builds)', () => {
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
 
       const inbound = xml(
         'message',
@@ -2037,7 +2031,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendMessage('bob@example.com', 'sure thing', { replyTo: encryptedReply })
 
@@ -2093,7 +2087,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendMessage('bob@example.com', 'sure thing', {
         replyTo: {
@@ -2125,7 +2119,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       const attachmentUrl = 'https://upload.example.com/file.bin'
       await plainChat.sendMessage('bob@example.com', 'sure thing', { replyTo: { id: 'orig', to: 'bob@example.com', fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true } }, attachment: { url: attachmentUrl, name: 'file.bin', mediaType: 'application/octet-stream' } })
@@ -2182,7 +2176,7 @@ describe('Chat E2EE wiring', () => {
       )
 
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
-      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+      const rxChat = new Chat(rxBuilt.deps, new MAM(rxBuilt.deps))
       rxChat.handle(inbound)
       await new Promise((r) => setTimeout(r, 0))
 
@@ -2205,7 +2199,7 @@ describe('Chat E2EE wiring', () => {
         manager: emptyManager,
         captureStanza: (el) => captured.push(el),
       })
-      const plainChat = new Chat(deps, stubMAM())
+      const plainChat = new Chat(deps, new MAM(deps))
 
       await plainChat.sendEasterEgg('bob@example.com', 'confetti')
 

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -368,9 +368,9 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
       // Verify loading state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: true })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: true, requestId: expect.any(String) })
       // Verify loading state was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false, requestId: expect.any(String) })
     })
 
     it('should merge messages into store on success', async () => {
@@ -414,9 +414,9 @@ describe('XMPPClient MAM', () => {
       await expect(xmppClient.messages.queryMAM({ with: 'alice@example.com' })).rejects.toThrow('Network error')
 
       // Verify error state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-error', { conversationId: 'alice@example.com', error: 'Network error' })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-error', { conversationId: 'alice@example.com', error: 'Network error', requestId: expect.any(String) })
       // Verify loading was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:history-loading', { conversationId: 'alice@example.com', isLoading: false, requestId: expect.any(String) })
     })
 
     it('should parse complete=false correctly', async () => {
@@ -2419,7 +2419,7 @@ describe('XMPPClient MAM', () => {
       })
     })
 
-    it('should preserve originalBody from cached message when emitting unresolved corrections', async () => {
+    it('should pass the unresolved correction author to the store boundary', async () => {
       let stanzaListener: ((stanza: any) => void) | null = null
       const originalOn = mockXmppClientInstance.on
       mockXmppClientInstance.on = vi.fn().mockImplementation((event: string, listener: Function) => {
@@ -2427,17 +2427,6 @@ describe('XMPPClient MAM', () => {
         return originalOn.call(mockXmppClientInstance, event, listener)
       }) as typeof mockXmppClientInstance.on
       await connectClient()
-
-      // Mock the store to return a cached message with the original body
-      vi.mocked(mockStores.chat.getMessage).mockReturnValue({
-        type: 'chat',
-        id: 'old-msg-with-body',
-        conversationId: 'alice@example.com',
-        from: 'alice@example.com',
-        body: 'https://example.com/original-link',
-        timestamp: new Date('2024-01-15T11:00:00Z'),
-        isOutgoing: false,
-      })
 
       const mamResponse = createMockElement('iq', { type: 'result' }, [
         {
@@ -2492,7 +2481,7 @@ describe('XMPPClient MAM', () => {
 
       await xmppClient.messages.queryMAM({ with: 'alice@example.com' })
 
-      // The unresolved correction should include originalBody from the cached message
+      // The store/cache boundary resolves the authorized target and its original body.
       const updateEvents = emitSDKSpy.mock.calls.filter(
         ([event]: [string, ...unknown[]]) => event === 'chat:message-updated'
       )
@@ -2500,10 +2489,10 @@ describe('XMPPClient MAM', () => {
       expect(updateEvents[0][1]).toMatchObject({
         conversationId: 'alice@example.com',
         messageId: 'old-msg-with-body',
+        correctionActor: { actorJid: 'alice@example.com' },
         updates: {
           body: 'Edited message without link',
           isEdited: true,
-          originalBody: 'https://example.com/original-link',
         },
       })
     })
@@ -3548,8 +3537,8 @@ describe('XMPPClient MAM', () => {
       await xmppClient.messages.queryRoomMAM({ roomJid })
 
       // Verify loading state was set and cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: true })
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: true, requestId: expect.any(String) })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false, requestId: expect.any(String) })
     })
 
     it('should merge room messages into store on success', async () => {
@@ -3621,9 +3610,9 @@ describe('XMPPClient MAM', () => {
       await expect(xmppClient.messages.queryRoomMAM({ roomJid })).rejects.toThrow('Room MAM not supported')
 
       // Verify error state was set
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-error', { roomJid, error: 'Room MAM not supported' })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-error', { roomJid, error: 'Room MAM not supported', requestId: expect.any(String) })
       // Verify loading was cleared
-      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:history-loading', { roomJid, isLoading: false, requestId: expect.any(String) })
     })
 
     it('should use RSM before parameter for pagination', async () => {

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -2623,6 +2623,7 @@ describe('XMPPClient Message', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
         messageId: 'original-msg-123',
+        correctionActor: { actorJid: 'me@example.com' },
         updates: expect.objectContaining({
           body: userText, // User text is preserved, not empty
           isEdited: true,
@@ -2653,6 +2654,7 @@ describe('XMPPClient Message', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
         messageId: 'original-msg-123',
+        correctionActor: { actorJid: 'me@example.com' },
         updates: expect.objectContaining({
           body: 'Updated',
           isEdited: true,
@@ -2677,6 +2679,7 @@ describe('XMPPClient Message', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message-updated', {
         conversationId: 'contact@example.com',
         messageId: 'original-msg-123',
+        correctionActor: { actorJid: 'me@example.com' },
         updates: expect.objectContaining({
           body: 'Now just text',
           isEdited: true,
@@ -2716,6 +2719,7 @@ describe('XMPPClient Message', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', {
         roomJid: 'room@conference.example.com',
         messageId: 'original-msg-123',
+        correctionActor: { actorJid: 'room@conference.example.com/me', actorOccupantId: undefined },
         updates: expect.objectContaining({
           body: 'Fixed',
           isEdited: true,
@@ -2778,6 +2782,9 @@ describe('XMPPClient Message', () => {
       ])
 
       mockXmppClientInstance._emit('stanza', correction1)
+      const handoff = emitSDKSpy.mock.calls.find(([event]: unknown[]) => event === 'room:message-updated')?.[1] as { onCorrectionMissing: () => void }
+      expect(handoff.onCorrectionMissing).toBeTypeOf('function')
+      handoff.onCorrectionMissing()
 
       // Should create a new message using the replace target ID, not the correction stanza ID
       expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
@@ -2850,6 +2857,8 @@ describe('XMPPClient Message', () => {
       expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', {
         roomJid: 'room@conference.example.com',
         messageId: 'original-msg-id',
+        correctionActor: { actorJid: 'room@conference.example.com/Alice', actorOccupantId: 'occupant-123' },
+        onCorrectionResolved: expect.any(Function),
         updates: expect.objectContaining({
           body: 'Corrected text v2',
           isEdited: true,
@@ -2874,6 +2883,10 @@ describe('XMPPClient Message', () => {
       ])
 
       mockXmppClientInstance._emit('stanza', correction)
+
+      const handoff = emitSDKSpy.mock.calls.find(([event]: unknown[]) => event === 'chat:message-updated')?.[1] as { onCorrectionMissing: () => void }
+      expect(handoff.onCorrectionMissing).toBeTypeOf('function')
+      handoff.onCorrectionMissing()
 
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
         isLiveArrival: true,
@@ -2907,7 +2920,7 @@ describe('XMPPClient Message', () => {
       return createMockElement('message', { from: `${roomJid}/${senderNick}`, to: 'user@example.com', type: 'groupchat', id: 'retraction-stanza' }, children)
     }
 
-    it('should reject a correction when occupant-id differs despite a matching nick (nickname takeover)', async () => {
+    it('should delegate a nickname collision to the occupant-scoped correction handoff', async () => {
       await connectClient()
       mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
       mockStores.room.getMessage = vi.fn().mockReturnValue({
@@ -2918,7 +2931,10 @@ describe('XMPPClient Message', () => {
       // Mallory has taken the nick "Alice" but carries a different occupant-id
       mockXmppClientInstance._emit('stanza', buildCorrection('Alice', 'mallory-occ'))
 
-      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+        correctionActor: { actorJid: `${roomJid}/Alice`, actorOccupantId: 'mallory-occ' },
+        onCorrectionMissing: expect.any(Function),
+      }))
     })
 
     it('should apply a correction when the occupant-id matches', async () => {

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1,6 +1,7 @@
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { BaseModule, type ModuleDependencies } from './BaseModule'
+import { captureStorageScope } from '../../utils/storageScope'
 import { getBareJid, getLocalPart, getResource, isQuickChatJid } from '../jid'
 import { isMucJid } from '../../utils/xmppUri'
 import { generateUUID, generateStableMessageId } from '../../utils/uuid'
@@ -65,14 +66,15 @@ import type {
   HistoryPagingSearchOptions,
   PollClosedData,
 } from '../types'
-import { getCorrectionStanzaIds } from '../types/message-internal'
-import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, createOriginIdElement, parseStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal } from './messagingUtils'
+import { getCorrectionStanzaIds, withCorrectionStanzaId, type StoredMessage, type StoredRoomMessage } from '../types/message-internal'
+import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, createOriginIdElement, parseStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, correctionMarks } from './messagingUtils'
 import { checkForMention } from '../mentionDetection'
 import { parsePollElement, parsePollClosedElement } from '../poll'
 import { logWarn } from '../logger'
 import { parseXMPPError, formatXMPPError } from '../../utils/xmppError'
 import { archiveReference, senderReference } from '../../utils/messageIdentity'
 import type { MAM } from './MAM'
+import type { CorrectionReceipts } from './CorrectionReceipts'
 import type { StanzaClaim } from '../stanzaRouting'
 
 /**
@@ -170,10 +172,12 @@ interface MessageEnvelopeContext {
 
 export class Chat extends BaseModule {
   private mamModule: MAM
+  private correctionReceipts: CorrectionReceipts
 
   constructor(deps: ModuleDependencies, mamModule: MAM) {
     super(deps)
     this.mamModule = mamModule
+    this.correctionReceipts = mamModule.correctionReceipts
   }
 
   /**
@@ -223,6 +227,8 @@ export class Chat extends BaseModule {
       }
       return { handled: true }
     }
+
+    this.correctionReceipts.observe(stanza)
 
     // E2EE decrypt hook: if a registered plugin claims one of the stanza's
     // children, decrypt asynchronously, then re-enter this method with the
@@ -311,7 +317,7 @@ export class Chat extends BaseModule {
 
       const whisperCorrection = parseCorrectionSignal(stanza)
       if (whisperCorrection?.targetId && body && this.handleIncomingCorrection(
-        stanza, whisperCorrection.targetId, from!, bareFrom, bareTo, body, 'groupchat', isSentCarbon,
+        stanza, whisperCorrection.targetId, from!, bareFrom, bareTo, body, 'groupchat', isSentCarbon, delayEl,
       )) {
         return { handled: true }
       }
@@ -376,7 +382,14 @@ export class Chat extends BaseModule {
         bareTo,
         body,
         type,
-        isSentCarbon
+        isSentCarbon,
+        delayEl,
+        () => {
+          const message = type === 'groupchat'
+            ? this.processRoomMessage(stanza, from, bareFrom, body, isCarbonCopy, isSentCarbon)
+            : this.processChatMessage(stanza, from, bareFrom, bareTo, body, isCarbonCopy, isSentCarbon, delayEl)
+          if (message && !isSentCarbon) this.deps.emit('message', message as Message)
+        },
       )
       if (handled) return { handled: true }
     }
@@ -491,12 +504,20 @@ export class Chat extends BaseModule {
     // outgoing messages being delivered back to us. Same rule MAM
     // applies on its archive entries — keeping the two paths aligned
     // through one function is what guards against the original bug.
-    const ownBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
+    const scope = captureStorageScope()
+    const jid = this.deps.getCurrentJid()
+    const ownBareJid = getBareJid(jid ?? '')
     const { peer, isSelfOutgoing } = deriveConversationContext(stanza, ownBareJid)
-    await decryptStanzaInPlace(stanza, manager, peer, 'live', {
-      isSelfOutgoing,
-    })
-    this.handleMessageInternal(stanza, context)
+    const finish = this.correctionReceipts.begin(stanza)
+    try {
+      await decryptStanzaInPlace(stanza, manager, peer, 'live', {
+        isSelfOutgoing,
+      })
+      if (!scope.isCurrent() || jid !== this.deps.getCurrentJid() || manager !== this.deps.getE2EEManager?.()) return
+      this.handleMessageInternal(stanza, context)
+    } finally {
+      finish()
+    }
   }
 
   /**
@@ -1265,6 +1286,14 @@ export class Chat extends BaseModule {
    * - Corrected messages are marked with `isEdited: true`
    */
   async sendCorrection(to: string, originalMessageId: string, newBody: string, attachment?: FileAttachment): Promise<void> {
+    const scope = captureStorageScope()
+    const jid = this.deps.getCurrentJid()
+    const xmpp = this.deps.getXmpp()
+    const manager = this.deps.getE2EEManager?.()
+    const assertCurrent = () => {
+      scope.assertCurrent()
+      if (jid !== this.deps.getCurrentJid() || xmpp !== this.deps.getXmpp() || manager !== this.deps.getE2EEManager?.()) throw new DOMException('Correction send cancelled', 'AbortError')
+    }
     const type = this.conversationKind(to)
     // XEP-0045 §7.5: if the target is a whisper, address the correction privately
     // to the one occupant (type=chat to room/nick + muc#user + no-store) instead of
@@ -1369,16 +1398,25 @@ export class Chat extends BaseModule {
       throw new E2EEEncryptionRequiredError({ kind: 'direct', peer: recipient })
     }
 
+    assertCurrent()
+    const receiveOrder = this.correctionReceipts.nextOrder()
     await this.deps.sendStanza(xml('message', { to: recipient, type: wireType, id: correctionStanzaId }, ...children))
+    assertCurrent()
 
     // SDK events only - bindings call store methods. Reuses the original
     // message fetched above for the correction reference.
     if (original) {
-      const updates = { body: newBody, isEdited: true, originalBody: original.originalBody ?? original.body, attachment }
+      const updates = {
+        body: newBody, isEdited: true, originalBody: original.originalBody ?? original.body, attachment,
+        encryptedPayload: undefined,
+        ...(correctionSecurityContext && { securityContext: correctionSecurityContext }),
+        correctionTimestamp: undefined, correctionTimestampSource: undefined, liveCorrection: true,
+        correctionRevision: { ids: [`id:${correctionStanzaId}`, `origin:${correctionStanzaId}`], supersedes: [], receiveOrder },
+      }
       if (type === 'groupchat') {
-        this.deps.emitSDK('room:message-updated', { roomJid: to, messageId: originalMessageId, updates })
+        this.deps.emitSDK('room:message-updated', { roomJid: to, messageId: originalMessageId, updates, correctionActor: { actorJid: original.from, actorOccupantId: (original as RoomMessage).occupantId } })
       } else {
-        this.deps.emitSDK('chat:message-updated', { conversationId: to, messageId: originalMessageId, updates })
+        this.deps.emitSDK('chat:message-updated', { conversationId: to, messageId: originalMessageId, updates, correctionActor: { actorJid: original.from } })
       }
     }
   }
@@ -1952,7 +1990,7 @@ export class Chat extends BaseModule {
     return original.from === from
   }
 
-  private handleIncomingCorrection(stanza: Element, originalId: string, from: string, bareFrom: string, bareTo: string | undefined, body: string, type: string, isSentCarbon: boolean): boolean {
+  private handleIncomingCorrection(stanza: Element, originalId: string, from: string, bareFrom: string, bareTo: string | undefined, body: string, type: string, isSentCarbon: boolean, delayEl?: Element, onMissing?: () => void): boolean {
     const myBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const isOutgoing = isSentCarbon || bareFrom === myBareJid
     const conversationId = isOutgoing ? bareTo : bareFrom
@@ -1965,30 +2003,62 @@ export class Chat extends BaseModule {
     const correctionExpectedBy = type === 'groupchat' ? conversationId : myBareJid
     const correctionStanzaId = parseStanzaId(stanza, correctionExpectedBy)
 
-    // SDK events only - bindings call store methods
+    if (!this.deps.stores) return false
+    const scope = captureStorageScope()
+    const jid = this.deps.getCurrentJid()
+    const manager = this.deps.getE2EEManager?.()
+    const onCorrectionMissing = onMissing ? () => {
+      if (scope.isCurrent() && jid === this.deps.getCurrentJid() && manager === this.deps.getE2EEManager?.()) onMissing()
+    } : undefined
     if (type === 'groupchat') {
-      const original = this.deps.stores?.room.getMessage(conversationId, originalId)
+      const candidate = this.deps.stores.room.getMessage(conversationId, originalId)
       const senderOccupantId = stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
-      if (original && this.isSameMucAuthor(original, from, senderOccupantId)) {
-        const correctionData = applyCorrection(stanza, body, original.originalBody ?? original.body)
-        if (correctionStanzaId) {
-          correctionData.correctionStanzaIds = [...(getCorrectionStanzaIds(original) ?? []), correctionStanzaId]
-        }
-        this.deps.emitSDK('room:message-updated', { roomJid: conversationId, messageId: originalId, updates: correctionData })
-        return true
-      }
+      const original = candidate && this.isSameMucAuthor(candidate, from, senderOccupantId) ? candidate : undefined
+      if (!original && !onMissing) return false
+      const updates = this.correctionUpdates(stanza, body, original, delayEl, correctionStanzaId, correctionExpectedBy)
+      if (updates) this.deps.emitSDK('room:message-updated', {
+        roomJid: conversationId, messageId: originalId, updates,
+        correctionActor: { actorJid: from, actorOccupantId: senderOccupantId }, ...(!original && { onCorrectionMissing }),
+        onCorrectionResolved: this.mamModule.correctionCompletion(conversationId, true, updates.correctionRevision),
+      })
     } else {
-      const original = this.deps.stores?.chat.getMessage(conversationId, originalId)
-      if (original && original.from === bareFrom) {
-        const correctionData = applyCorrection(stanza, body, original.originalBody ?? original.body)
-        if (correctionStanzaId) {
-          correctionData.correctionStanzaIds = [...(getCorrectionStanzaIds(original) ?? []), correctionStanzaId]
-        }
-        this.deps.emitSDK('chat:message-updated', { conversationId, messageId: originalId, updates: correctionData })
-        return true
-      }
+      const candidate = this.deps.stores.chat.getMessage(conversationId, originalId)
+      const original = candidate?.from === bareFrom ? candidate : undefined
+      if (!original && !onMissing) return false
+      const updates = this.correctionUpdates(stanza, body, original, delayEl, correctionStanzaId, correctionExpectedBy)
+      if (updates) this.deps.emitSDK('chat:message-updated', {
+        conversationId, messageId: originalId, updates, correctionActor: { actorJid: bareFrom }, ...(!original && { onCorrectionMissing }),
+        onCorrectionResolved: this.mamModule.correctionCompletion(conversationId, false, updates.correctionRevision),
+      })
     }
-    return false
+    return true
+  }
+
+  /**
+   * The updates an incoming XEP-0308 correction contributes to its target.
+   *
+   * The correction's own stanza-id is always recorded, even when the target
+   * already holds a newer revision: a reply or retraction may name the
+   * superseded revision's archive entry and must keep resolving.
+   */
+  private correctionUpdates(
+    stanza: Element,
+    body: string,
+    original: StoredMessage | StoredRoomMessage | undefined,
+    delayEl: Element | undefined,
+    correctionStanzaId: string | undefined,
+    expectedStanzaIdBy: string,
+  ): (Partial<StoredMessage> & Partial<StoredRoomMessage>) | undefined {
+    const authoredAt = readStashedAuthoredAt(stanza)
+    const correctionData = this.correctionReceipts.withOrder(stanza, applyCorrection(stanza, body, original?.originalBody ?? original?.body ?? '', {
+      ...(delayEl && { delayEl }),
+      ...(authoredAt && { authoredAt }),
+      expectedStanzaIdBy,
+    }))
+    if (correctionStanzaId) {
+      correctionData.correctionStanzaIds = withCorrectionStanzaId(original ? getCorrectionStanzaIds(original) : undefined, correctionStanzaId)
+    }
+    return correctionData
   }
 
   /**
@@ -2184,7 +2254,7 @@ export class Chat extends BaseModule {
       ...(parsed.noStyling && { noStyling: true }),
       ...(parsed.replyTo && { replyTo: parsed.replyTo }),
       ...(parsed.attachment && { attachment: parsed.attachment }),
-      ...(isCorrection && { isEdited: true }),
+      ...(isCorrection && this.correctionReceipts.withOrder(stanza, correctionMarks(parsed))),
       ...(securityContext && { securityContext }),
       ...(encryptedPayload && { encryptedPayload }),
       ...(unsupportedEncryption && { unsupportedEncryption }),
@@ -2273,7 +2343,7 @@ export class Chat extends BaseModule {
       ...(parsed.noStyling && { noStyling: true }),
       ...(parsed.replyTo && { replyTo: parsed.replyTo }),
       ...(parsed.attachment && { attachment: parsed.attachment }),
-      ...(isCorrection && { isEdited: true }),
+      ...(isCorrection && this.correctionReceipts.withOrder(stanza, correctionMarks(parsed))),
       ...(occupantId && { occupantId }),
       ...(securityContext && { securityContext }),
       ...(encryptedPayload && { encryptedPayload }),
@@ -2471,7 +2541,9 @@ export class Chat extends BaseModule {
     senderOccupantId?: string,
     closedTimestamp?: Date,
   ): void {
+    const session = this.captureQuery()
     this.mamModule.fetchRoomMessageById(roomJid, pollClosed.pollMessageId).then((originalMsg) => {
+      if (!session.isCurrent()) return
       if (!originalMsg?.poll) return // MAM fetch failed or message has no poll — keep trust-based acceptance
       if (!this.verifyPollClosed(pollClosed, originalMsg, senderNick, senderOccupantId)) {
         logWarn(`Poll-closed rejected (deferred): verification failed for poll ${pollClosed.pollMessageId} in ${roomJid}`)

--- a/packages/fluux-sdk/src/core/modules/CorrectionReceipts.ts
+++ b/packages/fluux-sdk/src/core/modules/CorrectionReceipts.ts
@@ -1,0 +1,88 @@
+import type { Element } from '@xmpp/client'
+import type { ModuleDependencies } from './BaseModule'
+import { getBareJid } from '../jid'
+import { NS_OCCUPANT_ID } from '../namespaces'
+import { captureStorageScope } from '../../utils/storageScope'
+import { generateUUID } from '../../utils/uuid'
+import { sameCorrection, type CorrectionRevision, type CorrectionReceiveOrder, type MessageImplState } from '../types/message-internal'
+import { parseCorrectionIds } from './messagingUtils'
+
+interface ReceiveObservation {
+  scope: string
+  correctionRevision: CorrectionRevision
+  order: CorrectionReceiveOrder
+  pending: number
+}
+
+export class CorrectionReceipts {
+  private receiveOrders = new WeakMap<Element, ReceiveObservation>()
+  private pendingReceives = new Set<ReceiveObservation>()
+  private receiveSession?: { id: string; sequence: number; isCurrent: () => boolean }
+
+  constructor(private deps: ModuleDependencies) {}
+
+  begin(stanza: Element): () => void {
+    const observation = this.receiveOrders.get(stanza)!
+    observation.pending++
+    this.pendingReceives.add(observation)
+    return () => {
+      if (--observation.pending === 0) this.pendingReceives.delete(observation)
+    }
+  }
+
+  observe(stanza: Element, archive = false, archiveId?: string): void {
+    const order = this.nextOrder()
+    const existing = this.receiveOrders.get(stanza)
+    if (existing?.order.session === order.session) {
+      if (!archive && existing.order.archive) existing.order = { ...order, replay: true }
+      return
+    }
+    const from = stanza.attrs.from ?? ''
+    const bareFrom = getBareJid(from)
+    const ownJid = getBareJid(this.deps.getCurrentJid() ?? '')
+    const isRoom = stanza.attrs.type === 'groupchat' || this.deps.stores?.room?.getRoom(bareFrom)?.joined === true
+    const conversation = isRoom || bareFrom !== ownJid ? bareFrom : getBareJid(stanza.attrs.to ?? '')
+    const author = isRoom ? stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id ?? from : bareFrom
+    const scope = JSON.stringify([isRoom, conversation, author])
+    if (archive) order.archive = true
+    const correctionRevision = { ids: parseCorrectionIds(stanza, isRoom ? conversation : ownJid, archiveId), supersedes: [] }
+    const matches = [...this.pendingReceives].filter(observation =>
+      observation.scope === scope && sameCorrection(observation, { correctionRevision }))
+    if (matches.length === 1) {
+      const observation = matches[0]
+      if (!archive && observation.order.archive) observation.order = { ...order, replay: true }
+      observation.correctionRevision.ids = [...new Set([...observation.correctionRevision.ids, ...correctionRevision.ids])]
+      this.receiveOrders.set(stanza, observation)
+      return
+    }
+    this.receiveOrders.set(stanza, { scope, correctionRevision, order, pending: 0 })
+  }
+
+  nextOrder(): CorrectionReceiveOrder {
+    if (!this.receiveSession?.isCurrent()) {
+      this.pendingReceives.clear()
+      const scope = captureStorageScope()
+      const jid = this.deps.getCurrentJid()
+      const manager = this.deps.getE2EEManager?.()
+      this.receiveSession = {
+        id: generateUUID(), sequence: 0,
+        isCurrent: () => scope.isCurrent() && jid === this.deps.getCurrentJid() && manager === this.deps.getE2EEManager?.(),
+      }
+    }
+    return { session: this.receiveSession.id, sequence: ++this.receiveSession.sequence }
+  }
+
+  withOrder<T extends MessageImplState>(stanza: Element, updates: T): T {
+    const observation = this.receiveOrders.get(stanza)
+    return observation && updates.correctionRevision
+      ? { ...updates, correctionRevision: {
+        ...updates.correctionRevision,
+        ...(sameCorrection(observation, updates) && {
+          ids: [...new Set([...observation.correctionRevision.ids, ...updates.correctionRevision.ids])],
+        }),
+        receiveOrder: observation.order,
+      } }
+      : updates
+  }
+
+}

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -40,6 +40,7 @@
 
 import { xml, Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
+import { CorrectionReceipts } from './CorrectionReceipts'
 import { getBareJid, getResource, getLocalPart } from '../jid'
 import { generateUUID, generateStableMessageId } from '../../utils/uuid'
 import { executeWithConcurrency } from '../../utils/concurrencyUtils'
@@ -84,7 +85,7 @@ import type {
   RoomHistorySearchOptions,
   HistoryPagingSearchOptions,
 } from '../types'
-import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, parseStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, isMessageSignal } from './messagingUtils'
+import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, parseStanzaId, parseArchiveStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, isMessageSignal } from './messagingUtils'
 import { getDomain } from '../jid'
 import { logInfo, logError as logErr } from '../logger'
 import {
@@ -97,16 +98,29 @@ import {
   recordUnclaimedEME,
 } from '../e2ee/stanzaDecrypt'
 import type { MessageSecurityContext } from '../types'
-import { getCorrectionStanzaIds, type MessageImplState } from '../types/message-internal'
+import { getCorrectionStanzaIds, correctionContent, resolveCorrectionUpdates, withCorrectionStanzaId, sameCorrection, withCorrectionPredecessor, type StoredMessage, type StoredRoomMessage, type CorrectionRevision } from '../types/message-internal'
 import { parseSearchQuery, tokenize } from '../../utils/searchIndex'
 import {
   chatMessageAuthor,
+  CHAT_SCOPE,
+  roomScope,
+  sameLogicalMessage,
+  correctionReferences,
+  archiveIdentityConflict,
+  occupantConflict,
+  type CorrectionReferences,
   resolveMessageReference,
   roomMessageAuthor,
   type MessageActor,
   type ResolutionPolicy,
 } from '../../utils/messageIdentity'
 
+
+/** XEP-0203: the date an archive or carbon envelope stamps on what it wraps. */
+function delayStamp(delayEl?: Element): Date | undefined {
+  const stamp = delayEl?.attrs.stamp
+  return stamp ? new Date(stamp) : undefined
+}
 
 /**
  * Raw MAM result buffered by {@link MAM.createMessageCollector} and drained
@@ -125,22 +139,49 @@ interface RawArchiveEntry {
  */
 interface MAMModifications {
   retractions: { targetId: string; from: string; occupantId?: string }[]
-  corrections: { targetId: string; from: string; occupantId?: string; body: string; messageEl: Element; correctionStanzaId?: string }[]
+  corrections: { targetId: string; from: string; occupantId?: string; body: string; messageEl: Element; correctionStanzaId?: string; revisionStanzaId?: string; delayEl?: Element; authoredAt?: Date; archivePredecessor?: CorrectionRevision }[]
   fastenings: { targetId: string; applyToEl: Element }[]
   reactions: { targetId: string; from: string; emojis: string[]; timestamp?: Date }[]
 }
 
 /**
- * Modifications that could not be applied to messages within the current MAM page.
- * These target messages already in the store/cache and need to be emitted as events.
+ * Modifications requiring store/cache events. Corrections and accepted retractions
+ * remain here even after updating an in-page row, because deduplication may retain
+ * a resident or cached copy instead. Other modifications enter only if unresolved.
  */
 interface UnresolvedModifications {
   retractions: { targetId: string; from: string; occupantId?: string }[]
-  corrections: { targetId: string; from: string; occupantId?: string; body: string; messageEl: Element; correctionStanzaId?: string }[]
+  corrections: { targetId: string; from: string; occupantId?: string; body: string; messageEl: Element; correctionStanzaId?: string; revisionStanzaId?: string; delayEl?: Element; authoredAt?: Date; archivePredecessor?: CorrectionRevision }[]
   fastenings: { targetId: string; applyToEl: Element }[]
   reactions: { targetId: string; from: string; emojis: string[]; timestamp?: Date }[]
 }
 
+
+interface CorrectionReconciliationTarget {
+  message: StoredMessage | StoredRoomMessage
+  isCurrent: () => boolean
+  generation: number
+  refresh?: boolean
+  traversal?: {
+    end: string
+    after?: string
+    cursors: Set<string>
+    archiveOrder: Map<string, Set<CorrectionOrderGroup>>
+  }
+}
+
+interface CorrectionReconciliation {
+  isCurrent: () => boolean
+  pending: Map<string, CorrectionReconciliationTarget>
+  observed: Map<string, { revisions: CorrectionRevision[]; isCurrent: () => boolean }>
+  generation: number
+  running: boolean
+}
+
+interface CorrectionOrderGroup {
+  revision: CorrectionRevision
+  identity?: CorrectionReferences['identity']
+}
 
 /**
  * Message Archive Management (XEP-0313) module.
@@ -180,6 +221,205 @@ interface UnresolvedModifications {
  * @category Core
  */
 export class MAM extends BaseModule {
+  readonly correctionReceipts = new CorrectionReceipts(this.deps)
+  private correctionQueries = new Map<string, CorrectionReconciliation>()
+  private observedArchives = new Map<string, () => boolean>()
+
+  correctionCompletion(conversationId: string, room: boolean, revision?: CorrectionRevision) {
+    const session = this.captureQuery()
+    return (message: StoredMessage | StoredRoomMessage, isStoreCurrent: () => boolean) => {
+      const isCurrent = () => session.isCurrent() && isStoreCurrent()
+      if (!isCurrent()) return
+      this.deps.recoverCorrection?.(message, isCurrent, updates => {
+        if (!isCurrent()) return
+        const correctionActor = { actorJid: message.from, actorOccupantId: 'occupantId' in message ? message.occupantId : undefined }
+        if (room) this.deps.emitSDK('room:message-updated', { roomJid: conversationId, messageId: message.stanzaId ?? message.id, updates, correctionActor })
+        else this.deps.emitSDK('chat:message-updated', { conversationId, messageId: message.stanzaId ?? message.id, updates, correctionActor })
+      })
+      if (revision && !message.isRetracted && message.correctionAlternatives?.length) {
+        void this.reconcileCorrections(conversationId, room, message, isStoreCurrent, revision)
+      }
+    }
+  }
+
+  private async reconcileCorrections(conversationId: string, room: boolean, message: StoredMessage | StoredRoomMessage,
+    isStoreCurrent: () => boolean, revision: CorrectionRevision): Promise<void> {
+    const key = JSON.stringify([room, conversationId])
+    const supported = room ? this.deps.stores?.room.getRoom(conversationId)?.supportsMAM
+      : this.deps.stores?.connection.getServerInfo?.()?.features?.includes(NS_MAM)
+    if (!supported && !this.observedArchives.get(key)?.()) return
+    const session = this.captureQuery()
+    for (const [scope, request] of this.correctionQueries) {
+      if (!request.isCurrent()) this.correctionQueries.delete(scope)
+    }
+    let request = this.correctionQueries.get(key)
+    if (!request) {
+      request = { isCurrent: session.isCurrent, pending: new Map(), observed: new Map(), generation: 0, running: false }
+      this.correctionQueries.set(key, request)
+    }
+    const targetKey = JSON.stringify([message.stanzaId ?? message.id, message.from, 'occupantId' in message ? message.occupantId : undefined])
+    const previous = request.observed.get(targetKey)
+    const revisions = previous?.isCurrent() ? previous.revisions : []
+    const observed = revisions.find(held => sameCorrection({ correctionRevision: held }, { correctionRevision: revision }))
+    if (observed) {
+      observed.ids = [...new Set([...observed.ids, ...revision.ids])]
+      return
+    }
+    revisions.push({ ids: [...revision.ids], supersedes: [] })
+    request.observed.set(targetKey, { revisions, isCurrent: isStoreCurrent })
+    request.pending.set(targetKey, {
+      message, isCurrent: isStoreCurrent, generation: ++request.generation, refresh: true,
+      traversal: request.pending.get(targetKey)?.traversal,
+    })
+    if (request.running) return
+    request.running = true
+    try {
+      await Promise.resolve()
+      while (session.isCurrent() && request.pending.size) {
+        const batch = [...request.pending.entries()].slice(0, 4)
+        const targets = batch.map(([, target]) => ({ ...target, message: { ...target.message } }))
+          .filter(target => target.isCurrent())
+        let completed = false
+        try {
+          if (targets.length) await this.reconcileCorrectionBatch(conversationId, room, targets)
+          completed = true
+        } catch (error) {
+          if (session.isCurrent()) logInfo(`Correction archive reconciliation failed: ${String(error)}`)
+        } finally {
+          for (const [id, target] of batch) {
+            const queued = request.pending.get(id)
+            const processed = targets.find(next => next.generation === target.generation)
+            if (queued?.generation !== target.generation) {
+              if (queued && processed?.isCurrent() && queued.isCurrent() && session.isCurrent()) {
+                queued.message = { ...queued.message, ...resolveCorrectionUpdates(queued.message, {
+                  ...correctionContent(processed.message), correctionAlternatives: processed.message.correctionAlternatives,
+                  isRetracted: processed.message.isRetracted,
+                }) }
+                queued.traversal ??= processed.traversal
+              }
+              continue
+            }
+            request.pending.delete(id)
+            if (completed && processed?.traversal && processed.isCurrent()) request.pending.set(id, processed)
+          }
+        }
+      }
+    } finally {
+      request.running = false
+      request.pending.clear()
+      if (!session.isCurrent() && this.correctionQueries.get(key) === request) this.correctionQueries.delete(key)
+    }
+  }
+
+  private async reconcileCorrectionBatch(conversationId: string, room: boolean, targets: CorrectionReconciliationTarget[]): Promise<void> {
+    const session = this.captureQuery()
+    const isCurrent = () => session.isCurrent() && targets.some(target => target.isCurrent())
+    const query = async (max: number, before?: string, after?: string, archiveOrder?: Map<string, Set<CorrectionOrderGroup>>, end?: string) => {
+      session.assertCurrent()
+      if (!isCurrent()) throw new DOMException('Correction target removed', 'AbortError')
+      const queryId = generateUUID()
+      const entries: RawArchiveEntry[] = []
+      const fields = [xml('field', { var: 'FORM_TYPE', type: 'hidden' }, xml('value', {}, NS_MAM))]
+      if (!room) fields.push(xml('field', { var: 'with' }, xml('value', {}, conversationId)))
+      const collector = this.createMessageCollector(queryId, (forwarded, messageEl, archiveId) => entries.push({ forwarded, messageEl, archiveId }))
+      const xmpp = this.deps.getXmpp()
+      const unregister = this.deps.registerMAMCollector?.(queryId, collector) ?? (() => {
+        xmpp?.on('stanza', collector)
+        return () => xmpp?.removeListener('stanza', collector)
+      })()
+      try {
+        const response = await this.deps.sendIQ(this.buildMAMQuery(queryId, fields, max, before, room ? conversationId : undefined, after))
+        session.assertCurrent()
+        if (!response.getChild('fin', NS_MAM)) throw new Error('Missing MAM completion')
+        const boundaryIndex = end ? entries.findIndex(entry => entry.archiveId === end) : -1
+        const boundedEntries = boundaryIndex < 0 ? entries : entries.slice(0, boundaryIndex + 1)
+        const modifications: MAMModifications = { retractions: [], corrections: [], fastenings: [], reactions: [] }
+        for (const { forwarded, messageEl, archiveId } of boundedEntries) {
+          if (!isCurrent()) throw new DOMException('Correction target removed', 'AbortError')
+          const delay = forwarded.getChild('delay', NS_DELAY)
+          await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, delayStamp(delay))
+          session.assertCurrent()
+          this.collectModification(messageEl, modifications, from => room ? from : getBareJid(from), delay,
+            room ? conversationId : getBareJid(this.deps.getCurrentJid() ?? ''), archiveId)
+        }
+        const isAuthor = room ? roomMessageAuthor : chatMessageAuthor
+        const currentMessages = () => targets.filter(target => target.isCurrent()).map(target => target.message)
+        const indexedReferences = new Map<string, CorrectionReferences | null | undefined>()
+        const lookup = async (id: string, actor: MessageActor) => {
+          const key = JSON.stringify([id, actor.actorJid, actor.actorOccupantId])
+          if (!indexedReferences.has(key)) {
+            const references = room
+              ? await this.deps.stores?.room.resolveCorrectionReferences?.(conversationId, id, actor)
+              : await this.deps.stores?.chat.resolveCorrectionReferences?.(conversationId, id, actor)
+            session.assertCurrent()
+            indexedReferences.set(key, references)
+          }
+          const references = indexedReferences.get(key)
+          return references && this.resolveCorrectionReferenceTarget(currentMessages(), references, actor, isAuthor) ? references : null
+        }
+        const unresolved = await this.applyModifications(currentMessages(),
+          { ...modifications, fastenings: [], reactions: [] }, isAuthor, undefined, archiveOrder, lookup)
+        session.assertCurrent()
+        const authorized = (modification: { targetId: string; from: string; occupantId?: string }) => {
+          const actor = { actorJid: modification.from, actorOccupantId: modification.occupantId }
+          const resolution = resolveMessageReference(currentMessages(), modification.targetId, 'archive-first')
+          if (resolution?.candidates.some(({ message: target }) => isAuthor(target, actor))) return true
+          if (resolution?.authoritative) return false
+          const references = indexedReferences.get(JSON.stringify([modification.targetId, actor.actorJid, actor.actorOccupantId]))
+          return !!references && !!this.resolveCorrectionReferenceTarget(currentMessages(), references, actor, isAuthor)
+        }
+        for (const modification of [...unresolved.corrections, ...unresolved.retractions]) {
+          if (!authorized(modification)) await lookup(modification.targetId, { actorJid: modification.from, actorOccupantId: modification.occupantId })
+        }
+        session.assertCurrent()
+        const corrections = unresolved.corrections.filter(authorized)
+        const retractions = unresolved.retractions.filter(authorized)
+        if (isCurrent()) {
+          if (room) this.emitUnresolvedRoomModifications(conversationId, { ...unresolved, corrections, retractions })
+          else this.emitUnresolvedChatModifications(conversationId, { ...unresolved, corrections, retractions })
+        }
+        const result = this.parseMAMResponse(response)
+        return {
+          ...result,
+          end: result.page.last || entries.at(-1)?.archiveId,
+          reachedEnd: boundaryIndex >= 0,
+        }
+      } finally { unregister() }
+    }
+    const latest = targets.some(target => target.refresh) ? await query(50, '') : undefined
+    for (const target of targets) target.refresh = false
+    for (const target of targets) {
+      const unresolved = () => target.isCurrent() && !target.message.isRetracted && !!target.message.correctionAlternatives?.length
+      if (!unresolved()) { target.traversal = undefined; continue }
+      if (!target.traversal) {
+        if (!latest?.end) continue
+        const candidates = [target.message, ...target.message.correctionAlternatives ?? []]
+        const missing = candidates.find(candidate => candidate.correctionRevision?.archiveTimestamp === undefined)
+        const anchor = (missing ?? target.message).correctionRevision?.ids.find(id => id.startsWith('stanza:'))?.slice(7)
+        let after = target.message.stanzaId
+        if (anchor) {
+          const previous = await query(1, anchor)
+          if (!previous.page.last && !previous.complete) continue
+          after = previous.page.last || undefined
+        } else if (!after) continue
+        if (after === latest.end) continue
+        target.traversal = { after, end: latest.end, cursors: new Set(after ? [after] : []), archiveOrder: new Map() }
+      }
+      const traversal = target.traversal
+      for (let page = 0; page < 2 && unresolved(); page++) {
+        const result = await query(50, undefined, traversal.after, traversal.archiveOrder, traversal.end)
+        const next = result.page.last
+        if (result.reachedEnd || result.complete || !next || next === traversal.after || traversal.cursors.has(next)) {
+          target.traversal = undefined
+          break
+        }
+        traversal.cursors.add(next)
+        traversal.after = next
+      }
+      if (!unresolved()) target.traversal = undefined
+    }
+  }
+
   /**
    * MAM module doesn't handle incoming stanzas directly.
    * Results are collected via temporary listeners during queries.
@@ -198,6 +438,8 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryArchive(options: HistoryQueryOptions): Promise<HistoryResult> {
+    const session = this.captureQuery()
+    const requestId = generateUUID()
     const { with: withJid, max = 50, before = '', start, end, after, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const conversationId = getBareJid(withJid)
     const mamStart = Date.now()
@@ -252,7 +494,7 @@ export class MAM extends BaseModule {
     let sawCoverageTop = false
     const maxAutoPages = isForwardPaginate ? maxAutoPagesOpt : MAM_BACKWARD_SIGNAL_RETRY_PAGES // cap to avoid infinite loops
 
-    this.deps.emitSDK('chat:history-loading', { conversationId, isLoading: true })
+    this.deps.emitSDK('chat:history-loading', { conversationId, requestId, isLoading: true })
 
     try {
       for (let page = 0; page < maxAutoPages; page++) {
@@ -302,7 +544,9 @@ export class MAM extends BaseModule {
           let response: Element
           try {
             response = await this.deps.sendIQ(iq)
+            session.assertCurrent()
           } catch (iqError) {
+            session.assertCurrent()
             if (page === 0 && after && isItemNotFoundError(iqError)) {
               // The archive no longer holds the after-anchor (expired/purged):
               // degrade to fetch-latest (spec §5 — degrade gracefully, never error).
@@ -314,6 +558,7 @@ export class MAM extends BaseModule {
               // start timestamp lets the next resume fall back to it and progress.
               this.deps.emitSDK('chat:history-anchor-purged', { conversationId, after })
               const degraded = await this.queryArchive({ with: withJid, max, before: '', preserveGapMarker })
+              session.assertCurrent()
               // Mark the result so callers (the catch-up orchestrator) can tell
               // this is ALREADY a fetch-latest page and skip issuing another one.
               return { ...degraded, degradedToFetchLatest: true }
@@ -325,6 +570,7 @@ export class MAM extends BaseModule {
               logInfo(`MAM before-cursor purged for ...@${getDomain(conversationId) || '*'} — degrading to fetch-latest`)
               this.deps.emitSDK('chat:history-coverage-purged', { conversationId, before: currentBefore })
               const degraded = await this.queryArchive({ with: withJid, max, before: '', preserveGapMarker })
+              session.assertCurrent()
               return { ...degraded, degradedToFetchLatest: true }
             }
             if (jumpedToFloor && preJumpCursor && coverageRecord && currentBefore === coverageRecord.bottomId && isItemNotFoundError(iqError)) {
@@ -341,13 +587,16 @@ export class MAM extends BaseModule {
             throw iqError
           }
           const { complete, page: pageInfo } = this.parseMAMResponse(response)
+          if (response.getChild('fin', NS_MAM)) this.observedArchives.set(JSON.stringify([false, conversationId]), session.isCurrent)
 
           // Drain the buffer: E2EE decrypt first (so modification bodies are
           // plaintext, not fallback hints), then modification detection, then parse.
+          const correctionStart = modifications.corrections.length
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
-            const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
-            await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
-            if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp, getBareJid(this.deps.getCurrentJid() ?? ''))) {
+            const forwardedDelayEl = forwarded.getChild('delay', NS_DELAY)
+            await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, delayStamp(forwardedDelayEl))
+            session.assertCurrent()
+            if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedDelayEl, getBareJid(this.deps.getCurrentJid() ?? ''), archiveId)) {
               continue
             }
             const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
@@ -357,6 +606,7 @@ export class MAM extends BaseModule {
           // Modifications are accumulated across pages and resolved once after
           // the loop (see the `modifications` declaration above) so a later
           // page's correction/reaction can still land on an earlier page's message.
+          if (!isForwardPaginate) modifications.corrections.unshift(...modifications.corrections.splice(correctionStart))
           allMessages.push(...collectedMessages)
           isComplete = complete
           lastPage = pageInfo
@@ -418,7 +668,9 @@ export class MAM extends BaseModule {
 
       // Resolve every collected modification against the full message set in a
       // single pass (so cross-page corrections/reactions land), then emit.
-      const unresolved = this.applyModifications(allMessages, modifications, chatMessageAuthor)
+      const unresolved = await this.applyModifications(allMessages, modifications, chatMessageAuthor, undefined, undefined,
+        (id, actor) => this.deps.stores?.chat.resolveCorrectionReferences?.(conversationId, id, actor))
+      session.assertCurrent()
 
       // Reported for BOTH directions: coverage never certifies over a walk whose
       // modification cache-writes are fire-and-forget, and that
@@ -428,6 +680,12 @@ export class MAM extends BaseModule {
         modifications.retractions.length + modifications.corrections.length +
         modifications.fastenings.length + modifications.reactions.length > 0
 
+      this.emitUnresolvedChatModifications(conversationId, { ...unresolved, fastenings: [], reactions: [] })
+      unresolved.corrections = []
+      unresolved.retractions = []
+      const reconciled = await this.deps.stores?.chat.reconcileHistoryMessages?.(allMessages)
+      session.assertCurrent()
+      if (reconciled) allMessages.splice(0, allMessages.length, ...reconciled)
       this.deps.emitSDK('chat:history-messages', {
         conversationId,
         messages: allMessages,
@@ -463,18 +721,20 @@ export class MAM extends BaseModule {
         })
       }
 
+      session.assertCurrent()
       return { messages: allMessages, complete: isComplete, page: lastPage }
     } catch (error) {
+      session.assertCurrent()
       const msg = error instanceof Error ? error.message : 'Unknown error'
       if (isConnectionError(error)) {
         logInfo(`MAM skipped: ...@${getDomain(conversationId) || '*'} — ${msg}`)
       } else {
         logErr(`MAM error: ...@${getDomain(conversationId) || '*'} — ${msg}`)
       }
-      this.deps.emitSDK('chat:history-error', { conversationId, error: msg })
+      this.deps.emitSDK('chat:history-error', { conversationId, requestId, error: msg })
       throw error
     } finally {
-      this.deps.emitSDK('chat:history-loading', { conversationId, isLoading: false })
+      if (session.isAccountCurrent()) this.deps.emitSDK('chat:history-loading', { conversationId, requestId, isLoading: false })
     }
   }
 
@@ -488,6 +748,8 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryRoomArchive(options: RoomHistoryQueryOptions): Promise<RoomHistoryResult> {
+    const session = this.captureQuery()
+    const requestId = generateUUID()
     const { roomJid, max = 50, before, after, start, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const roomMamStart = Date.now()
     // `after` alone (the XEP-0490 pointer-seed catch-up) selects forward mode
@@ -530,6 +792,7 @@ export class MAM extends BaseModule {
     // them ONCE after the loop (mirrors queryArchive's 1:1 batch model): a
     // signal on the first, signal-only page targets a message only fetched by
     // a later retry page — per-page resolution would drop it.
+    const forwardCorrectionOrder = new Map<string, Set<CorrectionOrderGroup>>()
     const backwardModifications: MAMModifications = { retractions: [], corrections: [], fastenings: [], reactions: [] }
     // Forward pages scope their modifications per page (see below), so the
     // walk-level fact has to be accumulated separately: the coverage bootstrap
@@ -540,7 +803,7 @@ export class MAM extends BaseModule {
     const room = this.deps.stores?.room.getRoom(roomJid)
     const myNickname = room?.nickname || ''
 
-    this.deps.emitSDK('room:history-loading', { roomJid, isLoading: true })
+    this.deps.emitSDK('room:history-loading', { roomJid, requestId, isLoading: true })
 
     try {
       for (let page = 0; page < maxAutoPages; page++) {
@@ -589,7 +852,9 @@ export class MAM extends BaseModule {
           let response: Element
           try {
             response = await this.deps.sendIQ(iq)
+            session.assertCurrent()
           } catch (iqError) {
+            session.assertCurrent()
             if (page === 0 && after && isItemNotFoundError(iqError)) {
               // The archive no longer holds the after-anchor (expired/purged):
               // degrade to fetch-latest (spec §5 — degrade gracefully, never error).
@@ -598,6 +863,7 @@ export class MAM extends BaseModule {
               // 1:1 twin in queryArchive for the full rationale.
               this.deps.emitSDK('room:history-anchor-purged', { roomJid, after })
               const degraded = await this.queryRoomArchive({ roomJid, max, before: '', preserveGapMarker })
+              session.assertCurrent()
               // Mark the result so callers (the catch-up orchestrator) can tell
               // this is ALREADY a fetch-latest page and skip issuing another one.
               return { ...degraded, degradedToFetchLatest: true }
@@ -609,6 +875,7 @@ export class MAM extends BaseModule {
               logInfo(`Room MAM before-cursor purged for ${roomJid} — degrading to fetch-latest`)
               this.deps.emitSDK('room:history-coverage-purged', { roomJid, before: currentBefore })
               const degraded = await this.queryRoomArchive({ roomJid, max, before: '', preserveGapMarker })
+              session.assertCurrent()
               return { ...degraded, degradedToFetchLatest: true }
             }
             if (jumpedToFloor && preJumpCursor && coverageRecord && currentBefore === coverageRecord.bottomId && isItemNotFoundError(iqError)) {
@@ -623,17 +890,22 @@ export class MAM extends BaseModule {
             throw iqError
           }
           const { complete, page: pageInfo } = this.parseMAMResponse(response)
+          if (response.getChild('fin', NS_MAM)) this.observedArchives.set(JSON.stringify([true, roomJid]), session.isCurrent)
 
           // Drain buffer: E2EE decrypt first, then modification detection, then parse.
+          const correctionStart = modifications.corrections.length
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
-            const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
-            await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, forwardedTimestamp)
-            if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp, roomJid)) {
+            const forwardedDelayEl = forwarded.getChild('delay', NS_DELAY)
+            await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, delayStamp(forwardedDelayEl))
+            session.assertCurrent()
+            if (this.collectModification(messageEl, modifications, (from) => from, forwardedDelayEl, roomJid, archiveId)) {
               continue
             }
             const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
             if (msg) collectedMessages.push(msg)
           }
+
+          if (!isForward) modifications.corrections.unshift(...modifications.corrections.splice(correctionStart))
 
           if (isForward) {
             forwardWalkCarriedModifications ||=
@@ -642,15 +914,21 @@ export class MAM extends BaseModule {
 
             // Apply modifications to collected messages (full JID comparison for rooms)
             // normalizeReactor extracts nick from full MUC JID for consistent reactor identifiers
-            const unresolved = this.applyModifications(
+            const unresolved = await this.applyModifications(
               collectedMessages, modifications,
               roomMessageAuthor,
-              (from) => getResource(from) || from
+              (from) => getResource(from) || from,
+              forwardCorrectionOrder,
+              (id, actor) => this.deps.stores?.room.resolveCorrectionReferences?.(roomJid, id, actor)
             )
+            session.assertCurrent()
 
             // Emit modifications targeting messages already in the store (from prior queries/cache)
             this.emitUnresolvedRoomModifications(roomJid, unresolved)
 
+            const reconciled = await this.deps.stores?.room.reconcileHistoryMessages?.(collectedMessages)
+            session.assertCurrent()
+            if (reconciled) collectedMessages.splice(0, collectedMessages.length, ...reconciled)
             allMessages.push(...collectedMessages)
 
             // Emit each page's messages immediately so the store can update incrementally
@@ -732,11 +1010,19 @@ export class MAM extends BaseModule {
       // leftovers target store-resident messages and are emitted after the
       // batch merge (same ordering as the 1:1 path).
       if (!isForward) {
-        const unresolved = this.applyModifications(
+        const unresolved = await this.applyModifications(
           allMessages, backwardModifications,
           roomMessageAuthor,
-          (from) => getResource(from) || from
+          (from) => getResource(from) || from, undefined,
+          (id, actor) => this.deps.stores?.room.resolveCorrectionReferences?.(roomJid, id, actor)
         )
+        session.assertCurrent()
+        this.emitUnresolvedRoomModifications(roomJid, { ...unresolved, fastenings: [], reactions: [] })
+        unresolved.corrections = []
+        unresolved.retractions = []
+        const reconciled = await this.deps.stores?.room.reconcileHistoryMessages?.(allMessages)
+        session.assertCurrent()
+        if (reconciled) allMessages.splice(0, allMessages.length, ...reconciled)
         this.deps.emitSDK('room:history-messages', {
           roomJid,
           messages: allMessages,
@@ -753,6 +1039,13 @@ export class MAM extends BaseModule {
             backwardModifications.fastenings.length + backwardModifications.reactions.length > 0,
         })
         this.emitUnresolvedRoomModifications(roomJid, unresolved)
+        session.assertCurrent()
+      }
+
+      if (isForward) {
+        const reconciled = await this.deps.stores?.room.reconcileHistoryMessages?.(allMessages)
+        session.assertCurrent()
+        if (reconciled) allMessages.splice(0, allMessages.length, ...reconciled)
       }
 
       logInfo(`Room MAM result: ${roomJid} → ${allMessages.length} msg(s), complete=${isComplete}, ${Date.now() - roomMamStart}ms`)
@@ -767,18 +1060,20 @@ export class MAM extends BaseModule {
         })
       }
 
+      session.assertCurrent()
       return { messages: allMessages, complete: isComplete, page: lastPage }
     } catch (error) {
+      session.assertCurrent()
       const msg = error instanceof Error ? error.message : 'Unknown error'
       if (isConnectionError(error)) {
         logInfo(`Room MAM skipped: ${roomJid} — ${msg}`)
       } else {
         logErr(`Room MAM error: ${roomJid} — ${msg}`)
       }
-      this.deps.emitSDK('room:history-error', { roomJid, error: msg })
+      this.deps.emitSDK('room:history-error', { roomJid, requestId, error: msg })
       throw error
     } finally {
-      this.deps.emitSDK('room:history-loading', { roomJid, isLoading: false })
+      if (session.isAccountCurrent()) this.deps.emitSDK('room:history-loading', { roomJid, requestId, isLoading: false })
     }
   }
 
@@ -797,6 +1092,7 @@ export class MAM extends BaseModule {
    * @returns Messages matching the query, with pagination info
    */
   async searchArchive(options: HistorySearchOptions): Promise<HistoryResult> {
+    const session = this.captureQuery()
     const { query, with: withJid, max = 20, before } = options
     const queryId = `mam_search_${generateUUID()}`
 
@@ -832,28 +1128,40 @@ export class MAM extends BaseModule {
     try {
       logInfo(`MAM search: query="${query}"${withJid ? `, with=${getBareJid(withJid)}` : ''}, max=${max}`)
       const response = await this.deps.sendIQ(iq)
+      session.assertCurrent()
       const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
       const currentJid = this.deps.getCurrentJid()
       const ownBareJid = currentJid ? getBareJid(currentJid) : ''
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
-        const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
+        const forwardedDelayEl = forwarded.getChild('delay', NS_DELAY)
         // Derive conversationId from the message's from/to
         const from = getBareJid(messageEl.attrs.from || '')
         const to = getBareJid(messageEl.attrs.to || '')
         const conversationId = from === ownBareJid ? to : from
-        await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
-        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp, ownBareJid)) {
+        await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, delayStamp(forwardedDelayEl))
+        session.assertCurrent()
+        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedDelayEl, ownBareJid, archiveId)) {
           continue
         }
         const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
         if (msg) collectedMessages.push(msg)
       }
 
-      this.applyModifications(collectedMessages, modifications, chatMessageAuthor)
+      const originalBodies = collectedMessages.map(message => message.body)
+      await this.applyModifications(collectedMessages, modifications, chatMessageAuthor, undefined, undefined,
+        (id, actor, messageEl) => this.deps.stores?.chat.resolveCorrectionReferences?.(
+          actor.actorJid === ownBareJid ? getBareJid(messageEl.attrs.to ?? '') : actor.actorJid, id, actor))
+      session.assertCurrent()
+      const reconciled = await this.deps.stores?.chat.reconcileHistoryMessages?.(collectedMessages)
+      session.assertCurrent()
+      collectedMessages.splice(0, collectedMessages.length, ...this.filterReconciledSearchMessages(originalBodies, reconciled ?? collectedMessages, query))
 
       logInfo(`MAM search result: ${collectedMessages.length} msg(s), complete=${complete}`)
       return { messages: collectedMessages, complete, page: pageInfo }
+    } catch (error) {
+      session.assertCurrent()
+      throw error
     } finally {
       unregister()
     }
@@ -866,6 +1174,7 @@ export class MAM extends BaseModule {
    * @returns Room messages matching the query, with pagination info
    */
   async searchRoomArchive(options: RoomHistorySearchOptions): Promise<RoomHistoryResult> {
+    const session = this.captureQuery()
     const { query, roomJid, max = 20, before } = options
     const queryId = `mam_rsearch_${generateUUID()}`
 
@@ -900,22 +1209,33 @@ export class MAM extends BaseModule {
     try {
       logInfo(`Room MAM search: query="${query}", room=${roomJid}, max=${max}`)
       const response = await this.deps.sendIQ(iq)
+      session.assertCurrent()
       const { complete, page: pageInfo } = this.parseMAMResponse(response)
 
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
-        const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
-        await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, forwardedTimestamp)
-        if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp, roomJid)) {
+        const forwardedDelayEl = forwarded.getChild('delay', NS_DELAY)
+        await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, delayStamp(forwardedDelayEl))
+        session.assertCurrent()
+        if (this.collectModification(messageEl, modifications, (from) => from, forwardedDelayEl, roomJid, archiveId)) {
           continue
         }
         const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
         if (msg) collectedMessages.push(msg)
       }
 
-      this.applyModifications(collectedMessages, modifications, roomMessageAuthor)
+      const originalBodies = collectedMessages.map(message => message.body)
+      await this.applyModifications(collectedMessages, modifications, roomMessageAuthor, undefined, undefined,
+        (id, actor) => this.deps.stores?.room.resolveCorrectionReferences?.(roomJid, id, actor))
+      session.assertCurrent()
+      const reconciled = await this.deps.stores?.room.reconcileHistoryMessages?.(collectedMessages)
+      session.assertCurrent()
+      collectedMessages.splice(0, collectedMessages.length, ...this.filterReconciledSearchMessages(originalBodies, reconciled ?? collectedMessages, query))
 
       logInfo(`Room MAM search result: ${collectedMessages.length} msg(s), complete=${complete}`)
       return { messages: collectedMessages, complete, page: pageInfo }
+    } catch (error) {
+      session.assertCurrent()
+      throw error
     } finally {
       unregister()
     }
@@ -935,6 +1255,7 @@ export class MAM extends BaseModule {
     options: HistoryPagingSearchOptions,
     signal?: AbortSignal
   ): Promise<HistoryResult> {
+    const session = this.captureQuery()
     const { query, with: withJid, end, maxPages = 20, maxResults = 50 } = options
     const parsed = parseSearchQuery(query)
     const phraseTokens = parsed.phrases.flatMap((p) => tokenize(p))
@@ -961,13 +1282,14 @@ export class MAM extends BaseModule {
         ...(page === 0 && end ? { end } : {}),
       })
 
+      session.assertCurrent()
       isComplete = result.complete
       lastPage = result.page
 
       // Match messages client-side
       for (const msg of result.messages) {
         if (matches.length >= maxResults) break
-        if (msg.body && this.matchesQuery(msg.body, allTokens, parsed.phrases)) {
+        if (!msg.isRetracted && msg.body && this.matchesQuery(msg.body, allTokens, parsed.phrases)) {
           matches.push(msg)
         }
       }
@@ -977,16 +1299,26 @@ export class MAM extends BaseModule {
 
       // Small delay between pages to avoid overwhelming the server
       await new Promise(resolve => setTimeout(resolve, 100))
+      session.assertCurrent()
     }
 
     logInfo(`MAM paging search result: scanned to find ${matches.length} match(es), complete=${isComplete}`)
+    session.assertCurrent()
     return { messages: matches, complete: isComplete, page: lastPage }
+  }
+
+  private filterReconciledSearchMessages<T extends Message | RoomMessage>(originalBodies: Array<string | undefined>, reconciled: T[], query: string): T[] {
+    const parsed = parseSearchQuery(query)
+    const tokens = [...new Set([...parsed.terms, ...parsed.phrases.flatMap(phrase => tokenize(phrase))])]
+    return reconciled.filter((message, index) => !message.isRetracted && (message.body === originalBodies[index] ||
+      this.matchesQuery(message.body ?? '', tokens, parsed.phrases)))
   }
 
   /**
    * Check if a message body matches all query tokens and exact phrases.
    */
   private matchesQuery(body: string, queryTokens: string[], phrases: string[] = []): boolean {
+    if (queryTokens.length === 0 && phrases.length === 0) return false
     const bodyLower = body.toLowerCase()
     const tokensMatch = queryTokens.every(token => bodyLower.includes(token))
     if (!tokensMatch) return false
@@ -1011,6 +1343,7 @@ export class MAM extends BaseModule {
     targetTimestamp: string,
     contextSize: number = 50
   ): Promise<{ messages: (Message | RoomMessage)[] }> {
+    const session = this.captureQuery()
     // Fetch messages before and after the target timestamp
     const oneHourBefore = new Date(new Date(targetTimestamp).getTime() - 3600000).toISOString()
 
@@ -1030,6 +1363,7 @@ export class MAM extends BaseModule {
         // silently inherit its MAM_ROOM_FORWARD_MAX_PAGES (50-page) default.
         maxAutoPages: 1,
       })
+      session.assertCurrent()
       return { messages: result.messages }
     } else {
       const result = await this.queryArchive({
@@ -1039,6 +1373,7 @@ export class MAM extends BaseModule {
         end: new Date(new Date(targetTimestamp).getTime() + 3600000).toISOString(),
         preserveGapMarker: true,
       })
+      session.assertCurrent()
       return { messages: result.messages }
     }
   }
@@ -1122,6 +1457,7 @@ export class MAM extends BaseModule {
    * @param options.concurrency - Maximum parallel requests (default: 3)
    */
   async refreshConversationPreviews(options: { concurrency?: number } = {}): Promise<void> {
+    const session = this.captureQuery()
     const { concurrency = 3 } = options
     const conversations = this.deps.stores?.chat.getAllConversations() || []
     if (conversations.length === 0) return
@@ -1137,10 +1473,11 @@ export class MAM extends BaseModule {
 
     await executeWithConcurrency(
       conversationIds,
-      (conversationId) => this.fetchPreviewForConversation(conversationId),
+      (conversationId) => session.isCurrent() ? this.fetchPreviewForConversation(conversationId) : Promise.resolve(),
       concurrency
     )
 
+    if (!session.isCurrent()) return
     logInfo(`Preview refresh complete for ${conversations.length} conversation(s)`)
   }
 
@@ -1157,6 +1494,7 @@ export class MAM extends BaseModule {
    * @param options.concurrency - Maximum parallel requests (default: 3)
    */
   async refreshArchivedConversationPreviews(options: { concurrency?: number } = {}): Promise<void> {
+    const session = this.captureQuery()
     const { concurrency = 3 } = options
     const archivedConversations = this.deps.stores?.chat.getArchivedConversations?.() || []
     if (archivedConversations.length === 0) return
@@ -1170,7 +1508,7 @@ export class MAM extends BaseModule {
 
     await executeWithConcurrency(
       conversationIds,
-      (conversationId) => this.fetchPreviewForConversation(conversationId, { unarchiveIfNewer: true }),
+      (conversationId) => session.isCurrent() ? this.fetchPreviewForConversation(conversationId, { unarchiveIfNewer: true }) : Promise.resolve(),
       concurrency
     )
   }
@@ -1658,6 +1996,7 @@ export class MAM extends BaseModule {
     conversationId: string,
     options: { unarchiveIfNewer?: boolean } = {}
   ): Promise<void> {
+    const session = this.captureQuery()
     try {
       const queryId = `preview_${generateUUID()}`
 
@@ -1695,16 +2034,19 @@ export class MAM extends BaseModule {
 
       try {
         const response = await this.deps.sendIQ(iq)
+        session.assertCurrent()
 
         let latestMessage: Message | null = null
         for (const { forwarded, messageEl, archiveId } of rawEntries) {
           const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
           await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
+          session.assertCurrent()
           const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
           if (msg) latestMessage = msg
         }
 
         const message = latestMessage
+        session.assertCurrent()
         if (response && message) {
           // For archived conversations: check if we should unarchive BEFORE updating preview
           // (updateLastMessagePreview uses shouldUpdateLastMessage internally)
@@ -1718,6 +2060,7 @@ export class MAM extends BaseModule {
           }
 
           // Update only the lastMessage preview, not the message history
+          session.assertCurrent()
           this.deps.stores?.chat.updateLastMessagePreview(conversationId, message)
         }
       } finally {
@@ -1740,6 +2083,7 @@ export class MAM extends BaseModule {
    * @param options.concurrency - Maximum parallel requests (default: 3)
    */
   async refreshRoomPreviews(options: { concurrency?: number } = {}): Promise<void> {
+    const session = this.captureQuery()
     const { concurrency = 3 } = options
     // Get all joined rooms (skip QuickChat rooms)
     const joinedRooms = this.deps.stores?.room.joinedRooms() || []
@@ -1759,13 +2103,14 @@ export class MAM extends BaseModule {
     const mamRoomJids = mamRooms.map((r) => r.jid)
     await executeWithConcurrency(
       mamRoomJids,
-      (roomJid) => this.fetchPreviewForRoom(roomJid),
+      (roomJid) => session.isCurrent() ? this.fetchPreviewForRoom(roomJid) : Promise.resolve(),
       concurrency
     )
 
     // For non-MAM rooms: load preview from cache to populate lastMessage
     // This only updates lastMessage without modifying the messages array
     for (const room of nonMamRooms) {
+      if (!session.isCurrent()) return
       if (!room.lastMessage) {
         await this.deps.stores?.room.loadPreviewFromCache(room.jid)
       }
@@ -1782,10 +2127,12 @@ export class MAM extends BaseModule {
    * @param roomJid - The bare JID of the room
    */
   async fetchPreviewForRoom(roomJid: string): Promise<void> {
+    const session = this.captureQuery()
     try {
       // Cache-first: try loading preview from IndexedDB before making a network query.
       // The delayed background room catch-up will correct the preview later if stale.
       const cached = await this.deps.stores?.room.loadPreviewFromCache(roomJid)
+      session.assertCurrent()
       if (cached) return
 
       const queryId = `preview_${generateUUID()}`
@@ -1821,6 +2168,7 @@ export class MAM extends BaseModule {
 
       try {
         const response = await this.deps.sendIQ(iq)
+        session.assertCurrent()
         if (response && latestMessage) {
           // Update only the lastMessage preview, not the message history
           this.deps.stores?.room.updateLastMessagePreview(roomJid, latestMessage)
@@ -1891,7 +2239,9 @@ export class MAM extends BaseModule {
     queryId: string,
     onMessage: (forwarded: Element, messageEl: Element, archiveId?: string) => void
   ): (stanza: Element) => void {
+    const session = this.captureQuery()
     return (stanza: Element) => {
+      if (!session.isCurrent()) return
       // Skip error stanzas - server may return error with stale MAM result inside
       if (stanza.attrs.type === 'error') return
 
@@ -1905,33 +2255,31 @@ export class MAM extends BaseModule {
       if (!messageEl) return
 
       // The <result id="..."> is the MAM archive ID — stable and unique per message
+      this.correctionReceipts.observe(messageEl, true, result.attrs.id)
       onMessage(forwarded, messageEl, result.attrs.id)
     }
   }
 
   /**
-   * Check for and collect modifications (retractions, corrections, fastenings, reactions).
-   * Returns true if the message was a modification (not a regular message).
-   */
-  /**
    * Extract the XEP-0203 delay timestamp from a MAM <forwarded> wrapper.
    * Returns undefined if no delay stamp is present.
    */
   private extractForwardedTimestamp(forwarded: Element): Date | undefined {
-    const delayEl = forwarded.getChild('delay', NS_DELAY)
-    const stamp = delayEl?.attrs.stamp
-    return stamp ? new Date(stamp) : undefined
+    return delayStamp(forwarded.getChild('delay', NS_DELAY))
   }
 
+  /** Collect modifications instead of treating them as standalone messages. */
   private collectModification(
     messageEl: Element,
     modifications: MAMModifications,
     normalizeFrom: (from: string) => string,
-    timestamp?: Date,
-    expectedStanzaIdBy?: string
+    delayEl?: Element,
+    expectedStanzaIdBy?: string,
+    archiveId?: string
   ): boolean {
     const from = messageEl.attrs.from
     if (!from) return false
+    const timestamp = delayStamp(delayEl)
 
     // Retraction
     const retraction = parseRetractionSignal(messageEl)
@@ -1953,7 +2301,9 @@ export class MAM extends BaseModule {
         // the corrected version's archive entry can resolve to the original message.
         // XEP-0359: prefer the id stamped by the queried archive (own bare JID
         // for 1:1, room JID for MUC) so it is a valid cross-client reference.
-        const correctionStanzaId = parseStanzaId(messageEl, expectedStanzaIdBy)
+        const correctionStanzaId = parseStanzaId(messageEl, expectedStanzaIdBy) || archiveId
+        const revisionStanzaId = parseArchiveStanzaId(messageEl, expectedStanzaIdBy) || archiveId
+        const authoredAt = readStashedAuthoredAt(messageEl)
         modifications.corrections.push({
           targetId: correction.targetId,
           from: normalizeFrom(from),
@@ -1961,6 +2311,9 @@ export class MAM extends BaseModule {
           body: bodyText,
           messageEl,
           correctionStanzaId,
+          revisionStanzaId,
+          ...(delayEl && { delayEl }),
+          ...(authoredAt && { authoredAt }),
         })
       }
       return true
@@ -1988,9 +2341,6 @@ export class MAM extends BaseModule {
     return false
   }
 
-  /**
-   * Apply collected modifications to messages.
-   */
   /**
    * The one target an in-page modification names, through the shared ladder.
    *
@@ -2021,17 +2371,89 @@ export class MAM extends BaseModule {
     return resolution.authoritative ? resolution.candidates[0].message : undefined
   }
 
-  private applyModifications<T extends Message | RoomMessage>(
+  private resolveCorrectionReferenceTarget<T extends Message | RoomMessage>(
+    messages: T[], references: CorrectionReferences, actor: MessageActor, isAuthor: (message: T, actor: MessageActor) => boolean,
+  ): T | undefined {
+    const identity = references.identity
+    const matches = messages.filter(message => isAuthor(message, actor) &&
+      identity.roomJid === ('roomJid' in message ? message.roomJid : undefined) &&
+      identity.conversationId === ('conversationId' in message ? message.conversationId : undefined) &&
+      !archiveIdentityConflict(message, identity) &&
+      sameLogicalMessage('roomJid' in message ? roomScope(message.roomJid) : CHAT_SCOPE, message, identity))
+    return matches.length === 1 ? matches[0] : undefined
+  }
+
+  private async applyModifications<T extends Message | RoomMessage>(
     messages: T[],
     modifications: MAMModifications,
     isAuthor: (msg: T, actor: MessageActor) => boolean,
-    normalizeReactor?: (from: string) => string
-  ): UnresolvedModifications {
+    normalizeReactor?: (from: string) => string,
+    archiveOrder = new Map<string, Set<CorrectionOrderGroup>>(),
+    lookupReferences?: (targetId: string, actor: MessageActor, messageEl: Element) => Promise<CorrectionReferences | null | undefined> | undefined,
+  ): Promise<UnresolvedModifications> {
+    const session = this.captureQuery()
     const unresolved: UnresolvedModifications = {
       retractions: [],
       corrections: [],
       fastenings: [],
       reactions: [],
+    }
+
+    // Apply corrections
+    for (const correction of modifications.corrections) {
+      const actor: MessageActor = { actorJid: correction.from, actorOccupantId: correction.occupantId }
+      // Corrections accept the sender's XEP-0359 identity claim only when the same author owns the target.
+      const resolution = resolveMessageReference(messages, correction.targetId, 'archive-first')
+      const candidates = resolution?.candidates.filter(({ message }) => isAuthor(message, actor)) ?? []
+      let target: T | undefined = candidates[0]?.message
+      if (!target && resolution?.authoritative) continue
+      const resolved = target ? candidates.length === 1 ? correctionReferences(target) : null
+        : await lookupReferences?.(correction.targetId, actor, correction.messageEl)
+      session.assertCurrent()
+      if (!target && resolved) target = this.resolveCorrectionReferenceTarget(messages, resolved, actor, isAuthor)
+      const data = this.correctionUpdates(target, correction)
+      const revision = data.correctionRevision
+      const author = correction.occupantId ? [getBareJid(correction.from), correction.occupantId] : correction.from
+      const keys = resolved === null ? [] : (resolved?.references ?? [correction.targetId]).map(reference => JSON.stringify([reference, author]))
+      const groups = [...new Set(keys.flatMap(key => [...(archiveOrder.get(key) ?? [])]))].filter(group => {
+        if (!resolved || !group.identity) return true
+        return !archiveIdentityConflict(resolved.identity, group.identity) &&
+          !occupantConflict(resolved.identity, group.identity) &&
+          resolved.identity.roomJid === group.identity.roomJid &&
+          resolved.identity.conversationId === group.identity.conversationId
+      })
+      const group = groups.length === 1 ? groups[0] : undefined
+      const previous = group?.revision
+      if (revision && resolved !== null) {
+        if (previous && revision.archiveTimestamp !== undefined && revision.archiveTimestamp === previous.archiveTimestamp &&
+            !sameCorrection({ correctionRevision: revision }, { correctionRevision: previous })) {
+          correction.archivePredecessor = previous
+          Object.assign(revision, withCorrectionPredecessor(revision, previous))
+        }
+        for (const reference of [correction.correctionStanzaId, correction.revisionStanzaId]) {
+          if (reference) keys.push(JSON.stringify([reference, author]))
+        }
+        const ordered: CorrectionOrderGroup = group ?? { revision }
+        ordered.revision = revision
+        if (resolved) ordered.identity = {
+          ...resolved.identity,
+          stanzaId: resolved.identity.stanzaId ?? ordered.identity?.stanzaId,
+          originId: resolved.identity.originId ?? ordered.identity?.originId,
+          occupantId: resolved.identity.occupantId ?? ordered.identity?.occupantId,
+        }
+        for (const key of keys) {
+          const matches = archiveOrder.get(key) ?? new Set<CorrectionOrderGroup>()
+          matches.add(ordered)
+          archiveOrder.set(key, matches)
+        }
+      }
+      if (target) {
+        const updates = resolveCorrectionUpdates(target, data)
+        if (updates) Object.assign(target, updates)
+        unresolved.corrections.push(correction)
+      } else if (!target) {
+        unresolved.corrections.push(correction)
+      }
     }
 
     // Apply retractions
@@ -2044,39 +2466,10 @@ export class MAM extends BaseModule {
         if (retractionData) {
           target.isRetracted = retractionData.isRetracted
           target.retractedAt = retractionData.retractedAt
+          unresolved.retractions.push(retraction)
         }
       } else {
         unresolved.retractions.push(retraction)
-      }
-    }
-
-    // Apply corrections
-    for (const correction of modifications.corrections) {
-      const actor: MessageActor = { actorJid: correction.from, actorOccupantId: correction.occupantId }
-      // Corrections accept the sender's XEP-0359 identity claim only when the same author owns the target.
-      const target = this.resolveModificationTarget(messages, correction.targetId, 'archive-first', (m) => isAuthor(m, actor))
-      if (target && isAuthor(target, actor)) {
-        const correctionData = applyCorrection(
-          correction.messageEl,
-          correction.body,
-          target.originalBody ?? target.body
-        )
-        target.body = correctionData.body
-        target.isEdited = correctionData.isEdited
-        target.originalBody = correctionData.originalBody
-        if (correctionData.attachment) {
-          target.attachment = correctionData.attachment
-        }
-        // Carry the correction's ciphertext onto the target (or clear a stale
-        // original one) so a deferred retry recovers the corrected text, not
-        // the original. See CorrectionResult.encryptedPayload.
-        target.encryptedPayload = correctionData.encryptedPayload
-        // Track the correction's stanza-id so replies referencing it can resolve
-        if (correction.correctionStanzaId) {
-          ;(target as MessageImplState).correctionStanzaIds = [...(getCorrectionStanzaIds(target) ?? []), correction.correctionStanzaId]
-        }
-      } else if (!target) {
-        unresolved.corrections.push(correction)
       }
     }
 
@@ -2140,9 +2533,40 @@ export class MAM extends BaseModule {
   }
 
   /**
-   * Emit unresolved chat modifications as store events.
-   * These target messages already in the store (from previous queries or cache).
+   * Content and provenance for an archived XEP-0308 correction. The caller
+   * selects content through resolveCorrectionUpdates at the target boundary.
+   *
+   * A superseded correction still contributes its stanza-id: a reply or
+   * retraction may name the superseded revision's archive entry and must keep
+   * resolving. Store events omit `target` so the store resolves against its
+   * current row, which may differ from the fetched page.
    */
+  private correctionUpdates(
+    target: Message | RoomMessage | undefined,
+    correction: UnresolvedModifications['corrections'][number],
+  ): Partial<StoredMessage> & Partial<StoredRoomMessage> {
+    const correctionData = applyCorrection(
+      correction.messageEl,
+      correction.body,
+      target?.originalBody ?? target?.body ?? '',
+      {
+        archiveId: correction.revisionStanzaId,
+        ...(correction.delayEl && { delayEl: correction.delayEl }),
+        ...(correction.authoredAt && { authoredAt: correction.authoredAt }),
+      },
+    )
+    if (correctionData.correctionRevision && correction.archivePredecessor) {
+      correctionData.correctionRevision = withCorrectionPredecessor(correctionData.correctionRevision, correction.archivePredecessor)
+    }
+    const existingIds = target ? getCorrectionStanzaIds(target) : undefined
+    let correctionStanzaIds = correction.correctionStanzaId
+      ? withCorrectionStanzaId(existingIds, correction.correctionStanzaId)
+      : existingIds
+    if (correction.revisionStanzaId) correctionStanzaIds = withCorrectionStanzaId(correctionStanzaIds, correction.revisionStanzaId)
+    if (correctionStanzaIds?.length) correctionData.correctionStanzaIds = correctionStanzaIds
+    return this.correctionReceipts.withOrder(correction.messageEl, correctionData)
+  }
+
   private emitUnresolvedChatModifications(
     conversationId: string,
     unresolved: UnresolvedModifications
@@ -2156,28 +2580,8 @@ export class MAM extends BaseModule {
     }
 
     for (const correction of unresolved.corrections) {
-      // Read the original body from the cached message in the store
-      const cachedMessage = this.deps.stores?.chat.getMessage(conversationId, correction.targetId)
-      const originalBody = cachedMessage?.originalBody ?? cachedMessage?.body ?? ''
-      const correctionData = applyCorrection(correction.messageEl, correction.body, originalBody)
-      const existingIds = (cachedMessage ? getCorrectionStanzaIds(cachedMessage) : undefined) ?? []
-      const correctionStanzaIds = correction.correctionStanzaId
-        ? [...existingIds, correction.correctionStanzaId]
-        : existingIds.length > 0 ? existingIds : undefined
-      this.deps.emitSDK('chat:message-updated', {
-        conversationId,
-        messageId: correction.targetId,
-        updates: {
-          body: correctionData.body,
-          isEdited: correctionData.isEdited,
-          originalBody: correctionData.originalBody,
-          ...(correctionData.attachment ? { attachment: correctionData.attachment } : {}),
-          ...(correctionStanzaIds ? { correctionStanzaIds } : {}),
-          // Stamp/clear the correction's ciphertext so a deferred retry
-          // recovers the corrected text, not the stale original.
-          encryptedPayload: correctionData.encryptedPayload,
-        },
-      })
+      const updates = this.correctionUpdates(undefined, correction)
+      this.deps.emitSDK('chat:message-updated', { conversationId, messageId: correction.targetId, updates, correctionActor: { actorJid: correction.from }, onCorrectionResolved: this.correctionCompletion(conversationId, false) })
     }
 
     for (const fastening of unresolved.fastenings) {
@@ -2203,10 +2607,6 @@ export class MAM extends BaseModule {
     }
   }
 
-  /**
-   * Emit unresolved room modifications as store events.
-   * These target messages already in the store (from previous queries or cache).
-   */
   private emitUnresolvedRoomModifications(
     roomJid: string,
     unresolved: UnresolvedModifications
@@ -2221,29 +2621,8 @@ export class MAM extends BaseModule {
     }
 
     for (const correction of unresolved.corrections) {
-      // Read the original body from the cached message in the store
-      const cachedMessage = this.deps.stores?.room.getMessage(roomJid, correction.targetId)
-      const originalBody = cachedMessage?.originalBody ?? cachedMessage?.body ?? ''
-      const correctionData = applyCorrection(correction.messageEl, correction.body, originalBody)
-      // Accumulate correction stanza-ids for reply lookup
-      const existingIds = (cachedMessage ? getCorrectionStanzaIds(cachedMessage) : undefined) ?? []
-      const correctionStanzaIds = correction.correctionStanzaId
-        ? [...existingIds, correction.correctionStanzaId]
-        : existingIds.length > 0 ? existingIds : undefined
-      this.deps.emitSDK('room:message-updated', {
-        roomJid,
-        messageId: correction.targetId,
-        updates: {
-          body: correctionData.body,
-          isEdited: correctionData.isEdited,
-          originalBody: correctionData.originalBody,
-          ...(correctionData.attachment ? { attachment: correctionData.attachment } : {}),
-          ...(correctionStanzaIds ? { correctionStanzaIds } : {}),
-          // Stamp/clear the correction's ciphertext so a deferred retry
-          // recovers the corrected text, not the stale original.
-          encryptedPayload: correctionData.encryptedPayload,
-        },
-      })
+      const updates = this.correctionUpdates(undefined, correction)
+      this.deps.emitSDK('room:message-updated', { roomJid, messageId: correction.targetId, updates, correctionActor: { actorJid: correction.from, actorOccupantId: correction.occupantId }, onCorrectionResolved: this.correctionCompletion(roomJid, true) })
     }
 
     for (const fastening of unresolved.fastenings) {
@@ -2298,6 +2677,7 @@ export class MAM extends BaseModule {
     peer: string,
     archiveTimestamp?: Date,
   ): Promise<void> {
+    const session = this.captureQuery()
     const manager = this.deps.getE2EEManager?.()
     if (!manager) {
       // No E2EE manager yet (archive replayed before E2EE init). Mirror the
@@ -2316,10 +2696,17 @@ export class MAM extends BaseModule {
     // is self-outgoing so the plugin can flip its envelope checks.
     const ownBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const { isSelfOutgoing } = deriveConversationContext(messageEl, ownBareJid)
-    await decryptStanzaInPlace(messageEl, manager, peer, 'archive', {
-      isSelfOutgoing,
-      archiveTimestamp,
-    })
+    this.correctionReceipts.observe(messageEl, true)
+    const finish = this.correctionReceipts.begin(messageEl)
+    try {
+      await decryptStanzaInPlace(messageEl, manager, peer, 'archive', {
+        isSelfOutgoing,
+        archiveTimestamp,
+      })
+      session.assertCurrent()
+    } finally {
+      finish()
+    }
   }
 
   /**
@@ -2544,6 +2931,7 @@ export class MAM extends BaseModule {
    * @returns The message if found, or null
    */
   async fetchRoomMessageById(roomJid: string, messageId: string): Promise<RoomMessage | null> {
+    const session = this.captureQuery()
     // Check store first — getMessage checks both id and stanzaId
     const existing = this.deps.stores?.room.getMessage(roomJid, messageId)
     if (existing) return existing
@@ -2575,6 +2963,7 @@ export class MAM extends BaseModule {
 
     try {
       await this.deps.sendIQ(iq)
+      if (!session.isCurrent()) return null
     } catch {
       // MAM query failed — server may not support {ids} filter
       return null
@@ -2585,7 +2974,13 @@ export class MAM extends BaseModule {
     let result: RoomMessage | null = null
     if (rawEntry) {
       const { forwarded, messageEl, archiveId } = rawEntry as RawArchiveEntry
-      await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, this.extractForwardedTimestamp(forwarded))
+      try {
+        await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, this.extractForwardedTimestamp(forwarded))
+      } catch (error) {
+        if (!session.isCurrent()) return null
+        throw error
+      }
+      if (!session.isCurrent()) return null
       result = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
     }
 
@@ -2600,6 +2995,6 @@ export class MAM extends BaseModule {
       })
     }
 
-    return result
+    return session.isCurrent() ? result : null
   }
 }

--- a/packages/fluux-sdk/src/core/modules/MUC.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.whisper.test.ts
@@ -551,6 +551,8 @@ describe('MUC Whispers', () => {
         message: expect.objectContaining({ body: 'corrected but orphaned', isPrivate: true }),
       }))
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+      expect(emitSDKSpy.mock.calls.filter(([event]: unknown[]) => event === 'room:whisper')).toHaveLength(1)
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message', expect.anything())
     })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -80,7 +80,7 @@ describe('messagingUtils', () => {
       expect(result.attachment).toBeUndefined()
     })
 
-    it('should handle correction with timestamp from delay element', () => {
+    it('dates the revision from the correction stanza delay', () => {
       const messageEl = createMockElement('message', { id: 'msg-1' }, [
         { name: 'body', text: 'Corrected text' },
         { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2024-01-15T10:00:00Z' } },
@@ -88,9 +88,44 @@ describe('messagingUtils', () => {
 
       const result = applyCorrection(messageEl, 'Corrected text', 'Original text')
 
-      // applyCorrection doesn't return timestamp, that's part of the message metadata
       expect(result.body).toBe('Corrected text')
       expect(result.isEdited).toBe(true)
+      expect(result.correctionTimestamp).toBe(Date.parse('2024-01-15T10:00:00Z'))
+    })
+
+    it('dates the revision from the envelope delay over the stanza own delay', () => {
+      const messageEl = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Corrected text' },
+        { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2024-01-15T10:00:00Z' } },
+      ])
+      const delayEl = createMockElement('delay', { xmlns: 'urn:xmpp:delay', stamp: '2024-01-15T11:00:00Z' })
+
+      const result = applyCorrection(messageEl, 'Corrected text', 'Original text', { delayEl })
+
+      expect(result.correctionTimestamp).toBe(Date.parse('2024-01-15T11:00:00Z'))
+    })
+
+    it('dates the revision from the signed authored-at, which a server cannot rewrite', () => {
+      const messageEl = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Corrected text' },
+        { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2024-01-15T10:00:00Z' } },
+      ])
+      const authoredAt = new Date('2024-01-15T09:30:00Z')
+
+      const result = applyCorrection(messageEl, 'Corrected text', 'Original text', { authoredAt })
+
+      expect(result.correctionTimestamp).toBe(authoredAt.getTime())
+      expect(result.correctionTimestampSource).toBe('authored')
+      expect(result.correctionRevision?.archiveTimestamp).toBe(Date.parse('2024-01-15T10:00:00Z'))
+    })
+
+    it('leaves an undated correction without a revision key', () => {
+      const messageEl = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Corrected text' },
+      ])
+
+      expect(applyCorrection(messageEl, 'Corrected text', 'Original text').correctionTimestamp)
+        .toBeUndefined()
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -9,6 +9,7 @@
  * @internal
  */
 
+import type { MessageImplState } from '../types/message-internal'
 import { Element, xml } from '@xmpp/client'
 import { getBareJid } from '../jid'
 import { readStashedEncryptedPayload } from '../e2ee/stanzaDecrypt'
@@ -257,14 +258,8 @@ export function parseOobData(stanza: Element): FileAttachment | undefined {
 export function parseStanzaId(messageEl: Element, expectedBy?: string): string | undefined {
   const stanzaIdEls = messageEl.getChildren('stanza-id', NS_STANZA_ID)
 
-  if (expectedBy) {
-    const expectedBare = getBareJid(expectedBy)
-    for (const el of stanzaIdEls) {
-      if (el.attrs.id && el.attrs.by && getBareJid(el.attrs.by) === expectedBare) {
-        return el.attrs.id
-      }
-    }
-  }
+  const archiveId = parseArchiveStanzaId(messageEl, expectedBy)
+  if (archiveId) return archiveId
 
   // Fallback: first stanza-id carrying an id (legacy single-archive behaviour).
   for (const el of stanzaIdEls) {
@@ -275,6 +270,14 @@ export function parseStanzaId(messageEl: Element, expectedBy?: string): string |
   return undefined
 }
 
+export function parseArchiveStanzaId(messageEl: Element, expectedBy?: string): string | undefined {
+  if (!expectedBy) return undefined
+  const expectedBare = getBareJid(expectedBy)
+  return messageEl.getChildren('stanza-id', NS_STANZA_ID).find(el =>
+    el.attrs.id && el.attrs.by && getBareJid(el.attrs.by) === expectedBare
+  )?.attrs.id
+}
+
 /**
  * Parse XEP-0359 origin-id from a message element.
  * Returns the sender-assigned stable ID (if the sender supports XEP-0359).
@@ -282,6 +285,12 @@ export function parseStanzaId(messageEl: Element, expectedBy?: string): string |
 export function parseOriginId(messageEl: Element): string | undefined {
   const originIdEl = messageEl.getChild('origin-id', NS_STANZA_ID)
   return originIdEl?.attrs.id
+}
+
+export function parseCorrectionIds(messageEl: Element, expectedBy?: string, archiveId?: string): string[] {
+  const originId = parseOriginId(messageEl)
+  const stanzaId = parseArchiveStanzaId(messageEl, expectedBy) ?? archiveId
+  return [...(messageEl.attrs.id ? [`id:${messageEl.attrs.id}`] : []), ...(originId ? [`origin:${originId}`] : []), ...(stanzaId ? [`stanza:${stanzaId}`] : [])]
 }
 
 /**
@@ -324,13 +333,23 @@ export interface ParseMessageContentOptions {
    * the room bare JID for MUC. Omit to keep first-match behaviour.
    */
   expectedStanzaIdBy?: string
+  archiveId?: string
 }
 
 /**
- * Result from parseMessageContent
+ * Where {@link ParsedMessageContent.timestamp} came from. `received` means no
+ * date rode with the stanza and the local clock was used — a value that must
+ * not be compared against server-dated timestamps from other devices.
  */
+export type MessageTimestampSource = 'authored' | 'delay' | 'received'
+
+/** Result from parseMessageContent. */
 export interface ParsedMessageContent {
   timestamp: Date
+  timestampSource: MessageTimestampSource
+  archiveTimestamp?: number
+  correctionIds: string[]
+  correctionLegacyStanzaIds?: string[]
   isDelayed: boolean
   stanzaId?: string
   originId?: string
@@ -354,21 +373,25 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
     preserveFullReplyToJid = false,
     authoredAt,
     expectedStanzaIdBy,
+    archiveId,
   } = options
 
   const fallbackTargets = messageContext === 'room' ? ROOM_FALLBACK_TARGETS : CHAT_FALLBACK_TARGETS
 
   // XEP-0203: Parse timestamp from delay element
   let timestamp = new Date()
+  let timestampSource: MessageTimestampSource = 'received'
   let isDelayed = forceDelayed
   const delay = delayEl || messageEl.getChild('delay', NS_DELAY)
   if (delay) {
     const stamp = delay.attrs.stamp
     if (stamp) {
       timestamp = new Date(stamp)
+      timestampSource = 'delay'
       isDelayed = true
     }
   }
+  const archiveTimestamp = timestampSource === 'delay' && Number.isFinite(timestamp.getTime()) ? timestamp.getTime() : undefined
   // E2EE in-envelope timestamp (e.g. XEP-0373 §4.1 `<time/>`) is sender-
   // attested and signed inside the ciphertext — more trustworthy than
   // `<delay/>`, which an intermediate server can rewrite. When present,
@@ -377,6 +400,7 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
   // source (a live MAM catch-up arrival is still "delayed").
   if (authoredAt) {
     timestamp = authoredAt
+    timestampSource = 'authored'
   }
 
   // XEP-0359: Unique stanza ID (server-assigned) and origin ID (sender-assigned).
@@ -384,6 +408,7 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
   // it is valid as a MAM pagination cursor and cross-client reference.
   const stanzaId = parseStanzaId(messageEl, expectedStanzaIdBy)
   const originId = parseOriginId(messageEl)
+  const correctionStanzaId = parseArchiveStanzaId(messageEl, expectedStanzaIdBy) ?? archiveId
 
   // XEP-0393: Message styling hints
   const noStyling = !!messageEl.getChild('no-styling', 'urn:xmpp:styling:0')
@@ -425,6 +450,10 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
 
   return {
     timestamp,
+    timestampSource,
+    archiveTimestamp,
+    correctionIds: parseCorrectionIds(messageEl, expectedStanzaIdBy, archiveId),
+    ...(stanzaId && stanzaId !== correctionStanzaId && { correctionLegacyStanzaIds: [stanzaId] }),
     isDelayed,
     stanzaId,
     originId,
@@ -490,10 +519,22 @@ export function applyRetraction(senderMatches: boolean): RetractionResult | null
   }
 }
 
+export function correctionMarks(parsed: ParsedMessageContent): MessageImplState & { isEdited: true } {
+  const dated = parsed.timestampSource !== 'received' && Number.isFinite(parsed.timestamp.getTime())
+  return {
+    isEdited: true,
+    correctionTimestamp: dated ? parsed.timestamp.getTime() : undefined,
+    correctionTimestampSource: dated ? parsed.timestampSource as 'authored' | 'delay' : undefined,
+    correctionRevision: { ids: parsed.correctionIds, supersedes: [], archiveTimestamp: parsed.archiveTimestamp,
+      ...(parsed.correctionLegacyStanzaIds && { legacyStanzaIds: parsed.correctionLegacyStanzaIds }),
+    },
+  }
+}
+
 /**
  * Result of applying a correction to a message.
  */
-export interface CorrectionResult {
+export interface CorrectionResult extends MessageImplState {
   body: string
   isEdited: true
   originalBody: string
@@ -520,17 +561,28 @@ export interface CorrectionResult {
  * @param messageEl - The correction message element
  * @param body - The new body text
  * @param originalBody - The original body text (before any corrections)
+ * @param options - Envelope date sources: the `<delay>` of a wrapping carbon or
+ *   MAM `<forwarded>`, and the sender-signed in-envelope authored-at of an
+ *   encrypted correction. Resolved by {@link parseMessageContent}.
  * @returns Correction data to apply
  */
 export function applyCorrection(
   messageEl: Element,
   body: string,
-  originalBody: string
+  originalBody: string,
+  options: { delayEl?: Element; authoredAt?: Date; expectedStanzaIdBy?: string; archiveId?: string } = {},
 ): CorrectionResult {
-  const parsed = parseMessageContent({ messageEl, body })
+  const parsed = parseMessageContent({
+    messageEl,
+    body,
+    ...(options.delayEl && { delayEl: options.delayEl }),
+    ...(options.authoredAt && { authoredAt: options.authoredAt }),
+    expectedStanzaIdBy: options.expectedStanzaIdBy,
+    archiveId: options.archiveId,
+  })
   return {
     body: parsed.processedBody,
-    isEdited: true,
+    ...correctionMarks(parsed),
     originalBody,
     ...(parsed.attachment && { attachment: parsed.attachment }),
     // Always present (string when the correction is still encrypted, undefined

--- a/packages/fluux-sdk/src/core/modules/reactionsLiveFlag.test.ts
+++ b/packages/fluux-sdk/src/core/modules/reactionsLiveFlag.test.ts
@@ -10,16 +10,11 @@ import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Chat } from './Chat'
 import { MAM } from './MAM'
-import type { MAM as MAMType } from './MAM'
 import type { ModuleDependencies } from './BaseModule'
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-function stubMAM(): MAMType {
-  return {} as unknown as MAMType
-}
 
 /** Minimal deps that capture emitSDK calls. */
 function makeDeps(jid: string): {
@@ -178,7 +173,7 @@ describe('reaction event isLive flag', () => {
     beforeEach(() => {
       const built = makeDeps(ME)
       emitted = built.emitted
-      chat = new Chat(built.deps, stubMAM())
+      chat = new Chat(built.deps, new MAM(built.deps))
     })
 
     it('emits chat:reactions with isLive: true for an incoming live reaction', () => {

--- a/packages/fluux-sdk/src/core/storeBindingKeys.ts
+++ b/packages/fluux-sdk/src/core/storeBindingKeys.ts
@@ -68,6 +68,8 @@ export const chatBindingMethodKeys = [
   // XEP-0313: MAM support
   'setMAMLoading',
   'setMAMError',
+  'resolveCorrectionReferences',
+  'reconcileHistoryMessages',
   'mergeMAMMessages',
   'getMAMQueryState',
   'resetMAMStates',
@@ -145,6 +147,8 @@ export const roomBindingMethodKeys = [
   // XEP-0313: MAM support for MUC rooms
   'setRoomMAMLoading',
   'setRoomMAMError',
+  'resolveCorrectionReferences',
+  'reconcileHistoryMessages',
   'mergeRoomMAMMessages',
   'getRoomMAMQueryState',
   'resetRoomMAMStates',

--- a/packages/fluux-sdk/src/core/types/message-internal.test.ts
+++ b/packages/fluux-sdk/src/core/types/message-internal.test.ts
@@ -7,7 +7,7 @@
  * shape lives in exactly one place.
  */
 import { describe, it, expect } from 'vitest'
-import { isNoLocalStore, getCorrectionStanzaIds, type StoredMessage } from './message-internal'
+import { isNoLocalStore, getCorrectionStanzaIds, compareCorrectionRevisions, resolveCorrectionUpdates, type StoredMessage } from './message-internal'
 import type { Message } from './chat'
 
 const baseMessage: Message = {
@@ -55,5 +55,204 @@ describe('public message type surface', () => {
     // @ts-expect-error correctionStanzaIds is internal impl-state, not on public Message
     void m.correctionStanzaIds
     expect(m).toBeDefined()
+  })
+})
+
+
+describe('correction receive evidence', () => {
+  const correction = (id: string, sequence: number, session = 'stream-one'): StoredMessage => ({
+    ...baseMessage, body: id, isEdited: true, liveCorrection: true,
+    correctionRevision: { ids: [`stanza:${id}`], supersedes: [], receiveOrder: { session, sequence } },
+  })
+  it('orders only observations from the same receive session', () => {
+    expect(compareCorrectionRevisions(correction('c1', 1), correction('c2', 2))).toBe(-1)
+    expect(compareCorrectionRevisions(correction('c1', 1), correction('c2', 100, 'stream-two'))).toBe(0)
+    expect(compareCorrectionRevisions(correction('c1', 100), correction('c2', 1, 'stream-two'))).toBe(0)
+  })
+  it('does not use receive counters to order distinct archive pages', () => {
+    const c1 = correction('c1', 2)
+    const c2 = correction('c2', 1)
+    c1.correctionRevision!.receiveOrder!.pendingLiveSequences = []
+    c2.correctionRevision!.receiveOrder!.pendingLiveSequences = []
+    c1.correctionRevision!.archiveTimestamp = 10
+    c2.correctionRevision!.archiveTimestamp = 10
+    expect(compareCorrectionRevisions(c1, c2)).toBe(0)
+    expect(compareCorrectionRevisions(c2, c1)).toBe(0)
+    expect(resolveCorrectionUpdates(c2, c1)).not.toHaveProperty('body')
+  })
+  it('retains receive order on same-revision replay and records the late predecessor', () => {
+    const c2 = correction('c2', 2)
+    const replayed = { ...c2, ...resolveCorrectionUpdates(c2, correction('c2', 3)) }
+    expect(replayed.correctionRevision?.receiveOrder?.sequence).toBe(2)
+    const current = { ...replayed, ...resolveCorrectionUpdates(replayed, correction('c1', 1)) }
+    expect(current.body).toBe('c2')
+    expect(current.correctionRevision?.supersedes).toEqual(['stanza:c1'])
+    expect(resolveCorrectionUpdates(current, correction('c1', 4))).not.toHaveProperty('body')
+  })
+  it('keeps a known archive floor authoritative over a delayed receive observation', () => {
+    const replay = correction('replay', 3)
+    replay.liveCorrection = false
+    replay.correctionRevision!.archiveTimestamp = 10
+    const current = correction('current', 2)
+    current.correctionRevision!.afterArchiveTimestamp = 20
+    expect(compareCorrectionRevisions(replay, current)).toBe(-1)
+    expect(compareCorrectionRevisions(current, replay)).toBe(1)
+    const merged = { ...current, ...resolveCorrectionUpdates(current, replay) }
+    expect(merged.body).toBe('current')
+    expect(merged.correctionRevision?.supersedes).toEqual([])
+  })
+  it('keeps archive chronology authoritative and signed dates with the accepted body', () => {
+    const c1 = correction('c1', 2)
+    const c2 = correction('c2', 1)
+    c1.correctionRevision!.archiveTimestamp = 10
+    c2.correctionRevision!.archiveTimestamp = 20
+    c1.correctionTimestamp = 900
+    c2.correctionTimestamp = 100
+    expect(compareCorrectionRevisions(c2, c1)).toBe(1)
+    expect(resolveCorrectionUpdates(c1, c2)).toMatchObject({ body: 'c2', correctionTimestamp: 100 })
+  })
+})
+
+
+describe('unresolved correction content', () => {
+  const archive: StoredMessage = { ...baseMessage, body: 'archive', isEdited: true, correctionTimestamp: 900, correctionTimestampSource: 'authored',
+    correctionRevision: { ids: ['stanza:archived'], supersedes: [], archiveTimestamp: 10,
+      receiveOrder: { session: 'same', sequence: 2, archive: true, overlapping: [1] } } }
+  const live: StoredMessage = { ...baseMessage, body: 'live', isEdited: true, correctionTimestamp: 100, correctionTimestampSource: 'authored',
+    correctionRevision: { ids: ['stanza:live'], supersedes: [], receiveOrder: { session: 'same', sequence: 1 } } }
+  it('keeps the retained plaintext and signed date when its archive echo remains encrypted', () => {
+    const held = { ...archive, ...resolveCorrectionUpdates(archive, live) }
+    const echo = { ...live, body: 'ciphertext hint', encryptedPayload: 'ciphertext', correctionTimestamp: 20, correctionTimestampSource: 'delay' as const,
+      correctionRevision: { ...live.correctionRevision!, archiveTimestamp: 20 } }
+    const resolved = { ...held, ...resolveCorrectionUpdates(held, echo) }
+    expect(resolved).toMatchObject({ body: 'live', correctionTimestamp: 100, correctionTimestampSource: 'authored', id: baseMessage.id, timestamp: baseMessage.timestamp })
+    expect(resolved.encryptedPayload).toBeUndefined()
+    expect(resolved.correctionAlternatives).toBeUndefined()
+  })
+  it('clears retained content on retraction and does not restore it on replay', () => {
+    const held = { ...archive, ...resolveCorrectionUpdates(archive, live) }
+    expect(held.correctionAlternatives).toHaveLength(1)
+    const retracted = { ...held, ...resolveCorrectionUpdates(held, { isRetracted: true }) }
+    expect(retracted.correctionAlternatives).toBeUndefined()
+    expect(resolveCorrectionUpdates(retracted, live)?.correctionAlternatives).toBeUndefined()
+  })
+})
+
+
+describe('partial correction chronology', () => {
+  const live: StoredMessage = { ...baseMessage, body: 'current live text', isEdited: true,
+    correctionTimestamp: 100, correctionTimestampSource: 'authored',
+    correctionRevision: { ids: ['stanza:live'], supersedes: [], receiveOrder: { session: 'same', sequence: 2 } } }
+  const archive: StoredMessage = { ...baseMessage, body: 'archived text', isEdited: true,
+    correctionTimestamp: 900, correctionTimestampSource: 'authored',
+    correctionRevision: { ids: ['stanza:archive'], supersedes: [], archiveTimestamp: 10 } }
+  it.each([false, true])('retains incomparable content without scheduling markers, archive first=%s', archiveFirst => {
+    const current = archiveFirst ? archive : live, incoming = archiveFirst ? live : archive
+    expect(compareCorrectionRevisions(current, incoming)).toBe(0)
+    expect(compareCorrectionRevisions(incoming, current)).toBe(0)
+    const held = { ...current, ...resolveCorrectionUpdates(current, incoming) }
+    expect(held).toMatchObject({ body: current.body, correctionTimestamp: current.correctionTimestamp })
+    expect(held.correctionRevision?.supersedes).toEqual([])
+    expect(held.correctionAlternatives).toEqual([expect.objectContaining({ body: incoming.body, correctionTimestamp: incoming.correctionTimestamp })])
+    const echo = { ...live, correctionRevision: { ...live.correctionRevision!, archiveTimestamp: 20 } }
+    const resolved = { ...held, ...resolveCorrectionUpdates(held, echo) }
+    expect(resolved).toMatchObject({ body: live.body, correctionTimestamp: live.correctionTimestamp })
+    expect(resolved.correctionAlternatives).toBeUndefined()
+  })
+  it('does not order two unknown revisions by different archive lower bounds', () => {
+    const a = { ...archive, correctionRevision: { ...archive.correctionRevision!, archiveTimestamp: undefined, afterArchiveTimestamp: 10 } }
+    const b = { ...live, correctionRevision: { ...live.correctionRevision!, afterArchiveTimestamp: 20 } }
+    expect(compareCorrectionRevisions(a, b)).toBe(0)
+    expect(compareCorrectionRevisions(b, a)).toBe(0)
+  })
+  it.each([false, true])('preserves the first live receipt across same-revision archive metadata, archive first=%s', archiveFirst => {
+    const archived = { ...live, correctionRevision: { ...live.correctionRevision!, archiveTimestamp: 10,
+      receiveOrder: { session: 'same', sequence: 1, archive: true } } }
+    const current = archiveFirst ? archived : live, incoming = archiveFirst ? live : archived
+    const held = { ...current, ...resolveCorrectionUpdates(current, incoming) }
+    expect(held.correctionRevision?.receiveOrder).toEqual(live.correctionRevision?.receiveOrder)
+    const later = { ...live, body: 'later', correctionRevision: { ids: ['stanza:later'], supersedes: [], receiveOrder: { session: 'same', sequence: 3 } } }
+    expect(resolveCorrectionUpdates(held, later)).toMatchObject({ body: 'later' })
+  })
+})
+
+
+describe('equal archive floor regression', () => {
+  it('retains a distinct equal-time candidate until archive order resolves it', () => {
+    const current: StoredMessage = { ...baseMessage, isEdited: true, body: 'live',
+      correctionRevision: { ids: ['id:live'], supersedes: ['id:first'], predecessors: [['id:first']], afterArchiveTimestamp: 10 } }
+    const candidate: StoredMessage = { ...baseMessage, isEdited: true, body: 'candidate', correctionTimestamp: 90,
+      correctionRevision: { ids: ['id:candidate'], supersedes: [], archiveTimestamp: 10 } }
+    expect(compareCorrectionRevisions(current, candidate)).toBe(0)
+    expect(compareCorrectionRevisions(candidate, current)).toBe(0)
+    const held = { ...current, ...resolveCorrectionUpdates(current, candidate) }
+    expect(held.body).toBe('live')
+    expect(held.correctionAlternatives).toEqual([expect.objectContaining({ body: 'candidate', correctionTimestamp: 90 })])
+    const echo = { ...current, correctionRevision: { ...current.correctionRevision!, archiveTimestamp: 9 } }
+    expect({ ...held, ...resolveCorrectionUpdates(held, echo) }).toMatchObject({ body: 'candidate', correctionTimestamp: 90 })
+  })
+})
+
+describe('completed archive receipt provenance', () => {
+  it.each([false, true])('retains an earlier unresolved live edit when a completed archive is replayed (reverse merge: %s)', reverse => {
+    const archived: StoredMessage = { ...baseMessage, body: 'archive', isEdited: true,
+      correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: 10, receiveOrder: { session: 'session', sequence: 1, archive: true } } }
+    const live: StoredMessage = { ...baseMessage, body: 'current', isEdited: true, correctionTimestamp: 90, correctionTimestampSource: 'authored',
+      correctionRevision: { ids: ['stanza:c2'], supersedes: [], receiveOrder: { session: 'session', sequence: 2 } } }
+    const replay: StoredMessage = { ...archived, correctionRevision: { ids: ['stanza:c1'], supersedes: [], receiveOrder: { session: 'session', sequence: 3 } } }
+    const held = reverse ? { ...replay, ...resolveCorrectionUpdates(replay, archived) } : { ...archived, ...resolveCorrectionUpdates(archived, replay) }
+    const retained = { ...held, ...resolveCorrectionUpdates(held, live) }
+    expect(retained.correctionAlternatives).toEqual([expect.objectContaining({ body: live.body, correctionTimestamp: 90 })])
+    expect(retained.correctionRevision?.supersedes).not.toContain('stanza:c2')
+    const echo = { ...live, correctionRevision: { ...live.correctionRevision!, archiveTimestamp: 20 } }
+    expect({ ...retained, ...resolveCorrectionUpdates(retained, echo) }).toMatchObject({ body: live.body, correctionTimestamp: 90 })
+  })
+})
+
+
+describe('retained replay provenance before content selection', () => {
+  it.each([false, true].flatMap(reload => [false, true].flatMap(alternative => [false, true].map(encrypted => ({ reload, alternative, encrypted })))))(
+    'keeps content and provenance together with reload=$reload alternative=$alternative encrypted=$encrypted', ({ reload, alternative, encrypted }) => {
+      const archived: StoredMessage = { ...baseMessage, body: 'earlier', originalBody: 'original', isEdited: true,
+        correctionTimestamp: 900, correctionTimestampSource: 'authored',
+        attachment: { url: 'https://example.test/earlier.png', mediaType: 'image/png' },
+        correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: 10,
+          receiveOrder: { session: reload ? 'old' : 'current', sequence: reload ? 900 : 1, archive: true } } }
+      const live: StoredMessage = { ...baseMessage, body: 'current', originalBody: 'original', isEdited: true,
+        correctionTimestamp: 100, correctionTimestampSource: 'authored',
+        correctionRevision: { ids: ['stanza:c2'], supersedes: [], receiveOrder: { session: 'current', sequence: 2 } } }
+      const held = alternative ? { ...live, ...resolveCorrectionUpdates(live, archived) } : { ...archived, ...resolveCorrectionUpdates(archived, live) }
+      const replay: StoredMessage = { ...baseMessage, body: encrypted ? 'ciphertext' : archived.body, isEdited: true,
+        encryptedPayload: encrypted ? 'encrypted-archive' : undefined, correctionTimestamp: 20, correctionTimestampSource: 'delay',
+        correctionRevision: { ids: ['stanza:c1'], supersedes: [], receiveOrder: { session: 'current', sequence: 3 } } }
+      const retained = { ...held, ...resolveCorrectionUpdates(held, replay) }
+      expect(retained.body).toBe(held.body)
+      expect(retained.correctionAlternatives).toHaveLength(1)
+      const contents = [retained, ...retained.correctionAlternatives ?? []]
+      const earlier = contents.find(candidate => candidate.correctionRevision?.ids.includes('stanza:c1'))
+      expect(earlier).toMatchObject({
+        body: archived.body, originalBody: archived.originalBody, attachment: archived.attachment,
+        correctionTimestamp: 900, correctionTimestampSource: 'authored',
+      })
+      expect(earlier?.encryptedPayload).toBeUndefined()
+      expect(earlier?.correctionRevision?.supersedes).not.toContain('stanza:c2')
+      expect(contents.find(candidate => candidate.correctionRevision?.ids.includes('stanza:c2'))).toMatchObject({ body: live.body, correctionTimestamp: 100 })
+      const next = { ...live, body: 'latest', correctionTimestamp: 50,
+        correctionRevision: { ids: ['stanza:c3'], supersedes: [], receiveOrder: { session: 'current', sequence: 4 } } }
+      const latest = { ...retained, ...resolveCorrectionUpdates(retained, next) }
+      expect(latest).toMatchObject({ body: 'latest', correctionTimestamp: 50 })
+      expect(latest.correctionAlternatives).toBeUndefined()
+      expect({ ...latest, ...resolveCorrectionUpdates(latest, replay) }).toMatchObject({ body: 'latest', correctionTimestamp: 50 })
+    })
+
+  it.each([1, 900])('keeps new-session live progress after hydrating an archived snapshot with counter %i', sequence => {
+    const old: StoredMessage = { ...baseMessage, isEdited: true, body: 'old',
+      correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: 10,
+        receiveOrder: { session: 'old', sequence, archive: true } } }
+    const replay = { ...old, correctionRevision: { ids: ['stanza:c1'], supersedes: [], receiveOrder: { session: 'current', sequence: 2 } } }
+    const observed = { ...old, ...resolveCorrectionUpdates(old, replay) }
+    const hydrated = { ...observed, ...resolveCorrectionUpdates(observed, old) }
+    const next = { ...old, body: 'current', correctionRevision: { ids: ['stanza:c2'], supersedes: [], receiveOrder: { session: 'current', sequence: 3 } } }
+    expect({ ...hydrated, ...resolveCorrectionUpdates(hydrated, next) }).toMatchObject({ body: next.body })
   })
 })

--- a/packages/fluux-sdk/src/core/types/message-internal.ts
+++ b/packages/fluux-sdk/src/core/types/message-internal.ts
@@ -31,6 +31,23 @@ export interface MessageImplState {
    * so we track them to keep reply lookups resolving correctly.
    */
   correctionStanzaIds?: string[]
+  /** Content date and its provenance; device-authored dates never order archive revisions. */
+  correctionTimestamp?: number
+  correctionTimestampSource?: 'authored' | 'delay'
+  correctionRevision?: CorrectionRevision
+  correctionAlternatives?: CorrectionAlternative[]
+  liveCorrection?: boolean
+  correctionHandoff?: ContentSource
+  contentRecovery?: ContentSource
+}
+
+export interface ContentSource {
+  encryptedPayload?: string
+  revisionIds: string[]
+  isEdited: boolean
+  from: string
+  occupantId?: string
+  accountScope: string | null
 }
 
 /** A stored 1:1 message: the public {@link Message} plus internal impl-state. */
@@ -53,4 +70,346 @@ export function isNoLocalStore(msg: Message | RoomMessage): boolean {
  */
 export function getCorrectionStanzaIds(msg: Message | RoomMessage): string[] | undefined {
   return (msg as MessageImplState).correctionStanzaIds
+}
+
+export interface CorrectionReceiveOrder {
+  replay?: boolean
+  archive?: boolean
+  overlapping?: number[]
+  pendingLiveSequences?: number[]
+  session: string
+  sequence: number
+}
+
+export interface CorrectionRevision {
+  receiveOrder?: CorrectionReceiveOrder
+  receiveOrders?: CorrectionReceiveOrder[]
+  /** Scoped to the corrected message's author, with separate client/origin/archive namespaces. */
+  ids: string[]
+  /** Known predecessor revisions, including aliases learned from subsequent archive echoes. */
+  supersedes: string[]
+  predecessors?: string[][]
+  legacyStanzaIds?: string[]
+  archiveTimestamp?: number
+  /** Archive chronology already observed when an undated correction replaced its predecessor. */
+  afterArchiveTimestamp?: number
+}
+
+export function withCorrectionStanzaId(existing: string[] | undefined, stanzaId: string): string[] {
+  return existing?.includes(stanzaId) ? existing : [...(existing ?? []), stanzaId]
+}
+
+export type CorrectionAlternative = Partial<Pick<Message, 'body' | 'originalBody' | 'attachment' | 'securityContext' | 'encryptedPayload' | 'unsupportedEncryption' | 'isEdited'>> &
+  Pick<MessageImplState, 'correctionRevision' | 'correctionTimestamp' | 'correctionTimestampSource' | 'correctionStanzaIds'>
+
+export type CorrectionUpdates = MessageImplState & CorrectionAlternative & { isEdited?: boolean; isRetracted?: boolean; encryptedPayload?: string; from?: string; occupantId?: string }
+
+function union(a: string[] = [], b: string[] = []): string[] {
+  return [...new Set([...a, ...b])].sort()
+}
+
+function latest(...values: (number | undefined)[]): number | undefined {
+  const valid = values.filter((value): value is number => value !== undefined && Number.isFinite(value))
+  return valid.length ? Math.max(...valid) : undefined
+}
+
+function overlaps(a: string[] = [], b: string[] = []): boolean {
+  return a.some(id => b.includes(id))
+}
+
+function sameRevisionIds(a: string[] = [], b: string[] = []): boolean {
+  for (const prefix of ['stanza:', 'origin:']) {
+    const left = a.filter(id => id.startsWith(prefix))
+    const right = b.filter(id => id.startsWith(prefix))
+    if (left.length && right.length) return overlaps(left, right)
+  }
+  return overlaps(a, b)
+}
+
+export function sameCorrection(a: MessageImplState, b: MessageImplState): boolean {
+  return sameRevisionIds(a.correctionRevision?.ids, b.correctionRevision?.ids)
+}
+
+function referencesPredecessor(revision: CorrectionRevision | undefined, previous: CorrectionRevision | undefined): boolean {
+  if (!revision || !previous || sameRevisionIds(revision.ids, previous.ids)) return false
+  const groups = revision.predecessors ?? []
+  const groupedIds = new Set(groups.flat())
+  const legacyIds = revision.supersedes.filter(id => !groupedIds.has(id))
+  return groups.some(ids => sameRevisionIds(ids, previous.ids)) || sameRevisionIds(legacyIds, previous.ids)
+}
+
+function mergePredecessors(...sources: (string[][] | undefined)[]): string[][] {
+  const groups: string[][] = []
+  const rank = (ids: string[]) => ids.some(id => id.startsWith('stanza:')) ? 2 : ids.some(id => id.startsWith('origin:')) ? 1 : 0
+  const ordered = sources.flatMap(source => source ?? []).map(ids => union(ids))
+    .sort((a, b) => rank(b) - rank(a) || JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  for (const ids of ordered) {
+    const matches = groups.filter(group => sameRevisionIds(group, ids))
+    if (matches.length === 0) groups.push(ids)
+    else if (matches.length === 1) groups[groups.indexOf(matches[0])] = union(matches[0], ids)
+  }
+  return groups
+}
+
+export function withCorrectionPredecessor(revision: CorrectionRevision, previous: CorrectionRevision): CorrectionRevision {
+  return {
+    ...revision,
+    supersedes: union(revision.supersedes, union(previous.ids, previous.supersedes)),
+    predecessors: mergePredecessors(revision.predecessors, previous.predecessors, [previous.ids]),
+    afterArchiveTimestamp: latest(revision.afterArchiveTimestamp, previous.afterArchiveTimestamp, previous.archiveTimestamp),
+  }
+}
+
+function receiptOrders(revision: CorrectionRevision | undefined): CorrectionReceiveOrder[] {
+  return [...(revision?.receiveOrder ? [revision.receiveOrder] : []), ...(revision?.receiveOrders ?? [])]
+}
+
+function mergeReceiptOrders(a: CorrectionRevision, b: CorrectionRevision | undefined): CorrectionReceiveOrder[] {
+  const sessions = new Map<string, { live?: CorrectionReceiveOrder; archive?: CorrectionReceiveOrder }>()
+  for (const receipt of [...receiptOrders(a), ...receiptOrders(b)]) {
+    const session = sessions.get(receipt.session) ?? {}
+    const channel = receipt.archive || receipt.pendingLiveSequences ? 'archive' : 'live'
+    session[channel] = mergeReceiveOrder(session[channel], receipt)
+    sessions.set(receipt.session, session)
+  }
+  return [...sessions.values()].flatMap(session => [session.live, session.archive].filter((receipt): receipt is CorrectionReceiveOrder => !!receipt))
+}
+
+function compareReceiveOrder(a: CorrectionRevision | undefined, b: CorrectionRevision | undefined): number | undefined {
+  const evidence = new Set<number>()
+  for (const left of receiptOrders(a)) {
+    for (const right of receiptOrders(b)) {
+      if (left.session !== right.session) continue
+      if (left.archive || right.archive || left.pendingLiveSequences || right.pendingLiveSequences) continue
+      const later = left.sequence > right.sequence ? left : right
+      const revision = left.sequence > right.sequence ? a : b
+      if (left.sequence !== right.sequence && (later.replay || receiptOrders(revision).some(receipt =>
+        receipt.archive && (receipt.session !== later.session || receipt.sequence < later.sequence)))) continue
+      evidence.add(Math.sign(left.sequence - right.sequence))
+    }
+  }
+  return evidence.size === 1 ? [...evidence][0] : undefined
+}
+
+function mergeReceiveOrder(a: CorrectionReceiveOrder | undefined, b: CorrectionReceiveOrder | undefined): CorrectionReceiveOrder | undefined {
+  if (!a) return b
+  if (!b || a.session !== b.session) return a
+  return a.sequence <= b.sequence ? a : b
+}
+
+export function correctionContent(message: CorrectionUpdates): CorrectionAlternative {
+  return {
+    body: message.body, originalBody: message.originalBody, attachment: message.attachment,
+    securityContext: message.securityContext, encryptedPayload: message.encryptedPayload,
+    unsupportedEncryption: message.unsupportedEncryption, isEdited: message.isEdited,
+    correctionRevision: message.correctionRevision, correctionTimestamp: message.correctionTimestamp,
+    correctionTimestampSource: message.correctionTimestampSource, correctionStanzaIds: message.correctionStanzaIds,
+  }
+}
+
+function mergeAlternatives(...groups: (CorrectionAlternative[] | undefined)[]): CorrectionAlternative[] | undefined {
+  const result: CorrectionAlternative[] = []
+  for (const candidate of groups.flatMap(group => group ?? [])) {
+    const index = result.findIndex(held => sameCorrection(held, candidate))
+    if (index < 0) result.push(candidate)
+    else result[index] = { ...result[index], ...resolveCorrectionUpdate(result[index], candidate) }
+  }
+  return result.length ? result : undefined
+}
+
+function provenCorrectionAncestor(held: CorrectionUpdates, updates: CorrectionUpdates): boolean {
+  if (!held.isEdited && updates.isEdited) return true
+  const incoming = updates.correctionRevision
+  const previous = held.correctionRevision
+  return referencesPredecessor(incoming, previous) || ((compareReceiveOrder(incoming, previous) ?? 0) > 0 && compareCorrectionRevisions(updates, held) > 0) ||
+    (incoming?.archiveTimestamp !== undefined && previous?.archiveTimestamp !== undefined && incoming.archiveTimestamp > previous.archiveTimestamp)
+}
+
+function isKnownLegacyCorrection(current: CorrectionUpdates, revision: CorrectionRevision | undefined): boolean {
+  return !!current.isEdited && !current.correctionRevision &&
+    (overlaps(current.correctionStanzaIds?.map(id => `stanza:${id}`), revision?.ids) ||
+      overlaps(current.correctionStanzaIds, revision?.legacyStanzaIds))
+}
+
+export function compareCorrectionRevisions(a: CorrectionUpdates, b: CorrectionUpdates): number {
+  const ar = a.correctionRevision
+  const br = b.correctionRevision
+  if (sameCorrection(a, b)) return 0
+  const at = ar?.archiveTimestamp
+  const bt = br?.archiveTimestamp
+  if (at !== undefined && bt !== undefined && at !== bt) return Math.sign(at - bt)
+  if (referencesPredecessor(ar, br)) return 1
+  if (referencesPredecessor(br, ar)) return -1
+  if (at !== undefined && bt === undefined && br?.afterArchiveTimestamp !== undefined && at < br.afterArchiveTimestamp) return -1
+  if (bt !== undefined && at === undefined && ar?.afterArchiveTimestamp !== undefined && bt < ar.afterArchiveTimestamp) return 1
+  const receivedOrder = compareReceiveOrder(ar, br)
+  if (receivedOrder) return receivedOrder
+  if (isKnownLegacyCorrection(a, br)) return 1
+  if (isKnownLegacyCorrection(b, ar)) return -1
+  if (at !== undefined && bt !== undefined) return 0
+  if (!ar && br) return -1
+  if (ar && !br) return 1
+  return 0
+}
+
+function correctionOrderEvidence(a: CorrectionUpdates, b: CorrectionUpdates): number | undefined {
+  if (sameCorrection(a, b)) return 0
+  const ar = a.correctionRevision, br = b.correctionRevision
+  if (!ar || !br) return undefined
+  if ((ar.archiveTimestamp !== undefined && br.archiveTimestamp !== undefined) ||
+      referencesPredecessor(ar, br) || referencesPredecessor(br, ar) ||
+      (ar.archiveTimestamp !== undefined && br.afterArchiveTimestamp !== undefined && ar.archiveTimestamp < br.afterArchiveTimestamp) ||
+      (br.archiveTimestamp !== undefined && ar.afterArchiveTimestamp !== undefined && br.archiveTimestamp < ar.afterArchiveTimestamp)) {
+    return compareCorrectionRevisions(a, b)
+  }
+  return compareReceiveOrder(ar, br)
+}
+
+export function canReplaceCorrection(
+  current: CorrectionUpdates,
+  incoming: CorrectionUpdates,
+  order = compareCorrectionRevisions(incoming, current),
+): boolean {
+  return order > 0 || (order === 0 &&
+    (sameCorrection(current, incoming) || !current.correctionRevision || !incoming.correctionRevision))
+}
+
+export function mergeCorrectionMetadata(
+  owner: CorrectionUpdates,
+  other: CorrectionUpdates,
+): MessageImplState {
+  const revision = owner.correctionRevision
+  const previous = other.correctionRevision
+  const same = sameCorrection(owner, other)
+  const predecessor = revision && previous && (
+    referencesPredecessor(revision, previous) || ((compareReceiveOrder(revision, previous) ?? 0) > 0 && compareCorrectionRevisions(owner, other) > 0) ||
+    (revision.archiveTimestamp !== undefined && previous.archiveTimestamp !== undefined &&
+      revision.archiveTimestamp > previous.archiveTimestamp)
+  )
+  const correctionStanzaIds = union(owner.correctionStanzaIds, other.correctionStanzaIds)
+  const alternatives = mergeAlternatives(owner.correctionAlternatives, other.correctionAlternatives,
+    !owner.isRetracted && revision && previous && !same && other.isEdited && other.body !== undefined &&
+      correctionOrderEvidence(owner, other) === undefined ? [correctionContent(other)] : undefined)
+  return {
+    ...(correctionStanzaIds.length && { correctionStanzaIds }),
+    ...((alternatives || owner.correctionAlternatives || other.correctionAlternatives) && { correctionAlternatives: alternatives }),
+    ...(revision && { correctionRevision: {
+      ...(previous && predecessor && !same ? withCorrectionPredecessor(revision, previous) : revision),
+      ids: same ? union(revision.ids, previous?.ids) : revision.ids,
+      receiveOrder: same ? mergeReceiptOrders(revision, previous)[0] : revision.receiveOrder,
+      ...(same && { receiveOrders: mergeReceiptOrders(revision, previous).slice(1) }),
+      ...((revision.legacyStanzaIds || (same && previous?.legacyStanzaIds)) && { legacyStanzaIds: same ? union(revision.legacyStanzaIds, previous?.legacyStanzaIds) : revision.legacyStanzaIds }),
+      ...(same && { supersedes: union(revision.supersedes, previous?.supersedes), predecessors: mergePredecessors(revision.predecessors, previous?.predecessors) }),
+      archiveTimestamp: same ? latest(revision.archiveTimestamp, previous?.archiveTimestamp) : revision.archiveTimestamp,
+      afterArchiveTimestamp: latest(revision.afterArchiveTimestamp, same || predecessor ? previous?.afterArchiveTimestamp : undefined, predecessor ? previous?.archiveTimestamp : undefined),
+    } }),
+  }
+}
+
+export function captureContentSource(message: CorrectionUpdates, accountScope: string | null): ContentSource {
+  return {
+    encryptedPayload: message.encryptedPayload,
+    revisionIds: message.correctionRevision?.ids ?? [],
+    isEdited: !!message.isEdited,
+    from: message.from ?? '',
+    occupantId: message.occupantId,
+    accountScope,
+  }
+}
+
+function matchesContentSource(held: CorrectionUpdates, source: ContentSource, accountScope?: string | null, allowDecryption = false): boolean {
+  const matchesPayload = held.encryptedPayload === source.encryptedPayload ||
+    (allowDecryption && !!held.correctionRevision && (!held.encryptedPayload || !source.encryptedPayload))
+  return matchesPayload && !!held.isEdited === source.isEdited &&
+    held.from === source.from && held.occupantId === source.occupantId && accountScope === source.accountScope &&
+    (held.correctionRevision ? sameRevisionIds(held.correctionRevision.ids, source.revisionIds) : source.revisionIds.length === 0)
+}
+
+function resolveCorrectionUpdate<T extends CorrectionUpdates>(
+  current: CorrectionUpdates | undefined,
+  updates: T,
+  accountScope?: string | null,
+): T | MessageImplState | undefined {
+  const held = current ?? {}
+  const { contentRecovery, correctionHandoff, liveCorrection, ...recovered } = updates
+  if (correctionHandoff) {
+    if (accountScope !== correctionHandoff.accountScope) return undefined
+    if (!matchesContentSource(held, correctionHandoff, accountScope, true) && !sameCorrection(held, updates) && !provenCorrectionAncestor(held, updates)) {
+      return mergeCorrectionMetadata(held, updates)
+    }
+    return resolveCorrectionUpdates(current, recovered as T, accountScope)
+  }
+  if (contentRecovery) {
+    if (held.isRetracted || !matchesContentSource(held, contentRecovery, accountScope)) return undefined
+    return { ...recovered, ...mergeCorrectionMetadata(held, updates) } as T
+  }
+  updates = recovered as T
+  if (!updates.isEdited) {
+    if (updates.correctionRevision && !sameCorrection(held, updates)) {
+      const { correctionRevision: _revision, correctionTimestamp: _time, correctionTimestampSource: _source, ...metadata } = updates
+      return { ...metadata, ...mergeCorrectionMetadata(held, updates) }
+    }
+    const { correctionRevision: _revision, ...metadata } = updates
+    return { ...metadata, ...mergeCorrectionMetadata(held, updates) }
+  }
+  const same = sameCorrection(held, updates)
+  const revision = updates.correctionRevision
+  const followsHeld = revision && revision.archiveTimestamp === undefined && liveCorrection === true &&
+    (compareReceiveOrder(revision, held.correctionRevision) ?? 1) > 0 &&
+    !same && !isKnownLegacyCorrection(held, revision) && !referencesPredecessor(held.correctionRevision, revision)
+  const order = followsHeld ? 1 : compareCorrectionRevisions(updates, held)
+  if (held.isRetracted || !canReplaceCorrection(held, updates, order)) {
+    return mergeCorrectionMetadata(held, updates)
+  }
+  if (same) {
+    return {
+      ...(held.encryptedPayload && !updates.encryptedPayload ? updates : {}),
+      ...mergeCorrectionMetadata(held, updates),
+      ...((updates.correctionTimestampSource === 'authored' || (!held.correctionTimestampSource && updates.correctionTimestampSource === 'delay')) && {
+        correctionTimestamp: updates.correctionTimestamp,
+        correctionTimestampSource: updates.correctionTimestampSource,
+      }),
+    }
+  }
+  const incoming = followsHeld ? {
+    ...updates,
+    correctionRevision: held.correctionRevision ? withCorrectionPredecessor(revision, held.correctionRevision) : revision,
+  } : updates
+  return { ...incoming, ...mergeCorrectionMetadata(incoming, held) }
+}
+
+export function resolveCorrectionUpdates<T extends CorrectionUpdates>(
+  current: CorrectionUpdates | undefined,
+  updates: T,
+  accountScope?: string | null,
+): T | MessageImplState | undefined {
+  if (!updates.contentRecovery && !updates.correctionHandoff && !current?.isRetracted && updates.isEdited) {
+    const retained = current?.correctionAlternatives?.find(candidate => sameCorrection(candidate, updates))
+    if (retained) {
+      updates = { ...updates, ...retained, ...resolveCorrectionUpdate(retained, updates, accountScope), liveCorrection: false }
+      current = { ...current, correctionAlternatives: current!.correctionAlternatives!.map(candidate =>
+        candidate === retained ? correctionContent(updates) : candidate) }
+    }
+  }
+  const result = resolveCorrectionUpdate(current, updates, accountScope)
+  if (!result) return result
+  if (current?.isRetracted || updates.isRetracted) return { ...result, correctionAlternatives: undefined }
+  const alternatives = mergeAlternatives(current?.correctionAlternatives, updates.correctionAlternatives, result.correctionAlternatives)
+  if (!alternatives) return result
+  let patch: CorrectionUpdates = result
+  let held = { ...current, ...result }
+  const pending = alternatives
+  for (let index = 0; index < pending.length;) {
+    const candidate = pending[index]
+    if (!sameCorrection(held, candidate) && !correctionOrderEvidence(candidate, held)) {
+      index++
+      continue
+    }
+    pending.splice(index, 1)
+    const resolved = resolveCorrectionUpdate(held, { ...candidate, liveCorrection: false }, accountScope)
+    patch = { ...patch, ...resolved }
+    held = { ...held, ...resolved }
+    index = 0
+  }
+  return { ...patch, correctionAlternatives: pending.length ? pending.map(correctionContent) : undefined }
 }

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -223,6 +223,7 @@ export interface HistoryPagingSearchOptions {
  * @category MAM
  */
 export interface HistoryQueryState {
+  loadingRequestId?: string
   /** True while query is in progress */
   isLoading: boolean
   /** Error message if query failed */

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -1,3 +1,4 @@
+import type { MessageActor } from '../../utils/messageIdentity'
 /**
  * Comprehensive SDK event types for event-based decoupling.
  *
@@ -149,6 +150,9 @@ export interface ChatEvents {
     messageId: string
     // Partial<StoredMessage>, not Partial<Message>: a correction update carries
     // internal impl-state (correctionStanzaIds) alongside the public fields.
+    correctionActor?: MessageActor
+    onCorrectionMissing?: () => void
+    onCorrectionResolved?: (message: StoredMessage, isCurrent: () => boolean) => void
     updates: Partial<StoredMessage>
   }
 
@@ -210,12 +214,14 @@ export interface ChatEvents {
 
   /** MAM loading state changed */
   'chat:history-loading': {
+    requestId?: string
     conversationId: string
     isLoading: boolean
   }
 
   /** MAM error occurred */
   'chat:history-error': {
+    requestId?: string
     conversationId: string
     error: string | null
   }
@@ -392,6 +398,9 @@ export interface RoomEvents {
   'room:message-updated': {
     roomJid: string
     messageId: string
+    correctionActor?: MessageActor
+    onCorrectionMissing?: () => void
+    onCorrectionResolved?: (message: StoredRoomMessage, isCurrent: () => boolean) => void
     updates: Partial<StoredRoomMessage>
   }
 
@@ -446,12 +455,14 @@ export interface RoomEvents {
 
   /** Room MAM loading state */
   'room:history-loading': {
+    requestId?: string
     roomJid: string
     isLoading: boolean
   }
 
   /** Room MAM error */
   'room:history-error': {
+    requestId?: string
     roomJid: string
     error: string | null
   }

--- a/packages/fluux-sdk/src/core/types/storeBindings.ts
+++ b/packages/fluux-sdk/src/core/types/storeBindings.ts
@@ -33,6 +33,7 @@ import type {
   MergeArchiveExtras,
   PageInfo,
 } from './pagination'
+import type { MessageActor, CorrectionReferences } from '../../utils/messageIdentity'
 import type { GetMessagesOptions } from '../../utils/messageCache'
 
 /**
@@ -146,8 +147,10 @@ export interface ChatBindings {
   triggerAnimation: (conversationId: string, animation: string, senderName?: string) => void
 
   // XEP-0313: MAM (Message Archive Management)
-  setMAMLoading: (conversationId: string, isLoading: boolean) => void
-  setMAMError: (conversationId: string, error: string | null) => void
+  setMAMLoading: (conversationId: string, isLoading: boolean, requestId?: string) => void
+  setMAMError: (conversationId: string, error: string | null, requestId?: string) => void
+  resolveCorrectionReferences?: (conversationId: string, targetId: string, actor: MessageActor) => Promise<CorrectionReferences | null | undefined>
+  reconcileHistoryMessages?: (messages: Message[]) => Promise<Message[]>
 
   /**
    * Merge MAM messages into conversation and update query state.
@@ -354,6 +357,8 @@ export interface RoomBindings {
     incrementMentions?: boolean
   }) => void
   updateReactions: (roomJid: string, messageId: string, reactorNick: string, emojis: string[]) => void
+  resolveCorrectionReferences?: (roomJid: string, targetId: string, actor: MessageActor) => Promise<CorrectionReferences | null | undefined>
+  reconcileHistoryMessages?: (messages: RoomMessage[]) => Promise<RoomMessage[]>
   updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
 
   /**
@@ -425,8 +430,8 @@ export interface RoomBindings {
   triggerAnimation: (roomJid: string, animation: string, senderName?: string) => void
 
   // MAM state management (XEP-0313 for MUC rooms)
-  setRoomMAMLoading: (roomJid: string, isLoading: boolean) => void
-  setRoomMAMError: (roomJid: string, error: string | null) => void
+  setRoomMAMLoading: (roomJid: string, isLoading: boolean, requestId?: string) => void
+  setRoomMAMError: (roomJid: string, error: string | null, requestId?: string) => void
 
   /**
    * Merge MAM messages into room and update query state.

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2,7 +2,7 @@ import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, HistoryQueryState, PageInfo } from '../core/types'
 import type { ReadStateGeneration } from '../core/types/readStateGeneration'
-import { isNoLocalStore } from '../core/types/message-internal'
+import { isNoLocalStore, resolveCorrectionUpdates, correctionContent, sameCorrection, type StoredMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import {
   CHAT_SCOPE,
@@ -12,11 +12,15 @@ import {
   findMessageRowIndex,
   identityKeys,
   resolveMessageReference,
+  messageReferences,
+  correctionReferences,
+  type CorrectionReferences,
   sameLogicalMessage,
   sameMessageRow,
   type MessageRowRef,
+  type MessageActor,
 } from '../utils/messageIdentity'
-import { logInfo } from '../core/logger'
+import { logInfo, logWarn } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
@@ -62,6 +66,9 @@ import {
   notePurgedMarker,
   type PurgedMarkerKey,
 } from './shared/purgedMarkers'
+import {
+  matchesCorrectionTarget, reconcileCachedCorrections, reconcileCorrectionHandoff, refreshCachedCorrections,
+} from './shared/correctionHandoff'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import { newArchiveMergeTally, reportArchiveMergeWhenDurable } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
@@ -85,7 +92,7 @@ import {
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
-import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
+import { buildScopedStorageKey, captureStorageScope, getStorageScopeJid } from '../utils/storageScope'
 import { countOnlyClear, recountLedger, reportUnreadCleared } from './shared/recountDiagnostics'
 import type { RecountDeferralReason } from '../diagnostics/channel'
 import { createRecountRetryScheduler } from './shared/recountRetry'
@@ -144,9 +151,16 @@ function getScopedStorageKey(jid?: string | null): string {
   return buildScopedStorageKey(STORAGE_KEY_BASE, jid)
 }
 
+function captureChatCacheRead(conversationId: string): () => boolean {
+  const scope = captureStorageScope()
+  const epoch = chatCacheEpoch
+  const entityEpoch = currentChatEntityEpoch(conversationId)
+  return () => scope.isCurrent() && epoch === chatCacheEpoch && entityEpoch === currentChatEntityEpoch(conversationId)
+}
+
 /**
  * Merge a batch of cached messages into a conversation's resident array, returning the partial
- * state update (or `null` when every cached message is already resident). Shared by
+ * state update (or `null` when the resident slice is unchanged). Shared by
  * {@link ChatState.loadMessagesFromCache} and {@link ChatState.loadMessagesAroundFromCache}: both
  * filter duplicates, merge/sort/trim, and refresh the sidebar preview to the newest previewable
  * message (healing a stuck encrypted-fallback placeholder). The only difference between the two
@@ -159,13 +173,15 @@ function mergeCachedChatMessages(
 ): Partial<Pick<ChatState, 'messages' | 'conversationEntities' | 'conversationMeta' | 'conversations' | 'pendingRetractions'>> | null {
   const existingMessages = state.messages.get(conversationId) || []
 
-  const { merged, newMessages } = timeline.latestSlice(
-    existingMessages,
+  const { merged } = timeline.latestSlice(
+    reconcileCachedCorrections(existingMessages, cachedMessages, getStorageScopeJid()),
     cachedMessages,
     chatTimelineConfig()
   )
-  if (newMessages.length === 0) return null
+  return commitCachedChatMessages(state, conversationId, merged)
+}
 
+function commitCachedChatMessages(state: ChatState, conversationId: string, merged: Message[]) {
   // XEP-0424: a retraction recorded while this conversation was unloaded applies
   // here, the moment its target becomes resident.
   const resolved = resolvePendingRetractions(state, conversationId, merged)
@@ -178,7 +194,11 @@ function mergeCachedChatMessages(
   // supersedes (or heals) the stored preview — e.g. opening a conversation
   // whose stored preview is a stuck placeholder heals it here.
   const meta = state.conversationMeta.get(conversationId)
-  const { lastMessage, changed } = derivePreviewAfterMerge(meta?.lastMessage, trimmed, findLastPreviewableMessage)
+  const previous = meta?.lastMessage
+  const current = previous ? reconcileCachedCorrections([previous], trimmed, getStorageScopeJid())[0] : previous
+  const { lastMessage } = derivePreviewAfterMerge(current, trimmed, findLastPreviewableMessage)
+  const changed = lastMessage !== previous
+  if (!changed && trimmed === state.messages.get(conversationId) && !resolved.pendingRetractions) return null
   const retractionPatch = resolved.pendingRetractions ? { pendingRetractions: resolved.pendingRetractions } : {}
   if (changed) {
     const draft = draftConversationMaps(state)
@@ -442,8 +462,11 @@ interface ChatState {
   updateMessage: (
     conversationId: string,
     messageId: string,
-    updates: Partial<Message>,
-    retractionReference?: string
+    updates: Partial<StoredMessage>,
+    retractionReference?: string,
+    correctionActor?: MessageActor,
+    onCorrectionMissing?: () => void,
+    onCorrectionResolved?: (message: StoredMessage, isCurrent: () => boolean) => void
   ) => void
   clearMessageStanzaId: (conversationId: string, stanzaId: string) => void
   /**
@@ -505,8 +528,8 @@ interface ChatState {
   getDraft: (conversationId: string) => string
   clearDraft: (conversationId: string) => void
   // XEP-0313: MAM (Message Archive Management)
-  setMAMLoading: (conversationId: string, isLoading: boolean) => void
-  setMAMError: (conversationId: string, error: string | null) => void
+  setMAMLoading: (conversationId: string, isLoading: boolean, requestId?: string) => void
+  setMAMError: (conversationId: string, error: string | null, requestId?: string) => void
   /**
    * Merge MAM messages into conversation and update query state.
    * @param conversationId - Conversation JID
@@ -552,7 +575,9 @@ interface ChatState {
    * @param messageId - id / stanzaId / originId of the decrypted message
    * @param updates - Partial content to merge into the preview message
    */
-  refreshLastMessageContent: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+  refreshLastMessageContent: (conversationId: string, messageId: string, updates: Partial<StoredMessage>) => void
+  resolveCorrectionReferences: (conversationId: string, targetId: string, actor: MessageActor) => Promise<CorrectionReferences | null | undefined>
+  reconcileHistoryMessages: (messages: Message[]) => Promise<Message[]>
   // IndexedDB message loading. `oldest` flips the latest-N default to the
   // OLDEST-N ascending slice (true cache bottom) — pointer-walk seeding; use
   // with `peek` (an oldest slice must never become the resident window).
@@ -2511,33 +2536,97 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
-      updateMessage: (conversationId, messageId, updates, retractionReference) => {
+      updateMessage: (conversationId, messageId, updates, retractionReference, correctionActor, onCorrectionMissing, onCorrectionResolved) => {
         let recountNeeded = false
+        const correctionPayload = updates
+        const contentRecovery = updates.contentRecovery
+        const liveCorrection = updates.liveCorrection
+        const persistCorrection = (pendingUpdates: Partial<StoredMessage>, targetId = messageId) => {
+          if (!correctionActor) return
+          const scope = captureStorageScope()
+          const epoch = chatCacheEpoch
+          const entityEpoch = currentChatEntityEpoch(conversationId)
+          const isCurrent = () => scope.isCurrent() && epoch === chatCacheEpoch && entityEpoch === currentChatEntityEpoch(conversationId)
+          const fallback = () => {
+            if (!isCurrent() || !onCorrectionMissing) return
+            const current = get().messages.get(conversationId) ?? []
+            const resolution = resolveMessageReference(current, messageId, 'archive-first')
+            if (resolution?.candidates.some(({ message }) => chatMessageAuthor(message, correctionActor))) {
+              get().updateMessage(conversationId, messageId, { ...pendingUpdates, liveCorrection: false }, undefined, correctionActor)
+            } else if (!resolution?.authoritative) onCorrectionMissing()
+          }
+          void messageCache.applyChatCorrection(conversationId, targetId, pendingUpdates, correctionActor, scope.jid)
+            .then(message => {
+              if (message) {
+                if (isCurrent()) set(current => {
+                  const rows = current.messages.get(conversationId) ?? []
+                  const index = rows.findIndex(row => matchesCorrectionTarget(row, message))
+                  const updated = reconcileCorrectionHandoff(rows[index], message, scope.jid)
+                  const draft = draftConversationMaps(current)
+                  const preview = reconcileCorrectionHandoff(current.conversationMeta.get(conversationId)?.lastMessage, message, scope.jid)
+                  if (preview) { draft.patchMeta(conversationId, { lastMessage: preview }) }
+                  if (!updated) return draft.commit()
+                  const replay = resolvePendingRetractions(current, conversationId, [updated], { persist: false })
+                  const completed = replay.messages[0]
+                  const messages = new Map(current.messages).set(conversationId, rows.map((row, i) => i === index ? completed : row))
+                  if (preview) draft.patchMeta(conversationId, { lastMessage: reconcileCorrectionHandoff(preview, completed, scope.jid) ?? preview })
+                  return { messages, ...draft.commit(), ...(replay.pendingRetractions && { pendingRetractions: replay.pendingRetractions }) }
+                })
+                void searchIndex.updateMessage(message, scope.jid).catch(error => logWarn(`Failed to index correction: ${String(error)}`))
+                if (isCurrent()) onCorrectionResolved?.(message, isCurrent)
+              } else if (message === undefined) {
+                if (typeof indexedDB === 'undefined' && isCurrent()) {
+                  const rows = get().messages.get(conversationId) ?? []
+                  const current = resolveMessageReference(rows, targetId, 'archive-first')?.candidates
+                    .find(({ message }) => chatMessageAuthor(message, correctionActor))?.message
+                  if (current) { onCorrectionResolved?.(current, isCurrent); return }
+                }
+                fallback()
+              }
+            }, error => { logWarn(`Failed to persist chat correction: ${String(error)}`) })
+        }
         set((state) => {
-          const convMessages = state.messages.get(conversationId)
-          if (!convMessages) return state
+          const convMessages = state.messages.get(conversationId) ?? []
 
-          // Resolve by id/stanzaId first, origin-id only as fallback. XEP-0308
-          // corrections reference the origin-id; retractions/MAM may use stanzaId.
           let messageIndex: number
-          if (retractionReference) {
+          if (correctionActor) {
+            messageIndex = resolveMessageReference(convMessages, messageId, 'archive-first')?.candidates
+              .find(({ message }) => chatMessageAuthor(message, correctionActor))?.index ?? -1
+          } else if (retractionReference) {
             messageIndex = convMessages.findIndex((message) => message.id === messageId)
           } else if (updates.isRetracted) {
             messageIndex = resolveMessageReference(convMessages, messageId, 'archive-first')?.candidates[0]?.index ?? -1
           } else {
             messageIndex = findMessageIndexById(convMessages, messageId)
           }
-          if (messageIndex === -1) return state
+          if (messageIndex === -1) {
+            if (correctionActor && resolveMessageReference(convMessages, messageId, 'archive-first')?.authoritative) return state
+            if (correctionActor) {
+              persistCorrection(updates)
+            }
+            return state
+          }
+          const target = convMessages[messageIndex]
+          const applicable = resolveCorrectionUpdates(target, {
+            ...updates,
+            ...(updates.isEdited && { originalBody: target.originalBody ?? target.body }),
+          }, getStorageScopeJid())
+          if (!applicable) return state
+          updates = applicable
 
           const newMessages = new Map(state.messages)
           const updatedConvMessages = [...convMessages]
-          const updatedMessage = {
+          let updatedMessage = {
             ...convMessages[messageIndex],
             ...updates,
             ...(updates.isRetracted && convMessages[messageIndex].retractedAt
               ? { retractedAt: convMessages[messageIndex].retractedAt }
               : {}),
           }
+          const replay = resolvePendingRetractions(state, conversationId, [updatedMessage], { persist: false })
+          updatedMessage = replay.messages[0]
+          if (updatedMessage.isRetracted) updates = { ...updates, isRetracted: true, retractedAt: updatedMessage.retractedAt }
+          const pendingPatch = replay.pendingRetractions ? { pendingRetractions: replay.pendingRetractions } : {}
           updatedConvMessages[messageIndex] = updatedMessage
           newMessages.set(conversationId, updatedConvMessages)
 
@@ -2554,14 +2643,20 @@ export const chatStore = createStore<ChatState>()(
               getStorageScopeJid(),
               retractionReference ?? messageId
             )
+          } else if (correctionActor) {
+            persistCorrection({ ...correctionPayload, ...(updates.isEdited && { ...correctionContent(updatedMessage), correctionAlternatives: updatedMessage.correctionAlternatives }), liveCorrection: liveCorrection && sameCorrection(correctionPayload, updatedMessage) }, messageReferences(target, 'archive-first')[0])
           } else {
+            const scope = captureStorageScope()
+            const reindex = updates.body !== undefined
             void messageCache.updateMessage(
               conversationId,
               convMessages[messageIndex].id,
-              updates,
-              convMessages[messageIndex].from
-            )
-            if (updates.body) void searchIndex.updateMessage(updatedMessage)
+              { ...updates, ...(contentRecovery && { contentRecovery }) },
+              convMessages[messageIndex].from,
+              scope.jid,
+            ).then(() => {
+              if (reindex && scope.isCurrent()) return searchIndex.updateMessage({ ...updatedMessage, ...(contentRecovery && { contentRecovery }) }, scope.jid)
+            }).catch(error => logWarn(`Failed to index message update: ${String(error)}`))
           }
 
           // A retraction may target a `noLocalStore` message noted in
@@ -2574,27 +2669,22 @@ export const chatStore = createStore<ChatState>()(
             if (removal.removed) recountNeeded = true
           }
 
-          // Refresh the lastMessage preview when this update touches it. Match
-          // positionally (the updated message is the newest array element) OR by
-          // identity (the updated message IS the current preview). The identity
-          // tier is load-bearing for deferred decrypt: an encrypted message can
-          // be the stored preview while a trailing bodiless-signal placeholder
-          // (an encrypted reaction/retraction) sits after it in the array, so a
-          // purely positional gate would leave the sidebar stuck on
-          // "[OpenPGP-encrypted message]" after the real message decrypts.
           const meta = state.conversationMeta.get(conversationId)
+          const existingPreview = meta?.lastMessage
           const isLastMessage = messageIndex === updatedConvMessages.length - 1
-          const isPreviewMessage =
-            !!meta?.lastMessage &&
-            findMessageIndexById([meta.lastMessage], updatedMessage.id) !== -1
-          if (isLastMessage || isPreviewMessage) {
+          const preview = correctionActor || updates.isEdited || updates.correctionRevision || updates.correctionStanzaIds || contentRecovery
+            ? reconcileCorrectionHandoff(existingPreview ?? (isLastMessage ? target : undefined), { ...updatedMessage, ...(contentRecovery && { contentRecovery }) }, getStorageScopeJid())
+            : existingPreview
+              ? matchesCorrectionTarget(existingPreview, updatedMessage) ? { ...existingPreview, ...updates } : undefined
+              : isLastMessage ? updatedMessage : undefined
+          if (preview) {
             const draft = draftConversationMaps(state)
-            if (draft.patchMeta(conversationId, { lastMessage: updatedMessage })) {
-              return { messages: newMessages, ...draft.commit() }
+            if (draft.patchMeta(conversationId, { lastMessage: preview })) {
+              return { messages: newMessages, ...draft.commit(), ...pendingPatch }
             }
           }
 
-          return { messages: newMessages }
+          return { messages: newMessages, ...pendingPatch }
         })
 
         if (recountNeeded) void get().recomputeUnreadForConversation(conversationId)
@@ -3039,15 +3129,15 @@ export const chatStore = createStore<ChatState>()(
       },
 
       // XEP-0313: MAM (Message Archive Management)
-      setMAMLoading: (conversationId, isLoading) => {
+      setMAMLoading: (conversationId, isLoading, requestId) => {
         set((state) => ({
-          mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, conversationId, isLoading),
+          mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, conversationId, isLoading, requestId),
         }))
       },
 
-      setMAMError: (conversationId, error) => {
+      setMAMError: (conversationId, error, requestId) => {
         set((state) => ({
-          mamQueryStates: mamState.setMAMError(state.mamQueryStates, conversationId, error),
+          mamQueryStates: mamState.setMAMError(state.mamQueryStates, conversationId, error, requestId),
         }))
       },
 
@@ -3478,6 +3568,31 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
+      resolveCorrectionReferences: async (conversationId, targetId, actor) => {
+        const scope = captureStorageScope()
+        const epoch = chatCacheEpoch
+        const resolution = resolveMessageReference(get().messages.get(conversationId) ?? [], targetId, 'archive-first')
+        const candidates = resolution?.candidates.filter(({ message }) => chatMessageAuthor(message, actor)) ?? []
+        const target = candidates[0]?.message
+        if (target) return candidates.length === 1 ? correctionReferences(target) : null
+        if (resolution?.authoritative) return null
+        const references = await messageCache.getCorrectionReferences('chat', conversationId, targetId, actor, scope.jid)
+        scope.assertCurrent()
+        if (epoch !== chatCacheEpoch) throw new DOMException('Correction lookup cancelled', 'AbortError')
+        return references
+      },
+
+      reconcileHistoryMessages: async (messages) => {
+        const scope = captureStorageScope()
+        const conversations = new Set(messages.map(message => message.conversationId))
+        const reconciled = await messageCache.reconcileChatHistoryMessages(messages, () => {
+          scope.assertCurrent()
+          return Array.from(conversations, id => get().messages.get(id) ?? []).flat()
+        }, scope.jid)
+        scope.assertCurrent()
+        return reconciled
+      },
+
       refreshLastMessageContent: (conversationId, messageId, updates) => {
         set((state) => {
           const meta = state.conversationMeta.get(conversationId)
@@ -3490,7 +3605,9 @@ export const chatStore = createStore<ChatState>()(
           // id/stanzaId/originId tiers so a MAM-id copy still resolves.
           if (findMessageIndexById([existing], messageId) === -1) return state
 
-          const updated = { ...existing, ...updates }
+          const applicable = resolveCorrectionUpdates(existing, updates, getStorageScopeJid())
+          if (!applicable) return state
+          const updated = { ...existing, ...applicable }
 
           const draft = draftConversationMaps(state)
           draft.patchMeta(conversationId, { lastMessage: updated })
@@ -3501,6 +3618,7 @@ export const chatStore = createStore<ChatState>()(
       // Load messages from IndexedDB cache for a conversation
       // For initial load (no 'before'), loads the LATEST 100 messages to show most recent first
       loadMessagesFromCache: async (conversationId, options = {}) => {
+        const isCurrent = captureChatCacheRead(conversationId)
         const { limit = 100, before, peek, oldest } = options
         try {
           const cachedMessages = await messageCache.getMessages(conversationId, {
@@ -3510,7 +3628,8 @@ export const chatStore = createStore<ChatState>()(
             // This prevents showing old messages and jumping to recent ones.
             // `oldest` opts out: ascending oldest-N (the true cache bottom).
             latest: !before && !oldest,
-          })
+          }).then(messages => refreshCachedCorrections(messages, isCurrent))
+          if (!isCurrent()) return []
 
           // `peek`: pure read that returns the messages WITHOUT writing the store —
           // used to compute a catch-up cursor for a non-active conversation without
@@ -3540,8 +3659,10 @@ export const chatStore = createStore<ChatState>()(
       },
 
       loadMessagesAroundFromCache: async (conversationId, anchorRow, options = {}) => {
+        const isCurrent = captureChatCacheRead(conversationId)
         try {
-          const slice = await messageCache.getMessagesAround(conversationId, anchorRow, options)
+          const slice = await messageCache.getMessagesAround(conversationId, anchorRow, options).then(messages => refreshCachedCorrections(messages, isCurrent))
+          if (!isCurrent()) return []
           if (slice.length > 0) {
             set((state) => mergeCachedChatMessages(state, conversationId, slice) ?? state)
           }
@@ -3554,6 +3675,7 @@ export const chatStore = createStore<ChatState>()(
 
       // Load older messages from IndexedDB (for lazy scrolling before hitting MAM)
       loadOlderMessagesFromCache: async (conversationId, limit = 50) => {
+        const isCurrent = captureChatCacheRead(conversationId)
         const state = get()
         const existingMessages = state.messages.get(conversationId) || []
         const oldestMessage = existingMessages[0]
@@ -3566,7 +3688,8 @@ export const chatStore = createStore<ChatState>()(
           const olderMessages = await messageCache.getMessages(conversationId, {
             limit,
             before: oldestMessage.timestamp,
-          })
+          }).then(messages => refreshCachedCorrections(messages, isCurrent))
+          if (!isCurrent()) return []
 
           if (olderMessages.length > 0) {
             set((state) => {
@@ -3576,22 +3699,21 @@ export const chatStore = createStore<ChatState>()(
               // slice can overlap at the `before:` boundary), sort, keep-oldest trim
               // (load-older slides the window so scroll-back past the bound works).
               const { merged: trimmed, newestEvicted } = timeline.loadOlderSlice(
-                currentMessages,
+                reconcileCachedCorrections(currentMessages, olderMessages, getStorageScopeJid()),
                 olderMessages,
                 chatTimelineConfig()
               )
 
-              const newMessagesMap = new Map(state.messages)
-              newMessagesMap.set(conversationId, trimmed)
+              const update = commitCachedChatMessages(state, conversationId, trimmed)
 
               // If keep-oldest evicted the newest resident message, the window has slid
               // off the live edge → gate live appends in addMessage. If the batch fit
               // under the bound (newest unchanged), leave the flag as-is.
-              if (!newestEvicted) return { messages: newMessagesMap }
+              if (!newestEvicted) return update ?? state
 
               const newWindowAtLiveEdge = new Map(state.windowAtLiveEdge)
               newWindowAtLiveEdge.set(conversationId, false)
-              return { messages: newMessagesMap, windowAtLiveEdge: newWindowAtLiveEdge }
+              return { ...update, windowAtLiveEdge: newWindowAtLiveEdge }
             })
           }
 
@@ -3603,6 +3725,7 @@ export const chatStore = createStore<ChatState>()(
       },
 
       loadNewerMessagesFromCache: async (conversationId, limit = 50) => {
+        const isCurrent = captureChatCacheRead(conversationId)
         const state = get()
         const existingMessages = state.messages.get(conversationId) || []
         const newestMessage = existingMessages[existingMessages.length - 1]
@@ -3615,7 +3738,8 @@ export const chatStore = createStore<ChatState>()(
           const newerMessages = await messageCache.getMessages(conversationId, {
             after: newestMessage.timestamp,
             limit,
-          })
+          }).then(messages => refreshCachedCorrections(messages, isCurrent))
+          if (!isCurrent()) return []
 
           // Fewer than the requested limit came back ⇒ nothing more newer remains in the
           // cache, so the window has reached the tail (live edge) regardless of whether the
@@ -3629,21 +3753,20 @@ export const chatStore = createStore<ChatState>()(
               // Shared timeline machine: dedupe (overlap at the `after:` boundary),
               // sort, keep-newest trim (load-newer slides the window back down).
               const { merged: trimmed } = timeline.loadNewerSlice(
-                currentMessages,
+                reconcileCachedCorrections(currentMessages, newerMessages, getStorageScopeJid()),
                 newerMessages,
                 chatTimelineConfig()
               )
 
-              const newMessagesMap = new Map(state.messages)
-              newMessagesMap.set(conversationId, trimmed)
+              const update = commitCachedChatMessages(state, conversationId, trimmed)
 
-              if (!reachedTail) return { messages: newMessagesMap }
+              if (!reachedTail) return update ?? state
 
               // Reached the tail: clear any slid flag (absent = at the edge).
-              if (!state.windowAtLiveEdge.has(conversationId)) return { messages: newMessagesMap }
+              if (!state.windowAtLiveEdge.has(conversationId)) return update ?? state
               const newWindowAtLiveEdge = new Map(state.windowAtLiveEdge)
               newWindowAtLiveEdge.delete(conversationId)
-              return { messages: newMessagesMap, windowAtLiveEdge: newWindowAtLiveEdge }
+              return { ...update, windowAtLiveEdge: newWindowAtLiveEdge }
             })
           } else if (reachedTail) {
             // Empty batch: still need to clear the flag if the conversation isn't already at the edge.

--- a/packages/fluux-sdk/src/stores/correctionAccountScope.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/correctionAccountScope.integration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import type { Message, RoomMessage } from '../core/types'
+import { createMockRoom } from '../core/test-utils'
+import * as messageCache from '../utils/messageCache'
+import * as searchIndex from '../utils/searchIndex'
+import { _clearRetractedIdentitiesForTesting } from '../utils/retractedIdentities'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+
+const ACCOUNT_A = 'account-a@example.test'
+const ACCOUNT_B = 'account-b@example.test'
+const PEER = 'peer@example.test'
+const ROOM = 'room@conference.example.test'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  globalThis.indexedDB = new IDBFactory()
+  messageCache._resetDBForTesting()
+  searchIndex._resetDBForTesting()
+  _resetStorageScopeForTesting()
+  _clearRetractedIdentitiesForTesting()
+  localStorage.clear()
+  chatStore.setState({ messages: new Map() })
+  roomStore.setState({ messages: new Map(), rooms: new Map([[ROOM, createMockRoom(ROOM)]]) })
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await searchIndex.closeSearchIndex()
+  messageCache._resetDBForTesting()
+  _resetStorageScopeForTesting()
+})
+
+describe.each(['chat', 'room'] as const)('%s cache-only correction account scope', kind => {
+  it.each([ACCOUNT_A, null])('keeps deferred cache and search writes in initiating scope %s', async initiatingScope => {
+    const common = {
+      id: 'original', stanzaId: 'archive-original', body: 'initial text',
+      timestamp: new Date('2026-09-01T10:00:00.000Z'), isOutgoing: false,
+    }
+    const message: Message | RoomMessage = kind === 'chat'
+      ? { ...common, type: 'chat', conversationId: PEER, from: PEER }
+      : { ...common, type: 'groupchat', roomJid: ROOM, from: `${ROOM}/Peer`, nick: 'Peer', occupantId: 'peer-occupant' }
+    const otherMessage = { ...message, body: 'unchanged text' }
+    const save = async (row: Message | RoomMessage) => {
+      if (row.type === 'chat') await messageCache.saveMessages([row])
+      else await messageCache.saveRoomMessages([row])
+      await searchIndex.indexMessage(row)
+    }
+    const read = () => kind === 'chat' ? messageCache.getMessages(PEER) : messageCache.getRoomMessages(ROOM, {})
+
+    setStorageScopeJid(ACCOUNT_B)
+    await save(otherMessage)
+    setStorageScopeJid(initiatingScope)
+    await save(message)
+    expect(kind === 'chat' ? chatStore.getState().getMessage(PEER, message.id) : roomStore.getState().getMessage(ROOM, message.id)).toBeUndefined()
+
+    const completion = deferred()
+    const writes: Promise<unknown>[] = []
+    const operations = {
+      chat: messageCache.applyChatCorrection,
+      room: messageCache.applyRoomCorrection,
+      search: searchIndex.updateMessage,
+    }
+    const track = <A extends unknown[], R>(operation: (...args: A) => Promise<R>, wait = Promise.resolve()) => (...args: A) => {
+      const pending = Promise.all([operation(...args), wait]).then(([result]) => result)
+      writes.push(pending)
+      return pending
+    }
+    if (kind === 'chat') {
+      vi.spyOn(messageCache, 'applyChatCorrection').mockImplementation(track(operations.chat, completion.promise))
+    } else {
+      vi.spyOn(messageCache, 'applyRoomCorrection').mockImplementation(track(operations.room, completion.promise))
+    }
+    vi.spyOn(searchIndex, 'updateMessage').mockImplementation(track(operations.search))
+
+    const updates = {
+      body: 'confidential correction', isEdited: true,
+      correctionRevision: { ids: ['correction-1'], supersedes: [], archiveTimestamp: Date.parse('2026-09-01T10:01:00.000Z') },
+    }
+    try {
+      if (kind === 'chat') {
+        chatStore.getState().updateMessage(PEER, message.id, updates, undefined, { actorJid: message.from })
+      } else {
+        roomStore.getState().updateMessage(ROOM, message.id, updates, undefined, undefined, { actorJid: message.from, actorOccupantId: 'peer-occupant' })
+      }
+      setStorageScopeJid(ACCOUNT_B)
+    } finally {
+      completion.resolve()
+      let cursor = 0
+      while (cursor < writes.length) {
+        const batch = writes.slice(cursor)
+        cursor = writes.length
+        await Promise.all(batch)
+      }
+    }
+
+    await searchIndex.closeSearchIndex()
+    messageCache._resetDBForTesting()
+    expect(await searchIndex.search('confidential')).toEqual([])
+    expect(await searchIndex.search('unchanged')).toMatchObject([{ messageId: message.id, body: otherMessage.body }])
+    expect(await read()).toMatchObject([{ id: message.id, body: otherMessage.body }])
+
+    setStorageScopeJid(initiatingScope)
+    expect(await searchIndex.search('confidential')).toMatchObject([{
+      messageId: message.id, body: updates.body, from: message.from,
+      conversationId: kind === 'chat' ? PEER : ROOM, isRoom: kind === 'room',
+    }])
+    expect(await searchIndex.search('initial')).toEqual([])
+    expect(await read()).toMatchObject([{ id: message.id, body: updates.body, originalBody: message.body }])
+  })
+})

--- a/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
+++ b/packages/fluux-sdk/src/stores/retractionPropagation.integration.test.ts
@@ -1580,8 +1580,8 @@ describe('a reused client id after a retraction', () => {
     // client id and so still holds two — the retraction has to reach both.
     const live = chatMessage({ id: 'live-id', originId: 'O', body: `the ${SECRET} plan` })
     const archived = chatMessage({ id: 'mam-id', originId: 'O', body: `the ${SECRET} plan` })
-    await messageCache.saveMessages([live, archived])
     await searchIndex.indexMessages([live, archived])
+    await messageCache.saveMessages([live, archived])
     expect(await searchIndex.search(SECRET)).toHaveLength(2)
 
     await retractChatMessageInStorage(CHAT, live)

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -6089,9 +6089,9 @@ describe('roomStore', () => {
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
         roomJid,
         'muc-rewritten-id',
-        { isEdited: true, body: 'Hello (fixed)' },
+        { isEdited: true, body: 'Hello (fixed)', originalBody: 'Hello' },
         `${roomJid}/alice`,
-        undefined,
+        null,
         expect.objectContaining({
           id: 'muc-rewritten-id',
           originId: 'sender-origin-uuid',

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -13,7 +13,7 @@ import type {
   PageInfo,
 } from '../core/types'
 import type { ReadStateGeneration } from '../core/types/readStateGeneration'
-import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
+import { isNoLocalStore, resolveCorrectionUpdates, correctionContent, sameCorrection, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import {
   findMessageById,
@@ -23,14 +23,18 @@ import {
   mergeableOccupantCandidates,
   isMessageRow,
   resolveMessageReference,
+  messageReferences,
+  correctionReferences,
+  type CorrectionReferences,
   roomMessageAuthor,
   roomScope,
   sameLogicalMessage,
   sameMessageRow,
   type MessageRowRef,
+  type MessageActor,
 } from '../utils/messageIdentity'
 import { getBareJid } from '../core/jid'
-import { logInfo } from '../core/logger'
+import { logInfo, logWarn } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
@@ -80,6 +84,9 @@ import {
   notePurgedMarker,
   type PurgedMarkerKey,
 } from './shared/purgedMarkers'
+import {
+  matchesCorrectionTarget, reconcileCachedCorrections, reconcileCorrectionHandoff, refreshCachedCorrections,
+} from './shared/correctionHandoff'
 import { createArchiveSaveChain } from './shared/archiveSaveChain'
 import { newArchiveMergeTally, reportArchiveMergeWhenDurable } from './shared/archiveMergeDiagnostics'
 import * as draftState from './shared/draftState'
@@ -99,7 +106,7 @@ import { roomActivityTone } from './roomSelectors'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
-import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
+import { buildScopedStorageKey, captureStorageScope, getStorageScopeJid } from '../utils/storageScope'
 import { countOnlyClear, recountLedger, reportUnreadCleared } from './shared/recountDiagnostics'
 import type { RecountDeferralReason } from '../diagnostics/channel'
 import { createRecountRetryScheduler } from './shared/recountRetry'
@@ -720,6 +727,12 @@ function commitRoomUpdate(
   return result
 }
 
+function commitRoomCorrectionPreview(state: RoomState, roomJid: string, message: StoredRoomMessage): Partial<RoomState> | null {
+  const existing = state.roomMeta.get(roomJid)?.lastMessage ?? state.rooms.get(roomJid)?.lastMessage ?? state.messages.get(roomJid)?.at(-1)
+  const preview = reconcileCorrectionHandoff(existing, message, getStorageScopeJid())
+  return preview ? commitRoomUpdate(state, roomJid, { lastMessage: preview }) : null
+}
+
 /**
  * Merge a batch of cached room messages into a room's resident array (and runtime mirror),
  * returning the partial state update (or `null` when the room is not present). Shared by
@@ -816,10 +829,26 @@ function mergeCachedRoomMessages(
   const existing = newRooms.get(roomJid)
   if (!existing) return null
 
-  // Shared timeline machine: dedupe (in-memory messages take precedence),
-  // sort, and keep-newest trim.
+  // Reconcile edit revisions before deduplicating and trimming the window.
   const resident = state.messages.get(roomJid) ?? []
-  const { merged: rawMerged } = timeline.latestSlice(resident, cachedMessages, roomTimelineConfig())
+  const { merged: rawMerged } = timeline.latestSlice(
+    reconcileCachedCorrections(resident, cachedMessages, getStorageScopeJid()),
+    cachedMessages,
+    roomTimelineConfig()
+  )
+  return commitCachedRoomMessages(state, roomJid, rawMerged)
+}
+
+function captureRoomCacheRead(roomJid: string): () => boolean {
+  const scope = captureStorageScope()
+  const epoch = roomCacheEpoch
+  const entityEpoch = currentRoomEntityEpoch(roomJid)
+  return () => scope.isCurrent() && epoch === roomCacheEpoch && entityEpoch === currentRoomEntityEpoch(roomJid)
+}
+
+function commitCachedRoomMessages(state: RoomState, roomJid: string, rawMerged: RoomMessage[], atLiveEdge?: boolean) {
+  const existing = state.rooms.get(roomJid)
+  if (!existing) return null
 
   // XEP-0424: a retraction recorded while this room was unloaded applies here,
   // the moment its target becomes resident.
@@ -829,11 +858,14 @@ function mergeCachedRoomMessages(
   // Sidebar preview via the shared policy: only replace when the merged set's
   // newest non-ignored message genuinely supersedes (or heals) the current
   // preview — a deep-history slice (scroll-position restore) must not regress it.
-  const { lastMessage } = derivePreviewAfterMerge(existing.lastMessage, merged, (msgs) =>
+  const current = existing.lastMessage
+    ? reconcileCachedCorrections([existing.lastMessage], merged, getStorageScopeJid())[0]
+    : undefined
+  const { lastMessage } = derivePreviewAfterMerge(current, merged, (msgs) =>
     findLastNonIgnoredMessage(msgs, roomJid, existing.nickToJidCache)
   )
 
-  const written = withRoomMessageWindow(state, roomJid, merged, { roomPatch: { lastMessage } })
+  const written = withRoomMessageWindow(state, roomJid, merged, { roomPatch: { lastMessage }, atLiveEdge })
   if (!written) return null
 
   // Update metadata with lastMessage for sidebar
@@ -994,12 +1026,17 @@ export interface RoomState {
     incrementMentions?: boolean
   }) => void
   updateReactions: (roomJid: string, messageId: string, reactorNick: string, emojis: string[]) => void
+  resolveCorrectionReferences: (roomJid: string, targetId: string, actor: MessageActor) => Promise<CorrectionReferences | null | undefined>
+  reconcileHistoryMessages: (messages: RoomMessage[]) => Promise<RoomMessage[]>
   updateMessage: (
     roomJid: string,
     messageId: string,
-    updates: Partial<RoomMessage>,
+    updates: Partial<StoredRoomMessage>,
     retractionReference?: string,
-    resolvedRetractionTarget?: RoomMessage
+    resolvedRetractionTarget?: RoomMessage,
+    correctionActor?: MessageActor,
+    onCorrectionMissing?: () => void,
+    onCorrectionResolved?: (message: StoredRoomMessage, isCurrent: () => boolean) => void
   ) => void
   clearMessageStanzaId: (roomJid: string, stanzaId: string) => void
   getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
@@ -1169,8 +1206,8 @@ export interface RoomState {
   hydratePreviewsFromCache: () => Promise<void>
 
   // MAM state management (XEP-0313 for MUC rooms)
-  setRoomMAMLoading: (roomJid: string, isLoading: boolean) => void
-  setRoomMAMError: (roomJid: string, error: string | null) => void
+  setRoomMAMLoading: (roomJid: string, isLoading: boolean, requestId?: string) => void
+  setRoomMAMError: (roomJid: string, error: string | null, requestId?: string) => void
   /**
    * Merge MAM messages into room and update query state.
    * @param roomJid - Room JID
@@ -2401,19 +2438,89 @@ export const roomStore = createStore<RoomState>()(
     })
   },
 
-  updateMessage: (roomJid, messageId, updates, retractionReference, resolvedRetractionTarget) => {
+  resolveCorrectionReferences: async (roomJid, targetId, actor) => {
+    const scope = captureStorageScope()
+    const epoch = roomCacheEpoch
+    const resolution = resolveMessageReference(get().messages.get(roomJid) ?? [], targetId, 'archive-first')
+    const candidates = resolution?.candidates.filter(({ message }) => roomMessageAuthor(message, actor)) ?? []
+    const target = candidates[0]?.message
+    if (target) return candidates.length === 1 ? correctionReferences(target) : null
+    if (resolution?.authoritative) return null
+    const references = await messageCache.getCorrectionReferences('room', roomJid, targetId, actor, scope.jid)
+    scope.assertCurrent()
+    if (epoch !== roomCacheEpoch) throw new DOMException('Correction lookup cancelled', 'AbortError')
+    return references
+  },
+
+  reconcileHistoryMessages: async (messages) => {
+    const scope = captureStorageScope()
+    const rooms = new Set(messages.map(message => message.roomJid))
+    const reconciled = await messageCache.reconcileRoomHistoryMessages(messages, () => {
+      scope.assertCurrent()
+      return Array.from(rooms, jid => get().messages.get(jid) ?? []).flat()
+    }, scope.jid)
+    scope.assertCurrent()
+    return reconciled
+  },
+
+  updateMessage: (roomJid, messageId, updates, retractionReference, resolvedRetractionTarget, correctionActor, onCorrectionMissing, onCorrectionResolved) => {
     let recountNeeded = false
+    const correctionPayload = updates
+    const contentRecovery = updates.contentRecovery
+    const liveCorrection = updates.liveCorrection
+    const persistCorrection = (pendingUpdates: Partial<StoredRoomMessage>, targetId = messageId) => {
+      if (!correctionActor) return
+      const scope = captureStorageScope()
+      const epoch = roomCacheEpoch
+      const entityEpoch = currentRoomEntityEpoch(roomJid)
+      const isCurrent = () => scope.isCurrent() && epoch === roomCacheEpoch && entityEpoch === currentRoomEntityEpoch(roomJid)
+      const fallback = () => {
+        if (!isCurrent() || !onCorrectionMissing) return
+        const current = get().messages.get(roomJid) ?? []
+        const resolution = resolveMessageReference(current, messageId, 'archive-first')
+        if (resolution?.candidates.some(({ message }) => roomMessageAuthor(message, correctionActor))) {
+          get().updateMessage(roomJid, messageId, { ...pendingUpdates, liveCorrection: false }, undefined, undefined, correctionActor)
+        } else if (!resolution?.authoritative) onCorrectionMissing()
+      }
+      void messageCache.applyRoomCorrection(roomJid, targetId, pendingUpdates, correctionActor, scope.jid)
+        .then(message => {
+          if (message) {
+            if (isCurrent()) set(current => {
+              const rows = current.messages.get(roomJid) ?? []
+              const index = rows.findIndex(row => matchesCorrectionTarget(row, message))
+              const updated = reconcileCorrectionHandoff(rows[index], message, scope.jid)
+              if (!updated) return commitRoomCorrectionPreview(current, roomJid, message) ?? current
+              const replay = resolveRoomPendingRetractions(current, roomJid, [updated], { persist: false })
+              const completed = replay.messages[0]
+              const written = withRoomMessageWindow(current, roomJid, rows.map((row, i) => i === index ? completed : row))
+              const previewPatch = commitRoomCorrectionPreview(current, roomJid, completed.isRetracted
+                ? { ...message, isRetracted: true, retractedAt: completed.retractedAt } : message)
+              return { ...written, ...previewPatch, ...(replay.pendingRetractions && { pendingRetractions: replay.pendingRetractions }) }
+            })
+            void searchIndex.updateMessage(message, scope.jid).catch(error => logWarn(`Failed to index correction: ${String(error)}`))
+            if (isCurrent()) onCorrectionResolved?.(message, isCurrent)
+          } else if (message === undefined) {
+            if (typeof indexedDB === 'undefined' && isCurrent()) {
+              const rows = get().messages.get(roomJid) ?? []
+              const current = resolveMessageReference(rows, targetId, 'archive-first')?.candidates
+                .find(({ message }) => roomMessageAuthor(message, correctionActor))?.message
+              if (current) { onCorrectionResolved?.(current, isCurrent); return }
+            }
+            fallback()
+          }
+        }, error => { logWarn(`Failed to persist room correction: ${String(error)}`) })
+    }
     set((state) => {
       const newRooms = new Map(state.rooms)
       const existing = newRooms.get(roomJid)
       if (!existing) return state
 
-      // Resolve to a single target: id/stanzaId win, origin-id is fallback only.
-      // Retractions (XEP-0424) reference the MUC stanza-id; corrections (XEP-0308)
-      // reference the sender-assigned origin-id (a MUC may rewrite the message id).
       const resident = state.messages.get(roomJid) ?? []
       let targetIdx: number
-      if (resolvedRetractionTarget) {
+      if (correctionActor) {
+        targetIdx = resolveMessageReference(resident, messageId, 'archive-first')?.candidates
+          .find(({ message }) => roomMessageAuthor(message, correctionActor))?.index ?? -1
+      } else if (resolvedRetractionTarget) {
         targetIdx = resident.indexOf(resolvedRetractionTarget)
       } else if (retractionReference) {
         targetIdx = resident.findIndex((message) => message.id === messageId)
@@ -2422,7 +2529,22 @@ export const roomStore = createStore<RoomState>()(
       } else {
         targetIdx = findMessageIndexById(resident, messageId)
       }
-      let updatedMessage: RoomMessage | undefined
+      if (targetIdx === -1 && correctionActor) {
+        if (resolveMessageReference(resident, messageId, 'archive-first')?.authoritative) return state
+        persistCorrection(updates)
+        return state
+      }
+      if (targetIdx !== -1) {
+        const target = resident[targetIdx]
+        const applicable = resolveCorrectionUpdates(target, {
+          ...updates,
+          ...(updates.isEdited && { originalBody: target.originalBody ?? target.body }),
+        }, getStorageScopeJid())
+        if (!applicable) return state
+        updates = applicable
+      }
+      let pendingPatch: Partial<Pick<RoomState, 'pendingRetractions'>> = {}
+      let updatedMessage: StoredRoomMessage | undefined
       const newMessages = targetIdx === -1 ? resident : resident.map((msg, i) => {
         if (i !== targetIdx) return msg
         updatedMessage = {
@@ -2430,6 +2552,10 @@ export const roomStore = createStore<RoomState>()(
           ...updates,
           ...(updates.isRetracted && msg.retractedAt ? { retractedAt: msg.retractedAt } : {}),
         }
+        const replay = resolveRoomPendingRetractions(state, roomJid, [updatedMessage], { persist: false })
+        updatedMessage = replay.messages[0]
+        if (updatedMessage.isRetracted) updates = { ...updates, isRetracted: true, retractedAt: updatedMessage.retractedAt }
+        if (replay.pendingRetractions) pendingPatch = { pendingRetractions: replay.pendingRetractions }
         return updatedMessage
       })
 
@@ -2440,16 +2566,22 @@ export const roomStore = createStore<RoomState>()(
           // document — is the storage sink's, so the resident path and the
           // not-resident path cannot drift.
           void retractRoomMessageInStorage(roomJid, updatedMessage, updates)
+        } else if (correctionActor) {
+          persistCorrection({ ...correctionPayload, ...(updates.isEdited && { ...correctionContent(updatedMessage), correctionAlternatives: updatedMessage.correctionAlternatives }), liveCorrection: liveCorrection && sameCorrection(correctionPayload, updatedMessage) }, messageReferences(updatedMessage, 'archive-first')[0])
         } else {
+          const scope = captureStorageScope()
+          const reindex = updates.body !== undefined
+          const message = updatedMessage
           void messageCache.updateRoomMessage(
             roomJid,
             updatedMessage.id,
-            updates,
+            { ...updates, ...(contentRecovery && { contentRecovery }) },
             updatedMessage.from,
-            undefined,
+            scope.jid,
             updatedMessage,
-          )
-          if (updates.body) void searchIndex.updateMessage(updatedMessage)
+          ).then(() => {
+            if (reindex && scope.isCurrent()) return searchIndex.updateMessage({ ...message, ...(contentRecovery && { contentRecovery }) }, scope.jid)
+          }).catch(error => logWarn(`Failed to index message update: ${String(error)}`))
         }
 
         // A retraction may target a `noLocalStore` message noted in
@@ -2478,15 +2610,15 @@ export const roomStore = createStore<RoomState>()(
       const written = withRoomMessageWindow(state, roomJid, newMessages)
       if (!written) return state
 
-      // Update metadata's lastMessage if the updated message is the last one
-      const lastMessage = newMessages[newMessages.length - 1]
-      const result: Partial<RoomState> = { ...written }
-      if (updatedMessage && lastMessage === updatedMessage) {
-        const newMeta = new Map(state.roomMeta)
-        const existingMeta = newMeta.get(roomJid)
-        if (existingMeta) {
-          newMeta.set(roomJid, { ...existingMeta, lastMessage })
-          result.roomMeta = newMeta
+      const result: Partial<RoomState> = { ...written, ...pendingPatch }
+      if (updatedMessage) {
+        if (correctionActor || updates.isEdited || updates.correctionRevision || updates.correctionStanzaIds || contentRecovery) {
+          Object.assign(result, commitRoomCorrectionPreview(state, roomJid, { ...updatedMessage, ...(contentRecovery && { contentRecovery }) }))
+        } else {
+          const preview = state.roomMeta.get(roomJid)?.lastMessage ?? existing.lastMessage
+          if (preview && matchesCorrectionTarget(preview, updatedMessage)) {
+            Object.assign(result, commitRoomUpdate(state, roomJid, { lastMessage: { ...preview, ...updates } }))
+          }
         }
       }
 
@@ -3806,6 +3938,7 @@ export const roomStore = createStore<RoomState>()(
   // IndexedDB cache loading
   // For initial load (no 'before'), loads the LATEST 100 messages to show most recent first
   loadMessagesFromCache: async (roomJid, options = {}) => {
+    const isCurrent = captureRoomCacheRead(roomJid)
     if (!messageCache.isMessageCacheAvailable()) {
       return []
     }
@@ -3820,7 +3953,8 @@ export const roomStore = createStore<RoomState>()(
         // `oldest` opts out: ascending oldest-N (the true cache bottom).
         latest: !options.before && !options.oldest,
       }
-      const cachedMessages = await messageCache.getRoomMessages(roomJid, queryOptions)
+      const cachedMessages = await messageCache.getRoomMessages(roomJid, queryOptions).then(messages => refreshCachedCorrections(messages, isCurrent))
+      if (!isCurrent()) return []
       // `peek`: a pure read that returns the messages WITHOUT pulling them into the
       // store. Used to compute a catch-up cursor for a non-active room without
       // breaking the invariant that only the active room is resident in RAM.
@@ -3850,12 +3984,14 @@ export const roomStore = createStore<RoomState>()(
   },
 
   loadMessagesAroundFromCache: async (roomJid, anchorRow, options = {}) => {
+    const isCurrent = captureRoomCacheRead(roomJid)
     if (!messageCache.isMessageCacheAvailable()) {
       return []
     }
 
     try {
-      const slice = await messageCache.getRoomMessagesAround(roomJid, anchorRow, options)
+      const slice = await messageCache.getRoomMessagesAround(roomJid, anchorRow, options).then(messages => refreshCachedCorrections(messages, isCurrent))
+      if (!isCurrent()) return []
       if (slice.length > 0) {
         set((state) => mergeCachedRoomMessages(state, roomJid, slice) ?? state)
       }
@@ -3867,6 +4003,7 @@ export const roomStore = createStore<RoomState>()(
   },
 
   loadOlderMessagesFromCache: async (roomJid, limit = 50) => {
+    const isCurrent = captureRoomCacheRead(roomJid)
     if (!messageCache.isMessageCacheAvailable()) {
       return []
     }
@@ -3885,7 +4022,8 @@ export const roomStore = createStore<RoomState>()(
       const cachedMessages = await messageCache.getRoomMessages(roomJid, {
         before: beforeDate,
         limit,
-      })
+      }).then(messages => refreshCachedCorrections(messages, isCurrent))
+      if (!isCurrent()) return []
 
       if (cachedMessages.length > 0) {
         // Prepend to existing messages via the shared timeline machine
@@ -3895,18 +4033,18 @@ export const roomStore = createStore<RoomState>()(
           if (!existing) return state
           const resident = state.messages.get(roomJid) ?? []
 
-          // Dedupe (in-memory messages take precedence), sort, keep-oldest trim
+          // Reconcile edits, preserve resident identity, sort, and keep-oldest trim
           // (load-older slides the window so scroll-back past the bound works).
           // If keep-oldest evicted the newest resident message, the window has
           // slid off the live edge → gate live appends in addMessage.
           const { merged, newestEvicted } = timeline.loadOlderSlice(
-            resident,
+            reconcileCachedCorrections(resident, cachedMessages, getStorageScopeJid()),
             cachedMessages,
             roomTimelineConfig()
           )
 
-          const written = withRoomMessageWindow(state, roomJid, merged,
-            newestEvicted ? { atLiveEdge: false } : {})
+          const written = commitCachedRoomMessages(state, roomJid, merged,
+            newestEvicted ? false : undefined)
           if (!written) return state
           return written
         })
@@ -3920,6 +4058,7 @@ export const roomStore = createStore<RoomState>()(
   },
 
   loadNewerMessagesFromCache: async (roomJid, limit = 50) => {
+    const isCurrent = captureRoomCacheRead(roomJid)
     if (!messageCache.isMessageCacheAvailable()) {
       return []
     }
@@ -3938,7 +4077,8 @@ export const roomStore = createStore<RoomState>()(
       const cachedMessages = await messageCache.getRoomMessages(roomJid, {
         after: afterDate,
         limit,
-      })
+      }).then(messages => refreshCachedCorrections(messages, isCurrent))
+      if (!isCurrent()) return []
 
       // Fewer than the requested limit came back ⇒ nothing more newer remains in the
       // cache, so the window has reached the tail (live edge) regardless of whether the
@@ -3953,16 +4093,16 @@ export const roomStore = createStore<RoomState>()(
           if (!existing) return state
           const resident = state.messages.get(roomJid) ?? []
 
-          // Dedupe (in-memory messages take precedence), sort, keep-newest trim
+          // Reconcile edits, preserve resident identity, sort, and keep-newest trim
           // (load-newer slides the window back down toward the live edge).
           const { merged } = timeline.loadNewerSlice(
-            resident,
+            reconcileCachedCorrections(resident, cachedMessages, getStorageScopeJid()),
             cachedMessages,
             roomTimelineConfig()
           )
 
-          const written = withRoomMessageWindow(state, roomJid, merged,
-            reachedTail ? { atLiveEdge: true } : {})
+          const written = commitCachedRoomMessages(state, roomJid, merged,
+            reachedTail ? true : undefined)
           if (!written) return state
           return written
         })
@@ -3996,6 +4136,7 @@ export const roomStore = createStore<RoomState>()(
   // Load the latest non-ignored message from cache for sidebar preview
   // This doesn't modify the messages array - it only updates lastMessage
   loadPreviewFromCache: async (roomJid) => {
+    const isCurrent = captureRoomCacheRead(roomJid)
     if (!messageCache.isMessageCacheAvailable()) {
       return null
     }
@@ -4013,12 +4154,15 @@ export const roomStore = createStore<RoomState>()(
         latest: true,
       })
 
+      if (!isCurrent()) return null
+
       if (cachedMessages.length > 0) {
         const latestMessage = findLastNonIgnoredMessage(cachedMessages, roomJid, room.nickToJidCache)
         if (!latestMessage) return null
 
         // Update only lastMessage in metadata and combined room
         set((state) => {
+          if (!isCurrent()) return state
           const room = state.rooms.get(roomJid)
           const meta = state.roomMeta.get(roomJid)
           if (!room || !meta) return state
@@ -4035,7 +4179,7 @@ export const roomStore = createStore<RoomState>()(
           return { roomMeta: newMeta, rooms: newRooms }
         })
 
-        return latestMessage
+        return isCurrent() ? latestMessage : null
       }
 
       return null
@@ -4058,11 +4202,12 @@ export const roomStore = createStore<RoomState>()(
     // Read caches in parallel (IndexedDB reads are cheap and non-blocking).
     const previews = await Promise.all(
       rooms.map(async (room) => {
+        const isCurrent = captureRoomCacheRead(room.jid)
         try {
           const cachedMessages = await messageCache.getRoomMessages(room.jid, { limit: 10, latest: true })
-          if (cachedMessages.length === 0) return null
+          if (!isCurrent() || cachedMessages.length === 0) return null
           const latest = findLastNonIgnoredMessage(cachedMessages, room.jid, room.nickToJidCache)
-          return latest ? { roomJid: room.jid, latest } : null
+          return latest ? { roomJid: room.jid, latest, isCurrent } : null
         } catch {
           // Best-effort per room - one room's cache failure shouldn't block others.
           return null
@@ -4070,7 +4215,7 @@ export const roomStore = createStore<RoomState>()(
       })
     )
 
-    const updates = previews.filter((p): p is { roomJid: string; latest: RoomMessage } => p !== null)
+    const updates = previews.filter((p): p is { roomJid: string; latest: RoomMessage; isCurrent: () => boolean } => p !== null)
     if (updates.length === 0) return
 
     // Apply every preview in a single write. shouldUpdateLastMessage guards against
@@ -4079,7 +4224,8 @@ export const roomStore = createStore<RoomState>()(
       const newMeta = new Map(state.roomMeta)
       const newRooms = new Map(state.rooms)
       let changed = false
-      for (const { roomJid, latest } of updates) {
+      for (const { roomJid, latest, isCurrent } of updates) {
+        if (!isCurrent()) continue
         const room = state.rooms.get(roomJid)
         const meta = state.roomMeta.get(roomJid)
         if (!room || !meta) continue
@@ -4094,15 +4240,15 @@ export const roomStore = createStore<RoomState>()(
   },
 
   // MAM state management (XEP-0313 for MUC rooms)
-  setRoomMAMLoading: (roomJid, isLoading) => {
+  setRoomMAMLoading: (roomJid, isLoading, requestId) => {
     set((state) => ({
-      mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, roomJid, isLoading),
+      mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, roomJid, isLoading, requestId),
     }))
   },
 
-  setRoomMAMError: (roomJid, error) => {
+  setRoomMAMError: (roomJid, error, requestId) => {
     set((state) => ({
-      mamQueryStates: mamState.setMAMError(state.mamQueryStates, roomJid, error),
+      mamQueryStates: mamState.setMAMError(state.mamQueryStates, roomJid, error, requestId),
     }))
   },
 

--- a/packages/fluux-sdk/src/stores/shared/correctionHandoff.ts
+++ b/packages/fluux-sdk/src/stores/shared/correctionHandoff.ts
@@ -1,0 +1,79 @@
+import { resolveCorrectionUpdates, type StoredMessage, type StoredRoomMessage } from '../../core/types/message-internal'
+import { archiveIdentityConflict, CHAT_SCOPE, chatMessageAuthor, roomMessageAuthor, roomScope, sameLogicalMessage } from '../../utils/messageIdentity'
+import { reconcileChatHistoryMessages, reconcileRoomHistoryMessages } from '../../utils/messageCache'
+import { getStorageScopeJid } from '../../utils/storageScope'
+
+type Row = StoredMessage | StoredRoomMessage
+
+export function matchesCorrectionTarget(held: Row, incoming: Row): boolean {
+  if (held.type !== incoming.type || archiveIdentityConflict(held, incoming)) return false
+  const actor = { actorJid: incoming.from, actorOccupantId: incoming.type === 'groupchat' ? incoming.occupantId : undefined }
+  if (held.type === 'chat' && incoming.type === 'chat') {
+    return held.conversationId === incoming.conversationId && chatMessageAuthor(held, actor) && sameLogicalMessage(CHAT_SCOPE, held, incoming)
+  }
+  return held.type === 'groupchat' && incoming.type === 'groupchat' && held.roomJid === incoming.roomJid &&
+    roomMessageAuthor(held, actor) && sameLogicalMessage(roomScope(held.roomJid), held, incoming)
+}
+
+export function reconcileCorrectionHandoff<T extends Row>(held: T | undefined, incoming: T, scope: string | null): T | undefined {
+  if (!held || !matchesCorrectionTarget(held, incoming)) return undefined
+  const updates = resolveCorrectionUpdates(held, {
+    body: incoming.body,
+    isEdited: incoming.isEdited,
+    originalBody: incoming.originalBody,
+    attachment: incoming.attachment,
+    encryptedPayload: incoming.encryptedPayload,
+    unsupportedEncryption: incoming.unsupportedEncryption,
+    securityContext: incoming.securityContext,
+    correctionTimestamp: incoming.correctionTimestamp,
+    correctionTimestampSource: incoming.correctionTimestampSource,
+    correctionRevision: incoming.correctionRevision,
+    correctionAlternatives: incoming.correctionAlternatives,
+    correctionStanzaIds: incoming.correctionStanzaIds,
+    correctionHandoff: incoming.correctionHandoff,
+    contentRecovery: incoming.contentRecovery,
+  }, scope)
+  const result = {
+    ...held,
+    ...updates,
+    ...(incoming.isRetracted && { isRetracted: true, retractedAt: held.retractedAt ?? incoming.retractedAt }),
+  }
+  return result.isRetracted ? {
+    ...result, body: '', originalBody: undefined, attachment: undefined,
+    linkPreview: undefined, poll: undefined, pollClosed: undefined,
+    encryptedPayload: undefined, unsupportedEncryption: undefined, correctionAlternatives: undefined,
+  } : result
+}
+
+/** Reconcile duplicate cache rows without replacing resident reactions or message identity. */
+export function reconcileCachedCorrections<T extends Row>(resident: T[], cached: readonly T[], scope: string | null): T[] {
+  let messages = resident
+  for (const incoming of cached) {
+    if (!incoming.isEdited && !incoming.isRetracted && !incoming.correctionStanzaIds?.length) continue
+    for (let index = 0; index < messages.length; index++) {
+      const held = messages[index]
+      const updated = reconcileCorrectionHandoff(held, incoming, scope)
+      if (!updated) continue
+      const next = updated
+      // Metadata unions can allocate equivalent arrays; unchanged hydration keeps row references.
+      const unchanged = (Object.keys(next) as (keyof T)[]).every(key =>
+        key === 'correctionRevision' || key === 'correctionStanzaIds' || key === 'correctionAlternatives'
+          ? JSON.stringify(next[key]) === JSON.stringify(held[key])
+          : next[key] === held[key]
+      )
+      if (unchanged) continue
+      if (messages === resident) messages = [...resident]
+      messages[index] = next
+    }
+  }
+  return messages
+}
+
+export async function refreshCachedCorrections<T extends Row>(cached: T[], isCurrent: () => boolean): Promise<T[]> {
+  if (!cached.length || !isCurrent()) return []
+  const scope = getStorageScopeJid()
+  const refreshed = cached[0].type === 'chat'
+    ? await reconcileChatHistoryMessages(cached as StoredMessage[], () => [], scope)
+    : await reconcileRoomHistoryMessages(cached as StoredRoomMessage[], () => [], scope)
+  return isCurrent() ? reconcileCachedCorrections(cached, refreshed as T[], scope) : []
+}

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -42,11 +42,13 @@ export function getMAMQueryState(
 export function setMAMLoading(
   states: Map<string, HistoryQueryState>,
   id: string,
-  isLoading: boolean
+  isLoading: boolean,
+  requestId?: string
 ): Map<string, HistoryQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
-  newStates.set(id, { ...current, isLoading })
+  if (!isLoading && requestId && current.loadingRequestId !== requestId) return states
+  newStates.set(id, { ...current, isLoading, loadingRequestId: isLoading ? requestId : undefined })
   return newStates
 }
 
@@ -56,11 +58,13 @@ export function setMAMLoading(
 export function setMAMError(
   states: Map<string, HistoryQueryState>,
   id: string,
-  error: string | null
+  error: string | null,
+  requestId?: string
 ): Map<string, HistoryQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
-  newStates.set(id, { ...current, error, isLoading: false })
+  if (requestId && current.loadingRequestId !== requestId) return states
+  newStates.set(id, { ...current, error, isLoading: false, loadingRequestId: undefined })
   return newStates
 }
 
@@ -213,7 +217,8 @@ export function setMAMQueryCompleted(
       : current.forwardGapTimestamp
 
   newStates.set(id, {
-    isLoading: false,
+    isLoading: current.loadingRequestId ? current.isLoading : false,
+    loadingRequestId: current.loadingRequestId,
     error: null,
     hasQueried: true,
     isHistoryComplete,

--- a/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { openDB } from 'idb'
+import * as cache from './messageCache'
+import * as searchIndex from './searchIndex'
+import { CHAT_SCOPE, correctionReferenceKeys, identityKeys, roomScope } from './messageIdentity'
+import { _resetStorageScopeForTesting } from './storageScope'
+import { _clearRetractedIdentitiesForTesting } from './retractedIdentities'
+import { retractUnresidentChatTarget, retractUnresidentRoomTarget } from '../stores/shared/retractionStorage'
+
+const DB_NAME = 'fluux-message-cache'
+const CHAT = 'peer@example.test'
+const ROOM = 'room@conference.example.test'
+const CHAT_STORE = 'messages-canonical'
+const ROOM_STORE = 'room-messages-canonical'
+
+function fixtures() {
+  const common = { id: 'original', stanzaId: 'original-archive', body: 'saved current correction', originalBody: 'original text', timestamp: 1000, isOutgoing: false, isEdited: true, correctionStanzaIds: ['older-alias', 'current-alias'], reactions: { ok: ['peer'] }, ids: ['original', 'old-client-id'] }
+  const chat: cache.StoredMessage = { ...common, type: 'chat', conversationId: CHAT, from: CHAT, cacheKey: 'preserved-chat-key', identityKeys: [] }
+  const room: cache.StoredRoomMessage = { ...common, type: 'groupchat', roomJid: ROOM, from: `${ROOM}/Peer`, nick: 'Peer', occupantId: 'peer-occupant', cacheKey: 'preserved-room-key', identityKeys: [] }
+  chat.identityKeys = identityKeys(CHAT_SCOPE, chat)
+  room.identityKeys = identityKeys(roomScope(ROOM), room)
+  return { chat, room }
+}
+
+async function seedV5() {
+  const rows = fixtures()
+  const db = await openDB(DB_NAME, 5, {
+    upgrade(database) {
+      const chat = database.createObjectStore(CHAT_STORE, { keyPath: 'cacheKey' })
+      chat.createIndex('conversationId', 'conversationId')
+      chat.createIndex('identityKeys', 'identityKeys', { multiEntry: true })
+      chat.createIndex('ids', 'ids', { multiEntry: true })
+      chat.createIndex('timestamp', 'timestamp')
+      chat.createIndex('conv_timestamp', ['conversationId', 'timestamp'])
+      chat.createIndex('encryptedPayload', 'encryptedPayload')
+      const room = database.createObjectStore(ROOM_STORE, { keyPath: 'cacheKey' })
+      room.createIndex('roomJid', 'roomJid')
+      room.createIndex('identityKeys', 'identityKeys', { multiEntry: true })
+      room.createIndex('ids', 'ids', { multiEntry: true })
+      room.createIndex('timestamp', 'timestamp')
+      room.createIndex('room_timestamp', ['roomJid', 'timestamp'])
+      room.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'])
+    },
+  })
+  const tx = db.transaction([CHAT_STORE, ROOM_STORE], 'readwrite')
+  await tx.objectStore(CHAT_STORE).put(rows.chat)
+  await tx.objectStore(ROOM_STORE).put(rows.room)
+  await tx.done
+  db.close()
+  return rows
+}
+
+beforeEach(() => {
+  globalThis.indexedDB = new IDBFactory()
+  cache._resetDBForTesting()
+  searchIndex._resetDBForTesting()
+  _resetStorageScopeForTesting()
+  _clearRetractedIdentitiesForTesting()
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await searchIndex.closeSearchIndex()
+  cache._resetDBForTesting()
+})
+
+describe('version-5 correction alias migration', () => {
+  it('preserves every row and key, then resolves and retracts cached correction aliases', async () => {
+    const rows = await seedV5()
+    expect((await cache.findChatRetractionTargets(CHAT, 'older-alias'))?.candidates).toHaveLength(1)
+    expect((await cache.findRoomRetractionTargets(ROOM, 'older-alias'))?.candidates).toHaveLength(1)
+    expect(await cache.findChatRetractionTargets('other@example.test', 'older-alias')).toBeUndefined()
+    expect(await cache.findRoomRetractionTargets('other@conference.example.test', 'older-alias')).toBeUndefined()
+    const db = await openDB(DB_NAME)
+    expect(db.version).toBe(6)
+    for (const [store, row, scope] of [[CHAT_STORE, rows.chat, CHAT_SCOPE], [ROOM_STORE, rows.room, roomScope(ROOM)]] as const) {
+      const saved = await db.getAll(store)
+      expect(saved).toEqual([{ ...row, identityKeys: [...new Set([...row.identityKeys, ...correctionReferenceKeys(scope, row)])].sort() }])
+    }
+    db.close()
+    await retractUnresidentChatTarget(CHAT, { targetId: 'older-alias', actorJid: 'other@example.test', retractedAt: 2000 })
+    await retractUnresidentRoomTarget(ROOM, { targetId: 'older-alias', actorJid: rows.room.from, actorOccupantId: 'other-occupant', retractedAt: 2000 })
+    expect((await cache.getMessages(CHAT))[0].body).toBe(rows.chat.body)
+    expect((await cache.getRoomMessages(ROOM))[0].body).toBe(rows.room.body)
+    await retractUnresidentChatTarget(CHAT, { targetId: 'older-alias', actorJid: rows.chat.from, retractedAt: 2000 })
+    await retractUnresidentRoomTarget(ROOM, { targetId: 'older-alias', actorJid: rows.room.from, actorOccupantId: rows.room.occupantId, retractedAt: 2000 })
+    expect((await cache.getMessages(CHAT))[0]).toMatchObject({ isRetracted: true, body: '' })
+    expect((await cache.getRoomMessages(ROOM))[0]).toMatchObject({ isRetracted: true, body: '' })
+  })
+
+  it('performs ordinary correction lookups without reading whole histories after upgrading', async () => {
+    const rows = await seedV5()
+    await cache.findChatRetractionTargets(CHAT, 'older-alias')
+    const getAll = IDBIndex.prototype.getAll
+    vi.spyOn(IDBIndex.prototype, 'getAll').mockImplementation(function (this: IDBIndex, ...args) {
+      if (this.name === 'conversationId' || this.name === 'roomJid') throw new Error('whole history read')
+      return getAll.apply(this, args)
+    })
+    vi.spyOn(IDBObjectStore.prototype, 'getAll').mockImplementation(() => { throw new Error('whole store read') })
+    const updates = { isEdited: true, body: 'new correction', correctionRevision: { ids: ['stanza:new-alias'], supersedes: [], archiveTimestamp: 3000 }, correctionStanzaIds: ['new-alias'] }
+    expect(await cache.applyChatCorrection(CHAT, 'original', updates, { actorJid: rows.chat.from })).toMatchObject({ body: 'new correction' })
+    expect(await cache.applyRoomCorrection(ROOM, 'original', updates, { actorJid: rows.room.from, actorOccupantId: rows.room.occupantId })).toMatchObject({ body: 'new correction' })
+    expect((await cache.findChatRetractionTargets(CHAT, 'older-alias'))?.candidates[0].body).toBe('new correction')
+    expect((await cache.findRoomRetractionTargets(ROOM, 'older-alias'))?.candidates[0].body).toBe('new correction')
+  })
+
+  it('rolls back both stores if alias backfill fails after its first update', async () => {
+    const rows = await seedV5()
+    const update = IDBCursor.prototype.update
+    let updates = 0
+    const fault = vi.spyOn(IDBCursor.prototype, 'update').mockImplementation(function (this: IDBCursor, value) {
+      if (++updates === 2) throw new Error('backfill interrupted')
+      return update.call(this, value)
+    })
+    await cache.findChatRetractionTargets(CHAT, 'older-alias')
+    fault.mockRestore()
+    const db = await openDB(DB_NAME)
+    expect(db.version).toBe(5)
+    expect(await db.getAll(CHAT_STORE)).toEqual([rows.chat])
+    expect(await db.getAll(ROOM_STORE)).toEqual([rows.room])
+    db.close()
+  })
+})

--- a/packages/fluux-sdk/src/utils/messageCache.corrections.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.corrections.test.ts
@@ -1,0 +1,5391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory, IDBIndex, IDBObjectStore } from 'fake-indexeddb'
+import { openDB } from 'idb'
+import { client as createClient, xml, type Element } from '@xmpp/client'
+import { MAM } from '../core/modules/MAM'
+import { Chat } from '../core/modules/Chat'
+import { Connection } from '../core/modules/Connection'
+import { createMockRoom, createMockStores, createMockXmppClient } from '../core/test-utils'
+import { createStoreBindings, type StoreRefs } from '../bindings/storeBindings'
+import type { ModuleDependencies } from '../core/modules/BaseModule'
+import { createPresenceReader } from '../core/presenceReader'
+import type { SDKEventSource } from '../core/types/eventSource'
+import type { SDKEvents } from '../core/types/sdk-events'
+import { captureContentSource, resolveCorrectionUpdates, type StoredMessage, type StoredRoomMessage } from '../core/types/message-internal'
+import { chatStore } from '../stores/chatStore'
+import { connectionStore } from '../stores/connectionStore'
+import { createFetchOlderHistory } from '../hooks/shared/createFetchOlderHistory'
+import { roomStore } from '../stores/roomStore'
+import { ignoreStore } from '../stores/ignoreStore'
+import { DeferredDecryptEngine } from '../core/e2ee/deferredDecrypt'
+import { E2EEManager, InMemoryStorageBackend } from '../core/e2ee'
+import { DummyPlaintextPlugin } from '../core/e2ee/DummyPlaintextPlugin'
+import { dataToElement } from '../core/e2ee/stanzaAdapter'
+import { serialize as serializePayload } from '../core/e2ee/payloadEnvelope'
+import * as cache from './messageCache'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
+import * as retractionStorage from '../stores/shared/retractionStorage'
+import { _clearRetractedIdentitiesForTesting } from './retractedIdentities'
+import * as searchIndex from './searchIndex'
+
+vi.mock('@xmpp/client', async importOriginal => ({
+  ...await importOriginal<typeof import('@xmpp/client')>(),
+  client: vi.fn(),
+}))
+
+const PEER = 'peer@example.test'
+const SELF = 'me@example.test'
+const ROOM = 'room@conference.example.test'
+const T0 = '2026-09-01T10:00:00.000Z'
+const T1 = '2026-09-01T10:01:00.000Z'
+const T2 = '2026-09-01T10:02:00.000Z'
+const FAST = '2026-09-01T10:05:00.000Z'
+type Kind = 'chat' | 'room'
+type Row = StoredMessage | StoredRoomMessage
+type Edit = { encrypted?: boolean; oobUrl?: string; to?: string; id: string; body: string; at?: string; authoredAt?: string; from?: string; occupantId?: string; locked?: boolean; stanzaIdBy?: string; omitStanzaId?: boolean; archiveId?: string; targetId?: string; omitOriginId?: boolean; stanzaId?: string; extraStanzaIds?: Array<{ id: string; by: string }> }
+const writes: Promise<unknown>[] = []
+let unbind: () => void
+
+function original(kind: Kind, own = false): Row {
+  const common = { id: 'original', stanzaId: 'archive-original', body: 'original text', timestamp: new Date(T0), isOutgoing: own }
+  return kind === 'chat'
+    ? { ...common, type: 'chat', conversationId: PEER, from: own ? SELF : PEER }
+    : { ...common, type: 'groupchat', roomJid: ROOM, from: `${ROOM}/Peer`, nick: 'Peer', occupantId: 'peer-occupant' }
+}
+
+function seed(kind: Kind, rows: Row[]) {
+  if (kind === 'chat') chatStore.setState({ messages: new Map([[PEER, rows as StoredMessage[]]]) })
+  else roomStore.setState({ messages: new Map([[ROOM, rows as StoredRoomMessage[]]]) })
+}
+
+function resident(kind: Kind): Row | undefined {
+  return (kind === 'chat' ? chatStore.getState().getMessage(PEER, 'original') : roomStore.getState().getMessage(ROOM, 'original')) as Row | undefined
+}
+
+async function drain() {
+  let cursor = 0
+  while (cursor < writes.length) {
+    const batch = writes.slice(cursor)
+    cursor = writes.length
+    await Promise.all(batch)
+  }
+}
+
+async function save(kind: Kind, ...messages: Row[]) {
+  if (kind === 'chat') await cache.saveMessages(messages as StoredMessage[])
+  else await cache.saveRoomMessages(messages as StoredRoomMessage[])
+}
+
+async function reload(kind: Kind): Promise<Row> {
+  await drain()
+  seed(kind, [])
+  cache._resetDBForTesting()
+  const messages = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+  expect(messages).toHaveLength(1)
+  seed(kind, messages)
+  return messages[0] as Row
+}
+
+function harness(kind: Kind, own = false, originalFields: Partial<Row> = {}) {
+  const listeners = new Map<keyof SDKEvents, (payload: never) => void>()
+  const source: SDKEventSource = {
+    subscribe(event, handler) {
+      listeners.set(event, handler as (payload: never) => void)
+      return () => { listeners.delete(event) }
+    },
+  }
+  const historyRows: Row[][] = []
+  const events: Array<{ event: keyof SDKEvents; payload: unknown }> = []
+  const emitSDK: ModuleDependencies['emitSDK'] = (event, payload) => {
+    events.push({ event, payload })
+    if (event === 'chat:history-messages' || event === 'room:history-messages') historyRows.push(structuredClone((payload as { messages: Row[] }).messages))
+    listeners.get(event)?.(payload as never)
+  }
+  unbind?.()
+  unbind = createStoreBindings(source, () => ({
+    chat: chatStore.getState(), room: roomStore.getState(), ignore: ignoreStore.getState(), console: { addEvent() {} },
+  }) as unknown as StoreRefs)
+  const stores = createMockStores()
+  stores.chat.resolveCorrectionReferences.mockImplementation((...args) => chatStore.getState().resolveCorrectionReferences(...args))
+  stores.room.resolveCorrectionReferences.mockImplementation((...args) => roomStore.getState().resolveCorrectionReferences(...args))
+  stores.chat.reconcileHistoryMessages.mockImplementation(messages => chatStore.getState().reconcileHistoryMessages(messages))
+  stores.room.reconcileHistoryMessages.mockImplementation(messages => roomStore.getState().reconcileHistoryMessages(messages))
+  stores.chat.refreshLastMessageContent.mockImplementation((...args) => chatStore.getState().refreshLastMessageContent(...args))
+  stores.chat.getEncryptedPreviews.mockImplementation(() => Array.from(chatStore.getState().conversationMeta).flatMap(([conversationId, meta]) =>
+    meta.lastMessage?.encryptedPayload ? [{ conversationId, lastMessage: meta.lastMessage }] : []))
+  stores.chat.getMessage.mockImplementation((id, ref) => chatStore.getState().getMessage(id, ref))
+  stores.room.getMessage.mockImplementation((id, ref) => roomStore.getState().getMessage(id, ref))
+  stores.room.getRoom.mockImplementation(id => roomStore.getState().rooms.get(id))
+  stores.chat.updateMessage.mockImplementation((...args) => chatStore.getState().updateMessage(...args))
+  stores.room.updateMessage.mockImplementation((...args) => roomStore.getState().updateMessage(...args))
+  stores.chat.getAllStoredMessages.mockImplementation(() => Array.from(chatStore.getState().messages, ([id, messages]) => ({ id, messages })))
+  stores.room.getAllRoomMessages.mockImplementation(() => Array.from(roomStore.getState().messages, ([jid, messages]) => ({ jid, messages })))
+  const collectors = new Map<string, (stanza: Element) => void>()
+  let page: Edit[] = []
+  let includeOriginal = false
+  let signals: Element[] = []
+  let signalsFirst = false
+  let searchComplete: boolean | undefined
+  let remainingPages: Array<{ edits: Edit[]; original?: boolean; signals?: Element[] }> = []
+  const sent: Element[] = []
+  const base = { ...original(kind, own), ...originalFields }
+  const archiveBy = kind === 'room' ? ROOM : SELF
+  const stanza = (entry: Edit) => {
+    const message = xml('message', { id: entry.id, from: entry.from ?? base.from, to: entry.to ?? SELF, type: base.type },
+      xml('body', {}, entry.encrypted ? 'encrypted fallback' : entry.body),
+      ...(entry.encrypted ? [xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from(entry.body).toString('base64'))] : []),
+      ...(entry.oobUrl ? [xml('x', { xmlns: 'jabber:x:oob' }, xml('url', {}, entry.oobUrl))] : []),
+      xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: entry.targetId ?? base.id }),
+      ...(entry.omitOriginId ? [] : [xml('origin-id', { xmlns: 'urn:xmpp:sid:0', id: entry.id })]),
+      ...(entry.omitStanzaId ? [] : [xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: entry.stanzaIdBy ?? archiveBy, id: entry.stanzaId ?? `sid-${entry.id}` })]),
+      ...(entry.extraStanzaIds ?? []).map(attrs => xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', ...attrs })),
+      ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: entry.occupantId ?? 'peer-occupant' })] : []),
+      ...(entry.at ? [xml('delay', { xmlns: 'urn:xmpp:delay', stamp: entry.at })] : []))
+    if (entry.authoredAt) Object.assign(message, { __authoredAt: new Date(entry.authoredAt) })
+    if (entry.locked) Object.assign(message, { __encryptedPayload: xml('message', { from: entry.from ?? base.from },
+      xml('body', {}, entry.body), xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, 'cmVjb3ZlcmVk')).toString() })
+    return message
+  }
+  const deps: ModuleDependencies = {
+    stores, presence: createPresenceReader(), getCurrentJid: () => SELF, getXmpp: () => null,
+    sendStanza: async s => { sent.push(s) }, emit: () => {}, emitSDK,
+    registerMAMCollector: (id, collector) => { collectors.set(id, collector); return () => { collectors.delete(id) } },
+    sendIQ: async iq => {
+      const nextPage = remainingPages.shift()
+      if (nextPage) { page = nextPage.edits; includeOriginal = !!nextPage.original; signals = nextPage.signals ?? [] }
+      const queryId = iq.getChild('query', 'urn:xmpp:mam:2')?.attrs.queryid
+      const collector = queryId && collectors.get(queryId)
+      if (!collector) throw new Error('MAM collector missing')
+      const entries = page.map(entry => ({ message: stanza(entry), at: entry.at, id: entry.archiveId ?? entry.stanzaId ?? `sid-${entry.id}` }))
+      if (includeOriginal) entries.unshift({ message: xml('message', { id: base.id, from: base.from, to: SELF, type: base.type },
+        xml('body', {}, base.body), xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: archiveBy, id: base.stanzaId! }),
+        ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : [])), at: T0, id: base.stanzaId! })
+      const signalEntries = signals.map((message, i) => ({ message, at: T2, id: `signal-${i}` }))
+      if (signalsFirst) entries.unshift(...signalEntries)
+      else entries.push(...signalEntries)
+      for (const entry of entries) collector(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: queryId, id: entry.id },
+        xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+          ...(entry.at ? [xml('delay', { xmlns: 'urn:xmpp:delay', stamp: entry.at })] : []), entry.message))))
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: searchComplete === false || remainingPages.length ? 'false' : 'true' },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, entries[0]?.id ?? ''), xml('last', {}, entries.at(-1)?.id ?? ''))))
+    },
+  }
+  const mam = new MAM(deps)
+  const chat = new Chat(deps, mam)
+  return {
+    stores, sent, historyRows, events, deps, chat, mam, stanza,
+    async archivePages(pages: Array<{ edits: Edit[]; original?: boolean; signals?: Element[] }>, forward: boolean) {
+      remainingPages = [...pages]
+      const options = forward ? { start: T0, maxAutoPages: pages.length } : {}
+      const result = kind === 'chat' ? await mam.queryArchive({ with: PEER, ...options }) : await mam.queryRoomArchive({ roomJid: ROOM, ...options })
+      await drain()
+      return result.messages as Row[]
+    },
+    async context(edits: Edit[]) {
+      page = edits; includeOriginal = true
+      const result = await mam.fetchContext(kind === 'chat' ? PEER : ROOM, kind === 'room', T0, 2)
+      await drain()
+      return result.messages as Row[]
+    },
+    async archive(edits: Edit[], withOriginal = false, extraSignals: Element[] = []) {
+      page = edits; includeOriginal = withOriginal; signals = extraSignals
+      const result = kind === 'chat' ? await mam.queryArchive({ with: PEER }) : await mam.queryRoomArchive({ roomJid: ROOM })
+      await drain()
+      return result.messages as Row[]
+    },
+    async search(edits: Edit[], withOriginal = true, extraSignals: Element[] = [], prependSignals = false, query = 'text') {
+      page = edits; includeOriginal = withOriginal; signals = extraSignals; signalsFirst = prependSignals
+      const result = kind === 'chat' ? await mam.searchArchive({ query, with: PEER }) : await mam.searchRoomArchive({ query, roomJid: ROOM })
+      await drain()
+      return result.messages as Row[]
+    },
+    async searchResult(query: string, options: { global?: boolean; before?: string; complete?: boolean; signals?: Element[]; withOriginal?: boolean; paging?: boolean } = {}) {
+      page = []; includeOriginal = options.withOriginal ?? true; signals = options.signals ?? []; searchComplete = options.complete
+      const result = options.paging
+        ? await mam.searchConversationByPaging({ query, with: PEER, maxPages: 1 })
+        : kind === 'chat'
+          ? await mam.searchArchive({ query, ...(options.global ? {} : { with: PEER }), before: options.before })
+          : await mam.searchRoomArchive({ query, roomJid: ROOM, before: options.before })
+      await drain()
+      return result
+    },
+    receive(edit: Edit) { chat.handle(stanza(edit)) },
+    async live(edit: Edit) { chat.handle(stanza(edit)); await drain() },
+    async carbon(edit: Edit & { at: string }) {
+      chat.handle(xml('message', {}, xml('received', { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+        xml('delay', { xmlns: 'urn:xmpp:delay', stamp: edit.at }), stanza({ ...edit, at: undefined })))))
+      await drain()
+    },
+    async outgoing(body: string, attachment?: Row['attachment']) { await chat.sendCorrection(kind === 'chat' ? PEER : ROOM, base.id, body, attachment); await drain(); return sent.at(-1)!.attrs.id },
+    emitSDK,
+  }
+}
+
+beforeEach(() => {
+  cache._resetDBForTesting(); searchIndex._resetDBForTesting(); _resetStorageScopeForTesting(); _clearRetractedIdentitiesForTesting()
+  globalThis.indexedDB = new IDBFactory()
+  chatStore.getState().reset(); roomStore.getState().reset()
+  chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+  roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+  writes.length = 0
+  const track = <A extends unknown[], R>(implementation: (...args: A) => Promise<R>, settle = false) => (...args: A) => {
+    const promise = implementation(...args)
+    writes.push(settle ? promise.catch(() => {}) : promise)
+    return promise
+  }
+  const updateSearch = searchIndex.updateMessage
+  const indexMessage = searchIndex.indexMessage
+  const indexMessages = searchIndex.indexMessages
+  const retractions = { ...retractionStorage }
+  vi.spyOn(searchIndex, 'updateMessage').mockImplementation(track(updateSearch, true))
+  vi.spyOn(searchIndex, 'indexMessage').mockImplementation(track(indexMessage, true))
+  vi.spyOn(searchIndex, 'indexMessages').mockImplementation(track(indexMessages, true))
+  vi.spyOn(retractionStorage, 'retractUnresidentChatTarget').mockImplementation(track(retractions.retractUnresidentChatTarget))
+  vi.spyOn(retractionStorage, 'retractUnresidentRoomTarget').mockImplementation(track(retractions.retractUnresidentRoomTarget))
+  vi.spyOn(retractionStorage, 'retractChatMessageInStorage').mockImplementation(track(retractions.retractChatMessageInStorage))
+  vi.spyOn(retractionStorage, 'retractRoomMessageInStorage').mockImplementation(track(retractions.retractRoomMessageInStorage))
+  const implementations = { ...cache }
+  vi.spyOn(cache, 'saveMessages').mockImplementation(track(implementations.saveMessages))
+  vi.spyOn(cache, 'saveRoomMessages').mockImplementation(track(implementations.saveRoomMessages))
+  vi.spyOn(cache, 'updateMessage').mockImplementation(track(implementations.updateMessage))
+  vi.spyOn(cache, 'updateRoomMessage').mockImplementation(track(implementations.updateRoomMessage))
+  vi.spyOn(cache, 'applyChatCorrection').mockImplementation(track(implementations.applyChatCorrection))
+  vi.spyOn(cache, 'applyRoomCorrection').mockImplementation(track(implementations.applyRoomCorrection))
+})
+afterEach(async () => {
+  try { await drain() } finally {
+    await searchIndex.closeSearchIndex(); unbind?.(); vi.useRealTimers(); vi.restoreAllMocks(); cache._resetDBForTesting()
+  }
+})
+
+function permutations<T>(items: T[]): T[][] {
+  return items.length ? items.flatMap((item, index) => permutations(items.filter((_, i) => i !== index)).map(rest => [item, ...rest])) : [[]]
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+async function blockedDecrypt(body = 'stale recovered text') {
+  const manager = new E2EEManager({ storage: new InMemoryStorageBackend(), account: { jid: SELF }, xmpp: {
+    sendStanza: async () => {}, queryDisco: async () => ({ features: [], identities: [] }),
+    publishPEP: async () => {}, retractPEP: async () => {}, deletePEP: async () => {}, queryPEP: async () => [], subscribePEP: () => ({ unsubscribe() {} }),
+  } })
+  await manager.register(new DummyPlaintextPlugin())
+  const started = deferred()
+  const release = deferred()
+  vi.spyOn(manager, 'decryptArchive').mockImplementation(async () => {
+    started.resolve()
+    await release.promise
+    return { plaintext: new TextEncoder().encode(body), senderDevice: { jid: PEER, deviceId: 'test' }, securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' as const }, authoredAt: new Date(FAST) }
+  })
+  return { manager, started, release }
+}
+
+
+describe.each<Kind>(['chat', 'room'])('%s live correction archive ownership', kind => {
+  it.each([false, true].flatMap(cachedOnly => [false, true].map(omitOriginId => ({ cachedOnly, omitOriginId }))))('retains current live text after foreign-ID replay, cache-only: $cachedOnly, omitted origin: $omitOriginId', async ({ cachedOnly, omitOriginId }) => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seedPreview(kind, base)
+    seed(kind, cachedOnly ? [] : [base])
+    const first: Edit = { id: 'c1', body: 'first superseded caption', stanzaId: 'foreign-c1', stanzaIdBy: 'foreign.example.test', omitOriginId }
+    const second: Edit = { id: 'c2', body: 'current live caption', stanzaId: 'foreign-c2', stanzaIdBy: 'foreign.example.test', omitOriginId }
+    await h.live(first); await h.live(second)
+    const current = await reload(kind)
+    expect(current.body).toBe(second.body)
+    if (cachedOnly) seed(kind, [])
+    const oldArchive = { ...first, at: T1, archiveId: 'archive-c1' }
+    expect((await h.search([oldArchive], true, [], false, second.body))[0].body).toBe(second.body)
+    await h.archive([oldArchive], !cachedOnly)
+    expect(preview(kind)?.body).toBe(second.body)
+    expect(await reload(kind)).toMatchObject({ body: second.body, timestamp: base.timestamp, stanzaId: base.stanzaId })
+    expect(await searchIndex.search('superseded')).toHaveLength(0)
+    expect(await searchIndex.search('current')).toHaveLength(1)
+    if (kind === 'chat') await h.carbon({ ...first, at: T1 })
+    else await h.live({ ...first, at: T1 })
+    expect((await reload(kind)).body).toBe(second.body)
+    await h.archive([{ ...second, at: T2, archiveId: 'archive-c2' }])
+    const enriched = await reload(kind)
+    expect(enriched.body).toBe(second.body)
+    expect(enriched.correctionRevision?.ids).toContain('stanza:archive-c2')
+    expect(enriched.correctionRevision?.ids).not.toContain('stanza:foreign-c2')
+    expect(enriched.correctionStanzaIds).toEqual(expect.arrayContaining(['foreign-c1', 'foreign-c2', 'archive-c1', 'archive-c2']))
+    await h.live({ id: 'c3', body: 'new live progress', stanzaId: 'foreign-c3', stanzaIdBy: 'foreign.example.test' })
+    await h.archive([oldArchive], true)
+    expect((await reload(kind)).body).toBe('new live progress')
+    expect(preview(kind)?.body).toBe('new live progress')
+    expect(await searchIndex.search('progress')).toHaveLength(1)
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s intrinsic archive correction references', kind => {
+  it.each([false, true].flatMap(forward => [false, true].flatMap(split => [false, true].map(reverseBody => ({ forward, split, reverseBody })))))(
+    'orders an archive-result target, forward: $forward, split: $split, reverse body: $reverseBody', async ({ forward, split, reverseBody }) => {
+      const h = harness(kind)
+      const base = original(kind)
+      await save(kind, base); seedPreview(kind, base)
+      expect(resident(kind)).toBeUndefined()
+      const first: Edit = { id: 'c1', body: reverseBody ? 'zulu' : 'alpha', at: T1, stanzaId: 'foreign-c1', stanzaIdBy: 'foreign.example.test', archiveId: 'archive-c1' }
+      const second: Edit = { id: 'c2', body: reverseBody ? 'alpha' : 'zulu', at: T1, targetId: 'archive-c1', stanzaId: 'foreign-c2', stanzaIdBy: 'foreign.example.test', archiveId: 'archive-c2', ...(kind === 'room' && { from: `${ROOM}/Renamed` }) }
+      const pages = split ? (forward ? [first, second] : [second, first]).map(edit => ({ edits: [edit] })) : [{ edits: [first, second] }]
+      await h.archivePages(pages, forward)
+      expect(preview(kind)?.body).toBe(second.body)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+      const held = await reload(kind)
+      expect(held).toMatchObject({ body: second.body, id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+      expect(held.correctionRevision?.ids).toContain('stanza:archive-c2')
+      expect(held.correctionRevision?.ids).not.toContain('stanza:foreign-c2')
+      expect(held.correctionRevision?.supersedes).toContain('stanza:archive-c1')
+      expect(held.correctionStanzaIds).toEqual(expect.arrayContaining(['foreign-c1', 'archive-c1', 'foreign-c2', 'archive-c2']))
+      expect(await searchIndex.search(first.body)).toHaveLength(0)
+      expect(await searchIndex.search(second.body)).toHaveLength(1)
+      expect((await h.search([first], true, [], false, second.body))[0].body).toBe(second.body)
+      await h.archive([first], true)
+      expect((await reload(kind)).body).toBe(second.body)
+      searchIndex._resetDBForTesting()
+      expect(await searchIndex.search(second.body)).toHaveLength(1)
+      await h.archive([{ id: 'c3', body: 'latest progress', at: T2, targetId: 'archive-c2' }])
+      await h.archive([first, second], true)
+      expect((await reload(kind)).body).toBe('latest progress')
+      expect(preview(kind)?.body).toBe('latest progress')
+      expect(await searchIndex.search(second.body)).toHaveLength(0)
+      expect(await searchIndex.search('progress')).toHaveLength(1)
+    })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s account switch after modification resolution', kind => {
+  it.each(['backward', 'forward', 'search'].flatMap(method => [false, true].flatMap(roundTrip => ['correction', 'retraction', 'original'].map(payload => ({ method, roundTrip, payload })))))(
+    'abandons $payload before effects, method: $method, round trip: $roundTrip', async ({ method, roundTrip, payload }) => {
+      const base = original(kind)
+      const other = { ...base, body: 'second account content' }
+      setStorageScopeJid('second@example.test')
+      await save(kind, other); await searchIndex.indexMessage(other)
+      setStorageScopeJid(SELF)
+      await save(kind, base); await searchIndex.indexMessage(base)
+      const h = harness(kind)
+      seed(kind, [])
+      const replacement = roundTrip ? base : other
+      let eventsAtSwitch: number | undefined
+      const switchAccount = () => {
+        setStorageScopeJid('second@example.test')
+        chatStore.getState().switchAccount('second@example.test'); roomStore.getState().switchAccount('second@example.test')
+        if (roundTrip) {
+          setStorageScopeJid(SELF)
+          chatStore.getState().switchAccount(SELF); roomStore.getState().switchAccount(SELF)
+        }
+        chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+        roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+        seed(kind, [replacement]); seedPreview(kind, replacement)
+        eventsAtSwitch = h.events.length
+      }
+      const scheduleSwitch = () => queueMicrotask(() => queueMicrotask(switchAccount))
+      if (payload === 'correction') {
+        if (kind === 'chat') h.stores.chat.resolveCorrectionReferences.mockImplementationOnce(async (...args) => {
+          const resolved = await chatStore.getState().resolveCorrectionReferences(...args)
+          scheduleSwitch()
+          return resolved
+        })
+        else h.stores.room.resolveCorrectionReferences.mockImplementationOnce(async (...args) => {
+          const resolved = await roomStore.getState().resolveCorrectionReferences(...args)
+          scheduleSwitch()
+          return resolved
+        })
+      } else h.deps.getE2EEManager = () => { scheduleSwitch(); return null }
+      const edits: Edit[] = payload === 'correction' ? [{ id: 'c1', body: 'first account private correction', at: T1 }] : []
+      const signals = payload === 'retraction' ? [xml('message', { from: base.from, type: base.type },
+        xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: base.stanzaId! }),
+        ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : []))] : []
+      const work = method === 'search' ? h.search(edits, payload === 'original', signals)
+        : h.archivePages([{ edits, original: payload === 'original', signals }], method === 'forward')
+      await expect(work).rejects.toMatchObject({ name: 'AbortError' })
+      await drain()
+      expect(eventsAtSwitch).toBeDefined()
+      expect(resident(kind)).toMatchObject(replacement)
+      expect(resident(kind)?.isRetracted).not.toBe(true)
+      expect(preview(kind)).toMatchObject(replacement)
+      expect(preview(kind)?.isRetracted).not.toBe(true)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+      expect(h.events.slice(eventsAtSwitch)).toEqual([])
+      expect(h.stores.chat.reconcileHistoryMessages).not.toHaveBeenCalled()
+      expect(h.stores.room.reconcileHistoryMessages).not.toHaveBeenCalled()
+      for (const [scope, expected] of [[SELF, base], ['second@example.test', other]] as const) {
+        setStorageScopeJid(scope)
+        cache._resetDBForTesting(); searchIndex._resetDBForTesting()
+        const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject(expected)
+        expect(rows[0].isRetracted).not.toBe(true)
+        expect(await searchIndex.search('private')).toHaveLength(0)
+        expect(await searchIndex.search(scope === SELF ? 'original' : 'second')).toHaveLength(1)
+      }
+    })
+})
+
+
+async function abortCorrectionWrite(kind: Kind, mutate: () => void) {
+  const put = IDBObjectStore.prototype.put
+  const storeName = kind === 'chat' ? 'messages-canonical' : 'room-messages-canonical'
+  let aborted = false
+  const fault = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = put.apply(this, args)
+    if (this.name === storeName && !aborted) {
+      request.addEventListener('success', () => { aborted = true; this.transaction.abort() })
+    }
+    return request
+  })
+  const offset = writes.length
+  try {
+    mutate()
+    const pending = writes.slice(offset)
+    for (let i = offset; i < writes.length; i++) writes[i] = writes[i].catch(() => {})
+    const results = await Promise.allSettled(pending)
+    await drain()
+    expect(aborted).toBe(true)
+    expect(results).toEqual(expect.arrayContaining([expect.objectContaining({ status: 'rejected', reason: expect.objectContaining({ name: 'AbortError' }) })]))
+  } finally { fault.mockRestore() }
+}
+
+
+describe.each<Kind>(['chat', 'room'])('%s correction persistence retry', kind => {
+  const read = () => kind === 'chat' ? cache.getMessages(PEER) : cache.getRoomMessages(ROOM, {})
+  const retryModes = kind === 'chat' ? ['mam', 'live', 'carbon'] : ['mam', 'live']
+
+  it.each(retryModes.flatMap(mode => ['text', 'empty caption', 'ciphertext'].map(content => ({ mode, content }))))(
+    'repairs an aborted write through $mode with $content', async ({ mode, content }) => {
+      const h = harness(kind)
+      const base = original(kind)
+      await save(kind, base); seed(kind, [base]); seedPreview(kind, base); await searchIndex.indexMessage(base)
+      const edit: Edit = { id: 'c1', body: content === 'empty caption' ? 'https://files.example.test/image.png' : 'replacement caption',
+        ...(content === 'empty caption' && { oobUrl: 'https://files.example.test/image.png' }), ...(content === 'ciphertext' && { locked: true }) }
+      await abortCorrectionWrite(kind, () => h.receive(edit))
+      const current = structuredClone(resident(kind)!)
+      expect(current.isEdited).toBe(true)
+      expect(current.body).toBe(content === 'empty caption' ? '' : edit.body)
+      expect((await read())[0].body).toBe(base.body)
+      expect(await searchIndex.search('original')).toHaveLength(1)
+      const replay = { ...edit, ...(mode !== 'live' && { at: T1 }) }
+      if (mode === 'mam') await h.archivePages([{ edits: [replay] }], true)
+      else if (mode === 'carbon') await h.carbon({ ...replay, at: T1 })
+      else await h.live(replay)
+      expect(resident(kind)?.body).toBe(current.body)
+      expect(preview(kind)?.body).toBe(current.body)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+      const repaired = (await read())[0] as Row
+      expect(repaired).toMatchObject({ body: current.body, isEdited: true, timestamp: base.timestamp, stanzaId: base.stanzaId })
+      expect(repaired.encryptedPayload).toBe(current.encryptedPayload)
+      expect(repaired.correctionRevision?.supersedes).toEqual([])
+      expect(repaired.liveCorrection).toBeUndefined()
+      const writer = kind === 'chat' ? vi.mocked(cache.applyChatCorrection) : vi.mocked(cache.applyRoomCorrection)
+      expect(writer.mock.calls.at(-1)?.[2].liveCorrection).not.toBe(true)
+      expect(await searchIndex.search('original')).toHaveLength(0)
+      expect(await searchIndex.search('replacement')).toHaveLength(content === 'empty caption' ? 0 : 1)
+      expect((await reload(kind)).body).toBe(current.body)
+      searchIndex._resetDBForTesting()
+      expect(await searchIndex.search('original')).toHaveLength(0)
+    })
+
+  it.each(retryModes.flatMap(mode => [false, true].map(cacheHasC1 => ({ mode, cacheHasC1 }))))(
+    'keeps C2 resident while resolving older $mode replay against cache C1: $cacheHasC1', async ({ mode, cacheHasC1 }) => {
+      const h = harness(kind)
+      const base = original(kind)
+      await save(kind, base); seed(kind, [base]); seedPreview(kind, base); await searchIndex.indexMessage(base)
+      const c1: Edit = { id: 'c1', body: 'first caption' }
+      if (cacheHasC1) await h.live(c1)
+      else await abortCorrectionWrite(kind, () => h.receive(c1))
+      await abortCorrectionWrite(kind, () => h.receive({ id: 'c2', body: 'second caption' }))
+      const current = structuredClone(resident(kind)!)
+      expect(current.body).toBe('second caption')
+      expect((await read())[0].body).toBe(cacheHasC1 ? c1.body : base.body)
+      if (mode === 'mam') await h.archivePages([{ edits: [{ ...c1, at: T1 }] }], true)
+      else if (mode === 'carbon') await h.carbon({ ...c1, at: T1 })
+      else await h.live(c1)
+      expect(resident(kind)?.body).toBe(current.body)
+      expect(preview(kind)?.body).toBe(current.body)
+      const repaired = (await read())[0] as Row
+      expect(repaired.body).toBe(c1.body)
+      expect(repaired.correctionRevision?.ids).toContain('stanza:sid-c1')
+      expect(repaired.correctionRevision?.supersedes).not.toContain('stanza:sid-c2')
+      expect(await searchIndex.search('first')).toHaveLength(1)
+      expect(await searchIndex.search('original')).toHaveLength(0)
+      await h.archivePages([{ edits: [{ id: 'c2', body: current.body, at: T2 }] }], true)
+      expect((await reload(kind)).body).toBe(current.body)
+      expect(await searchIndex.search('first')).toHaveLength(0)
+      expect(await searchIndex.search('second')).toHaveLength(1)
+    })
+
+  it('does not grant a known live replay authority over a newer durable revision', async () => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    const c1: Edit = { id: 'c1', body: 'first caption' }
+    await abortCorrectionWrite(kind, () => h.receive(c1))
+    const durable: Row = { ...base, body: 'newer durable caption', isEdited: true,
+      correctionRevision: { ids: ['stanza:sid-c2'], supersedes: [], archiveTimestamp: Date.parse(T2) } }
+    await save(kind, durable)
+    await h.live(c1)
+    expect((await read())[0].body).toBe(durable.body)
+    expect(await searchIndex.search('newer')).toHaveLength(1)
+    expect(await searchIndex.search('first')).toHaveLength(0)
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s queried retraction handoff', kind => {
+  it.each([false, true].flatMap(forward => ['canonical', 'new alias', 'existing alias', 'cross-page alias', 'foreign author'].map(target => ({ forward, target }))))('tombstones queried duplicates, forward: $forward, target: $target', async ({ forward, target }) => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await searchIndex.indexMessage(base)
+    if (target === 'existing alias') await h.live({ id: 'c0', body: 'existing caption' })
+    const correction: Edit = { id: 'c1', body: 'corrected caption', at: T1 }
+    const targetId = target === 'canonical' ? base.stanzaId! : target === 'existing alias' ? 'sid-c0' : 'sid-c1'
+    const foreign = target === 'foreign author'
+    const signal = xml('message', { from: foreign && kind === 'chat' ? 'foreign@example.test' : base.from, type: base.type, id: 'retract' },
+      xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: targetId }),
+      ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: foreign ? 'foreign-occupant' : 'peer-occupant' })] : []))
+    const pages = target === 'cross-page alias'
+      ? forward ? [{ edits: [correction], original: true }, { edits: [], signals: [signal] }]
+        : [{ edits: [], signals: [signal] }, { edits: [correction], original: true }]
+      : [{ edits: [correction], original: true, signals: [signal] }]
+    for (let replay = 0; replay < 2; replay++) {
+      await h.archivePages(pages, forward)
+      expect(resident(kind)?.isRetracted === true).toBe(!foreign)
+      expect(preview(kind)?.isRetracted === true).toBe(!foreign)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+      const durable = (kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0]
+      expect(durable.isRetracted === true).toBe(!foreign)
+      expect(await searchIndex.search('caption')).toHaveLength(foreign ? 1 : 0)
+      expect(await searchIndex.search('original')).toHaveLength(0)
+    }
+    await h.archive([correction], true)
+    expect((await reload(kind)).isRetracted === true).toBe(!foreign)
+    expect(preview(kind)?.isRetracted === true).toBe(!foreign)
+    expect(await searchIndex.search('caption')).toHaveLength(foreign ? 1 : 0)
+  })
+
+  it('abandons a queried retraction after an account generation change', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await searchIndex.indexMessage(base)
+    const send = h.deps.sendIQ
+    h.deps.sendIQ = async (...args) => {
+      const result = await send(...args)
+      setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+      return result
+    }
+    const signal = xml('message', { from: base.from, type: base.type },
+      xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'sid-c1' }),
+      ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : []))
+    await expect(h.archive([{ id: 'c1', body: 'corrected caption', at: T1 }], true, [signal])).rejects.toThrow()
+    expect(resident(kind)).toMatchObject(base)
+    expect(preview(kind)).toMatchObject(base)
+    expect((await reload(kind)).isRetracted).not.toBe(true)
+    expect(await searchIndex.search('original')).toHaveLength(1)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s preview recovery source ownership', kind => {
+  it.each([false, true].flatMap(edited => (kind === 'chat' ? [false, true] : [false]).flatMap(cachedOnly => ['recovered original caption', ''].map(body => ({ edited, cachedOnly, body })))))('keeps a newer preview after interrupted persistence, edited source: $edited, cache-only: $cachedOnly, body: "$body"', async ({ edited, cachedOnly, body }) => {
+    const h = harness(kind)
+    const url = 'https://files.example.test/photo.png'
+    const source: Row = { ...original(kind), body: 'encrypted fallback caption',
+      encryptedPayload: xml('message', {}, xml('body', {}, 'encrypted fallback caption'), xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, 'cGVuZGluZw=='),
+        ...(body === '' ? [xml('x', { xmlns: 'jabber:x:oob' }, xml('url', {}, url))] : [])).toString(),
+      ...(edited && { isEdited: true, correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) }, correctionStanzaIds: ['sid-c1'] }),
+    }
+    await save(kind, source); seed(kind, [source]); seedPreview(kind, source)
+    if (kind === 'chat') vi.mocked(cache.applyChatCorrection).mockResolvedValueOnce(null)
+    else vi.mocked(cache.applyRoomCorrection).mockResolvedValueOnce(null)
+    await h.live({ id: 'c2', body: 'newest unsaved caption', at: T2, authoredAt: T2 })
+    const before = structuredClone(preview(kind)!)
+    expect(before.body).toBe('newest unsaved caption')
+    seed(kind, [])
+    if (!cachedOnly || kind === 'room') {
+      if (kind === 'chat') await chatStore.getState().loadMessagesFromCache(PEER)
+      else await roomStore.getState().loadMessagesFromCache(ROOM)
+      expect(resident(kind)).toMatchObject(source)
+    }
+    expect(preview(kind)).toEqual(before)
+    const decrypt = await blockedDecrypt(body === '' ? url : body)
+    const engine = new DeferredDecryptEngine({ getManager: () => decrypt.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    expect(await retry).toBe(1); await drain()
+    if (!cachedOnly || kind === 'room') expect(resident(kind)?.body).toBe(body)
+    expect(preview(kind)).toEqual(before)
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(before)
+    const durable = await reload(kind)
+    expect(durable.body).toBe(body)
+    expect(durable.encryptedPayload).toBeUndefined()
+    expect(durable.contentRecovery).toBeUndefined()
+    expect(durable.correctionRevision?.ids).toEqual(source.correctionRevision?.ids)
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+    expect(await searchIndex.search('recovered')).toHaveLength(body ? 1 : 0)
+    expect(preview(kind)).toEqual(before)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s same-page correction alias retractions', kind => {
+  it.each([false, true].flatMap(signalsFirst => [false, true].flatMap(chained => [false, true].map(foreign => ({ signalsFirst, chained, foreign })))))('resolves retractions after aliases, first: $signalsFirst, chained: $chained, foreign: $foreign', async ({ signalsFirst, chained, foreign }) => {
+    const h = harness(kind)
+    const base = original(kind)
+    const corrections: Edit[] = [{ id: 'c1', body: 'corrected caption', at: T1 }]
+    if (chained) corrections.push({ id: 'c2', body: 'chained caption', targetId: 'sid-c1', at: T2 })
+    const targetId = chained ? 'sid-c2' : 'sid-c1'
+    const actor = foreign && kind === 'chat' ? 'foreign@example.test' : base.from
+    const signal = xml('message', { from: actor, type: base.type, id: 'retraction' },
+      xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: targetId }),
+      ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: foreign ? 'foreign-occupant' : 'peer-occupant' })] : []))
+    const matches = await h.search(corrections, true, [signal], signalsFirst, 'caption')
+    expect(matches).toHaveLength(foreign ? 1 : 0)
+    expect(kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})).toHaveLength(0)
+    const [row] = await h.archive(corrections, true, [signal])
+    expect(row.id).toBe(base.id)
+    expect(row.stanzaId).toBe(base.stanzaId)
+    expect(row.isRetracted === true).toBe(!foreign)
+    expect(row.correctionStanzaIds).toContain(targetId)
+    await save(kind, row); seedPreview(kind, row); seed(kind, [row])
+    await searchIndex.indexMessage(row)
+    await h.archive([{ id: 'c1', body: 'corrected caption', at: T1 }], true)
+    const durable = await reload(kind)
+    expect(durable.isRetracted === true).toBe(!foreign)
+    expect(preview(kind)?.isRetracted === true).toBe(!foreign)
+    expect(await searchIndex.search('caption')).toHaveLength(foreign ? 1 : 0)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s corrections in historical windows', kind => {
+  it.each(['unrelated newer', 'same original', 'newer revision', 'conflicting archive', 'foreign author'] as const)('preserves preview ownership for $0', async mode => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base])
+    let sidebar: Row = base
+    if (mode === 'unrelated newer') sidebar = { ...base, id: 'newer-original', stanzaId: 'newer-archive', body: 'unrelated newest preview', timestamp: new Date(FAST) }
+    if (mode === 'conflicting archive') sidebar = { ...base, stanzaId: 'different-archive', body: 'separate original preview', timestamp: new Date(FAST) }
+    if (mode === 'foreign author') sidebar = { ...base, from: kind === 'chat' ? 'foreign@example.test' : `${ROOM}/Other`, ...(kind === 'room' && { occupantId: 'other-occupant' }), body: 'different author preview', timestamp: new Date(FAST) }
+    if (mode === 'newer revision') sidebar = { ...base, body: 'newest revision preview', isEdited: true, correctionRevision: { ids: ['stanza:sid-c2'], supersedes: [], archiveTimestamp: Date.parse(T2) } }
+    seedPreview(kind, sidebar)
+    const before = structuredClone(preview(kind))
+    await h.archive([{ id: 'c1', body: 'historical corrected caption', at: T1 }], true)
+    if (mode === 'same original') expect(preview(kind)?.body).toBe('historical corrected caption')
+    else expect(preview(kind)).toMatchObject({ id: before!.id, stanzaId: before!.stanzaId, body: before!.body, timestamp: before!.timestamp })
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+    if (mode === 'same original') {
+      await h.archive([{ id: 'c0', body: 'stale caption', at: T0 }], true)
+      expect(preview(kind)?.body).toBe('historical corrected caption')
+    }
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s intrinsic legacy correction evidence', kind => {
+  it.each(['cache-only', 'resident', 'page'].flatMap(mode => [['alpha', 'zulu'], ['zulu', 'alpha']].map(([older, current]) => ({ mode, older, current }))))('preserves $current against $older through $mode replay', async ({ mode, older, current }) => {
+    const h = harness(kind)
+    const edit: Edit = { id: 'c1', body: older, at: T1, stanzaId: 'foreign-c1', stanzaIdBy: 'foreign.example.test', archiveId: 'archive-c1' }
+    const [oldPage] = await h.search([edit], true, [], false, older)
+    const legacy: Row = { ...original(kind), body: current, originalBody: 'original text', isEdited: true, correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored', correctionStanzaIds: ['foreign-c1', 'foreign-c2'] }
+    await save(kind, legacy); seedPreview(kind, legacy)
+    seed(kind, mode === 'resident' ? [legacy] : [])
+    await searchIndex.backfillFromMessageCache()
+    const rows = await h.archive([edit], mode === 'page')
+    if (mode === 'page') expect(rows[0].body).toBe(current)
+    if (mode === 'resident') expect(resident(kind)?.body).toBe(current)
+    expect(preview(kind)?.body).toBe(current)
+    expect(await reload(kind)).toMatchObject({ body: current, correctionTimestamp: Date.parse(FAST), stanzaId: legacy.stanzaId, timestamp: legacy.timestamp })
+    await save(kind, oldPage)
+    await searchIndex.indexMessages([oldPage])
+    await searchIndex.closeSearchIndex(); cache._resetDBForTesting()
+    const held = await reload(kind)
+    expect(held.body).toBe(current)
+    expect(held.correctionRevision).toBeUndefined()
+    expect(await searchIndex.search(current)).toHaveLength(1)
+    expect(await searchIndex.search(older)).toHaveLength(0)
+    await h.archive([{ id: 'c3', body: 'progressing revision', at: T2, stanzaId: 'foreign-c3', stanzaIdBy: 'foreign.example.test', archiveId: 'archive-c3' }], true)
+    const next = await reload(kind)
+    expect(next.body).toBe('progressing revision')
+    expect(next.correctionRevision?.ids).toContain('stanza:archive-c3')
+    expect(next.correctionRevision?.ids).not.toContain('stanza:foreign-c3')
+    expect(next.correctionStanzaIds).toEqual(expect.arrayContaining(['foreign-c1', 'foreign-c2', 'foreign-c3']))
+    await h.archive([edit], true)
+    expect((await reload(kind)).body).toBe(next.body)
+    expect(await searchIndex.search('progressing')).toHaveLength(1)
+    expect(await searchIndex.search(older)).toHaveLength(0)
+  })
+})
+
+describe.each(['chat-cache', 'chat-resident', 'room-resident'] as const)('%s recovered correction search', mode => {
+  const kind: Kind = mode === 'room-resident' ? 'room' : 'chat'
+  const attachmentUrl = 'https://files.example.test/photo.png'
+  async function prepare(body: string) {
+    const h = harness(kind)
+    const source: Row = {
+      ...original(kind), body: 'encrypted fallback caption', isEdited: true,
+      encryptedPayload: xml('message', {}, xml('body', {}, 'encrypted fallback caption'), xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, 'cGVuZGluZw=='),
+        ...(body === '' ? [xml('x', { xmlns: 'jabber:x:oob' }, xml('url', {}, attachmentUrl))] : [])).toString(),
+      correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+    }
+    await save(kind, source); seedPreview(kind, source)
+    seed(kind, mode === 'chat-cache' ? [] : [source])
+    await searchIndex.backfillFromMessageCache()
+    expect(await searchIndex.search('fallback')).toHaveLength(1)
+    const decrypt = await blockedDecrypt(body === '' ? attachmentUrl : body)
+    const engine = new DeferredDecryptEngine({ getManager: () => decrypt.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    return { h, source, decrypt, engine }
+  }
+
+  it.each(['recovered searchable caption', '', '👍'])('indexes accepted body "%s" after completed backfill and reopen', async body => {
+    const { source, decrypt, engine } = await prepare(body)
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    expect(await retry).toBe(1); await drain()
+    if (mode !== 'chat-cache') expect(resident(kind)?.body).toBe(body)
+    expect(preview(kind)?.body).toBe(body)
+    const row = await reload(kind)
+    expect(row).toMatchObject({ body, encryptedPayload: undefined, correctionTimestamp: Date.parse(FAST), correctionRevision: source.correctionRevision })
+    if (body === '') expect(row.attachment?.url).toBe(attachmentUrl)
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+    expect(await searchIndex.search('recovered')).toHaveLength(body === 'recovered searchable caption' ? 1 : 0)
+    await searchIndex.closeSearchIndex(); cache._resetDBForTesting()
+    await searchIndex.backfillFromMessageCache()
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+    expect((await reload(kind)).body).toBe(body)
+  })
+
+  it.each(['newer correction', 'retraction', 'account round trip'] as const)('keeps search aligned across a concurrent %s', async change => {
+    const { h, source, decrypt, engine } = await prepare('stale recovered text')
+    const retry = engine.retryPending()
+    await decrypt.started.promise
+    if (change === 'newer correction') await h.archive([{ id: 'c2', body: 'newest searchable revision', at: T2 }])
+    else if (change === 'retraction') {
+      if (kind === 'chat') await retractionStorage.retractChatMessageInStorage(PEER, source as StoredMessage, { isRetracted: true, body: '' })
+      else await retractionStorage.retractRoomMessageInStorage(ROOM, source as StoredRoomMessage, { isRetracted: true, body: '' })
+    } else { setStorageScopeJid('other@example.test'); setStorageScopeJid(null) }
+    decrypt.release.resolve(); await retry; await drain()
+    expect(await searchIndex.search('stale')).toHaveLength(0)
+    const row = await reload(kind)
+    if (change === 'newer correction') {
+      expect(row.body).toBe('newest searchable revision')
+      expect(preview(kind)?.body).toBe(row.body)
+      expect(await searchIndex.search('newest')).toHaveLength(1)
+    } else if (change === 'retraction') {
+      expect(row.isRetracted).toBe(true)
+      expect(await searchIndex.search('fallback')).toHaveLength(0)
+    } else {
+      expect(row.body).toBe(source.body)
+      expect(preview(kind)?.body).toBe(source.body)
+      expect(await searchIndex.search('fallback')).toHaveLength(1)
+    }
+  })
+
+  it('indexes the durable winner when a newer correction arrives after recovery writes', async () => {
+    const { h, decrypt, engine } = await prepare('stale recovered text')
+    const written = deferred(), releaseWrite = deferred()
+    if (kind === 'chat') {
+      const update = vi.mocked(cache.updateMessage).getMockImplementation()!
+      vi.mocked(cache.updateMessage).mockImplementationOnce(async (...args) => {
+        await update(...args); written.resolve(); await releaseWrite.promise
+      })
+    } else {
+      const update = vi.mocked(cache.updateRoomMessage).getMockImplementation()!
+      vi.mocked(cache.updateRoomMessage).mockImplementationOnce(async (...args) => {
+        await update(...args); written.resolve(); await releaseWrite.promise
+      })
+    }
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve(); await written.promise
+    await h.archive([{ id: 'c2', body: 'newest searchable revision', at: T2 }])
+    releaseWrite.resolve(); await retry; await drain()
+    expect((await reload(kind)).body).toBe('newest searchable revision')
+    expect(preview(kind)?.body).toBe('newest searchable revision')
+    expect(await searchIndex.search('newest')).toHaveLength(1)
+    expect(await searchIndex.search('stale')).toHaveLength(0)
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+  })
+
+  it('keeps recovery usable after local indexing fails and permits a search retry', async () => {
+    const { decrypt, engine } = await prepare('recovered searchable caption')
+    vi.mocked(searchIndex.updateMessage).mockRejectedValueOnce(new Error('transient search failure'))
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    expect(await retry).toBe(1); await drain()
+    const row = await reload(kind)
+    expect(row.body).toBe('recovered searchable caption')
+    expect(preview(kind)?.body).toBe(row.body)
+    expect(await searchIndex.search('fallback')).toHaveLength(1)
+    await searchIndex.updateMessage(row)
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+    expect(await searchIndex.search('recovered')).toHaveLength(1)
+  })
+
+  if (mode !== 'chat-cache') it('keeps nonpersistent recovered captions out of cache and search', async () => {
+    const h = harness(kind)
+    const source: Row = { ...original(kind), body: 'encrypted fallback caption', isEdited: true, noLocalStore: true,
+      encryptedPayload: '<message><body>encrypted fallback caption</body><plain xmlns="urn:fluux:e2ee-dummy:0">cGVuZGluZw==</plain></message>' }
+    seed(kind, [source]); seedPreview(kind, source)
+    const decrypt = await blockedDecrypt('recovered private caption')
+    const engine = new DeferredDecryptEngine({ getManager: () => decrypt.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    expect(await retry).toBe(1); await drain()
+    expect(resident(kind)?.body).toBe('recovered private caption')
+    expect(preview(kind)?.body).toBe('recovered private caption')
+    expect(kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})).toHaveLength(0)
+    expect(await searchIndex.search('private')).toHaveLength(0)
+    expect(await searchIndex.search('fallback')).toHaveLength(0)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s durable corrections', kind => {
+  it('lets later archive evidence replace a provisional winner in every full-row merge order', async () => {
+    const h = harness(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    await h.archive([{ id: 'c0', body: 'archived baseline', at: T0 }])
+    await h.live({ id: 'c2', body: 'latest text' })
+    const undated = await reload(kind)
+    await h.archive([{ id: 'c1', body: 'provisional text', at: T1 }])
+    const provisional = await reload(kind)
+    expect(provisional.body).toBe('provisional text')
+    expect(provisional.correctionRevision?.supersedes).not.toContain('stanza:sid-c2')
+    await h.archive([{ id: 'c2', body: 'latest text', at: T2 }])
+    const dated = await reload(kind)
+    expect(dated.body).toBe('latest text')
+    for (const order of permutations([undated, provisional, dated])) {
+      await cache.clearAllMessages(); seed(kind, [])
+      await save(kind, ...order)
+      expect(await reload(kind)).toMatchObject({ body: 'latest text', timestamp: new Date(T0), correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+    }
+  })
+
+  it.each([['alpha', 'zulu'], ['zulu', 'alpha']])('preserves equal-date archive order through replay and full-row merges: %s then %s', async (first, second) => {
+    const h = harness(kind)
+    const [older] = await h.archive([{ id: 'c1', body: first, at: T1 }], true)
+    const [newer] = await h.archive([{ id: 'c1', body: first, at: T1 }, { id: 'c2', body: second, at: T1 }], true)
+    expect(newer.body).toBe(second)
+    expect((await reload(kind)).body).toBe(second)
+    expect((await h.archive([{ id: 'c1', body: first, at: T1 }], true))[0].body).toBe(second)
+    for (const order of permutations([older, newer])) {
+      await cache.clearAllMessages(); seed(kind, [])
+      await save(kind, ...order)
+      expect((await reload(kind)).body).toBe(second)
+    }
+  })
+
+  it.each([false, true])('retains equal-date correction order across query pages; forward: %s', async forward => {
+    const h = harness(kind)
+    const older = { edits: [{ id: 'c1', body: 'older text', at: T1 }], original: true }
+    const newer = { edits: [{ id: 'c2', body: 'later text', at: T1 }] }
+    const result = await h.archivePages(forward ? [older, newer] : [newer, older], forward)
+    expect(result[0].body).toBe('later text')
+    expect((await reload(kind)).body).toBe('later text')
+    await h.archive([{ id: 'c1', body: 'older text', at: T1 }], true)
+    expect((await reload(kind)).body).toBe('later text')
+  })
+
+  it.each([false, true])('preserves a legacy edit against known aliases with the original in-page: %s', async inPage => {
+    const legacy = { ...original(kind), body: 'legacy current', originalBody: 'original text', isEdited: true, correctionTimestamp: Date.parse(FAST), correctionStanzaIds: ['sid-c1', 'sid-c2'] }
+    const old = { ...original(kind), body: 'known older', isEdited: true, correctionStanzaIds: ['sid-c1'], correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }
+    await save(kind, legacy); seed(kind, [legacy])
+    const h = harness(kind)
+    const rows = await h.archive([{ id: 'c1', body: 'known older', at: T1 }], inPage)
+    if (inPage) expect(rows[0].body).toBe('legacy current')
+    expect((await reload(kind)).body).toBe('legacy current')
+    for (const order of permutations([legacy, old])) {
+      await cache.clearAllMessages(); seed(kind, [])
+      await save(kind, ...order)
+      expect(await reload(kind)).toMatchObject({ body: 'legacy current', correctionTimestamp: Date.parse(FAST) })
+    }
+    await h.archive([{ id: 'c3', body: 'new revision', at: T2 }], true)
+    expect((await reload(kind)).body).toBe('new revision')
+  })
+
+  it('distinguishes known undated legacy replays from new undated edits', async () => {
+    const legacy = { ...original(kind), isEdited: true, body: 'legacy current', correctionStanzaIds: ['sid-c1', 'sid-c2'] }
+    await save(kind, legacy); seed(kind, [legacy])
+    const h = harness(kind)
+    await h.live({ id: 'c1', body: 'known older' })
+    expect((await reload(kind)).body).toBe('legacy current')
+    await h.live({ id: 'c3', body: 'new undated edit' })
+    expect((await reload(kind)).body).toBe('new undated edit')
+  })
+
+  it('returns and emits the newer cached correction outside a bounded context query', async () => {
+    const h = harness(kind)
+    await h.archive([{ id: 'c2', body: 'current outside window', at: '2026-09-01T12:00:00.000Z' }], true)
+    seed(kind, [])
+    const rows = await h.context([{ id: 'c1', body: 'old inside window', at: T1 }])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].body).toBe('current outside window')
+    expect(h.historyRows.at(-1)?.[0].body).toBe('current outside window')
+    expect(await reload(kind)).toMatchObject({ body: 'current outside window', timestamp: new Date(T0), correctionStanzaIds: ['sid-c1', 'sid-c2'] })
+  })
+
+  it.each([false, true])('rejects stale resident decryption after a correction; source already edited: %s', async edited => {
+    const h = harness(kind)
+    const source = {
+      ...original(kind), encryptedPayload: '<plain xmlns="urn:fluux:e2ee-dummy:0">c3RhbGU=</plain>',
+      ...(edited && { isEdited: true, correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }),
+    }
+    await save(kind, source); seed(kind, [source])
+    if (source.type === 'chat') chatStore.getState().updateLastMessagePreview(PEER, source)
+    const blocked = await blockedDecrypt()
+    const engine = new DeferredDecryptEngine({ getManager: () => blocked.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await blocked.started.promise
+    let current: Row
+    try {
+      await h.archive([{ id: 'c2', body: 'current locked correction', at: T2, locked: true }])
+      current = resident(kind)!
+    } finally {
+      blocked.release.resolve()
+      await retry; await drain()
+    }
+    expect(resident(kind)).toMatchObject({ body: current!.body, encryptedPayload: current!.encryptedPayload })
+    if (kind === 'chat') expect(chatStore.getState().conversations.get(PEER)?.lastMessage).toMatchObject({ body: current!.body, encryptedPayload: current!.encryptedPayload })
+    else expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage).toMatchObject({ body: current!.body, encryptedPayload: current!.encryptedPayload })
+    const row = await reload(kind)
+    expect(row).toMatchObject({ body: 'current locked correction', encryptedPayload: current!.encryptedPayload })
+    expect(row.contentRecovery).toBeUndefined()
+  })
+
+  it.each([['alpha', 'zulu'], ['zulu', 'alpha']])('preserves recency and full-row alias unions: %s to %s', async (first, second) => {
+    const h = harness(kind)
+    const [older] = await h.archive([{ id: 'c1', body: first, at: T1 }], true)
+    const [newer] = await h.archive([{ id: 'c2', body: second, at: T2 }], true)
+    await save(kind, older, newer, older, original(kind))
+    const row = await reload(kind)
+    expect(row).toMatchObject({ body: second, originalBody: 'original text', stanzaId: 'archive-original', timestamp: new Date(T0), correctionStanzaIds: ['sid-c1', 'sid-c2'] })
+  })
+
+  it.each([false, true])('persists catch-up when original is resident: %s', async inPage => {
+    await save(kind, original(kind)); seed(kind, inPage ? [original(kind)] : [])
+    const h = harness(kind)
+    await h.archive([{ id: 'c2', body: 'newest', at: T2 }, { id: 'c1', body: 'older', at: T1 }], inPage)
+    if (inPage) expect(resident(kind)?.body).toBe('newest')
+    else expect(resident(kind)).toBeUndefined()
+    expect(await reload(kind)).toMatchObject({ body: 'newest', originalBody: 'original text', correctionStanzaIds: ['sid-c1', 'sid-c2'] })
+  })
+
+  it.each(['live', 'outgoing'] as const)('keeps two successive undated %s edits ahead of the first archive echo', async mode => {
+    const own = mode === 'outgoing'
+    const h = harness(kind, own)
+    await save(kind, original(kind, own)); seed(kind, [original(kind, own)])
+    await h.archive([{ id: 'c0', body: 'dated', at: T0 }])
+    if (mode === 'live') await h.live({ id: 'c0', body: 'dated' })
+    vi.useFakeTimers({ toFake: ['Date'] }); vi.setSystemTime(new Date(FAST))
+    const firstId = mode === 'outgoing' ? await h.outgoing('first') : 'c1'
+    if (mode === 'live') await h.live({ id: firstId, body: 'first' })
+    const secondId = mode === 'outgoing' ? await h.outgoing('second') : 'c2'
+    if (mode === 'live') await h.live({ id: secondId, body: 'second' })
+    const second = await reload(kind)
+    expect(second.body).toBe('second')
+    expect(second.correctionRevision?.archiveTimestamp).toBeUndefined()
+    await h.archive([{ id: firstId, body: 'first', at: T1 }])
+    expect((await reload(kind)).body).toBe('second')
+    await h.archive([{ id: secondId, body: 'second', at: T2 }])
+    expect((await reload(kind)).correctionRevision?.archiveTimestamp).toBe(Date.parse(T2))
+    await save(kind, second)
+    expect((await reload(kind)).body).toBe('second')
+  })
+
+  it('uses carbon envelope chronology and retains a superseded correction alias', async () => {
+    const h = harness(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    await h.carbon({ id: 'c2', body: 'newest', at: T2, authoredAt: T1 })
+    await h.carbon({ id: 'c1', body: 'older', at: T1, authoredAt: FAST })
+    expect(await reload(kind)).toMatchObject({ body: 'newest', correctionTimestamp: Date.parse(T1), correctionStanzaIds: ['sid-c1', 'sid-c2'], correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+  })
+
+  it('uses archive chronology across signed device clocks and retains authored dates', async () => {
+    const h = harness(kind)
+    await h.archive([{ id: 'desktop', body: 'desktop', at: T1, authoredAt: FAST }], true)
+    await h.archive([{ id: 'phone', body: 'phone', at: T2, authoredAt: T2 }])
+    await reload(kind)
+    await h.live({ id: 'desktop', body: 'desktop', at: T1, authoredAt: FAST })
+    expect(await reload(kind)).toMatchObject({ body: 'phone', correctionTimestamp: Date.parse(T2), correctionTimestampSource: 'authored', correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+  })
+
+  it('retains the signed content date when a full-row archive echo has only a delay', async () => {
+    const h = harness(kind)
+    const [signed] = await h.archive([{ id: 'c1', body: 'edited', at: T1, authoredAt: FAST }], true)
+    const [echo] = await h.archive([{ id: 'c1', body: 'edited', at: T1 }], true)
+    await save(kind, signed, echo, signed)
+    expect(await reload(kind)).toMatchObject({
+      body: 'edited', correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored',
+      correctionRevision: { archiveTimestamp: Date.parse(T1) },
+    })
+  })
+
+  it('lets a distinct archived correction replace an undated edit despite a fast clock', async () => {
+    const h = harness(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    await h.live({ id: 'desktop', body: 'desktop', authoredAt: FAST })
+    await h.archive([{ id: 'desktop', body: 'desktop', at: T1, authoredAt: FAST }])
+    await h.archive([{ id: 'phone', body: 'phone', at: T2, authoredAt: T1 }])
+    expect(await reload(kind)).toMatchObject({ body: 'phone', correctionTimestamp: Date.parse(T1), correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+  })
+
+  it.each(['stale', 'id-only'] as const)('unions aliases through %s partial updates and resolves them outside RAM', async mode => {
+    const h = harness(kind)
+    await h.archive([{ id: 'c2', body: 'newest', at: T2 }], true)
+    const updates = mode === 'id-only' ? { correctionStanzaIds: ['sid-c1'] } : {
+      isEdited: true, body: 'stale', correctionStanzaIds: ['sid-c1'],
+      correctionRevision: { ids: ['id:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+    }
+    if (kind === 'chat') await cache.updateMessage(PEER, 'original', updates, PEER)
+    else await cache.updateRoomMessage(ROOM, 'original', updates, `${ROOM}/Peer`)
+    const row = await reload(kind)
+    expect(row).toMatchObject({ body: 'newest', correctionStanzaIds: ['sid-c1', 'sid-c2'] })
+    seed(kind, [])
+    const resolution = kind === 'chat' ? await cache.findChatRetractionTargets(PEER, 'sid-c1') : await cache.findRoomRetractionTargets(ROOM, 'sid-c1')
+    expect(resolution?.candidates).toHaveLength(1)
+    expect(kind === 'chat' ? await cache.findChatRetractionTargets('other@example.test', 'sid-c1') : await cache.findRoomRetractionTargets('other@conference.example.test', 'sid-c1')).toBeUndefined()
+    if (kind === 'chat') h.emitSDK('chat:retraction-pending', { conversationId: PEER, targetId: 'sid-c1', actorJid: PEER })
+    else h.emitSDK('room:retraction-pending', { roomJid: ROOM, targetId: 'sid-c1', actorJid: `${ROOM}/Peer`, actorOccupantId: 'peer-occupant' })
+    await vi.waitFor(async () => {
+      const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+      expect(rows[0].isRetracted).toBe(true)
+      expect(rows[0].body).not.toBe('newest')
+    })
+  })
+
+  it.each([false, true])('rejects corrections from another author with resident target: %s', async inMemory => {
+    await save(kind, original(kind)); seed(kind, inMemory ? [original(kind)] : [])
+    await harness(kind).archive([{ id: 'forged', body: 'forged', at: T2, from: kind === 'chat' ? 'other@example.test' : `${ROOM}/Peer`, occupantId: 'other-occupant' }])
+    expect((await reload(kind)).body).toBe('original text')
+  })
+
+  it('does not restore a retracted body through catch-up', async () => {
+    await save(kind, { ...original(kind), isRetracted: true, body: '', retractedAt: new Date(T1) })
+    await harness(kind).archive([{ id: 'new', body: 'must remain hidden', at: T2 }], true)
+    const row = await reload(kind)
+    expect(row.isRetracted).toBe(true)
+    expect(row.body).not.toBe('must remain hidden')
+  })
+
+  it('carries signed time through deferred decryption without changing archive order', async () => {
+    const h = harness(kind)
+    await h.archive([{ id: 'locked', body: 'locked', at: T2, locked: true }], true)
+    const manager = new E2EEManager({ storage: new InMemoryStorageBackend(), account: { jid: SELF }, xmpp: {
+      sendStanza: async () => {}, queryDisco: async () => ({ features: [], identities: [] }),
+      publishPEP: async () => {}, retractPEP: async () => {}, deletePEP: async () => {}, queryPEP: async () => [], subscribePEP: () => ({ unsubscribe() {} }),
+    } })
+    await manager.register(new DummyPlaintextPlugin())
+    vi.spyOn(manager, 'decryptArchive').mockResolvedValue({ plaintext: new TextEncoder().encode('recovered'), senderDevice: { jid: PEER, deviceId: 'test' }, securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' }, authoredAt: new Date(FAST) })
+    if (kind === 'chat') seed(kind, [])
+    else await reload(kind)
+    const engine = new DeferredDecryptEngine({ getManager: () => manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    expect(await engine.retryPending()).toBe(1)
+    const row = await reload(kind)
+    expect(row).toMatchObject({ body: 'recovered', correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored', correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+    expect(row.encryptedPayload).toBeUndefined()
+    await h.archive([{ id: 'locked', body: 'locked', at: T2, locked: true }], true)
+    expect((await reload(kind)).body).toBe('recovered')
+    await h.archive([{ id: 'later', body: 'later device', at: '2026-09-01T10:03:00.000Z', authoredAt: T2 }])
+    expect((await reload(kind)).body).toBe('later device')
+  })
+})
+
+describe.each(['cache', 'preview'] as const)('%s deferred recovery race', mode => {
+  it.each([false, true])('retains an intervening correction and its preview; source already edited: %s', async edited => {
+    const h = harness('chat')
+    const source: StoredMessage = {
+      ...original('chat') as StoredMessage, encryptedPayload: '<plain xmlns="urn:fluux:e2ee-dummy:0">c3RhbGU=</plain>',
+      ...(edited && { isEdited: true, correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }),
+    }
+    if (mode === 'cache') await save('chat', source)
+    seed('chat', [])
+    chatStore.getState().updateLastMessagePreview(PEER, source)
+    const blocked = await blockedDecrypt()
+    const engine = new DeferredDecryptEngine({ getManager: () => blocked.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await blocked.started.promise
+    let current: Row
+    try {
+      if (mode === 'preview') await save('chat', source)
+      seed('chat', [source])
+      await h.archive([{ id: 'c2', body: 'current locked correction', at: T2, locked: true }])
+      current = resident('chat')!
+    } finally {
+      blocked.release.resolve()
+      await retry; await drain()
+    }
+    expect(chatStore.getState().conversations.get(PEER)?.lastMessage).toMatchObject({ body: 'current locked correction', encryptedPayload: current!.encryptedPayload })
+    expect(await reload('chat')).toMatchObject({ body: 'current locked correction', encryptedPayload: current!.encryptedPayload })
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s history reconciliation boundaries', kind => {
+  const entity = kind === 'chat' ? PEER : ROOM
+  const newer = (): Row => ({
+    ...original(kind), body: 'confidential latest', isEdited: true,
+    correctionStanzaIds: ['sid-c2'],
+    correctionRevision: { ids: ['stanza:sid-c2'], supersedes: [], archiveTimestamp: Date.parse(T2) },
+  })
+  const read = () => kind === 'chat' ? cache.getMessages(PEER) : cache.getRoomMessages(ROOM, {})
+  const retract = async (h: ReturnType<typeof harness>, targetId: string, foreign: boolean) => {
+    if (kind === 'chat') h.emitSDK('chat:retraction-pending', { conversationId: PEER, targetId, actorJid: foreign ? 'foreign@example.test' : PEER })
+    else h.emitSDK('room:retraction-pending', { roomJid: ROOM, targetId, actorJid: `${ROOM}/Peer`, actorOccupantId: foreign ? 'foreign-occupant' : 'peer-occupant' })
+    await drain()
+  }
+
+  it.each([false, true])('adopts a newly learned correction alias only for its author; foreign: %s', async foreign => {
+    const h = harness(kind)
+    await save(kind, original(kind))
+    await searchIndex.indexMessage(original(kind))
+    await retract(h, 'result-c1', foreign)
+    expect((await read())[0].isRetracted).not.toBe(true)
+    await h.archive([{ id: 'c1', body: 'corrected secret', at: T1, omitStanzaId: true, archiveId: 'result-c1' }])
+    expect(resident(kind)).toBeUndefined()
+    expect((await read())[0]).toMatchObject(foreign
+      ? { body: 'corrected secret', correctionStanzaIds: ['result-c1'] }
+      : { body: '', isRetracted: true, correctionStanzaIds: ['result-c1'] })
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await searchIndex.search('secret')).toHaveLength(foreign ? 1 : 0)
+    expect((await reload(kind)).body).toBe(foreign ? 'corrected secret' : '')
+  })
+
+  it.each(['missing', 'foreign', 'trusted'] as const)('retains reference aliases with a %s inner stanza ID', async inner => {
+    const h = harness(kind)
+    await save(kind, original(kind))
+    const edit = { id: 'c1', body: 'corrected secret', at: T1, archiveId: 'result-c1',
+      omitStanzaId: inner === 'missing', ...(inner === 'foreign' ? { stanzaIdBy: 'untrusted@example.test' } : {}) }
+    await h.archive([edit])
+    const alias = inner === 'missing' ? 'result-c1' : 'sid-c1'
+    const revisionId = inner === 'trusted' ? 'sid-c1' : 'result-c1'
+    expect((await read())[0]).toMatchObject({ correctionStanzaIds: [...new Set([alias, revisionId])].sort(), correctionRevision: { ids: expect.arrayContaining([`stanza:${revisionId}`]) } })
+    const resolution = kind === 'chat' ? await cache.findChatRetractionTargets(PEER, alias) : await cache.findRoomRetractionTargets(ROOM, alias)
+    expect(resolution?.candidates).toHaveLength(1)
+    await retract(h, alias, false)
+    expect((await read())[0]).toMatchObject({ body: '', isRetracted: true })
+    expect(await searchIndex.search('secret')).toEqual([])
+  })
+
+  it('keeps result-only correction aliases on fulltext search rows', async () => {
+    const h = harness(kind)
+    const [row] = await h.search([{ id: 'c1', body: 'corrected secret', at: T1, omitStanzaId: true, archiveId: 'result-c1' }], true, [], false, 'secret')
+    expect(row.correctionStanzaIds).toEqual(['result-c1'])
+    await save(kind, row)
+    await retract(h, 'result-c1', false)
+    expect((await reload(kind)).isRetracted).toBe(true)
+  })
+
+  it.each([false, true])('preserves the fetched replacement reaction set with a resident row: %s', async inMemory => {
+    const h = harness(kind)
+    const row = { ...newer(), reactions: { '👍': [kind === 'chat' ? 'bob@example.test' : 'Bob'] } }
+    await save(kind, row); seed(kind, inMemory ? [row] : [])
+    const reaction = xml('message', { from: kind === 'chat' ? 'bob@example.test' : `${ROOM}/Bob` },
+      xml('reactions', { xmlns: 'urn:xmpp:reactions:0', id: 'original' }))
+    const rows = await h.archive([{ id: 'c1', body: 'older text', at: T1 }], true, [reaction])
+    expect(rows[0]).toMatchObject({ body: row.body, timestamp: new Date(T0) })
+    expect(rows[0].reactions).toBeUndefined()
+    expect(h.historyRows.at(-1)?.[0].reactions).toBeUndefined()
+    expect((await reload(kind)).body).toBe(row.body)
+  })
+
+  it('preserves unrelated fetched fields when selecting a cached correction', async () => {
+    await save(kind, { ...newer(), noStyling: false, pollClosed: { pollMessageId: 'cached-poll', title: 'Cached poll', results: [] }, pollClosedAt: new Date(T2) })
+    const page = { ...original(kind), noStyling: true, reactions: {} }
+    const rows = kind === 'chat'
+      ? await chatStore.getState().reconcileHistoryMessages([page as StoredMessage])
+      : await roomStore.getState().reconcileHistoryMessages([page as StoredRoomMessage])
+    expect(rows[0]).toMatchObject({ body: 'confidential latest', noStyling: true, reactions: {}, timestamp: page.timestamp, id: page.id })
+    expect(rows[0].pollClosed).toBeUndefined()
+    expect(rows[0].pollClosedAt).toBeUndefined()
+  })
+
+  it('delivers network history and corrections when local search resolution fails', async () => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)]); seedPreview(kind, original(kind))
+    const fault = vi.spyOn(cache, 'resolveMessagesForIndex').mockRejectedValue(new Error('search cache unavailable'))
+    const rows = await h.archive([{ id: 'c2', body: 'current network edit', at: T2 }], true)
+    expect(rows[0].body).toBe('current network edit')
+    expect(resident(kind)?.body).toBe('current network edit')
+    expect(preview(kind)?.body).toBe('current network edit')
+    expect(h.events.some(({ event }) => event.endsWith('history-error'))).toBe(false)
+    expect(await searchIndex.search('current')).toEqual([])
+    fault.mockRestore()
+    await searchIndex.backfillFromMessageCache()
+    expect(await searchIndex.search('current')).toHaveLength(1)
+    expect((await reload(kind)).body).toBe('current network edit')
+  })
+
+  it.each([['open', false], ['open', true], ['read', false], ['read', true]] as const)('keeps network history when cache %s fails; resident: %s', async (failure, inMemory) => {
+    const h = harness(kind)
+    const held = newer()
+    await save(kind, held); seed(kind, inMemory ? [held] : [])
+    cache._resetDBForTesting()
+    const open = indexedDB.open.bind(indexedDB)
+    const fault = failure === 'open'
+      ? vi.spyOn(indexedDB, 'open').mockImplementation((name, version) => {
+          if (name.startsWith('fluux-message-cache')) throw new Error('cache unavailable')
+          return open(name, version)
+        })
+      : vi.spyOn(IDBIndex.prototype, 'getAll').mockImplementation(() => { throw new Error('cache read failed') })
+    const rows = await h.archive([], true)
+    expect(rows[0].body).toBe(inMemory ? held.body : original(kind).body)
+    expect(h.historyRows.at(-1)?.[0].body).toBe(inMemory ? held.body : original(kind).body)
+    expect(h.events.some(({ event }) => event.endsWith('history-error'))).toBe(false)
+    fault.mockRestore()
+    cache._resetDBForTesting()
+    expect((await reload(kind)).body).toBe(held.body)
+  })
+
+  it.each(['read', 'failed-read'] as const)('cancels history when the account switches during a cache %s', async phase => {
+    const h = harness(kind)
+    const other = { ...original(kind), body: 'unchanged account' }
+    setStorageScopeJid('other@example.test')
+    await save(kind, other); await searchIndex.indexMessage(other)
+    setStorageScopeJid(SELF)
+    await save(kind, newer()); await searchIndex.indexMessage(newer())
+    let eventsAtSwitch = 0
+    let switched = false
+    const getAll = IDBIndex.prototype.getAll
+    const changeAccount = () => {
+      switched = true
+      setStorageScopeJid('other@example.test')
+      chatStore.getState().switchAccount('other@example.test')
+      roomStore.getState().switchAccount('other@example.test')
+      seed(kind, [other])
+      if (kind === 'chat') chatStore.getState().setMAMLoading(entity, true)
+      else roomStore.getState().setRoomMAMLoading(entity, true)
+      eventsAtSwitch = h.events.length
+    }
+    const fault = vi.spyOn(IDBIndex.prototype, 'getAll').mockImplementationOnce(function (this: IDBIndex, ...args) {
+      if (phase === 'failed-read') { changeAccount(); throw new Error('read failed after switch') }
+      const request = getAll.apply(this, args)
+      request.addEventListener('success', changeAccount)
+      return request
+    })
+    await expect(h.archive([], true)).rejects.toMatchObject({ name: 'AbortError' })
+    fault.mockRestore()
+    expect(switched).toBe(true)
+    expect(h.events).toHaveLength(eventsAtSwitch)
+    expect(resident(kind)?.body).toBe(other.body)
+    const states = kind === 'chat' ? chatStore.getState().mamQueryStates : roomStore.getState().mamQueryStates
+    expect(states.get(entity)?.isLoading).toBe(true)
+    expect((await read())[0].body).toBe(other.body)
+    expect(await searchIndex.search('confidential')).toEqual([])
+    setStorageScopeJid(SELF)
+    expect((await read())[0].body).toBe(newer().body)
+    expect(await searchIndex.search('confidential')).toHaveLength(1)
+  })
+
+  it.each(['archive', 'forward', 'context', 'search'] as const)('cancels %s results after reconciliation even if the account switches back', async method => {
+    const h = harness(kind)
+    setStorageScopeJid(SELF)
+    await save(kind, newer()); await searchIndex.indexMessage(newer())
+    const started = deferred(), release = deferred()
+    if (kind === 'chat') h.stores.chat.reconcileHistoryMessages.mockImplementationOnce(async messages => {
+      const rows = await chatStore.getState().reconcileHistoryMessages(messages)
+      started.resolve(); await release.promise
+      return rows
+    })
+    else h.stores.room.reconcileHistoryMessages.mockImplementationOnce(async messages => {
+      const rows = await roomStore.getState().reconcileHistoryMessages(messages)
+      started.resolve(); await release.promise
+      return rows
+    })
+    const work = method === 'forward' ? h.archivePages([{ edits: [], original: true }], true)
+      : method === 'context' ? h.context([]) : method === 'search' ? h.search([]) : h.archive([], true)
+    const result = work.then(value => ({ value }), error => ({ error }))
+    await started.promise
+    const eventCount = h.events.length
+    setStorageScopeJid('other@example.test')
+    setStorageScopeJid(SELF)
+    release.resolve()
+    expect(await result).toMatchObject({ error: { name: 'AbortError' } })
+    expect(h.events).toHaveLength(eventCount)
+    expect((await read())[0].body).toBe(newer().body)
+    setStorageScopeJid('other@example.test')
+    expect(await read()).toEqual([])
+    expect(await searchIndex.search('confidential')).toEqual([])
+  })
+
+  it('does not emit stale loading or errors when an IQ rejects after an account switch', async () => {
+    const h = harness(kind)
+    const started = deferred(), release = deferred()
+    h.deps.sendIQ = async () => { started.resolve(); await release.promise; throw new Error('old connection failed') }
+    const result = h.archive([], true).then(value => ({ value }), error => ({ error }))
+    await started.promise
+    const count = h.events.length
+    setStorageScopeJid('other@example.test')
+    release.resolve()
+    expect(await result).toMatchObject({ error: { name: 'AbortError' } })
+    expect(h.events).toHaveLength(count)
+    expect(await read()).toEqual([])
+    expect(await searchIndex.search('original')).toEqual([])
+  })
+  it('cancels a completed reconciliation when the connection ends', async () => {
+    const h = harness(kind)
+    await save(kind, newer())
+    const started = deferred(), release = deferred()
+    if (kind === 'chat') h.stores.chat.reconcileHistoryMessages.mockImplementationOnce(async messages => {
+      const rows = await chatStore.getState().reconcileHistoryMessages(messages)
+      started.resolve(); await release.promise
+      return rows
+    })
+    else h.stores.room.reconcileHistoryMessages.mockImplementationOnce(async messages => {
+      const rows = await roomStore.getState().reconcileHistoryMessages(messages)
+      started.resolve(); await release.promise
+      return rows
+    })
+    const result = h.archive([], true).then(value => ({ value }), error => ({ error }))
+    await started.promise
+    const count = h.events.length
+    h.deps.getCurrentJid = () => null
+    release.resolve()
+    expect(await result).toMatchObject({ error: { name: 'AbortError' } })
+    expect(h.events).toHaveLength(count)
+    expect((await read())[0].body).toBe(newer().body)
+  })
+
+})
+
+
+it('cancels the final room reconciliation after an already-emitted forward page', async () => {
+  const h = harness('room')
+  setStorageScopeJid(SELF)
+  const started = deferred(), release = deferred()
+  h.stores.room.reconcileHistoryMessages
+    .mockImplementationOnce(messages => roomStore.getState().reconcileHistoryMessages(messages))
+    .mockImplementationOnce(async messages => {
+      const rows = await roomStore.getState().reconcileHistoryMessages(messages)
+      await drain()
+      started.resolve(); await release.promise
+      return rows
+    })
+  const result = h.archivePages([{ edits: [{ id: 'c1', body: 'confidential room', at: T1 }], original: true }], true)
+    .then(value => ({ value }), error => ({ error }))
+  await started.promise
+  expect(h.historyRows).toHaveLength(1)
+  const count = h.events.length
+  setStorageScopeJid('other@example.test')
+  chatStore.getState().switchAccount('other@example.test')
+  roomStore.getState().switchAccount('other@example.test')
+  release.resolve()
+  expect(await result).toMatchObject({ error: { name: 'AbortError' } })
+  expect(h.events).toHaveLength(count)
+  expect(roomStore.getState().messages.size).toBe(0)
+  expect(await cache.getRoomMessages(ROOM, {})).toEqual([])
+  expect(await searchIndex.search('confidential')).toEqual([])
+  setStorageScopeJid(SELF)
+  expect((await cache.getRoomMessages(ROOM, {}))[0].body).toBe('confidential room')
+  expect(await searchIndex.search('confidential')).toHaveLength(1)
+})
+
+
+function preview(kind: Kind): Row | undefined {
+  return (kind === 'chat' ? chatStore.getState().conversationMeta.get(PEER)?.lastMessage : roomStore.getState().roomMeta.get(ROOM)?.lastMessage) as Row | undefined
+}
+
+function seedPreview(kind: Kind, message: Row) {
+  if (kind === 'chat') chatStore.getState().updateLastMessagePreview(PEER, message as StoredMessage)
+  else roomStore.getState().updateLastMessagePreview(ROOM, message as StoredRoomMessage)
+}
+
+function activate(kind: Kind) {
+  if (kind === 'chat') chatStore.setState({ activeConversationId: PEER })
+  else roomStore.setState({ activeRoomJid: ROOM })
+}
+
+describe.each<Kind>(['chat', 'room'])('%s cached correction hydration', kind => {
+  type LoadMode = 'latest' | 'around' | 'older' | 'newer'
+  function load(mode: LoadMode) {
+    const store = kind === 'chat' ? chatStore.getState() : roomStore.getState()
+    const target = kind === 'chat' ? PEER : ROOM
+    if (mode === 'around') return store.loadMessagesAroundFromCache(target, { id: 'original' })
+    if (mode === 'older') return store.loadOlderMessagesFromCache(target)
+    if (mode === 'newer') return store.loadNewerMessagesFromCache(target)
+    return store.loadMessagesFromCache(target)
+  }
+
+  function blockRead(mode: LoadMode) {
+    const started = deferred()
+    const release = deferred()
+    const block = <A extends unknown[], T>(read: (...args: A) => Promise<T>) => async (...args: A) => {
+      const result = await read(...args)
+      started.resolve()
+      await release.promise
+      return result
+    }
+    if (kind === 'chat') {
+      if (mode === 'around') vi.spyOn(cache, 'getMessagesAround').mockImplementationOnce(block(cache.getMessagesAround))
+      else vi.spyOn(cache, 'getMessages').mockImplementationOnce(block(cache.getMessages))
+    } else {
+      if (mode === 'around') vi.spyOn(cache, 'getRoomMessagesAround').mockImplementationOnce(block(cache.getRoomMessagesAround))
+      else vi.spyOn(cache, 'getRoomMessages').mockImplementationOnce(block(cache.getRoomMessages))
+    }
+    return { started, release }
+  }
+
+  it.each(['latest', 'around', 'older', 'newer'] as const)('installs a sole completed cache-only correction after a stale %s read', async mode => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    seedPreview(kind, base)
+    if (mode === 'older' || mode === 'newer') {
+      const anchor = { ...base, id: 'anchor', stanzaId: 'archive-anchor', body: 'anchor content', timestamp: new Date(base.timestamp.getTime() + (mode === 'older' ? 1000 : -1000)) }
+      seed(kind, [anchor])
+    }
+    const splitRead = () => {
+      const started = deferred(), release = deferred()
+      const read = async () => {
+        const before = { before: new Date(base.timestamp.getTime() + 1), limit: 51 }
+        const after = { after: base.timestamp }
+        const older = kind === 'chat' ? await cache.getMessages(PEER, before) : await cache.getRoomMessages(ROOM, before)
+        started.resolve()
+        await release.promise
+        const newer = kind === 'chat' ? await cache.getMessages(PEER, after) : await cache.getRoomMessages(ROOM, after)
+        return [...older, ...newer]
+      }
+      if (kind === 'chat') vi.spyOn(cache, 'getMessagesAround').mockImplementationOnce(async () => await read() as StoredMessage[])
+      else vi.spyOn(cache, 'getRoomMessagesAround').mockImplementationOnce(async () => await read() as StoredRoomMessage[])
+      return { started, release }
+    }
+    const read = mode === 'around' ? splitRead() : blockRead(mode)
+    const loading = load(mode)
+    await read.started.promise
+    await h.live({ id: 'c1', body: 'sole completed correction', authoredAt: FAST })
+    expect(resident(kind)).toBeUndefined()
+    expect((kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0].body).toBe('sole completed correction')
+    read.release.resolve()
+    const loaded = await loading
+    const expected = {
+      id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp,
+      body: 'sole completed correction', isEdited: true,
+      correctionTimestamp: Date.parse(FAST), correctionStanzaIds: ['sid-c1'],
+    }
+    expect(loaded.find(row => row.id === base.id)).toMatchObject(expected)
+    expect(resident(kind)).toMatchObject(expected)
+    if (mode === 'older') expect(preview(kind)?.body).toBe('anchor content')
+    else expect(preview(kind)).toMatchObject(expected)
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+    expect(await searchIndex.search('sole')).toHaveLength(1)
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await reload(kind)).toMatchObject(expected)
+  })
+
+  it.each(['latest', 'around'] as const)('reconciles a cached edit with a resident original on %s loading', async mode => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    await h.archive([{ id: 'c2', body: 'cached current edit', at: T2 }])
+    seed(kind, [base])
+    seedPreview(kind, base)
+
+    if (kind === 'chat') {
+      if (mode === 'latest') await chatStore.getState().loadMessagesFromCache(PEER)
+      else await chatStore.getState().loadMessagesAroundFromCache(PEER, { id: base.id })
+    } else {
+      if (mode === 'latest') await roomStore.getState().loadMessagesFromCache(ROOM)
+      else await roomStore.getState().loadMessagesAroundFromCache(ROOM, { id: base.id, occupantId: 'peer-occupant' })
+    }
+
+    expect(resident(kind)).toMatchObject({
+      id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp,
+      body: 'cached current edit', isEdited: true,
+      correctionStanzaIds: ['sid-c2'],
+      correctionRevision: { archiveTimestamp: Date.parse(T2) },
+    })
+    expect(preview(kind)?.body).toBe('cached current edit')
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+    expect(await searchIndex.search('cached')).toHaveLength(1)
+    expect((await reload(kind)).body).toBe('cached current edit')
+  })
+
+  it.each(['latest', 'around'] as const)('preserves a newer resident edit and reactions during %s hydration', async mode => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    await h.archive([{ id: 'c1', body: 'older cached edit', at: T1 }])
+    seed(kind, [base])
+    const read = blockRead(mode)
+    const loading = load(mode)
+    await read.started.promise
+    await h.archive([{ id: 'c2', body: 'newer resident edit', at: T2 }])
+    const current = { ...resident(kind)!, reactions: { '👍': ['someone'] } }
+    seed(kind, [current]); seedPreview(kind, current)
+    read.release.resolve()
+    await loading
+    expect(resident(kind)).toMatchObject({ body: current.body, reactions: current.reactions, correctionRevision: current.correctionRevision })
+    expect(preview(kind)?.body).toBe(current.body)
+    const settled = resident(kind)
+    await load(mode)
+    const hydrated = resident(kind)
+    await load(mode)
+    expect(resident(kind)).toBe(hydrated)
+    expect(resident(kind)?.reactions).toBe(settled?.reactions)
+  })
+
+  it('repairs a stale preview when the current edit is already resident', async () => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    await h.archive([{ id: 'c2', body: 'current edit', at: T2 }])
+    const current = (kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0]
+    seed(kind, [current]); seedPreview(kind, base)
+    await load('latest')
+    expect(resident(kind)?.body).toBe('current edit')
+    expect(preview(kind)?.body).toBe('current edit')
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+  })
+
+  it.each(['older', 'newer'] as const)('reconciles an original that becomes resident during %s pagination', async mode => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    await h.archive([{ id: 'c2', body: 'cached current edit', at: T2 }])
+    const anchor = { ...base, id: 'anchor', stanzaId: 'archive-anchor', body: 'another message', timestamp: new Date(base.timestamp.getTime() + (mode === 'older' ? 1000 : -1000)) }
+    seed(kind, [anchor]); seedPreview(kind, anchor)
+    const read = blockRead(mode)
+    const loading = load(mode)
+    await read.started.promise
+    seed(kind, mode === 'older' ? [base, anchor] : [anchor, base])
+    if (mode === 'newer') seedPreview(kind, base)
+    read.release.resolve()
+    await loading
+    expect(resident(kind)).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'cached current edit' })
+    expect(preview(kind)?.body).toBe(mode === 'older' ? anchor.body : 'cached current edit')
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+  })
+
+  it.each(['account round trip', 'store reset'] as const)('discards durable hydration reconciliation after a %s', async change => {
+    setStorageScopeJid(SELF)
+    const base = original(kind)
+    await save(kind, base)
+    const started = deferred(), release = deferred()
+    const block = <A extends unknown[], T>(read: (...args: A) => Promise<T>) => async (...args: A) => {
+      const result = await read(...args)
+      started.resolve()
+      await release.promise
+      return result
+    }
+    if (kind === 'chat') vi.spyOn(cache, 'reconcileChatHistoryMessages').mockImplementationOnce(block(cache.reconcileChatHistoryMessages))
+    else vi.spyOn(cache, 'reconcileRoomHistoryMessages').mockImplementationOnce(block(cache.reconcileRoomHistoryMessages))
+    const loading = load('around')
+    await started.promise
+    if (change === 'account round trip') {
+      setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+    } else if (kind === 'chat') {
+      chatStore.getState().reset()
+      chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+    } else {
+      roomStore.getState().reset()
+      roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+    }
+    const replacement = { ...base, body: 'replacement state' }
+    seed(kind, [replacement]); seedPreview(kind, replacement)
+    release.resolve()
+    expect(await loading).toEqual([])
+    expect(resident(kind)).toBe(replacement)
+    expect(preview(kind)?.body).toBe(replacement.body)
+  })
+
+  describe.each(['latest', 'around', 'older', 'newer'] as const)('%s pending read', mode => {
+    it.each(['account round trip', 'store reset'] as const)('discards a completed read after a %s', async change => {
+      setStorageScopeJid(SELF)
+      const base = original(kind)
+      await save(kind, base)
+      const anchor = { ...base, id: 'anchor', stanzaId: 'archive-anchor', timestamp: new Date(base.timestamp.getTime() + (mode === 'older' ? 1000 : -1000)) }
+      seed(kind, [anchor])
+      const read = blockRead(mode)
+      const loading = load(mode)
+      await read.started.promise
+      if (change === 'account round trip') {
+        setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+      } else if (kind === 'chat') {
+        chatStore.getState().reset()
+        chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+      } else {
+        roomStore.getState().reset()
+        roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+      }
+      const replacement = { ...base, body: 'replacement state' }
+      seed(kind, [replacement]); seedPreview(kind, replacement)
+      read.release.resolve()
+      expect(await loading).toEqual([])
+      expect(resident(kind)).toBe(replacement)
+      expect(preview(kind)?.body).toBe(replacement.body)
+    })
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s resident correction handoffs', kind => {
+  it('keeps legacy revision identity through an empty-window load and a second known replay', async () => {
+    const h = harness(kind)
+    activate(kind)
+    const legacy: Row = { ...original(kind), body: 'legacy current c3', isEdited: true, correctionStanzaIds: ['sid-c1', 'sid-c2', 'sid-c3'] }
+    await save(kind, legacy); seed(kind, [])
+    const [returned] = await h.archive([{ id: 'c1', body: 'older c1', at: T1 }], true)
+    expect(returned.body).toBe(legacy.body)
+    expect(returned.correctionRevision).toBeUndefined()
+    expect(resident(kind)?.correctionRevision).toBeUndefined()
+    await h.archive([{ id: 'c2', body: 'older c2', at: T2 }])
+    expect(resident(kind)).toMatchObject({ body: legacy.body, timestamp: legacy.timestamp })
+    expect(resident(kind)?.correctionRevision).toBeUndefined()
+    expect(preview(kind)?.body).toBe(legacy.body)
+    expect(preview(kind)?.correctionRevision).toBeUndefined()
+    const loaded = await reload(kind)
+    expect(loaded.body).toBe(legacy.body)
+    expect(loaded.correctionRevision).toBeUndefined()
+    expect(await searchIndex.search('older')).toEqual([])
+  })
+
+  it.each(['new', 'older', 'metadata'] as const)('replays a pending retraction when a %s update learns its alias', async mode => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    if (mode !== 'new') await h.archive([{ id: 'c2', body: 'newest secret', at: T2 }])
+    seedPreview(kind, resident(kind)!)
+    await searchIndex.indexMessage(resident(kind)!)
+    if (kind === 'chat') h.emitSDK('chat:retraction-pending', { conversationId: PEER, targetId: 'sid-c1', actorJid: PEER })
+    else h.emitSDK('room:retraction-pending', { roomJid: ROOM, targetId: 'sid-c1', actorJid: `${ROOM}/Peer`, actorOccupantId: 'peer-occupant' })
+    await drain()
+    expect(resident(kind)?.isRetracted).not.toBe(true)
+    if (mode === 'metadata') {
+      if (kind === 'chat') h.emitSDK('chat:message-updated', { conversationId: PEER, messageId: 'original', updates: { correctionStanzaIds: ['sid-c1'] }, correctionActor: { actorJid: PEER } })
+      else h.emitSDK('room:message-updated', { roomJid: ROOM, messageId: 'original', updates: { correctionStanzaIds: ['sid-c1'] }, correctionActor: { actorJid: `${ROOM}/Peer`, actorOccupantId: 'peer-occupant' } })
+      await drain()
+    } else await h.archive([{ id: 'c1', body: 'corrected secret', at: T1 }])
+    expect(resident(kind)?.isRetracted).toBe(true)
+    expect(preview(kind)?.isRetracted).toBe(true)
+    expect((await reload(kind))).toMatchObject({ isRetracted: true, body: '' })
+    expect(await searchIndex.search('secret')).toEqual([])
+    expect(await searchIndex.search('original')).toEqual([])
+  })
+
+  it.each(['author', 'occupant'] as const)('rejects a foreign %s pending retraction after learning a correction alias', async foreign => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    seedPreview(kind, original(kind))
+    if (kind === 'chat') h.emitSDK('chat:retraction-pending', { conversationId: PEER, targetId: 'sid-c1', actorJid: 'foreign@example.test' })
+    else h.emitSDK('room:retraction-pending', { roomJid: ROOM, targetId: 'sid-c1', actorJid: foreign === 'author' ? `${ROOM}/Foreign` : `${ROOM}/Peer`, ...(foreign === 'occupant' ? { actorOccupantId: 'foreign-occupant' } : {}) })
+    await drain()
+    await h.archive([{ id: 'c1', body: 'corrected secret', at: T1 }])
+    expect(resident(kind)?.isRetracted).not.toBe(true)
+    expect(preview(kind)?.isRetracted).not.toBe(true)
+    expect(preview(kind)?.body).toBe('corrected secret')
+    expect(await reload(kind)).toMatchObject({ body: 'corrected secret' })
+    expect(await searchIndex.search('secret')).toHaveLength(1)
+  })
+
+  it('selects outgoing predecessors after asynchronous sending completes', async () => {
+    const h = harness(kind, true)
+    activate(kind)
+    await save(kind, original(kind, true)); seed(kind, [original(kind, true)])
+    await h.archive([{ id: 'c0', body: 'baseline', at: T0 }])
+    const started = deferred(), release = deferred()
+    if (kind === 'chat') {
+      const manager = new E2EEManager({ storage: new InMemoryStorageBackend(), account: { jid: SELF }, xmpp: {
+        sendStanza: async () => {}, queryDisco: async () => ({ features: [], identities: [] }),
+        publishPEP: async () => {}, retractPEP: async () => {}, deletePEP: async () => {}, queryPEP: async () => [], subscribePEP: () => ({ unsubscribe() {} }),
+      } })
+      await manager.register(new DummyPlaintextPlugin())
+      const encrypt = manager.encryptOutbound.bind(manager)
+      vi.spyOn(manager, 'encryptOutbound').mockImplementation(async (...args) => { started.resolve(); await release.promise; return encrypt(...args) })
+      h.deps.getE2EEManager = () => manager
+    } else {
+      const send = h.deps.sendStanza
+      h.deps.sendStanza = async stanza => { started.resolve(); await release.promise; return send(stanza) }
+    }
+    const outgoing = h.outgoing('successfully sent c2')
+    await started.promise
+    try {
+      await h.archive([{ id: 'c1', body: 'other device c1', at: T1, authoredAt: FAST }])
+      expect(resident(kind)?.body).toBe('other device c1')
+    } finally { release.resolve() }
+    const id = await outgoing
+    expect(resident(kind)).toMatchObject({ body: 'successfully sent c2', id: 'original', stanzaId: 'archive-original', timestamp: new Date(T0), correctionRevision: { afterArchiveTimestamp: Date.parse(T1), ids: expect.arrayContaining([`id:${id}`]), supersedes: expect.arrayContaining(['stanza:sid-c1']) } })
+    expect(resident(kind)?.correctionTimestamp).toBeUndefined()
+    if (kind === 'chat') expect(h.sent.at(-1)?.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeDefined()
+    await h.archive([{ id: 'c1', body: 'other device c1', at: T1, authoredAt: FAST }], true)
+    expect(preview(kind)?.body).toBe('successfully sent c2')
+    expect(await reload(kind)).toMatchObject({ body: 'successfully sent c2', timestamp: new Date(T0), stanzaId: 'archive-original' })
+    expect(await searchIndex.search('successfully')).toHaveLength(1)
+    expect(await searchIndex.search('other')).toEqual([])
+  })
+})
+
+describe('live cache-only chat corrections', () => {
+  it('updates the canonical original and preview before stale archive replay', async () => {
+    const h = harness('chat')
+    activate('chat')
+    const base = original('chat') as StoredMessage
+    await save('chat', base); seedPreview('chat', base); await searchIndex.indexMessage(base)
+    const before = (await cache.findChatMessageCopies(PEER, base))[0]
+    expect(resident('chat')).toBeUndefined()
+    await h.live({ id: 'c2', body: 'live newest secret', at: T2 })
+    expect(resident('chat')).toBeUndefined()
+    expect(h.events.filter(({ event }) => event === 'chat:message')).toHaveLength(0)
+    const copies = await cache.findChatMessageCopies(PEER, base)
+    expect(copies).toHaveLength(1)
+    expect(copies[0].cacheKey).toBe(before.cacheKey)
+    expect(copies[0].message).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'live newest secret', correctionStanzaIds: ['sid-c2'], correctionRevision: { ids: expect.arrayContaining(['stanza:sid-c2', 'origin:c2']) } })
+    expect(preview('chat')?.body).toBe('live newest secret')
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await searchIndex.search('secret')).toHaveLength(1)
+    await h.archive([{ id: 'c1', body: 'stale c1', at: T1 }], true)
+    expect(resident('chat')?.body).toBe('live newest secret')
+    expect(preview('chat')?.body).toBe('live newest secret')
+    expect(await reload('chat')).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'live newest secret', correctionStanzaIds: ['sid-c1', 'sid-c2'] })
+    expect(await searchIndex.search('stale')).toEqual([])
+  })
+
+  it('retains the existing message fallback for a truly unknown target', async () => {
+    const h = harness('chat')
+    activate('chat')
+    h.stores.roster.hasContact.mockReturnValue(true)
+    h.stores.chat.hasConversation.mockReturnValue(true)
+    await h.live({ id: 'c1', body: 'unknown original correction', at: T1 })
+    expect(h.events.filter(({ event }) => event === 'chat:message')).toHaveLength(1)
+    expect(resident('chat')).toMatchObject({ id: 'original', body: 'unknown original correction', isEdited: true })
+    expect(await reload('chat')).toMatchObject({ id: 'original', body: 'unknown original correction', timestamp: new Date(T1) })
+  })
+
+  it('rejects an authoritative cached reference owned by another author', async () => {
+    const h = harness('chat')
+    activate('chat')
+    const foreign = original('chat', true)
+    await save('chat', foreign)
+    await h.live({ id: 'c1', body: 'forged correction', at: T1, targetId: foreign.stanzaId })
+    expect(h.events.filter(({ event }) => event === 'chat:message')).toHaveLength(0)
+    expect(resident('chat')).toBeUndefined()
+    expect(await cache.getMessages(PEER)).toMatchObject([{ body: 'original text', from: foreign.from }])
+    expect(await searchIndex.search('forged')).toEqual([])
+  })
+
+  it('keeps an unknown sender target distinct from another author reusing its client ID', async () => {
+    const h = harness('chat')
+    activate('chat')
+    h.stores.roster.hasContact.mockReturnValue(true)
+    h.stores.chat.hasConversation.mockReturnValue(true)
+    const foreign = original('chat', true)
+    await save('chat', foreign)
+    await h.live({ id: 'c1', body: 'unknown sender correction', at: T1 })
+    expect(h.events.filter(({ event }) => event === 'chat:message')).toHaveLength(1)
+    expect(resident('chat')).toMatchObject({ id: foreign.id, from: PEER, body: 'unknown sender correction' })
+    cache._resetDBForTesting()
+    const messages = await cache.getMessages(PEER)
+    expect(messages).toHaveLength(2)
+    expect(messages.find(message => message.from === SELF)).toMatchObject(foreign)
+    expect(messages.find(message => message.from === PEER)).toMatchObject({ id: foreign.id, stanzaId: 'sid-c1', timestamp: new Date(T1), body: 'unknown sender correction' })
+    expect(await searchIndex.search('unknown')).toHaveLength(1)
+  })
+
+  it.each([false, true])('keeps a deferred live correction in its account; target cached: %s', async cached => {
+    const h = harness('chat')
+    activate('chat')
+    setStorageScopeJid(SELF)
+    if (cached) { await save('chat', original('chat')); seedPreview('chat', original('chat')) }
+    const apply = vi.mocked(cache.applyChatCorrection).getMockImplementation()!
+    const started = deferred(), release = deferred()
+    vi.mocked(cache.applyChatCorrection).mockImplementationOnce((...args) => {
+      const pending = (async () => {
+        const result = await apply(...args)
+        started.resolve(); await release.promise
+        return result
+      })()
+      writes.push(pending)
+      return pending
+    })
+    const work = h.live({ id: 'c2', body: 'account secret', at: T2 })
+    await started.promise
+    setStorageScopeJid('other@example.test')
+    chatStore.getState().switchAccount('other@example.test')
+    release.resolve(); await work; await drain()
+    expect(chatStore.getState().messages.size).toBe(0)
+    expect(await cache.getMessages(PEER)).toEqual([])
+    expect(await searchIndex.search('secret')).toEqual([])
+    expect(h.events.filter(({ event }) => event === 'chat:message')).toHaveLength(0)
+    setStorageScopeJid(SELF)
+    expect(await searchIndex.search('secret')).toHaveLength(cached ? 1 : 0)
+  })
+})
+
+function deferCorrectionCompletion(kind: Kind) {
+  const started = deferred(), release = deferred()
+  const wrap = <A extends unknown[], R>(apply: (...args: A) => Promise<R>) => (...args: A) => {
+    const work = (async () => {
+      const result = await apply(...args)
+      started.resolve()
+      await release.promise
+      return result
+    })()
+    writes.push(work)
+    return work
+  }
+  if (kind === 'chat') vi.mocked(cache.applyChatCorrection).mockImplementationOnce(wrap(vi.mocked(cache.applyChatCorrection).getMockImplementation()!))
+  else vi.mocked(cache.applyRoomCorrection).mockImplementationOnce(wrap(vi.mocked(cache.applyRoomCorrection).getMockImplementation()!))
+  return { started, release }
+}
+
+function loadWindow(kind: Kind) {
+  return kind === 'chat' ? chatStore.getState().loadMessagesFromCache(PEER) : roomStore.getState().loadMessagesFromCache(ROOM)
+}
+
+function indexedBase(kind: Kind, edited: boolean): Row {
+  return { ...original(kind), ...(edited && { isEdited: true, body: 'baseline correction', correctionRevision: { ids: ['stanza:sid-c0'], supersedes: [], archiveTimestamp: Date.parse(T0) } }) }
+}
+
+describe.each<Kind>(['chat', 'room'])('%s correction completion ownership', kind => {
+  it.each([
+    ['live', false, false], ['live', false, true], ['live', true, false], ['live', true, true],
+    ['mam', false, false], ['mam', false, true], ['mam', true, false], ['mam', true, true],
+  ] as const)('reconciles activation: %s, edited base %s, intervening edit %s', async (source, edited, intervening) => {
+    const h = harness(kind)
+    activate(kind)
+    const base = indexedBase(kind, edited)
+    await save(kind, base); seedPreview(kind, base); await searchIndex.indexMessage(base)
+    const readStarted = deferred(), install = deferred()
+    if (kind === 'chat') {
+      const get = cache.getMessages
+      vi.spyOn(cache, 'getMessages').mockImplementationOnce(async (...args) => {
+        const rows = await get(...args); readStarted.resolve(); await install.promise; return rows
+      })
+    } else {
+      const get = cache.getRoomMessages
+      vi.spyOn(cache, 'getRoomMessages').mockImplementationOnce(async (...args) => {
+        const rows = await get(...args); readStarted.resolve(); await install.promise; return rows
+      })
+    }
+    const loading = loadWindow(kind)
+    await readStarted.promise
+    const completion = deferCorrectionCompletion(kind)
+    const c2 = { id: 'c2', body: 'second correction', at: T1 }
+    const work = source === 'live' ? h.live(c2) : h.archive([c2])
+    await completion.started.promise
+    try {
+      install.resolve(); await loading
+      expect(resident(kind)?.body).toBe(c2.body)
+      seed(kind, [base]); seedPreview(kind, base)
+      if (intervening) {
+        const offset = writes.length
+        h.receive({ id: 'c3', body: 'third correction', at: T2 })
+        await Promise.all(writes.slice(offset))
+        expect(resident(kind)?.body).toBe('third correction')
+      }
+    } finally { install.resolve(); completion.release.resolve() }
+    await work; await drain()
+    const expected = intervening ? 'third correction' : 'second correction'
+    expect(resident(kind)).toMatchObject({ body: expected, id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+    expect(preview(kind)?.body).toBe(expected)
+    expect(await reload(kind)).toMatchObject({ body: expected, id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+    expect(await searchIndex.search(intervening ? 'second' : 'third')).toEqual([])
+    expect(await searchIndex.search(intervening ? 'third' : 'second')).toHaveLength(1)
+  })
+
+  it.each(['other-author', 'other-archive'] as const)('does not change an unrelated %s resident or preview sharing the client ID', async collision => {
+    const h = harness(kind)
+    activate(kind)
+    const base = original(kind)
+    await save(kind, base); await searchIndex.indexMessage(base)
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'corrected cached secret' })
+    await completion.started.promise
+    const other: Row = {
+      ...base, stanzaId: 'different-archive', originId: 'different-origin', body: 'unrelated visible text',
+      timestamp: new Date(T2), reactions: { '👍': ['someone'] },
+      ...(collision === 'other-author' ? kind === 'chat' ? { from: SELF, isOutgoing: true } : { occupantId: 'other-occupant' } : {}),
+    }
+    const persistOther = kind === 'chat' || collision === 'other-author'
+    try {
+      seed(kind, [other]); seedPreview(kind, other)
+      if (persistOther) await save(kind, other)
+    }
+    finally { completion.release.resolve() }
+    await work; await drain()
+    expect(resident(kind)).toEqual(other)
+    expect(preview(kind)).toEqual(other)
+    const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+    expect(rows).toHaveLength(persistOther ? 2 : 1)
+    expect(rows.find(row => row.stanzaId === base.stanzaId)?.body).toBe('corrected cached secret')
+    if (persistOther) expect(rows.find(row => row.stanzaId === other.stanzaId)).toMatchObject(other)
+    expect(await searchIndex.search('secret')).toHaveLength(1)
+  })
+
+  it('preserves preview identity, timestamps and unrelated fields when its correction is applied', async () => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    const shown = { ...base, timestamp: new Date(T1), reactions: { '👍': ['someone'] }, linkPreview: { url: 'https://example.test', title: 'Preview' } }
+    seedPreview(kind, shown)
+    await h.live({ id: 'c2', body: 'new correction' })
+    expect(preview(kind)).toMatchObject({ ...shown, body: 'new correction' })
+    expect(await reload(kind)).toMatchObject({ body: 'new correction', timestamp: base.timestamp })
+  })
+
+  it.each(['account', 'session'] as const)('does not complete into a replacement %s', async change => {
+    const h = harness(kind)
+    setStorageScopeJid(SELF)
+    await save(kind, original(kind))
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'initiating account secret' })
+    await completion.started.promise
+    try {
+      if (change === 'account') setStorageScopeJid('other@example.test')
+      if (kind === 'chat') {
+        chatStore.getState().reset()
+        chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+      } else {
+        roomStore.getState().reset()
+        roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+      }
+      const other = { ...original(kind), body: 'replacement state' }
+      seed(kind, [other]); seedPreview(kind, other)
+    } finally { completion.release.resolve() }
+    await work; await drain()
+    expect(resident(kind)?.body).toBe('replacement state')
+    expect(preview(kind)?.body).toBe('replacement state')
+    if (change === 'account') {
+      expect(await searchIndex.search('secret')).toEqual([])
+      expect(kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})).toEqual([])
+    }
+    setStorageScopeJid(SELF)
+    expect(await searchIndex.search('secret')).toHaveLength(kind === 'chat' && change === 'session' ? 0 : 1)
+  })
+
+  it('keeps recovered current ciphertext content when an older completion arrives', async () => {
+    const h = harness(kind)
+    activate(kind)
+    const base = { ...indexedBase(kind, true), encryptedPayload: 'baseline ciphertext' }
+    await save(kind, base); seedPreview(kind, base)
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'older pending correction', at: T1 })
+    await completion.started.promise
+    try {
+      seed(kind, [base])
+      const offset = writes.length
+      h.receive({ id: 'c3', body: 'recovered newer content', at: T2, authoredAt: FAST })
+      await Promise.all(writes.slice(offset))
+    } finally { completion.release.resolve() }
+    await work; await drain()
+    expect(resident(kind)).toMatchObject({ body: 'recovered newer content', correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored' })
+    expect(preview(kind)?.body).toBe('recovered newer content')
+    expect(await reload(kind)).toMatchObject({ body: 'recovered newer content', correctionTimestamp: Date.parse(FAST) })
+    expect(await searchIndex.search('older')).toEqual([])
+  })
+})
+
+describe('live room correction cache handoff', () => {
+  it('uses room authority and stable occupant identity outside RAM', async () => {
+    const h = harness('room')
+    activate('room')
+    const base = indexedBase('room', true) as StoredRoomMessage
+    await save('room', base); seedPreview('room', base)
+    const before = (await cache.findRoomMessageCopies(ROOM, base))[0]
+    await h.live({ id: 'c2', body: 'live room correction', at: T1, from: `${ROOM}/NewNick` })
+    expect(h.events.filter(({ event }) => event === 'room:message')).toEqual([])
+    const after = (await cache.findRoomMessageCopies(ROOM, base))[0]
+    expect(after.cacheKey).toBe(before.cacheKey)
+    expect(after.message).toMatchObject({ body: 'live room correction', id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, occupantId: base.occupantId,
+      correctionStanzaIds: ['sid-c2'], correctionRevision: { ids: expect.arrayContaining(['stanza:sid-c2', 'origin:c2']), supersedes: ['stanza:sid-c0'], afterArchiveTimestamp: Date.parse(T0) } })
+    expect(preview('room')?.body).toBe('live room correction')
+    await h.archive([{ id: 'c0', body: 'baseline correction', at: T0 }], true)
+    expect(await reload('room')).toMatchObject({ body: 'live room correction', timestamp: base.timestamp, occupantId: base.occupantId })
+    expect(await searchIndex.search('live')).toHaveLength(1)
+  })
+
+  it.each(['unknown', 'weak-foreign', 'authoritative-foreign'] as const)('preserves scoped missing-target behavior: %s', async target => {
+    const h = harness('room')
+    activate('room')
+    const foreign = { ...original('room'), occupantId: 'different-occupant' } as StoredRoomMessage
+    if (target !== 'unknown') await save('room', foreign)
+    await h.live({ id: 'c2', body: 'new occupant correction', targetId: target === 'authoritative-foreign' ? foreign.stanzaId : foreign.id })
+    const rows = await cache.getRoomMessages(ROOM, {})
+    if (target === 'authoritative-foreign') {
+      expect(h.events.filter(({ event }) => event === 'room:message')).toEqual([])
+      expect(rows).toMatchObject([foreign])
+      expect(await searchIndex.search('occupant')).toEqual([])
+    } else {
+      expect(h.events.filter(({ event }) => event === 'room:message')).toHaveLength(1)
+      expect(rows.find(row => row.occupantId === 'peer-occupant')?.body).toBe('new occupant correction')
+      if (target === 'weak-foreign') expect(rows.find(row => row.occupantId === foreign.occupantId)).toMatchObject(foreign)
+    }
+  })
+})
+
+it('routes a chat correction past a resident foreign client-ID collision to its cached author', async () => {
+  const h = harness('chat')
+  activate('chat')
+  const base = indexedBase('chat', true)
+  const foreign = { ...original('chat', true), stanzaId: 'outgoing-archive', timestamp: new Date(T2) }
+  await save('chat', base, foreign); seed('chat', [foreign]); seedPreview('chat', foreign)
+  await h.live({ id: 'c2', body: 'cached peer correction', at: T1 })
+  expect(resident('chat')).toEqual(foreign)
+  expect(preview('chat')).toEqual(foreign)
+  expect(h.events.filter(({ event }) => event === 'chat:message')).toEqual([])
+  const rows = await cache.getMessages(PEER)
+  expect(rows).toHaveLength(2)
+  expect(rows.find(row => row.from === PEER)).toMatchObject({ body: 'cached peer correction', stanzaId: base.stanzaId, timestamp: base.timestamp })
+  expect(await searchIndex.search('cached')).toHaveLength(1)
+})
+
+describe('equal-date room author ordering', () => {
+  it.each([[false, false], [true, false], [false, true], [true, true]] as const)('follows a stable occupant across nick changes and target aliases, original in page %s, return to original %s', async (inPage, returnToOriginal) => {
+    const h = harness('room')
+    activate('room')
+    await save('room', original('room'))
+    const edits = [
+      { id: 'c1', body: 'old nick edit', at: T1, from: `${ROOM}/OldNick` },
+      { id: 'c2', body: 'new nick edit', at: T1, from: `${ROOM}/NewNick`, targetId: 'sid-c1' },
+    ]
+    if (returnToOriginal) edits.push({ id: 'c3', body: 'third nick edit', at: T1, from: `${ROOM}/ThirdNick`, targetId: 'original' })
+    await h.archive(edits, inPage)
+    const expected = returnToOriginal ? 'third nick edit' : 'new nick edit'
+    expect(await reload('room')).toMatchObject({ body: expected, correctionRevision: { ids: expect.arrayContaining([returnToOriginal ? 'stanza:sid-c3' : 'stanza:sid-c2']), supersedes: expect.arrayContaining(returnToOriginal ? ['stanza:sid-c1', 'stanza:sid-c2'] : ['stanza:sid-c1']) } })
+    await h.archive([edits[0]], true)
+    expect(resident('room')?.body).toBe(expected)
+    expect(await reload('room')).toMatchObject({ body: expected })
+  })
+
+  it('keeps reused nicknames with different occupant IDs in separate order groups', async () => {
+    const h = harness('room')
+    await save('room', original('room'))
+    await h.archive([
+      { id: 'c1', body: 'foreign nick edit', at: T1, occupantId: 'foreign-occupant' },
+      { id: 'c2', body: 'authorized nick edit', at: T1 },
+    ], true)
+    const row = await reload('room')
+    expect(row.body).toBe('authorized nick edit')
+    expect(row.correctionRevision?.supersedes).not.toContain('stanza:sid-c1')
+    expect(row.correctionStanzaIds).not.toContain('sid-c1')
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s delayed durable search completion', kind => {
+  it('serializes overlapping durable replacements through their index insertion', async () => {
+    setStorageScopeJid(SELF)
+    const base = original(kind)
+    await save(kind, base)
+    await searchIndex.indexMessage(base)
+    const apply = async (id: string, body: string) => {
+      const updates = { body, isEdited: true, liveCorrection: true, correctionRevision: { ids: [`stanza:${id}`], supersedes: [] } }
+      return kind === 'chat'
+        ? await cache.applyChatCorrection(PEER, base.id, updates, { actorJid: base.from })
+        : await cache.applyRoomCorrection(ROOM, base.id, updates, { actorJid: base.from, actorOccupantId: 'peer-occupant' })
+    }
+    const first = await apply('c1', 'first searchable revision')
+    const firstInsert = deferred(), secondInsert = deferred()
+    const releaseFirst = deferred(), releaseSecond = deferred()
+    const checkRetractions = cache.areRetractedInCache
+    vi.spyOn(cache, 'areRetractedInCache').mockImplementation(async (messages, scope) => {
+      if (messages[0]?.body === 'first searchable revision') {
+        firstInsert.resolve()
+        await releaseFirst.promise
+      } else if (messages[0]?.body === 'second searchable revision') {
+        secondInsert.resolve()
+        await releaseSecond.promise
+      }
+      return checkRetractions(messages, scope)
+    })
+    const firstUpdate = searchIndex.updateMessage(first!)
+    await firstInsert.promise
+    const second = await apply('c2', 'second searchable revision')
+    const secondUpdate = searchIndex.updateMessage(second!)
+    try {
+      await Promise.race([secondInsert.promise, new Promise(resolve => setTimeout(resolve, 50))])
+      releaseFirst.resolve()
+      await firstUpdate
+    } finally {
+      releaseFirst.resolve()
+      releaseSecond.resolve()
+      await Promise.all([firstUpdate, secondUpdate])
+    }
+    expect(await searchIndex.search('second')).toHaveLength(1)
+    expect(await searchIndex.search('first')).toEqual([])
+    expect((await reload(kind)).body).toBe('second searchable revision')
+  })
+
+  it('indexes the current cache revision when another cache-only edit completed first', async () => {
+    const h = harness(kind)
+    await save(kind, indexedBase(kind, true))
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'second archived content', at: T1 })
+    await completion.started.promise
+    try {
+      const offset = writes.length
+      h.receive({ id: 'c3', body: 'third archived content', at: T2 })
+      await Promise.all(writes.slice(offset))
+    } finally { completion.release.resolve() }
+    await work; await drain()
+    expect(await reload(kind)).toMatchObject({ body: 'third archived content' })
+    expect(await searchIndex.search('second')).toEqual([])
+    expect(await searchIndex.search('third')).toHaveLength(1)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s correction identity and older activation snapshots', kind => {
+  it('keeps distinct archive revisions when the sender reuses its client ID without an origin ID', async () => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    const c1 = { id: 'reused', stanzaId: 's1', omitOriginId: true, body: 'first revision', at: T1, authoredAt: FAST }
+    const c2 = { ...c1, stanzaId: 's2', body: 'second revision', at: T2, authoredAt: T1 }
+    await h.live(c1)
+    const older = structuredClone(resident(kind)!)
+    await h.live(c2)
+    expect(resident(kind)).toMatchObject({ body: c2.body, correctionTimestamp: Date.parse(T1), correctionRevision: { ids: expect.arrayContaining(['stanza:s2']), archiveTimestamp: Date.parse(T2) } })
+    expect(resident(kind)?.correctionRevision?.ids).not.toContain('stanza:s1')
+    await save(kind, resident(kind)!, older)
+    await h.archive([c1], true)
+    expect(await reload(kind)).toMatchObject({ body: c2.body, correctionTimestamp: Date.parse(T1), correctionRevision: { archiveTimestamp: Date.parse(T2) }, correctionStanzaIds: ['s1', 's2'] })
+    expect(await searchIndex.search('second')).toHaveLength(1)
+    expect(await searchIndex.search('first')).toEqual([])
+  })
+
+  it('enriches a live revision and keeps same-date replay distinct despite client-ID reuse', async () => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)])
+    await h.live({ id: 'reused', body: 'first revision', omitOriginId: true, omitStanzaId: true })
+    const c1 = { id: 'reused', body: 'first revision', omitOriginId: true, stanzaId: 's1', at: T1 }
+    await h.archive([c1])
+    expect(resident(kind)?.correctionRevision?.ids).toEqual(expect.arrayContaining(['id:reused', 'stanza:s1']))
+    const c2 = { ...c1, body: 'second revision', stanzaId: 's2' }
+    const c3 = { ...c1, body: 'third revision', stanzaId: 's3' }
+    await h.archive([c1, c2, c3])
+    await h.archive([c2])
+    expect(await reload(kind)).toMatchObject({ body: 'third revision', correctionRevision: { ids: expect.arrayContaining(['stanza:s3']), archiveTimestamp: Date.parse(T1) }, correctionStanzaIds: ['s1', 's2', 's3'] })
+  })
+
+  it.each([false, true])('accepts a completion over a proven older activation snapshot; intervening newer edit %s', async intervening => {
+    const h = harness(kind)
+    activate(kind)
+    const base = indexedBase(kind, true)
+    await save(kind, base); seedPreview(kind, base)
+    const read = deferred(), install = deferred()
+    if (kind === 'chat') {
+      const get = cache.getMessagesAround
+      vi.spyOn(cache, 'getMessagesAround').mockImplementationOnce(async (...args) => { const rows = await get(...args); read.resolve(); await install.promise; return rows })
+    } else {
+      const get = cache.getRoomMessagesAround
+      vi.spyOn(cache, 'getRoomMessagesAround').mockImplementationOnce(async (...args) => { const rows = await get(...args); read.resolve(); await install.promise; return rows })
+    }
+    const loading = kind === 'chat' ? chatStore.getState().loadMessagesAroundFromCache(PEER, { id: base.id })
+      : roomStore.getState().loadMessagesAroundFromCache(ROOM, { id: base.id, occupantId: (base as StoredRoomMessage).occupantId })
+    await read.promise
+    await h.live({ id: 'c1', body: 'first completed edit', at: T1 })
+    expect(resident(kind)).toBeUndefined()
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'second completed edit', at: T1 })
+    await completion.started.promise
+    try {
+      install.resolve(); await loading
+      expect(resident(kind)?.body).toBe('second completed edit')
+      seed(kind, [base]); seedPreview(kind, base)
+      if (intervening) {
+        const offset = writes.length
+        h.receive({ id: 'c3', body: 'third completed edit', at: T2 })
+        await Promise.all(writes.slice(offset))
+      }
+    } finally { install.resolve(); completion.release.resolve() }
+    await work; await drain()
+    const expected = intervening ? 'third completed edit' : 'second completed edit'
+    expect(resident(kind)?.body).toBe(expected)
+    expect(preview(kind)?.body).toBe(expected)
+    expect(await reload(kind)).toMatchObject({ body: expected, timestamp: base.timestamp, stanzaId: base.stanzaId })
+    expect(await searchIndex.search(intervening ? 'third' : 'second')).toHaveLength(1)
+    expect(await searchIndex.search(intervening ? 'second' : 'third')).toEqual([])
+  })
+
+  it('preserves decryption and archive enrichment of the same revision during completion', async () => {
+    const h = harness(kind)
+    activate(kind)
+    const base = indexedBase(kind, true)
+    await save(kind, base); seedPreview(kind, base)
+    const completion = deferCorrectionCompletion(kind)
+    const edit = { id: 'c2', body: 'locked correction', locked: true, omitOriginId: true, at: T2 }
+    const work = h.live({ ...edit, omitStanzaId: true })
+    await completion.started.promise
+    const blocked = await blockedDecrypt()
+    try {
+      await loadWindow(kind)
+      const engine = new DeferredDecryptEngine({ getManager: () => blocked.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+      const retry = engine.retryPending()
+      await blocked.started.promise
+      blocked.release.resolve(); await retry
+      const offset = writes.length
+      h.receive({ ...edit, at: T2 })
+      await Promise.all(writes.slice(offset))
+    } finally { blocked.release.resolve(); completion.release.resolve() }
+    await work; await drain()
+    expect(resident(kind)).toMatchObject({ body: 'stale recovered text', encryptedPayload: undefined, correctionTimestamp: Date.parse(FAST), correctionRevision: { ids: expect.arrayContaining(['stanza:sid-c2']), archiveTimestamp: Date.parse(T2) } })
+    expect(preview(kind)?.body).toBe('stale recovered text')
+    expect(await reload(kind)).toMatchObject({ body: 'stale recovered text', encryptedPayload: undefined, correctionTimestamp: Date.parse(FAST), correctionRevision: { archiveTimestamp: Date.parse(T2) } })
+    expect(await searchIndex.search('recovered')).toHaveLength(1)
+  })
+
+  it.each([false, true])('groups known cached target aliases within archive order; separate pages %s', async pages => {
+    const h = harness(kind)
+    activate(kind)
+    const base = { ...original(kind), originId: 'origin-original' }
+    await save(kind, base); seedPreview(kind, base)
+    const edits = [
+      { id: 'c1', body: 'first alias edit', at: T1, targetId: base.id, ...(kind === 'room' && { from: `${ROOM}/OldNick` }) },
+      { id: 'c2', body: 'second alias edit', at: T1, targetId: base.originId, ...(kind === 'room' && { from: `${ROOM}/NewNick` }) },
+    ]
+    const reads = vi.spyOn(IDBIndex.prototype, 'getAll')
+    if (pages) await h.archivePages(edits.map(edit => ({ edits: [edit] })), true)
+    else await h.archive(edits)
+    expect(reads.mock.contexts.filter(index => index instanceof IDBIndex && (index.name === 'conversationId' || index.name === 'roomJid'))).toEqual([])
+    expect(await reload(kind)).toMatchObject({ body: 'second alias edit', originId: base.originId, correctionRevision: { supersedes: expect.arrayContaining(['stanza:sid-c1']) } })
+    await h.archive([edits[0]])
+    expect(await reload(kind)).toMatchObject({ body: 'second alias edit' })
+  })
+
+  it('does not infer equal-date order between separate archive queries', async () => {
+    const h = harness(kind)
+    await save(kind, { ...original(kind), originId: 'origin-original' })
+    await h.archive([{ id: 'c1', body: 'first query edit', at: T1 }])
+    await h.archive([{ id: 'c2', body: 'second query edit', at: T1, targetId: 'origin-original' }])
+    const row = await reload(kind)
+    expect(row.body).toBe('first query edit')
+    expect(row.correctionRevision?.supersedes).not.toContain('stanza:sid-c2')
+  })
+})
+
+describe('room correction preview projections', () => {
+  it.each([false, true])('keeps both previews current when reopening; resident %s', async inMemory => {
+    const h = harness('room')
+    activate('room')
+    const base = original('room')
+    await save('room', base); seedPreview('room', base)
+    if (inMemory) seed('room', [base])
+    await h.live({ id: 'c2', body: 'current room edit', at: T2 })
+    expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('current room edit')
+    expect(preview('room')?.body).toBe('current room edit')
+    seed('room', [])
+    await roomStore.getState().loadMessagesFromCache(ROOM)
+    expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview('room'))
+    expect(preview('room')?.body).toBe('current room edit')
+    await h.archive([{ id: 'c1', body: 'old edit', at: T1 }])
+    expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview('room'))
+    expect((preview('room') as StoredRoomMessage)?.correctionStanzaIds).toContain('sid-c1')
+  })
+
+  it.each([false, true])('keeps pending retractions in both projections; resident %s', async inMemory => {
+    const h = harness('room')
+    const base = original('room')
+    await save('room', base); seedPreview('room', base)
+    if (inMemory) seed('room', [base])
+    await h.live({ id: 'c2', body: 'current room correction', at: T2 })
+    h.emitSDK('room:retraction-pending', { roomJid: ROOM, targetId: 'sid-c1', actorJid: base.from, actorOccupantId: 'peer-occupant' })
+    await drain()
+    await h.live({ id: 'c1', body: 'retracted corrected content', at: T1 })
+    expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.isRetracted).toBe(true)
+    expect(preview('room')?.isRetracted).toBe(true)
+    seed('room', []); await roomStore.getState().loadMessagesFromCache(ROOM)
+    expect(preview('room')?.isRetracted).toBe(true)
+    expect(await searchIndex.search('retracted')).toEqual([])
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s cached correction reference isolation', kind => {
+  it('keeps archive-distinct targets with a reused weak ID in separate order groups', async () => {
+    const h = harness(kind)
+    const first = { ...original(kind), originId: 'origin-first' }
+    const second = { ...original(kind), id: kind === 'chat' ? first.id : 'second', stanzaId: 'archive-second', originId: 'origin-second', body: 'second original' }
+    await save(kind, first, second)
+    await h.archive([
+      { id: 'c1', targetId: first.stanzaId, body: 'first target edit', at: T1 },
+      { id: 'c2', targetId: second.stanzaId, body: 'second target edit', at: T1 },
+    ])
+    await drain()
+    const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+    expect(rows).toHaveLength(2)
+    expect(rows.find(row => row.stanzaId === first.stanzaId)?.body).toBe('first target edit')
+    const other = rows.find(row => row.stanzaId === second.stanzaId) as Row
+    expect(other.body).toBe('second target edit')
+    expect(other.correctionRevision?.supersedes).not.toContain('stanza:sid-c1')
+  })
+
+  it.each([false, true])('retains forward-page order across a concurrent context fetch enriching the original; resident %s', async inMemory => {
+    const h = harness(kind)
+    activate(kind)
+    const base = { ...original(kind), stanzaId: undefined, originId: 'origin-original' }
+    await save(kind, base); seedPreview(kind, base)
+    if (inMemory) seed(kind, [base])
+    let lookups = 0
+    const resolve = kind === 'chat' ? h.stores.chat.resolveCorrectionReferences : h.stores.room.resolveCorrectionReferences
+    const implementation = resolve.getMockImplementation()!
+    resolve.mockImplementation(async (...args) => {
+      if (++lookups === 2) {
+        await h.context([])
+        const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+        expect(rows[0]).toMatchObject({ id: base.id, stanzaId: 'archive-original', originId: base.originId, timestamp: base.timestamp })
+        if (!inMemory) seed(kind, [])
+      }
+      return implementation(...args)
+    })
+    const edits = [
+      { id: 'c1', targetId: base.originId, body: 'first page edit', at: T1, ...(kind === 'room' && { from: `${ROOM}/OldNick` }) },
+      { id: 'c2', targetId: base.originId, body: 'second page edit', at: T1, ...(kind === 'room' && { from: `${ROOM}/NewNick` }) },
+    ]
+    await h.archivePages(edits.map(edit => ({ edits: [edit] })), true)
+    expect(lookups).toBe(2)
+    expect(preview(kind)?.body).toBe('second page edit')
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('second page edit')
+    expect(await reload(kind)).toMatchObject({ id: base.id, stanzaId: 'archive-original', originId: base.originId, timestamp: base.timestamp,
+      body: 'second page edit', correctionRevision: { supersedes: expect.arrayContaining(['stanza:sid-c1']) } })
+    await h.archive([edits[0]])
+    expect((await reload(kind)).body).toBe('second page edit')
+    expect(preview(kind)?.body).toBe('second page edit')
+  })
+
+  it('keeps overlapping references on strongly distinct originals in separate forward-page groups', async () => {
+    const h = harness(kind)
+    const first = { ...original(kind), originId: 'origin-first' }
+    const second = { ...original(kind), id: 'second', stanzaId: 'archive-second', originId: first.id, body: 'second original' }
+    await save(kind, first, second)
+    await h.archivePages([
+      { edits: [{ id: 'c1', targetId: first.stanzaId, body: 'first target edit', at: T1 }] },
+      { edits: [{ id: 'c2', targetId: second.stanzaId, body: 'second target edit', at: T1 }] },
+      { edits: [{ id: 'c3', targetId: first.stanzaId, body: 'latest first target', at: T1 }] },
+    ], true)
+    const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+    expect(rows).toHaveLength(2)
+    const one = rows.find(row => row.stanzaId === first.stanzaId) as Row
+    const two = rows.find(row => row.stanzaId === second.stanzaId) as Row
+    expect(one).toMatchObject({ body: 'latest first target', timestamp: first.timestamp })
+    expect(one.correctionRevision?.supersedes).toContain('stanza:sid-c1')
+    expect(one.correctionRevision?.supersedes).not.toContain('stanza:sid-c2')
+    expect(two).toMatchObject({ body: 'second target edit', timestamp: second.timestamp })
+    expect(two.correctionRevision?.supersedes).not.toContain('stanza:sid-c1')
+  })
+
+  it('rejects foreign authors before adopting cached target aliases', async () => {
+    const h = harness(kind)
+    const base = { ...original(kind), originId: 'origin-original' }
+    await save(kind, base)
+    await h.archive([
+      { id: 'foreign', body: 'foreign correction', at: T1, targetId: base.originId,
+        ...(kind === 'chat' ? { from: 'foreign@example.test' } : { occupantId: 'foreign-occupant' }) },
+      { id: 'valid', body: 'valid correction', at: T1, targetId: base.id },
+    ])
+    const row = await reload(kind)
+    expect(row.body).toBe('valid correction')
+    expect(row.correctionRevision?.supersedes).not.toContain('stanza:sid-foreign')
+    expect(row.correctionStanzaIds).not.toContain('sid-foreign')
+  })
+
+  it('cancels a lookup after its initiating account changes', async () => {
+    const h = harness(kind)
+    setStorageScopeJid(SELF)
+    await save(kind, { ...original(kind), originId: 'origin-original' })
+    const get = cache.getCorrectionReferences
+    const started = deferred(), release = deferred()
+    vi.spyOn(cache, 'getCorrectionReferences').mockImplementationOnce(async (...args) => {
+      const refs = await get(...args); started.resolve(); await release.promise; return refs
+    })
+    const result = h.archive([{ id: 'c1', body: 'account secret', at: T1, targetId: 'origin-original' }]).then(value => ({ value }), error => ({ error }))
+    await started.promise
+    const count = h.events.length
+    setStorageScopeJid('other@example.test'); release.resolve()
+    expect(await result).toMatchObject({ error: { name: 'AbortError' } })
+    expect(h.events).toHaveLength(count)
+    expect(await searchIndex.search('secret')).toEqual([])
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s grouped correction predecessor evidence', kind => {
+  it.each([[false, false], [false, true], [true, false], [true, true]])('accepts a reused client ID with a distinct archive; resident %s, archived arrival %s', async (inMemory, archived) => {
+    const h = harness(kind)
+    activate(kind)
+    const base = original(kind)
+    await save(kind, base); seedPreview(kind, base)
+    if (inMemory) seed(kind, [base])
+    const c1 = { id: 'reused', stanzaId: 's1', omitOriginId: true, body: 'first predecessor' }
+    const c2 = { id: 'other', stanzaId: 's2', omitOriginId: true, body: 'second predecessor' }
+    const c3 = { ...c1, stanzaId: 's3', body: 'third current edit', authoredAt: FAST }
+    await h.live(c1); await h.live(c2)
+    if (archived) await h.archive([{ ...c2, at: T1 }, { ...c3, at: T2 }])
+    else await h.live(c3)
+    if (inMemory) expect(resident(kind)?.body).toBe(c3.body)
+    expect(preview(kind)?.body).toBe(c3.body)
+    await reload(kind)
+    await h.archive([{ ...c1, at: T1 }, { ...c2, at: T1 }])
+    expect(resident(kind)).toMatchObject({ body: c3.body, correctionTimestamp: Date.parse(FAST), correctionRevision: { ids: expect.arrayContaining(['stanza:s3']) } })
+    expect(preview(kind)?.body).toBe(c3.body)
+    expect(await reload(kind)).toMatchObject({ body: c3.body, id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, correctionStanzaIds: ['s1', 's2', 's3'] })
+    expect(await searchIndex.search('third')).toHaveLength(1)
+    expect(await searchIndex.search('second')).toEqual([])
+  })
+
+  it.each([false, true])('rejects equal-date C2 replay after C3 reuses C1 identity; contiguous pages %s', async pages => {
+    const h = harness(kind)
+    activate(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    const c1 = { id: 'reused', stanzaId: 's1', omitOriginId: true, body: 'first equal edit', at: T1 }
+    const c2 = { ...c1, id: 'other', stanzaId: 's2', body: 'second equal edit' }
+    const c3 = { ...c1, stanzaId: 's3', body: 'third equal edit' }
+    if (pages) await h.archivePages([c1, c2, c3].map(edit => ({ edits: [edit] })), true)
+    else await h.archive([c1, c2, c3])
+    const current = structuredClone(resident(kind)!)
+    await h.archive([c2])
+    expect(resident(kind)?.body).toBe(c3.body)
+    expect(resident(kind)?.correctionRevision?.ids).not.toContain('stanza:s2')
+    const legacy = { ...current, correctionRevision: { ...current.correctionRevision!, predecessors: undefined } }
+    const old = { ...base, body: c2.body, isEdited: true, correctionRevision: { ids: ['id:other', 'stanza:s2'], supersedes: ['id:reused', 'stanza:s1'], archiveTimestamp: Date.parse(T1) } }
+    for (const rows of [[legacy, old], [old, legacy]]) {
+      await save(kind, ...rows)
+      expect(await reload(kind)).toMatchObject({ body: c3.body, correctionRevision: { ids: expect.arrayContaining(['stanza:s3']) } })
+    }
+    expect(preview(kind)?.body).toBe(c3.body)
+    expect(await searchIndex.search('third')).toHaveLength(1)
+    expect(await searchIndex.search('second')).toEqual([])
+  })
+
+  it.each([false, true])('preserves older flat predecessor metadata without weak-ID false matches; resident %s', async inMemory => {
+    const h = harness(kind)
+    activate(kind)
+    const current = { ...original(kind), body: 'third legacy edit', isEdited: true,
+      correctionRevision: { ids: ['id:reused', 'stanza:s3'], supersedes: ['id:reused', 'stanza:s1', 'id:other', 'stanza:s2'], archiveTimestamp: Date.parse(T1) } }
+    await save(kind, current); seedPreview(kind, current)
+    if (inMemory) seed(kind, [current])
+    await h.archive([{ id: 'other', stanzaId: 's2', omitOriginId: true, body: 'second legacy edit', at: T1 }])
+    expect(preview(kind)?.body).toBe(current.body)
+    expect(await reload(kind)).toMatchObject({ body: current.body, correctionRevision: { ids: ['id:reused', 'stanza:s3'] } })
+    expect(await searchIndex.search('second')).toEqual([])
+  })
+
+  it('enriches a weak-only predecessor before a later revision reuses that client ID', async () => {
+    const h = harness(kind)
+    activate(kind)
+    await save(kind, original(kind)); seedPreview(kind, original(kind))
+    const c1 = { id: 'reused', omitStanzaId: true, omitOriginId: true, body: 'first weak edit' }
+    await h.live(c1)
+    await h.live({ id: 'other', body: 'second weak edit' })
+    const echo = { ...c1, omitStanzaId: false, stanzaId: 's1', at: T1 }
+    await h.archive([echo])
+    const second = await reload(kind)
+    expect(second.body).toBe('second weak edit')
+    expect(second.correctionRevision?.predecessors).toContainEqual(expect.arrayContaining(['id:reused', 'stanza:s1']))
+    await h.live({ ...c1, omitStanzaId: false, stanzaId: 's3', body: 'third weak edit' })
+    await h.archive([echo])
+    expect(await reload(kind)).toMatchObject({ body: 'third weak edit', correctionRevision: { ids: expect.arrayContaining(['stanza:s3']) } })
+    expect(preview(kind)?.body).toBe('third weak edit')
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s durable live predecessor selection', kind => {
+  it.each([false, true])('records the durable predecessor after installing an older activation snapshot; outgoing %s', async outgoing => {
+    const h = harness(kind, outgoing)
+    activate(kind)
+    const base = { ...indexedBase(kind, true), ...(kind === 'chat' && outgoing && { from: SELF, isOutgoing: true }) }
+    await save(kind, base); seedPreview(kind, base)
+    await h.live({ id: 'c0', body: base.body, ...(kind === 'chat' && outgoing && { to: PEER }) })
+    const observed = (kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0] as Row
+    Object.assign(base, observed)
+    const read = deferred(), install = deferred()
+    if (kind === 'chat') {
+      const get = cache.getMessages
+      vi.spyOn(cache, 'getMessages').mockImplementationOnce(async (...args) => { const rows = await get(...args); read.resolve(); await install.promise; return rows })
+    } else {
+      const get = cache.getRoomMessages
+      vi.spyOn(cache, 'getRoomMessages').mockImplementationOnce(async (...args) => { const rows = await get(...args); read.resolve(); await install.promise; return rows })
+    }
+    const loading = loadWindow(kind)
+    await read.promise
+    const c1 = { id: 'c1', body: 'durable first edit', ...(kind === 'chat' && outgoing && { to: PEER }) }
+    try { await h.live(c1) } finally { install.resolve() }
+    await loading
+    expect(resident(kind)?.body).toBe(c1.body)
+    seed(kind, [base]); seedPreview(kind, base)
+    if (outgoing) await h.outgoing('current second edit')
+    else await h.live({ id: 'c2', body: 'current second edit' })
+    expect(resident(kind)?.correctionRevision?.supersedes).toContain('stanza:sid-c1')
+    expect((preview(kind) as Row | undefined)?.correctionRevision?.supersedes).toContain('stanza:sid-c1')
+    expect(resident(kind)?.liveCorrection).toBeUndefined()
+    await h.archive([{ ...c1, at: T1 }])
+    expect(resident(kind)?.body).toBe('current second edit')
+    expect(preview(kind)?.body).toBe('current second edit')
+    const reloaded = await reload(kind)
+    expect(reloaded).toMatchObject({ body: 'current second edit', id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+    expect(reloaded.liveCorrection).toBeUndefined()
+    expect(reloaded.correctionHandoff).toBeUndefined()
+    expect(await searchIndex.search('second')).toHaveLength(1)
+    expect(await searchIndex.search('first')).toEqual([])
+  })
+
+  it('does not apply a resident live completion after an account A to B to A transition', async () => {
+    const h = harness(kind)
+    setStorageScopeJid(SELF)
+    activate(kind)
+    const base = indexedBase(kind, true)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    const completion = deferCorrectionCompletion(kind)
+    const work = h.live({ id: 'c2', body: 'completed edit' })
+    await completion.started.promise
+    try {
+      setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+      const replacement = { ...base, body: 'replacement account state', timestamp: new Date(T2) }
+      seed(kind, [replacement]); seedPreview(kind, replacement)
+    } finally { completion.release.resolve() }
+    await work; await drain()
+    expect(resident(kind)?.body).toBe('replacement account state')
+    expect(preview(kind)?.body).toBe('replacement account state')
+  })
+})
+
+
+describe('deferred recovery storage generation', () => {
+  it.each(['resident chat', 'resident room', 'peer', 'durable decrypt', 'durable write'] as const)('discards %s recovery across an account round trip', async phase => {
+    setStorageScopeJid(SELF)
+    const kind = phase === 'resident room' ? 'room' : 'chat'
+    const h = harness(kind)
+    const base: Row = {
+      ...original(kind), body: 'locked current correction', isEdited: true,
+      encryptedPayload: '<message><body>locked current correction</body><plain xmlns="urn:fluux:e2ee-dummy:0">c3RhbGU=</plain></message>',
+      correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+    }
+    await save(kind, base)
+    seedPreview(kind, base)
+    if (!phase.startsWith('durable')) seed(kind, [base])
+    h.stores.chat.getConversationMessages.mockImplementation(() => chatStore.getState().messages.get(PEER) ?? [])
+    const blocked = await blockedDecrypt()
+    const writeStarted = deferred(), releaseWrite = deferred()
+    const update = cache.updateMessage
+    const port = phase === 'durable write' ? {
+      ...cache,
+      updateMessage: async (...args: Parameters<typeof cache.updateMessage>) => {
+        await update(...args)
+        writeStarted.resolve()
+        await releaseWrite.promise
+      },
+    } : cache
+    const engine = new DeferredDecryptEngine({ getManager: () => blocked.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache: port, updateSearchIndex: searchIndex.updateMessage })
+    const retry = phase === 'peer' ? engine.retryForPeer(PEER) : engine.retryPending()
+    await blocked.started.promise
+    if (phase === 'durable write') {
+      blocked.release.resolve()
+      await writeStarted.promise
+    }
+    setStorageScopeJid('other@example.test')
+    setStorageScopeJid(SELF)
+    const replacement = structuredClone(base)
+    seed(kind, [replacement]); seedPreview(kind, replacement)
+    blocked.release.resolve(); releaseWrite.resolve()
+    await retry; await drain()
+    expect(resident(kind)).toEqual(replacement)
+    expect(preview(kind)).toEqual(replacement)
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(replacement)
+    expect(await searchIndex.search('stale')).toEqual([])
+    const durable = (kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0]
+    expect(durable.body).toBe(phase === 'durable write' ? 'stale recovered text' : base.body)
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s atomic correction indexing', kind => {
+  it.each(['direct', 'batch'] as const)('keeps corrected tokens when %s history indexing overlaps replacement', async mode => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base)
+    await searchIndex.indexMessage(base)
+    const started = deferred(), release = deferred()
+    const check = cache.areRetractedInCache
+    vi.spyOn(cache, 'areRetractedInCache').mockImplementation(async (messages, scope) => {
+      if (messages.length === 1 && messages[0].body === 'corrected searchable text') {
+        started.resolve(); await release.promise
+      }
+      return check(messages, scope)
+    })
+    const correction = h.live({ id: 'c1', body: 'corrected searchable text' })
+    await started.promise
+    try {
+      if (mode === 'direct') await searchIndex.indexMessage(base)
+      else {
+        const history = Array.from({ length: 51 }, (_, index) => ({ ...base, id: `history-${index}`, stanzaId: `archive-${index}`, body: `filler message ${index}` }))
+        await searchIndex.indexMessages([...history, base])
+        expect(await searchIndex.search('filler', { limit: 100 })).toHaveLength(51)
+      }
+    } finally { release.resolve() }
+    await correction; await drain()
+    expect(await searchIndex.search('corrected')).toHaveLength(1)
+    expect(await searchIndex.search('original')).toEqual([])
+    expect((await reload(kind)).body).toBe('corrected searchable text')
+  })
+
+  it.each(['👍', '!!!', 'a'].flatMap(body => ['direct', 'batch'].map(mode => ({ body, mode }))))('protects a tokenless correction $body against $mode history insertion', async ({ body, mode }) => {
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); await searchIndex.indexMessage(base)
+    const history = Array.from({ length: 51 }, (_, index) => ({ ...base, id: `history-${index}`, stanzaId: `archive-${index}`, body: `filler message ${index}` }))
+    const started = deferred(), release = deferred()
+    const check = cache.areRetractedInCache
+    vi.spyOn(cache, 'areRetractedInCache').mockImplementation(async (messages, scope) => {
+      const result = await check(messages, scope)
+      if (messages.length > 50) { started.resolve(); await release.promise }
+      return result
+    })
+    const pendingHistory = searchIndex.indexMessages([...history, base])
+    writes.splice(writes.indexOf(pendingHistory), 1)
+    await started.promise
+    try {
+      await searchIndex.indexMessage(base)
+      await h.live({ id: 'c1', body })
+      expect(await searchIndex.search('original')).toEqual([])
+      if (mode === 'direct') {
+        await searchIndex.indexMessage(base)
+        expect(await searchIndex.search('original')).toEqual([])
+      }
+    } finally { release.resolve(); await pendingHistory }
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await searchIndex.search('text')).toEqual([])
+    expect(await searchIndex.search('filler', { limit: 100 })).toHaveLength(51)
+    expect((await reload(kind)).body).toBe(body)
+    await searchIndex.closeSearchIndex()
+    await searchIndex.indexMessage(base)
+    expect(await searchIndex.search('original')).toEqual([])
+    await h.live({ id: 'c2', body: 'searchable successor' })
+    expect(await searchIndex.search('successor')).toHaveLength(1)
+  })
+
+  it('rolls back failed token replacement and releases the target queue', async () => {
+    const base = original(kind)
+    await save(kind, base); await searchIndex.indexMessage(base)
+    const edited = { ...base, body: 'replacement text', isEdited: true }
+    const put = IDBObjectStore.prototype.put
+    const fail = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+      if (this.name === 'search-tokens' && args[0].token === 'replacement') throw new Error('token write failed')
+      return put.apply(this, args)
+    })
+    const failed = searchIndex.updateMessage(edited)
+    await expect(failed).rejects.toThrow('token write failed')
+    writes[writes.indexOf(failed)] = failed.catch(() => {})
+    fail.mockRestore()
+    expect(await searchIndex.search('original')).toHaveLength(1)
+    expect(await searchIndex.search('replacement')).toEqual([])
+    await searchIndex.updateMessage(edited)
+    expect(await searchIndex.search('replacement')).toHaveLength(1)
+    expect(await searchIndex.search('original')).toEqual([])
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s empty-caption indexing', kind => {
+  const attachment = { url: 'https://files.example.test/photo.png', mediaType: 'image/png', name: 'photo.png', size: 42 }
+
+  async function documents() {
+    const db = await openDB('fluux-search-index')
+    try {
+      const tx = db.transaction(['search-docs', 'search-tokens'], 'readonly')
+      const docs = await tx.objectStore('search-docs').getAll()
+      const tokens = await tx.objectStore('search-tokens').getAll()
+      await tx.done
+      return { docs, tokens }
+    } finally { db.close() }
+  }
+
+  it('keeps a removed caption absent after outgoing SDK correction and a pending 52-row history batch', async () => {
+    const h = harness(kind, true)
+    const base = { ...original(kind, true), attachment }
+    activate(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await searchIndex.indexMessage(base)
+    const history = Array.from({ length: 51 }, (_, index) => ({ ...base, id: `history-${index}`, stanzaId: `archive-${index}`, body: `filler message ${index}` }))
+    const started = deferred(), release = deferred()
+    const check = cache.areRetractedInCache
+    vi.spyOn(cache, 'areRetractedInCache').mockImplementation(async (messages, scope) => {
+      const result = await check(messages, scope)
+      if (messages.length > 50) { started.resolve(); await release.promise }
+      return result
+    })
+    const pendingHistory = searchIndex.indexMessages([...history, base])
+    writes.splice(writes.indexOf(pendingHistory), 1)
+    await started.promise
+    try {
+      await h.outgoing('', attachment)
+      expect(resident(kind)).toMatchObject({ id: base.id, timestamp: base.timestamp, body: '', attachment, isEdited: true })
+      expect(preview(kind)).toMatchObject({ body: '', attachment })
+      expect(await reload(kind)).toMatchObject({ id: base.id, timestamp: base.timestamp, body: '', attachment })
+      expect(await searchIndex.search('original')).toEqual([])
+    } finally { release.resolve(); await pendingHistory }
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await searchIndex.search('filler', { limit: 100 })).toHaveLength(51)
+    await searchIndex.indexMessage(base)
+    expect(await searchIndex.search('original')).toEqual([])
+    const persisted = await documents()
+    expect(persisted.docs.find(doc => doc.messageId === base.id)).toMatchObject({ body: '', tokens: [] })
+    expect(persisted.tokens.map(entry => entry.token)).not.toContain('original')
+  })
+
+  it.each(['single', 'batch', 'backfill', 'rebuild'])('retains an already-current empty edit through reopening and %s indexing', async mode => {
+    const h = harness(kind, true)
+    const base = { ...original(kind, true), attachment }
+    await save(kind, base); seed(kind, [base])
+    await h.outgoing('', attachment)
+    const current = await reload(kind)
+    expect(current).toMatchObject({ body: '', isEdited: true, attachment })
+    await searchIndex.clearSearchIndex(); await searchIndex.closeSearchIndex()
+    if (mode === 'single') await searchIndex.indexMessage(current)
+    else if (mode === 'batch') await searchIndex.indexMessages([current])
+    else if (mode === 'backfill') await searchIndex.backfillFromMessageCache()
+    else await searchIndex.rebuildSearchIndex()
+    await searchIndex.closeSearchIndex()
+    await searchIndex.indexMessage(base)
+    const history = Array.from({ length: 51 }, (_, index) => ({ ...base, id: `history-${index}`, stanzaId: `archive-${index}`, body: `filler message ${index}` }))
+    await searchIndex.indexMessages([...history, base])
+    expect(await searchIndex.search('original')).toEqual([])
+    const persisted = await documents()
+    expect(persisted.docs.find(doc => doc.messageId === base.id)).toMatchObject({ body: '', tokens: [] })
+    expect(persisted.tokens.map(entry => entry.token)).not.toContain('original')
+  })
+
+  it.each(['noLocalStore', 'isRetracted'] as const)('excludes an empty edit carrying %s from replacement, single and batch indexing', async flag => {
+    const base = original(kind)
+    await searchIndex.indexMessage(base)
+    const excluded = { ...base, body: '', isEdited: true, [flag]: true }
+    await searchIndex.updateMessage(excluded)
+    await searchIndex.indexMessage(excluded)
+    await searchIndex.indexMessages([excluded], { fromCache: true })
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await documents()).toEqual({ docs: [], tokens: [] })
+  })
+
+  it('rolls back an empty-document write failure and permits a clean retry', async () => {
+    const base = original(kind)
+    await searchIndex.indexMessage(base)
+    const current = { ...base, body: '', isEdited: true }
+    const put = IDBObjectStore.prototype.put
+    const fail = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+      if (this.name === 'search-docs' && args[0].body === '') throw new Error('document write failed')
+      return put.apply(this, args)
+    })
+    const failed = searchIndex.updateMessage(current)
+    try { await expect(failed).rejects.toThrow('document write failed') }
+    finally { writes[writes.indexOf(failed)] = failed.catch(() => {}); fail.mockRestore() }
+    expect(await searchIndex.search('original')).toHaveLength(1)
+    await searchIndex.updateMessage(current)
+    await searchIndex.indexMessage(base)
+    expect(await searchIndex.search('original')).toEqual([])
+    expect((await documents()).tokens).toEqual([])
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s archive identity isolation', kind => {
+  it.each([false, true])('keeps read-only search separate from a conflicting cached original; retracted: %s', async retracted => {
+    const held = { ...original(kind), stanzaId: 'archive-A', body: 'private edited text', isEdited: true,
+      correctionStanzaIds: ['edit-A'], correctionRevision: { ids: ['stanza:edit-A'], supersedes: [], archiveTimestamp: Date.parse(T2) },
+      ...(retracted && { isRetracted: true, retractedAt: new Date(T2) }) }
+    await save(kind, held)
+    const before = await reload(kind)
+    seed(kind, [])
+    const h = harness(kind, false, { stanzaId: 'archive-B', body: 'separate original text' })
+    const rows = await h.search([])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ id: held.id, stanzaId: 'archive-B', body: 'separate original text', from: held.from, timestamp: held.timestamp })
+    expect(rows[0].isEdited).toBeFalsy()
+    expect(rows[0].isRetracted).toBeFalsy()
+    expect(rows[0].correctionRevision).toBeUndefined()
+    expect(rows[0].correctionStanzaIds).toBeUndefined()
+    expect(h.historyRows).toEqual([])
+    expect(await reload(kind)).toEqual(before)
+  })
+
+  it('enriches the identity of the same original during read-only search', async () => {
+    const held = { ...original(kind), stanzaId: undefined, body: 'current edited text', isEdited: true,
+      correctionRevision: { ids: ['stanza:edit-A'], supersedes: [], archiveTimestamp: Date.parse(T2) } }
+    await save(kind, held)
+    const h = harness(kind)
+    const rows = await h.search([])
+    expect(rows[0]).toMatchObject({ id: held.id, stanzaId: 'archive-original', body: held.body, correctionRevision: held.correctionRevision })
+    expect((await reload(kind)).stanzaId).toBeUndefined()
+  })
+
+  it.each(['foreign', 'matching-and-foreign', 'absent', 'conflicting'] as const)('uses the queried archive identity for a %s inner stanza ID', async mode => {
+    const h = harness(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)]); seedPreview(kind, original(kind))
+    await h.live({ id: 'c1', body: 'older text', stanzaId: 'R1' })
+    await h.live({ id: 'c2', body: 'current text', stanzaId: 'R2' })
+    const replay: Edit = { id: 'c1', body: 'older text', at: T1, archiveId: 'R1', stanzaId: 'F1', stanzaIdBy: 'foreign.example.test' }
+    if (mode === 'absent') replay.omitStanzaId = true
+    if (mode === 'matching-and-foreign' || mode === 'conflicting') replay.extraStanzaIds = [{ id: mode === 'conflicting' ? 'R3' : 'R1', by: kind === 'chat' ? SELF : ROOM }]
+    if (mode === 'conflicting') await h.archive([{ id: 'c2', body: 'current text', stanzaId: 'R2', at: T0 }])
+    await h.archive([replay])
+    const expectedBody = mode === 'conflicting' ? 'older text' : 'current text'
+    expect(resident(kind)?.body).toBe(expectedBody)
+    expect(preview(kind)?.body).toBe(expectedBody)
+    const stored = await reload(kind)
+    expect(stored.body).toBe(expectedBody)
+    expect(stored.correctionRevision?.ids).toContain(mode === 'conflicting' ? 'stanza:R3' : 'stanza:R2')
+    expect(stored.correctionRevision?.ids).not.toContain('stanza:F1')
+    if (mode === 'foreign') expect(stored.correctionStanzaIds).toEqual(expect.arrayContaining(['R1', 'R2', 'F1']))
+    expect(await searchIndex.search(mode === 'conflicting' ? 'current' : 'older')).toEqual([])
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s independent equal-time revision ingestion', kind => {
+  it.each(['alpha', 'zulu'])('retains current %s through independent MAM pages, persistence and search', async body => {
+    const h = harness(kind)
+    const oldBody = body === 'alpha' ? 'zulu' : 'alpha'
+    activate(kind)
+    await save(kind, original(kind)); seed(kind, [original(kind)]); seedPreview(kind, original(kind))
+    await h.archive([{ id: 'c2', body, at: T1, authoredAt: T0 }])
+    const current = await reload(kind)
+    const stale = { ...current, body: oldBody, correctionTimestamp: Date.parse(FAST),
+      correctionRevision: { ids: ['stanza:sid-c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }
+    for (const memory of [true, false]) {
+      seed(kind, memory ? [current] : [])
+      const rows = await h.archive([{ id: 'c1', body: oldBody, at: T1, authoredAt: FAST }], true)
+      expect(rows[0]).toMatchObject({ body, timestamp: new Date(T0), correctionTimestamp: Date.parse(T0), correctionRevision: { ids: expect.arrayContaining(['stanza:sid-c2']) } })
+      expect(h.historyRows.at(-1)?.[0].body).toBe(body)
+      expect(resident(kind)?.body).toBe(body)
+      expect(preview(kind)?.body).toBe(body)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe(body)
+      await searchIndex.indexMessage(stale)
+      await searchIndex.indexMessages([stale])
+      await searchIndex.updateMessage(stale)
+      expect(await searchIndex.search(oldBody)).toEqual([])
+      expect(await searchIndex.search(body)).toHaveLength(1)
+      await save(kind, stale)
+      expect(await reload(kind)).toMatchObject({ body, correctionTimestamp: Date.parse(T0), correctionRevision: { ids: expect.arrayContaining(['stanza:sid-c2']) } })
+    }
+    await h.archive([{ id: 'c1', body: oldBody, at: T1 }])
+    expect((await reload(kind)).body).toBe(body)
+  })
+
+  it('keeps current ciphertext over plaintext from an unrelated equal-time revision', async () => {
+    const held = { ...original(kind), body: 'locked current', isEdited: true, encryptedPayload: '<current/>',
+      correctionTimestamp: Date.parse(T0), correctionTimestampSource: 'authored' as const,
+      correctionRevision: { ids: ['stanza:c2'], supersedes: [], archiveTimestamp: Date.parse(T1) } }
+    const stale = { ...held, body: 'obsolete plaintext', encryptedPayload: undefined,
+      correctionTimestamp: Date.parse(FAST), correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }
+    await save(kind, held)
+    const reconciled = kind === 'chat'
+      ? await cache.reconcileChatHistoryMessages([stale as StoredMessage], () => [])
+      : await cache.reconcileRoomHistoryMessages([stale as StoredRoomMessage], () => [])
+    expect(reconciled[0]).toMatchObject({ body: held.body, encryptedPayload: held.encryptedPayload, correctionTimestamp: held.correctionTimestamp })
+    await searchIndex.indexMessage(stale)
+    expect(await searchIndex.search('obsolete')).toEqual([])
+    await save(kind, stale)
+    expect(await reload(kind)).toMatchObject({ body: held.body, encryptedPayload: held.encryptedPayload, correctionTimestamp: held.correctionTimestamp })
+    const recovered = { ...held, body: 'recovered current', encryptedPayload: undefined }
+    await save(kind, recovered)
+    expect(await reload(kind)).toMatchObject({ body: recovered.body, correctionTimestamp: held.correctionTimestamp })
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s search insertion after identity enrichment', kind => {
+  const attachment = { url: 'https://files.example.test/photo.png', mediaType: 'image/png' }
+
+  it.each(['current searchable revision', '', '👍'].flatMap(body => ['single', 'batch', 'backfill', 'rebuild'].map(mode => ({ body, mode }))))('keeps current body "$body" after stale $mode insertion and reopening', async ({ body, mode }) => {
+    const h = harness(kind, true)
+    const base = { ...original(kind, true), stanzaId: undefined, originId: 'origin-original', attachment }
+    activate(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await searchIndex.indexMessage(base)
+    const history = Array.from({ length: 51 }, (_, index) => ({ ...base, id: `history-${index}`, stanzaId: `archive-${index}`, originId: `origin-${index}`, body: `filler message ${index}` }))
+    const started = deferred(), release = deferred()
+    let pending: Promise<void> | undefined
+    if (mode === 'backfill' || mode === 'rebuild') {
+      await save(kind, ...history)
+      const method = kind === 'chat' ? 'iterateAllMessages' : 'iterateAllRoomMessages'
+      const iterate = cache[method]
+      vi.spyOn(cache, method).mockImplementation(async (size: number, onBatch: Parameters<typeof cache.iterateAllMessages>[1] | Parameters<typeof cache.iterateAllRoomMessages>[1]) => {
+        await iterate(size, async batch => {
+          const rows = [...batch.filter(row => row.id !== base.id), ...batch.filter(row => row.id === base.id)]
+          await onBatch(rows.slice(0, 50) as never)
+          started.resolve(); await release.promise
+          await onBatch(rows.slice(50) as never)
+        })
+      })
+      pending = mode === 'backfill' ? searchIndex.backfillFromMessageCache() : searchIndex.rebuildSearchIndex().then(() => {})
+      await started.promise
+    }
+    try {
+      await h.context([])
+      await h.outgoing(body, attachment)
+      const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+      expect(rows.find(row => row.id === base.id)).toMatchObject({ body, stanzaId: 'archive-original', originId: base.originId, timestamp: base.timestamp, attachment })
+      expect(await searchIndex.search('original')).toEqual([])
+      await searchIndex.closeSearchIndex(); cache._resetDBForTesting()
+      if (mode === 'single') await searchIndex.indexMessage(base)
+      else if (mode === 'batch') await searchIndex.indexMessages([...history, base])
+    } finally { release.resolve(); await pending }
+    expect(await searchIndex.search('original')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(body ? (body === '👍' ? 0 : 1) : 0)
+    await searchIndex.closeSearchIndex(); cache._resetDBForTesting()
+    await searchIndex.indexMessage(base)
+    expect(await searchIndex.search('original')).toEqual([])
+    const db = await openDB('fluux-search-index')
+    try {
+      const docs = await db.getAll('search-docs')
+      expect(docs.filter(doc => doc.messageId === base.id)).toMatchObject([{ body, stanzaId: 'archive-original' }])
+    } finally { db.close() }
+  })
+
+  it('serializes a stale resolved snapshot with a correction using its enriched key', async () => {
+    const base = { ...original(kind), stanzaId: undefined, originId: 'origin-original' }
+    await save(kind, base); await searchIndex.indexMessage(base)
+    const read = cache.resolveMessagesForIndex
+    const started = deferred(), release = deferred()
+    vi.spyOn(cache, 'resolveMessagesForIndex').mockImplementationOnce(async (...args) => {
+      const snapshot = await read(...args)
+      started.resolve(); await release.promise
+      return snapshot
+    })
+    const stale = searchIndex.indexMessage(base)
+    await started.promise
+    const enriched = { ...base, stanzaId: 'archive-original' }
+    await save(kind, enriched)
+    const updates = { body: '', isEdited: true, correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } }
+    const current = kind === 'chat'
+      ? await cache.applyChatCorrection(PEER, base.id, updates, { actorJid: base.from })
+      : await cache.applyRoomCorrection(ROOM, base.id, updates, { actorJid: base.from, actorOccupantId: 'peer-occupant' })
+    expect(current).toBeTruthy()
+    const correction = searchIndex.updateMessage(current!)
+    try { await Promise.race([correction, new Promise(resolve => setTimeout(resolve, 50))]) }
+    finally { release.resolve() }
+    await Promise.all([stale, correction])
+    expect(await searchIndex.search('original')).toEqual([])
+    const db = await openDB('fluux-search-index')
+    try { expect(await db.getAll('search-docs')).toMatchObject([{ body: '', stanzaId: enriched.stanzaId, tokens: [] }]) }
+    finally { db.close() }
+  })
+
+  it('retains recovered content when an encrypted snapshot arrives after enrichment', async () => {
+    const encrypted = { ...original(kind), stanzaId: undefined, originId: 'origin-original', body: 'locked placeholder', encryptedPayload: '<message/>' }
+    const recovered = { ...encrypted, stanzaId: 'archive-original', body: 'recovered plaintext', encryptedPayload: undefined }
+    await save(kind, recovered)
+    await searchIndex.indexMessage(recovered)
+    await searchIndex.indexMessage(encrypted)
+    expect(await searchIndex.search('locked')).toEqual([])
+    expect(await searchIndex.search('recovered')).toMatchObject([{ body: recovered.body, stanzaId: recovered.stanzaId }])
+  })
+
+  it('skips stale insertion on a failed cache lookup and recovers on retry', async () => {
+    const base = { ...original(kind), stanzaId: undefined, originId: 'origin-original' }
+    await save(kind, { ...base, stanzaId: 'archive-original', body: '', isEdited: true })
+    const failure = vi.spyOn(cache, 'resolveMessagesForIndex').mockRejectedValueOnce(new Error('lookup unavailable'))
+    await expect(searchIndex.indexMessage(base)).rejects.toThrow('lookup unavailable')
+    expect(await searchIndex.search('original')).toEqual([])
+    failure.mockRestore()
+    await searchIndex.indexMessage(base)
+    const db = await openDB('fluux-search-index')
+    try { expect(await db.getAll('search-docs')).toMatchObject([{ body: '', stanzaId: 'archive-original', tokens: [] }]) }
+    finally { db.close() }
+  })
+
+  it('cancels a backfill snapshot after an account round trip', async () => {
+    setStorageScopeJid(SELF)
+    await save(kind, { ...original(kind), body: 'account secret' })
+    const method = kind === 'chat' ? 'iterateAllMessages' : 'iterateAllRoomMessages'
+    const iterate = cache[method]
+    const started = deferred(), release = deferred()
+    vi.spyOn(cache, method).mockImplementationOnce(async (size: number, onBatch: Parameters<typeof cache.iterateAllMessages>[1] | Parameters<typeof cache.iterateAllRoomMessages>[1]) => {
+      await iterate(size, async batch => { started.resolve(); await release.promise; await onBatch(batch as never) })
+    })
+    const result = searchIndex.backfillFromMessageCache().then(() => null, error => error)
+    await started.promise
+    setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+    release.resolve()
+    expect(await result).toMatchObject({ name: 'AbortError' })
+    expect(await searchIndex.search('secret')).toEqual([])
+    await searchIndex.backfillFromMessageCache()
+    expect(await searchIndex.search('secret')).toHaveLength(1)
+    setStorageScopeJid('other@example.test')
+    expect(await searchIndex.search('secret')).toEqual([])
+  })
+
+  it.each(['archive', 'origin', 'author', 'occupant'] as const)('does not adopt a cached revision with conflicting %s evidence', async conflict => {
+    const current = { ...original(kind), originId: 'origin-current', body: 'private cached revision', isEdited: true }
+    const incoming: Row = { ...original(kind), body: 'different original', stanzaId: undefined, originId: current.originId }
+    if (conflict === 'archive') incoming.stanzaId = 'other-archive'
+    if (conflict === 'origin') incoming.originId = 'other-origin'
+    if (conflict === 'author') incoming.from = kind === 'chat' ? SELF : `${ROOM}/Other`
+    if (kind === 'room' && (conflict === 'occupant' || conflict === 'author')) (incoming as StoredRoomMessage).occupantId = 'other-occupant'
+    if (kind === 'chat' && conflict === 'occupant') incoming.from = SELF
+    await save(kind, current)
+    await searchIndex.indexMessage(incoming)
+    expect(await searchIndex.search('private')).toEqual([])
+    expect(await searchIndex.search('different')).toMatchObject([{ body: incoming.body, from: incoming.from }])
+  })
+})
+
+it('resolves an absorbed chat client ID to its current canonical cached edit', async () => {
+  const base = { ...original('chat'), id: 'z-original', stanzaId: undefined, originId: 'origin-original' }
+  await save('chat', base); await searchIndex.indexMessage(base)
+  await save('chat', { ...base, id: 'a-canonical', stanzaId: 'archive-original' })
+  const corrected = await cache.applyChatCorrection(PEER, base.id, {
+    body: '', isEdited: true, correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+  }, { actorJid: base.from })
+  expect(corrected?.id).toBe('a-canonical')
+  await searchIndex.indexMessage(base)
+  expect(await searchIndex.search('original')).toEqual([])
+  const db = await openDB('fluux-search-index')
+  try { expect(await db.getAll('search-docs')).toMatchObject([{ indexId: 'chat:a-canonical', body: '', tokens: [] }]) }
+  finally { db.close() }
+})
+
+it('does not resolve an ambiguous chat client ID to another cached original', async () => {
+  const first = { ...original('chat'), body: 'first private edit', isEdited: true }
+  const second = { ...first, stanzaId: 'other-archive', body: 'second private edit' }
+  await save('chat', first, second)
+  await searchIndex.indexMessage({ ...first, stanzaId: undefined, isEdited: false, body: 'ambiguous original' })
+  expect(await searchIndex.search('private')).toEqual([])
+})
+
+describe.each<Kind>(['chat', 'room'])('%s legacy encrypted correction preservation', kind => {
+  it.each([false, true])('retains ciphertext across cache reopen and history reconciliation; edit saved first %s', async editFirst => {
+    const h = harness(kind)
+    const base = original(kind)
+    const legacy: Row = {
+      ...base, body: 'locked legacy correction', isEdited: true, originalBody: base.body,
+      encryptedPayload: '<message><body>locked legacy correction</body><plain xmlns="urn:fluux:e2ee-dummy:0">bGVnYWN5</plain></message>',
+      correctionStanzaIds: ['sid-legacy'], correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored',
+    }
+    await save(kind, ...(editFirst ? [legacy, base] : [base, legacy]))
+    expect(await reload(kind)).toMatchObject(legacy)
+    seed(kind, [])
+    const reconcile = async (rows: Row[]) => kind === 'chat'
+      ? cache.reconcileChatHistoryMessages(rows as StoredMessage[], () => [])
+      : cache.reconcileRoomHistoryMessages(rows as StoredRoomMessage[], () => [])
+    expect((await reconcile([base]))[0]).toMatchObject(legacy)
+    await cache.clearAllMessages()
+    await save(kind, base)
+    expect((await reconcile([legacy]))[0]).toMatchObject(legacy)
+    await save(kind, legacy)
+    if (kind === 'room') seed(kind, [legacy])
+    const decrypt = await blockedDecrypt()
+    const engine = new DeferredDecryptEngine({ getManager: () => decrypt.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    expect(await retry).toBe(1)
+    await drain()
+    const recovered = await reload(kind)
+    expect(recovered).toMatchObject({ body: 'stale recovered text', isEdited: true, correctionTimestamp: Date.parse(FAST), correctionTimestampSource: 'authored', correctionStanzaIds: ['sid-legacy'] })
+    expect(recovered.encryptedPayload).toBeUndefined()
+    expect(recovered.correctionRevision).toBeUndefined()
+    await save(kind, base)
+    expect((await reload(kind)).body).toBe(recovered.body)
+    await h.archive([{ id: 'c2', body: 'newer known correction', at: T2, authoredAt: T1 }])
+    expect(await reload(kind)).toMatchObject({ body: 'newer known correction', correctionTimestamp: Date.parse(T1), correctionRevision: { archiveTimestamp: Date.parse(T2) }, correctionStanzaIds: ['sid-c2', 'sid-legacy'] })
+  })
+
+  it('keeps a legacy edited tombstone when the original and ciphertext return', async () => {
+    const base = original(kind)
+    const legacy = { ...base, body: 'legacy ciphertext placeholder', isEdited: true, encryptedPayload: 'legacy ciphertext', correctionStanzaIds: ['sid-legacy'] }
+    await save(kind, { ...legacy, isRetracted: true, retractedAt: new Date(T1), body: '' })
+    await save(kind, base, legacy)
+    const row = await reload(kind)
+    expect(row).toMatchObject({ isRetracted: true, retractedAt: new Date(T1), body: '', correctionStanzaIds: ['sid-legacy'] })
+    expect(row.encryptedPayload).toBeUndefined()
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s correction handoff after recovered source', kind => {
+  it('updates a ciphertext preview after durable recovery completes across an account round trip', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const c1: Row = {
+      ...original(kind), body: 'locked first correction', isEdited: true,
+      encryptedPayload: '<message><body>locked first correction</body><plain xmlns="urn:fluux:e2ee-dummy:0">Zmlyc3Q=</plain></message>',
+      correctionRevision: { ids: ['id:c1', 'stanza:sid-c1'], supersedes: [] },
+    }
+    await save(kind, c1); seedPreview(kind, c1)
+    if (kind === 'room') seed(kind, [c1])
+    const decrypt = await blockedDecrypt()
+    const written = deferred(), release = deferred()
+    const block = <A extends unknown[], R>(update: (...args: A) => Promise<R>) => (...args: A) => {
+      const pending = (async () => {
+        const result = await update(...args)
+        written.resolve(); await release.promise
+        return result
+      })()
+      writes.push(pending)
+      return pending
+    }
+    const port = { ...cache, updateMessage: block(cache.updateMessage) }
+    if (kind === 'room') vi.spyOn(cache, 'updateRoomMessage').mockImplementationOnce(block(cache.updateRoomMessage))
+    const engine = new DeferredDecryptEngine({ getManager: () => decrypt.manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache: port, updateSearchIndex: searchIndex.updateMessage })
+    const retry = engine.retryPending()
+    await decrypt.started.promise; decrypt.release.resolve()
+    await written.promise
+    setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+    if (kind === 'chat') {
+      chatStore.getState().switchAccount(SELF)
+      chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+    } else {
+      roomStore.getState().reset()
+      roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+    }
+    setStorageScopeJid(SELF)
+    seed(kind, []); seedPreview(kind, structuredClone(c1))
+    release.resolve(); await retry; await drain()
+    expect(preview(kind)?.body).toBe(c1.body)
+    const durable = (kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0] as Row
+    expect(durable.body).toBe('stale recovered text')
+    expect(durable.encryptedPayload).toBeUndefined()
+    expect(durable.correctionRevision?.archiveTimestamp).toBeUndefined()
+    await h.archive([{ id: 'c1', body: durable.body, at: T1 }])
+    await h.archive([{ id: 'c2', body: 'current second correction', at: T2, authoredAt: T1 }])
+    expect(resident(kind)).toBeUndefined()
+    expect(preview(kind)).toMatchObject({ id: c1.id, stanzaId: c1.stanzaId, timestamp: c1.timestamp, body: 'current second correction', correctionTimestamp: Date.parse(T1) })
+    if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+    expect((await reload(kind)).body).toBe('current second correction')
+    expect(await searchIndex.search('second')).toHaveLength(1)
+  })
+
+  it.each(['strong identity', 'owner', 'account', 'newer edit', 'different ciphertext'] as const)('rejects a handoff with a mismatched %s', mismatch => {
+    const held: Row = { ...original(kind), isEdited: true, body: 'held correction', encryptedPayload: 'ciphertext', correctionRevision: { ids: ['id:c1', 'stanza:sid-c1'], supersedes: [] } }
+    const source = captureContentSource({ ...held, encryptedPayload: undefined }, SELF)
+    if (mismatch === 'strong identity') source.revisionIds = ['id:c1', 'stanza:other-c1']
+    if (mismatch === 'owner') source.from = 'other@example.test'
+    if (mismatch === 'account') source.accountScope = 'other@example.test'
+    if (mismatch === 'newer edit') held.correctionRevision = { ids: ['stanza:sid-c3'], supersedes: [], archiveTimestamp: Date.parse(FAST) }
+    if (mismatch === 'different ciphertext') source.encryptedPayload = 'unrelated ciphertext'
+    const updates = resolveCorrectionUpdates(held, { body: 'incoming correction', isEdited: true, correctionRevision: { ids: ['stanza:sid-c2'], supersedes: [], archiveTimestamp: Date.parse(T2) }, correctionHandoff: source }, SELF)
+    expect({ ...held, ...updates }.body).toBe('held correction')
+    const recovery = resolveCorrectionUpdates(held, { body: 'unrelated recovery', contentRecovery: source }, SELF)
+    expect({ ...held, ...recovery }.body).toBe('held correction')
+  })
+})
+
+
+describe('live encrypted receive session ownership', () => {
+  const cases = (['live', 'received', 'sent'] as const).flatMap(shape =>
+    (['resident', 'cache-only', 'missing'] as const).flatMap(location =>
+      (['same', 'account', 'roundtrip', 'logout', 'reset', 'session', 'manager', 'jid'] as const).map(change => ({ shape, location, change }))))
+
+  it.each(cases)('keeps $shape correction for $location in its initiating $change session', async ({ shape, location, change }) => {
+    const own = shape === 'sent'
+    setStorageScopeJid(SELF)
+    const h = harness('chat', own)
+    let jid: string | null = SELF
+    let connection: ReturnType<ModuleDependencies['getXmpp']> = {} as NonNullable<ReturnType<ModuleDependencies['getXmpp']>>
+    const plugin = new DummyPlaintextPlugin()
+    const manager = new E2EEManager({ storage: new InMemoryStorageBackend(), account: { jid: SELF }, xmpp: {
+      sendStanza: async () => {}, queryDisco: async () => ({ features: [], identities: [] }),
+      publishPEP: async () => {}, retractPEP: async () => {}, deletePEP: async () => {}, queryPEP: async () => [], subscribePEP: () => ({ unsubscribe() {} }),
+    } })
+    await manager.register(plugin)
+    let currentManager: E2EEManager | null = manager
+    h.deps.getCurrentJid = () => jid
+    h.deps.getXmpp = () => connection
+    h.deps.getE2EEManager = () => currentManager
+    const base = original('chat', own)
+    if (location !== 'missing') {
+      await save('chat', base); seedPreview('chat', base)
+      if (location === 'resident') seed('chat', [base])
+    }
+    const started = deferred(), release = deferred()
+    const decrypt = plugin.decrypt.bind(plugin)
+    vi.spyOn(plugin, 'decrypt').mockImplementation(async (...args) => {
+      started.resolve(); await release.promise
+      return { ...await decrypt(...args), securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' as const }, authoredAt: new Date(FAST) }
+    })
+    const { payload } = (await manager.encryptOutbound({ kind: 'direct', peer: PEER }, new TextEncoder().encode('private decrypted correction')))!
+    const stanza = xml('message', { id: 'c1', from: base.from, to: own ? PEER : SELF, type: 'chat' },
+      xml('body', {}, payload.fallbackBody!), dataToElement(payload.stanzaElement),
+      xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }),
+      xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: SELF, id: 'sid-c1' }))
+    const input = shape === 'live' ? stanza : xml('message', { from: SELF },
+      xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+        xml('delay', { xmlns: 'urn:xmpp:delay', stamp: T1 }), stanza)))
+    const task = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+    h.chat.handle(input)
+    await started.promise
+    if (change === 'account' || change === 'roundtrip' || change === 'logout') {
+      jid = change === 'logout' ? null : 'other@example.test'
+      setStorageScopeJid(jid); chatStore.getState().switchAccount(jid)
+      if (change === 'roundtrip') { jid = SELF; setStorageScopeJid(jid); chatStore.getState().switchAccount(jid) }
+      chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+    } else if (change === 'reset') {
+      connection = null; currentManager = null; chatStore.getState().reset()
+      chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+    } else if (change === 'session') {
+      connection = {} as NonNullable<ReturnType<ModuleDependencies['getXmpp']>>
+      currentManager = (await blockedDecrypt()).manager
+    } else if (change === 'manager') currentManager = null
+    else if (change === 'jid') jid = `${SELF}/replacement`
+    const replacement = { ...base, from: own ? (jid ?? SELF) : PEER, body: 'current session content' }
+    if (change !== 'same' && location !== 'missing') {
+      await save('chat', replacement); seedPreview('chat', replacement)
+      seed('chat', location === 'resident' ? [replacement] : [])
+    }
+    const durableBefore = await cache.getMessages(PEER)
+    const before = structuredClone(chatStore.getState().messages)
+    const beforePreview = structuredClone(preview('chat'))
+    const beforeEvents = h.events.length
+    release.resolve()
+    await expect(task.mock.results[0].value).resolves.toBeUndefined()
+    await drain()
+    if (change === 'same') {
+      const rows = await cache.getMessages(PEER)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].body).toBe('private decrypted correction')
+      expect(await searchIndex.search('private')).toHaveLength(1)
+      if (location !== 'missing') {
+        expect(preview('chat')?.body).toBe('private decrypted correction')
+        expect((rows[0] as StoredMessage).correctionTimestamp).toBe(Date.parse(FAST))
+        expect((rows[0] as StoredMessage).correctionRevision?.archiveTimestamp).toBe(shape === 'live' ? undefined : Date.parse(T1))
+      }
+    } else {
+      expect(chatStore.getState().messages).toEqual(before)
+      expect(preview('chat')).toEqual(beforePreview)
+      expect(await cache.getMessages(PEER)).toEqual(durableBefore)
+      expect(await searchIndex.search('private')).toEqual([])
+      expect(h.events.slice(beforeEvents)).toEqual([])
+      cache._resetDBForTesting(); searchIndex._resetDBForTesting()
+      expect(await searchIndex.search('private')).toEqual([])
+      expect(await cache.getMessages(PEER)).toEqual(durableBefore)
+    }
+  })
+
+  it.each([false, true].flatMap(cachedOnly => [false, true].map(roundtrip => ({ cachedOnly, roundtrip }))))(
+    'guards supported groupchat plugin routing, cache-only: $cachedOnly, account roundtrip: $roundtrip', async ({ cachedOnly, roundtrip }) => {
+      setStorageScopeJid(SELF)
+      const h = harness('room')
+      const blocked = await blockedDecrypt()
+      h.deps.getE2EEManager = () => blocked.manager
+      const started = deferred(), release = deferred()
+      const decrypt = blocked.manager.decryptInbound.bind(blocked.manager)
+      vi.spyOn(blocked.manager, 'decryptInbound').mockImplementation(async (...args) => {
+        started.resolve(); await release.promise
+        return decrypt(...args)
+      })
+      const base = original('room')
+      await save('room', base); seedPreview('room', base)
+      seed('room', cachedOnly ? [] : [base])
+      const stanza = xml('message', { id: 'c1', from: base.from, type: 'groupchat' },
+        xml('body', {}, 'encrypted fallback'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from('private room correction').toString('base64')),
+        xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }),
+        xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' }))
+      const task = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      h.chat.handle(stanza); await started.promise
+      if (roundtrip) {
+        setStorageScopeJid('other@example.test'); roomStore.getState().switchAccount('other@example.test')
+        setStorageScopeJid(SELF); roomStore.getState().switchAccount(SELF)
+        roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+        seed('room', cachedOnly ? [] : [base]); seedPreview('room', base)
+      }
+      const before = structuredClone(roomStore.getState().messages)
+      const eventCount = h.events.length
+      release.resolve(); await task.mock.results[0].value; await drain()
+      if (roundtrip) expect(roomStore.getState().messages).toEqual(before)
+      expect(preview('room')?.body).toBe(roundtrip ? base.body : 'private room correction')
+      expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview('room'))
+      expect((await reload('room')).body).toBe(roundtrip ? base.body : 'private room correction')
+      expect(await searchIndex.search('private')).toHaveLength(roundtrip ? 0 : 1)
+      if (roundtrip) expect(h.events.slice(eventCount)).toEqual([])
+    })
+
+  it.each(['live', 'received', 'sent'] as const)('cancels a decrypted %s retraction across an account generation', async shape => {
+    setStorageScopeJid(SELF)
+    const own = shape === 'sent'
+    const h = harness('chat', own)
+    const blocked = await blockedDecrypt()
+    h.deps.getE2EEManager = () => blocked.manager
+    const started = deferred(), release = deferred()
+    const decrypt = blocked.manager.decryptInbound.bind(blocked.manager)
+    vi.spyOn(blocked.manager, 'decryptInbound').mockImplementation(async (...args) => {
+      started.resolve(); await release.promise
+      return decrypt(...args)
+    })
+    const payload = serializePayload([xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'original' })])
+    const stanza = xml('message', { id: 'retraction', from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+      xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from(payload).toString('base64')))
+    const input = shape === 'live' ? stanza : xml('message', {}, xml(shape, { xmlns: 'urn:xmpp:carbons:2' },
+      xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, stanza)))
+    const task = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+    h.chat.handle(input); await started.promise
+    setStorageScopeJid('other@example.test'); chatStore.getState().switchAccount('other@example.test')
+    setStorageScopeJid(SELF); chatStore.getState().switchAccount(SELF)
+    chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+    const base = original('chat', own)
+    await save('chat', base); seed('chat', [base]); seedPreview('chat', base); await searchIndex.indexMessage(base)
+    const eventCount = h.events.length
+    release.resolve(); await task.mock.results[0].value; await drain()
+    expect(resident('chat')).toEqual(base)
+    expect(preview('chat')).toEqual(base)
+    const durable = await reload('chat')
+    expect(durable).toMatchObject(base)
+    expect(durable.isRetracted).toBeFalsy()
+    expect(await searchIndex.search('original')).toHaveLength(1)
+    expect(h.events.slice(eventCount)).toEqual([])
+  })
+})
+
+describe.each(['chat', 'global', 'room'] as const)('%s reconciled fulltext matches', mode => {
+  const kind = mode === 'room' ? 'room' : 'chat'
+  it.each([
+    { query: 'apple', body: 'pear', matches: false },
+    { query: 'apple', body: 'green APPLE', matches: true },
+    { query: 'apple red', body: 'red pear', matches: false },
+    { query: 'apple red', body: 'red and green apple', matches: true },
+    { query: '"red apple"', body: 'apple red', matches: false },
+    { query: '"red apple"', body: 'fresh red apple pie', matches: true },
+    { query: 'apple', body: '', matches: false },
+    { query: 'apple', body: 'apple', matches: false, retracted: true },
+  ])('rechecks cached "$body" for $query', async ({ query, body, matches, retracted }) => {
+    const base = { ...original(kind), body: 'red apple' }
+    const h = harness(kind, false, base)
+    const current = { ...base, body, isEdited: true, correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+      ...(retracted && { isRetracted: true, retractedAt: new Date(T2) }) }
+    await save(kind, current)
+    const result = await h.searchResult(query, { global: mode === 'global', complete: false })
+    expect(result.messages).toHaveLength(matches ? 1 : 0)
+    if (matches) expect(result.messages[0].body).toBe(body)
+    expect(result.complete).toBe(false)
+    expect(result.page).toMatchObject({ first: base.stanzaId, last: base.stanzaId })
+    const send = vi.spyOn(h.deps, 'sendIQ')
+    const next = xml('message', { id: 'next', from: base.from, to: SELF, type: base.type }, xml('body', {}, 'red apple next page'))
+    const nextResult = await h.searchResult(query, { global: mode === 'global', before: result.page.first, withOriginal: false, signals: [next] })
+    expect(send.mock.calls[0][0].getChild('query')?.getChild('set')?.getChildText('before')).toBe(base.stanzaId)
+    expect(nextResult.complete).toBe(true)
+    expect(nextResult.messages.map(row => row.body)).toEqual(['red apple next page'])
+  })
+
+  it('rechecks a correction resolved within the server page', async () => {
+    const h = harness(kind, false, { body: 'apple' })
+    const result = await h.search([{ id: 'c1', body: 'pear', at: T1 }], true, [], false, 'apple')
+    expect(result).toEqual([])
+  })
+
+  it('preserves unchanged server matches on a mixed reconciled page', async () => {
+    const base = { ...original(kind), body: 'apple' }
+    const h = harness(kind, false, base)
+    await save(kind, { ...base, body: 'pear', isEdited: true, correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } })
+    const unchanged = xml('message', { id: 'server-match', from: base.from, to: SELF, type: base.type }, xml('body', {}, 'server linguistic match'))
+    const matching = xml('message', { id: 'matching', from: base.from, to: SELF, type: base.type }, xml('body', {}, 'apple original'),
+      xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: kind === 'room' ? ROOM : SELF, id: 'signal-1' }))
+    await save(kind, { ...base, id: 'matching', stanzaId: 'signal-1', body: 'apple updated', isEdited: true,
+      correctionRevision: { ids: ['stanza:c2'], supersedes: [], archiveTimestamp: Date.parse(T2) } })
+    const result = await h.searchResult('apple', { global: mode === 'global', complete: false, signals: [unchanged, matching] })
+    expect(result.messages.map(row => row.body)).toEqual(['server linguistic match', 'apple updated'])
+    expect(result.page).toMatchObject({ first: base.stanzaId, last: 'signal-1' })
+    expect(result.complete).toBe(false)
+  })
+
+  if (mode === 'chat') it('retains client matching and raw cursors in the paging search sibling', async () => {
+    const base = { ...original(kind), body: 'apple' }
+    const h = harness(kind, false, base)
+    await save(kind, { ...base, body: 'pear', isEdited: true, correctionRevision: { ids: ['stanza:c1'], supersedes: [], archiveTimestamp: Date.parse(T1) } })
+    const result = await h.searchResult('apple', { paging: true })
+    expect(result.messages).toEqual([])
+    expect(result.page).toMatchObject({ first: base.stanzaId, last: base.stanzaId })
+  })
+})
+
+
+describe('encrypted receive through transport recovery', () => {
+  it.each((['live', 'received', 'sent'] as const).flatMap(shape =>
+    (['message', 'resident correction', 'cached correction', 'missing correction'] as const).flatMap(content =>
+      (content === 'missing correction' ? ['disconnected', 'resumed', 'logout', 'replaced session', 'lookup resumption'] as const
+        : ['disconnected', 'resumed', 'logout', 'replaced session'] as const).map(completion => ({ shape, content, completion })))))(
+    'retains $shape $content completed while $completion', async ({ shape, content, completion }) => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
+      setStorageScopeJid(SELF)
+      const own = shape === 'sent'
+      const h = harness('chat', own)
+      const manager = (await blockedDecrypt()).manager
+      let currentManager: E2EEManager | null = manager
+      h.deps.getE2EEManager = () => currentManager
+      const connection = new Connection(h.deps)
+      h.deps.getXmpp = () => connection.getClient()
+      connection.setStanzaHandler(stanza => { h.chat.handle(stanza) })
+      connection.setDisconnectHandler(() => { currentManager = null })
+      const sessions: boolean[] = []
+      connection.setConnectionSuccessHandler(async resumed => { sessions.push(resumed) })
+      const oldTransport = createMockXmppClient()
+      vi.mocked(createClient).mockReturnValue(oldTransport as unknown as ReturnType<typeof createClient>)
+      const connectOptions = { jid: SELF, password: 'test-password', server: 'wss://example.test/ws', skipDiscovery: true }
+      const connected = connection.connect(connectOptions)
+      oldTransport._emit('online')
+      await connected
+      Object.assign(oldTransport.streamManagement, { id: 'sm-owned-session', enabled: true, inbound: 12 })
+      oldTransport._emit('nonza', xml('enabled', { xmlns: 'urn:xmpp:sm:3', id: 'sm-owned-session', resume: 'true' }))
+      const base = original('chat', own)
+      const correction = content !== 'message'
+      const known = content === 'resident correction' || content === 'cached correction'
+      if (known) {
+        await save('chat', base); seedPreview('chat', base)
+        if (content === 'resident correction') seed('chat', [base])
+      }
+      const started = deferred(), release = deferred()
+      const decrypt = manager.decryptInbound.bind(manager)
+      vi.spyOn(manager, 'decryptInbound').mockImplementation(async (...args) => {
+        started.resolve(); await release.promise
+        return decrypt(...args)
+      })
+      const incoming = () => xml('message', { id: 'incoming', from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+        xml('body', {}, 'encrypted fallback'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from('recovered received content').toString('base64')),
+        xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: SELF, id: 'incoming-archive' }),
+        ...(correction ? [xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id })] : []))
+      const envelope = () => {
+        const stanza = incoming()
+        return shape === 'live' ? stanza : xml('message', { from: SELF },
+          xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, stanza)))
+      }
+      const task = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      oldTransport.streamManagement.inbound++
+      oldTransport._emit('stanza', envelope())
+      await started.promise
+      const lookupReleased = deferred()
+      if (completion === 'lookup resumption') {
+        const lookupStarted = deferred()
+        const apply = vi.mocked(cache.applyChatCorrection).getMockImplementation()!
+        vi.mocked(cache.applyChatCorrection).mockImplementationOnce((...args) => {
+          const pending = (async () => {
+            const result = await apply(...args)
+            lookupStarted.resolve(); await lookupReleased.promise
+            return result
+          })()
+          writes.push(pending)
+          return pending
+        })
+        release.resolve(); await task.mock.results[0].value; await lookupStarted.promise
+      }
+      connection.handleDeadSocket()
+      expect(connection.getClient()).toBeNull()
+      expect(connection.getStreamManagementState()).toMatchObject({ id: 'sm-owned-session', inbound: 13 })
+      const replacement = createMockXmppClient()
+      const resume = async () => {
+        vi.mocked(createClient).mockReturnValue(replacement as unknown as ReturnType<typeof createClient>)
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(connection.getClient()).toBe(replacement)
+        expect(replacement.streamManagement.inbound).toBe(13)
+        replacement._emit('nonza', xml('resumed', { xmlns: 'urn:xmpp:sm:3', previd: 'sm-owned-session', h: '0' }))
+        await vi.advanceTimersByTimeAsync(0)
+        expect(sessions).toEqual([false, true])
+        expect(currentManager).toBe(manager)
+      }
+      try {
+        if (completion === 'resumed' || completion === 'lookup resumption') await resume()
+        else if (completion === 'logout' || completion === 'replaced session') {
+          await connection.disconnect()
+          expect(currentManager).toBeNull()
+          if (completion === 'replaced session') {
+            currentManager = (await blockedDecrypt()).manager
+            vi.mocked(createClient).mockReturnValue(replacement as unknown as ReturnType<typeof createClient>)
+            const next = connection.connect(connectOptions)
+            replacement._emit('online'); await next
+            expect(currentManager).not.toBe(manager)
+          }
+        }
+        lookupReleased.resolve(); release.resolve(); await task.mock.results[0].value; await drain()
+        const cancelled = completion === 'logout' || completion === 'replaced session'
+        let rows = await cache.getMessages(PEER)
+        expect(rows).toHaveLength(known || !cancelled ? 1 : 0)
+        expect(rows[0]?.body).toBe(cancelled ? (known ? base.body : undefined) : 'recovered received content')
+        if (known) expect(preview('chat')?.body).toBe(cancelled ? base.body : 'recovered received content')
+        expect(await searchIndex.search('recovered')).toHaveLength(cancelled ? 0 : 1)
+        if (cancelled) return
+        if (completion === 'disconnected') await resume()
+        const eventCount = h.events.filter(({ event }) => event === (correction ? 'chat:message-updated' : 'chat:message')).length
+        expect(eventCount).toBe(1)
+        replacement._emit('stanza', envelope()); await task.mock.results.at(-1)!.value; await drain()
+        cache._resetDBForTesting(); searchIndex._resetDBForTesting(); seed('chat', [])
+        rows = await cache.getMessages(PEER)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].body).toBe('recovered received content')
+        expect(await searchIndex.search('recovered')).toHaveLength(1)
+        if (known) expect(rows[0]).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+      } finally { release.resolve(); lookupReleased.resolve(); await connection.disconnect(); connection.getConnectionActor().stop() }
+    })
+})
+
+describe('deferred decrypt queued across account cancellation', () => {
+  it.each((['chat resident', 'chat cache', 'chat preview', 'room resident'] as const).flatMap(path =>
+    (['changed', 'same', 'unavailable manager', 'locked key'] as const).map(mode => ({ path, mode }))))(
+    'drains a $path retry after $mode', async ({ path, mode }) => {
+      const kind = path === 'room resident' ? 'room' : 'chat'
+      setStorageScopeJid(SELF)
+      const h = harness(kind)
+      const blocked = await blockedDecrypt('old account plaintext')
+      let manager: E2EEManager | null = blocked.manager
+      let jid = SELF
+      const engine = new DeferredDecryptEngine({ getManager: () => manager, getStores: () => h.stores, getOwnBareJid: () => jid, cache, updateSearchIndex: searchIndex.updateMessage })
+      const locked = { ...original(kind), body: 'locked correction', isEdited: true,
+        correctionRevision: { ids: ['stanza:locked-edit'], supersedes: [], archiveTimestamp: Date.parse(T1) },
+        encryptedPayload: '<message><body>locked correction</body><plain xmlns="urn:fluux:e2ee-dummy:0">cGF5bG9hZA==</plain></message>' }
+      const install = async () => {
+        if (path !== 'chat preview') await save(kind, locked)
+        seed(kind, path.endsWith('resident') ? [locked] : [])
+        seedPreview(kind, locked)
+      }
+      await install()
+      const work = engine.retryPending()
+      await blocked.started.promise
+      let decryptCurrent = vi.mocked(blocked.manager.decryptArchive)
+      if (mode !== 'same') {
+        jid = 'next@example.test'; setStorageScopeJid(jid)
+        chatStore.getState().switchAccount(jid); roomStore.getState().switchAccount(jid)
+        chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 0 })
+        roomStore.getState().addRoom(createMockRoom(ROOM, { nickname: 'Peer', joined: true }))
+        manager = (await blockedDecrypt()).manager
+        decryptCurrent = vi.mocked(manager.decryptArchive)
+        decryptCurrent.mockResolvedValue({ plaintext: new TextEncoder().encode('current account recovery'), senderDevice: { jid: PEER, deviceId: 'test' }, securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' } })
+        if (mode === 'unavailable manager') manager = null
+        if (mode === 'locked key') decryptCurrent.mockResolvedValue(null)
+        await install()
+      }
+      expect(await engine.retryPending()).toBe(0)
+      expect(await engine.retryPending()).toBe(0)
+      blocked.release.resolve(); await work; await drain()
+      const recovered = mode === 'changed' || mode === 'same'
+      const expectedBody = mode === 'same' ? 'old account plaintext' : recovered ? 'current account recovery' : locked.body
+      expect(preview(kind)?.body).toBe(expectedBody)
+      if (kind === 'room') expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toEqual(preview(kind))
+      if (path !== 'chat preview') expect((await reload(kind)).body).toBe(expectedBody)
+      if (mode !== 'same') expect(await searchIndex.search('old')).toEqual([])
+      if (mode === 'changed') expect(decryptCurrent).toHaveBeenCalledTimes(1)
+      if (mode === 'unavailable manager') expect(decryptCurrent).not.toHaveBeenCalled()
+      if (mode === 'locked key') expect(decryptCurrent).toHaveBeenCalledTimes(1)
+      if (mode === 'same') expect(await engine.retryPending()).toBe(0)
+    })
+})
+
+describe.each(['chat', 'global', 'room'] as const)('%s tokenless reconciled search', mode => {
+  const kind = mode === 'room' ? 'room' : 'chat'
+  it.each(['x', '👍', '!!!', '"x"', '"👍"'])('filters changed results for %s without changing the server page', async query => {
+    const phrase = query.startsWith('"')
+    const term = query.replaceAll('"', '')
+    const base = { ...original(kind), body: term }
+    const h = harness(kind, false, base)
+    await save(kind, { ...base, body: 'pear', isEdited: true, correctionRevision: { ids: ['stanza:edit'], supersedes: [], archiveTimestamp: Date.parse(T1) } })
+    const empty = await h.searchResult(query, { global: mode === 'global', complete: false })
+    expect(empty.messages).toEqual([])
+    expect(empty.complete).toBe(false)
+    expect(empty.page).toMatchObject({ first: base.stanzaId, last: base.stanzaId })
+    const unchanged = xml('message', { id: 'unchanged', from: base.from, to: SELF, type: base.type }, xml('body', {}, term))
+    const modified = xml('message', { id: 'modified', from: base.from, to: SELF, type: base.type }, xml('body', {}, term),
+      xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: kind === 'room' ? ROOM : SELF, id: 'signal-1' }))
+    await save(kind, { ...base, id: 'modified', stanzaId: 'signal-1', body: `new ${term}`, isEdited: true,
+      correctionRevision: { ids: ['stanza:other-edit'], supersedes: [], archiveTimestamp: Date.parse(T1) } })
+    const mixed = await h.searchResult(query, { global: mode === 'global', complete: false, signals: [unchanged, modified] })
+    expect(mixed.messages.map(row => row.body)).toEqual(phrase ? [term, `new ${term}`] : [term])
+    expect(mixed.page).toMatchObject({ first: base.stanzaId, last: 'signal-1' })
+    expect(mixed.complete).toBe(false)
+    expect(await h.search([{ id: 'c2', body: 'pear', at: T2 }], true, [], false, query)).toEqual([])
+  })
+})
+
+describe('receive order survives deferred correction completion', () => {
+  it.each((['live', 'received', 'sent'] as const).flatMap(shape =>
+    (['resident', 'cache', 'preview', 'missing'] as const).flatMap(path =>
+      [false, true].flatMap(resume => [false, true].flatMap(encryptedNewer => [
+        'original', 'replay', 'original first', 'newer forwarded', 'newer outer', 'replay forwarded', 'replay outer', 'mixed duplicate first', 'mixed original first',
+      ].map(scenario => ({ shape, path, resume, encryptedNewer, scenario })))))))(
+    'retains C2 for $shape $path resume=$resume encryptedNewer=$encryptedNewer $scenario', async ({ shape, path, resume, encryptedNewer, scenario }) => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
+      setStorageScopeJid(SELF)
+      const own = shape === 'sent'
+      const h = harness('chat', own)
+      const manager = (await blockedDecrypt()).manager
+      h.deps.getE2EEManager = () => manager
+      const connection = new Connection(h.deps)
+      h.deps.getXmpp = () => connection.getClient()
+      connection.setStanzaHandler(stanza => { h.chat.handle(stanza) })
+      connection.setConnectionSuccessHandler(async () => {})
+      const transport = createMockXmppClient()
+      vi.mocked(createClient).mockReturnValue(transport as unknown as ReturnType<typeof createClient>)
+      const connected = connection.connect({ jid: SELF, password: 'test-password', server: 'wss://example.test/ws', skipDiscovery: true })
+      transport._emit('online'); await connected
+      Object.assign(transport.streamManagement, { id: 'ordered-stream', enabled: true, inbound: 1 })
+      transport._emit('nonza', xml('enabled', { xmlns: 'urn:xmpp:sm:3', id: 'ordered-stream', resume: 'true' }))
+      const base = original('chat', own)
+      if (path === 'resident' || path === 'cache') await save('chat', base)
+      if (path === 'resident') seed('chat', [base])
+      if (path !== 'missing') seedPreview('chat', base)
+      const started = deferred(), release = deferred()
+      const decrypt = manager.decryptInbound.bind(manager)
+      vi.spyOn(manager, 'decryptInbound').mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      const stanza = (id: string, body: string, encrypted: boolean, delayed = '') => {
+        const message = xml('message', { id, from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+          xml('body', {}, encrypted ? 'encrypted fallback' : body),
+          ...(encrypted ? [xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from(body).toString('base64'))] : []),
+          xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: SELF, id: `archive-${id}` }),
+          xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }))
+        const delay = xml('delay', { xmlns: 'urn:xmpp:delay', stamp: id === 'c1' ? T1 : T2 })
+        if (shape === 'live') { if (delayed) message.children.push(delay); return message }
+        return xml('message', { from: SELF }, ...(delayed === 'outer' ? [delay] : []),
+          xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+            ...(delayed === 'forwarded' ? [delay] : []), message)))
+      }
+      const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      transport._emit('stanza', stanza('c1', 'older private correction', true))
+      await started.promise
+      try {
+        if (resume) {
+          connection.handleDeadSocket()
+          const replacement = createMockXmppClient()
+          vi.mocked(createClient).mockReturnValue(replacement as unknown as ReturnType<typeof createClient>)
+          await vi.advanceTimersByTimeAsync(1000)
+          replacement._emit('nonza', xml('resumed', { xmlns: 'urn:xmpp:sm:3', previd: 'ordered-stream', h: '0' }))
+          await vi.advanceTimersByTimeAsync(0)
+        }
+        h.chat.handle(stanza('c2', 'newer current correction', encryptedNewer,
+          scenario === 'newer forwarded' || scenario === 'mixed duplicate first' ? 'forwarded' :
+            scenario === 'newer outer' || scenario === 'mixed original first' ? 'outer' : ''))
+        if (encryptedNewer) await tasks.mock.results[1].value
+        await drain()
+        expect((await cache.getMessages(PEER))[0].body).toBe('newer current correction')
+        if (scenario.startsWith('replay') || scenario.includes('first')) {
+          const duplicateRelease = deferred(), duplicateStarted = deferred()
+          const originalFirst = scenario.includes('original first')
+          if (originalFirst) vi.mocked(manager.decryptInbound).mockImplementationOnce(async (...args) => {
+            duplicateStarted.resolve(); await duplicateRelease.promise; return decrypt(...args)
+          })
+          h.chat.handle(stanza('c1', 'older private correction', true,
+            scenario === 'replay forwarded' || scenario === 'mixed original first' ? 'forwarded' :
+              scenario === 'replay outer' || scenario === 'mixed duplicate first' ? 'outer' : ''))
+          if (originalFirst) {
+            await duplicateStarted.promise
+            release.resolve(); await tasks.mock.results[0].value; await drain()
+            duplicateRelease.resolve()
+          }
+          await tasks.mock.results.at(-1)!.value; await drain()
+          expect((await cache.getMessages(PEER))[0].body).toBe('newer current correction')
+        }
+        release.resolve(); await tasks.mock.results[0].value; await drain()
+        const current = await reload('chat')
+        expect(current.body).toBe('newer current correction')
+        expect(current.correctionRevision?.ids).toContain('stanza:archive-c2')
+        expect(current.correctionRevision?.supersedes).toContain('stanza:archive-c1')
+        expect([current.stanzaId, ...(current.correctionStanzaIds ?? [])]).toEqual(expect.arrayContaining(['archive-c1', 'archive-c2']))
+        expect(preview('chat')?.body).toBe('newer current correction')
+        expect(await searchIndex.search('older')).toEqual([])
+        expect(await searchIndex.search('newer')).toHaveLength(1)
+        if (path === 'resident' || path === 'cache') expect(current).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+        const emitted = h.events.filter(e => e.event === 'chat:message-updated').map(e => (e.payload as SDKEvents['chat:message-updated']).updates as StoredMessage)
+        expect(emitted.filter(u => u.correctionRevision?.ids.includes('stanza:archive-c1')).every(u => !u.correctionRevision?.supersedes.includes('stanza:archive-c2'))).toBe(true)
+        h.chat.handle(xml('message', { from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+          xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'archive-c1' })))
+        await drain()
+        expect((await reload('chat')).isRetracted).toBe(true)
+        expect(await searchIndex.search('newer')).toEqual([])
+      } finally { release.resolve(); await connection.disconnect(); connection.getConnectionActor().stop() }
+    })
+})
+
+describe.each(['chat', 'room'] as const)('%s context loading ownership', kind => {
+  const state = () => kind === 'chat' ? chatStore.getState().getMAMQueryState(PEER) : roomStore.getState().getRoomMAMQueryState(ROOM)
+  it('allows later pagination after context cancellation through SM resumption', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const connection = new Connection(h.deps)
+    h.deps.getXmpp = () => connection.getClient()
+    connection.setConnectionSuccessHandler(async () => {})
+    const transport = createMockXmppClient()
+    vi.mocked(createClient).mockReturnValue(transport as unknown as ReturnType<typeof createClient>)
+    const connected = connection.connect({ jid: SELF, password: 'test-password', server: 'wss://example.test/ws', skipDiscovery: true })
+    transport._emit('online'); await connected
+    Object.assign(transport.streamManagement, { id: 'context-stream', enabled: true, inbound: 1 })
+    transport._emit('nonza', xml('enabled', { xmlns: 'urn:xmpp:sm:3', id: 'context-stream', resume: 'true' }))
+    const started = deferred(), release = deferred()
+    const send = h.deps.sendIQ
+    h.deps.sendIQ = async iq => { started.resolve(); await release.promise; return send(iq) }
+    const work = h.chat.fetchContextAround(kind === 'chat' ? PEER : ROOM, T0, 2).catch(error => error)
+    const previousStatus = connectionStore.getState().status
+    try {
+      await started.promise
+      connection.handleDeadSocket()
+      const replacement = createMockXmppClient()
+      vi.mocked(createClient).mockReturnValue(replacement as unknown as ReturnType<typeof createClient>)
+      await vi.advanceTimersByTimeAsync(1000)
+      replacement._emit('nonza', xml('resumed', { xmlns: 'urn:xmpp:sm:3', previd: 'context-stream', h: '0' }))
+      await vi.advanceTimersByTimeAsync(0)
+      release.resolve()
+      expect(await work).toMatchObject({ name: 'AbortError' })
+      expect(state().isLoading).toBe(false)
+      h.deps.sendIQ = send
+      const query = vi.fn(async () => { await h.archive([], true) })
+      const fetchOlder = createFetchOlderHistory({
+        getActiveId: () => kind === 'chat' ? PEER : ROOM, isValidTarget: () => true, getMAMState: state,
+        setMAMLoading: kind === 'chat' ? chatStore.getState().setMAMLoading : roomStore.getState().setRoomMAMLoading,
+        loadFromCache: async () => [], getOldestMessageId: () => 'archive-original', queryMAM: query, errorLogPrefix: 'Context test',
+      })
+      connectionStore.setState({ status: 'online' })
+      await fetchOlder()
+      expect(query).toHaveBeenCalledTimes(1)
+      expect(state()).toMatchObject({ isLoading: false, hasQueried: true, error: null })
+    } finally {
+      release.resolve(); await connection.disconnect(); connection.getConnectionActor().stop()
+      connectionStore.setState({ status: previousStatus })
+    }
+  })
+  it.each(['transport', 'account', 'roundtrip'] as const)('releases only current-account loading after %s cancellation', async mode => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    let jid = SELF
+    let transport = createMockXmppClient()
+    h.deps.getCurrentJid = () => jid
+    h.deps.getXmpp = () => transport as unknown as ReturnType<typeof createClient>
+    const started = deferred(), release = deferred()
+    const send = h.deps.sendIQ
+    h.deps.sendIQ = async iq => { started.resolve(); await release.promise; return send(iq) }
+    const work = h.chat.fetchContextAround(kind === 'chat' ? PEER : ROOM, T0, 2).catch(error => error)
+    await started.promise
+    expect(state().isLoading).toBe(true)
+    if (mode === 'transport') transport = createMockXmppClient()
+    else {
+      jid = 'next@example.test'; setStorageScopeJid(jid)
+      if (mode === 'roundtrip') { jid = SELF; setStorageScopeJid(jid) }
+      if (kind === 'chat') chatStore.getState().setMAMLoading(PEER, true)
+      else roomStore.getState().setRoomMAMLoading(ROOM, true)
+    }
+    release.resolve()
+    expect(await work).toMatchObject({ name: 'AbortError' })
+    expect(state().isLoading).toBe(mode !== 'transport')
+    expect(h.events.filter(e => e.event === `${kind}:history-error`)).toEqual([])
+    h.deps.sendIQ = send
+    await h.archive([], true)
+    expect(state().isLoading).toBe(false)
+    expect(state().hasQueried).toBe(true)
+  })
+  it.each([false, true].flatMap(newerFirst => ['success', 'error', 'transport'].map(outcome => ({ newerFirst, outcome }))))(
+    'preserves the newer slot when older $outcome settles newerFirst=$newerFirst', async ({ newerFirst, outcome }) => {
+      setStorageScopeJid(SELF)
+      const h = harness(kind)
+      let transport = createMockXmppClient()
+      h.deps.getXmpp = () => transport as unknown as ReturnType<typeof createClient>
+      const send = h.deps.sendIQ
+      const releases = [deferred(), deferred()], starts = [deferred(), deferred()]
+      let calls = 0
+      h.deps.sendIQ = async iq => {
+        const index = calls++
+        starts[index].resolve(); await releases[index].promise
+        if (index === 0 && outcome === 'error') throw new Error('old query failed')
+        return send(iq)
+      }
+      const request = () => h.chat.fetchContextAround(kind === 'chat' ? PEER : ROOM, T0, 2).catch(error => error)
+      const first = request(); await starts[0].promise
+      if (outcome === 'transport') transport = createMockXmppClient()
+      const second = request(); await starts[1].promise
+      expect(state().isLoading).toBe(true)
+      if (newerFirst) {
+        releases[1].resolve(); await second
+        expect(state().isLoading).toBe(false)
+        releases[0].resolve(); await first
+      } else {
+        releases[0].resolve(); await first
+        expect(state().isLoading).toBe(true)
+        releases[1].resolve(); await second
+      }
+      expect(state().isLoading).toBe(false)
+      expect(state().error).toBeNull()
+      h.deps.sendIQ = send
+      await h.archive([], true)
+      expect(state().hasQueried).toBe(true)
+    })
+})
+
+
+it('keeps a local outgoing correction ahead of an earlier encrypted sent carbon', async () => {
+  setStorageScopeJid(SELF)
+  const h = harness('chat', true)
+  const base = original('chat', true)
+  await save('chat', base); seed('chat', [base]); seedPreview('chat', base)
+  const manager = (await blockedDecrypt()).manager
+  h.deps.getE2EEManager = () => manager
+  const started = deferred(), release = deferred()
+  const decrypt = manager.decryptInbound.bind(manager)
+  vi.spyOn(manager, 'decryptInbound').mockImplementationOnce(async (...args) => {
+    started.resolve(); await release.promise; return decrypt(...args)
+  })
+  const task = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+  h.chat.handle(xml('message', { from: SELF }, xml('sent', { xmlns: 'urn:xmpp:carbons:2' },
+    xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('message', { id: 'c1', from: SELF, to: PEER, type: 'chat' },
+      xml('body', {}, 'encrypted fallback'), xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from('older private correction').toString('base64')),
+      xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }))))))
+  await started.promise
+  await h.outgoing('newer local correction')
+  release.resolve(); await task.mock.results[0].value; await drain()
+  expect((await reload('chat')).body).toBe('newer local correction')
+  expect(preview('chat')?.body).toBe('newer local correction')
+  expect(await searchIndex.search('older')).toEqual([])
+  expect(await searchIndex.search('newer')).toHaveLength(1)
+})
+
+
+it.each(['success', 'send error', 'account change'] as const)('orders outgoing edits after encryption: %s', async outcome => {
+  setStorageScopeJid(SELF)
+  const h = harness('chat', true)
+  const base = original('chat', true)
+  await save('chat', base); seed('chat', [base]); seedPreview('chat', base)
+  const manager = (await blockedDecrypt()).manager
+  h.deps.getE2EEManager = () => manager
+  const started = deferred(), release = deferred()
+  const encrypt = manager.encryptOutbound.bind(manager)
+  vi.spyOn(manager, 'encryptOutbound').mockImplementationOnce(async (...args) => {
+    started.resolve(); await release.promise; return encrypt(...args)
+  })
+  const outgoing = h.outgoing('later successful local edit').catch(error => error)
+  await started.promise
+  h.chat.handle(xml('message', { from: SELF }, xml('sent', { xmlns: 'urn:xmpp:carbons:2' },
+    xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('message', { id: 'other-device', from: SELF, to: PEER, type: 'chat' },
+      xml('body', {}, 'intervening carbon edit'), xml('origin-id', { xmlns: 'urn:xmpp:sid:0', id: 'other-device' }),
+      xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }))))))
+  await drain()
+  expect((await cache.getMessages(PEER))[0].body).toBe('intervening carbon edit')
+  if (outcome === 'send error') h.deps.sendStanza = async () => { throw new Error('send failed') }
+  if (outcome === 'account change') setStorageScopeJid('other@example.test')
+  release.resolve()
+  const result = await outgoing
+  if (outcome === 'account change') setStorageScopeJid(SELF)
+  expect(result instanceof Error).toBe(outcome !== 'success')
+  const current = await reload('chat')
+  expect(current.body).toBe(outcome === 'success' ? 'later successful local edit' : 'intervening carbon edit')
+  expect(preview('chat')?.body).toBe(current.body)
+  expect(current.timestamp).toEqual(base.timestamp)
+  if (outcome === 'success') {
+    expect(current.correctionRevision?.supersedes).toContain('origin:other-device')
+    expect(await searchIndex.search('intervening')).toEqual([])
+    expect(await searchIndex.search('successful')).toHaveLength(1)
+  }
+})
+
+describe.each<Kind>(['chat', 'room'])('%s asynchronous correction request failure', kind => {
+  it('observes the transaction rejection and repairs the failed write on replay', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base); await searchIndex.indexMessage(base)
+    const unhandled: unknown[] = []
+    const onUnhandled = (error: unknown) => { unhandled.push(error) }
+    process.on('unhandledRejection', onUnhandled)
+    const put = IDBObjectStore.prototype.put
+    let requestError: DOMException | null = null
+    let failed = false
+    const fault = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+      if (this.name === (kind === 'chat' ? 'messages-canonical' : 'room-messages-canonical') && !failed) {
+        failed = true
+        const request = this.add(...args)
+        request.addEventListener('error', () => { requestError = request.error })
+        return request
+      }
+      return put.apply(this, args)
+    })
+    const offset = writes.length
+    try {
+      h.receive({ id: 'c1', body: 'repaired content' })
+      const pending = writes.slice(offset)
+      for (let i = offset; i < writes.length; i++) writes[i] = writes[i].catch(() => {})
+      const results = await Promise.allSettled(pending)
+      await new Promise(resolve => setTimeout(resolve, 0)); await drain()
+      expect(requestError).toMatchObject({ name: 'ConstraintError' })
+      expect(results.filter(result => result.status === 'rejected')).toHaveLength(1)
+      expect(unhandled).toEqual([])
+      const read = () => kind === 'chat' ? cache.getMessages(PEER) : cache.getRoomMessages(ROOM, {})
+      expect((await read())[0].body).toBe(base.body)
+      expect(await searchIndex.search('original')).toHaveLength(1)
+      fault.mockRestore()
+      await h.archivePages([{ edits: [{ id: 'c1', body: 'repaired content', at: T1 }] }], true)
+      expect((await reload(kind)).body).toBe('repaired content')
+      expect(preview(kind)?.body).toBe('repaired content')
+      expect(await searchIndex.search('repaired')).toHaveLength(1)
+      expect(await searchIndex.search('original')).toEqual([])
+    } finally { fault.mockRestore(); process.removeListener('unhandledRejection', onUnhandled) }
+  })
+})
+
+describe.each(['live', 'received', 'sent'] as const)('%s pending correction identity', shape => {
+  it.each([false, true].flatMap(resident => [false, true].map(enrich => ({ resident, enrich })) ))(
+    'retains alias enrichment without collapsing conflicting archives resident=$resident enrich=$enrich', async ({ resident: inMemory, enrich }) => {
+      setStorageScopeJid(SELF)
+      const own = shape === 'sent'
+      const h = harness('chat', own)
+      const base = original('chat', own)
+      await save('chat', base); if (inMemory) seed('chat', [base]); seedPreview('chat', base)
+      const manager = (await blockedDecrypt()).manager
+      h.deps.getE2EEManager = () => manager
+      const started = deferred(), release = deferred()
+      const decrypt = manager.decryptInbound.bind(manager)
+      vi.spyOn(manager, 'decryptInbound').mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      const stanza = (id: string, body: string, archive: string | undefined, encrypted: boolean) => {
+        const message = xml('message', { id, from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+          xml('body', {}, encrypted ? 'encrypted fallback' : body),
+          ...(encrypted ? [xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from(body).toString('base64'))] : []),
+          ...(archive ? [xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: SELF, id: archive })] : []),
+          xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id }))
+        return shape === 'live' ? message : xml('message', { from: SELF }, xml(shape, { xmlns: 'urn:xmpp:carbons:2' },
+          xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, message)))
+      }
+      h.chat.handle(stanza('shared', 'older encrypted revision', enrich ? undefined : 's1', true))
+      await started.promise
+      try {
+        h.chat.handle(stanza('middle', 'middle revision', 's2', false)); await drain()
+        h.chat.handle(stanza('shared', 'older encrypted revision', 's1', true))
+        await tasks.mock.results[1].value; await drain()
+        expect((await cache.getMessages(PEER))[0].body).toBe('middle revision')
+        h.chat.handle(stanza('shared', 'latest distinct revision', 's3', false)); await drain()
+        expect((await cache.getMessages(PEER))[0].body).toBe('latest distinct revision')
+        release.resolve(); await tasks.mock.results[0].value; await drain()
+        const current = await reload('chat')
+        expect(current).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'latest distinct revision' })
+        expect(current.correctionRevision?.ids).toEqual(expect.arrayContaining(['id:shared', 'stanza:s3']))
+        expect(current.correctionRevision?.ids).not.toContain('stanza:s1')
+        expect(current.correctionRevision?.supersedes).toEqual(expect.arrayContaining(['stanza:s1', 'stanza:s2']))
+        expect(preview('chat')?.body).toBe(current.body)
+        expect(await searchIndex.search('older')).toEqual([])
+        expect(await searchIndex.search('latest')).toHaveLength(1)
+        await h.archivePages([{ edits: [{ id: 'shared', body: 'older encrypted revision', stanzaId: 's1', omitOriginId: true, at: T1 }] }], true)
+        expect((await reload('chat')).body).toBe('latest distinct revision')
+        h.chat.handle(xml('message', { from: own ? SELF : PEER, to: own ? PEER : SELF, type: 'chat' },
+          xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 's1' })))
+        await drain()
+        expect((await reload('chat')).isRetracted).toBe(true)
+      } finally { release.resolve(); await tasks.mock.results[0].value }
+    })
+})
+
+it('keeps pending weak correction identities scoped to the sender and conversation', async () => {
+  setStorageScopeJid(SELF)
+  const h = harness('chat')
+  const base = original('chat')
+  const otherPeer = 'other-peer@example.test'
+  const other = { ...base, conversationId: otherPeer, from: otherPeer }
+  chatStore.getState().addConversation({ id: otherPeer, name: 'Other', type: 'chat', unreadCount: 0 })
+  await save('chat', base, other); seed('chat', [base]); seedPreview('chat', base)
+  const manager = (await blockedDecrypt()).manager
+  h.deps.getE2EEManager = () => manager
+  const started = deferred(), release = deferred()
+  const decrypt = manager.decryptInbound.bind(manager)
+  vi.spyOn(manager, 'decryptInbound').mockImplementationOnce(async (...args) => {
+    started.resolve(); await release.promise; return decrypt(...args)
+  })
+  const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+  h.chat.handle(xml('message', { id: 'shared', from: otherPeer, to: SELF, type: 'chat' },
+    xml('body', {}, 'encrypted fallback'), xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, Buffer.from('other sender content').toString('base64')),
+    xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: base.id })))
+  await started.promise
+  try {
+    await h.live({ id: 'middle', body: 'middle revision', omitOriginId: true, omitStanzaId: true })
+    await h.live({ id: 'shared', body: 'latest peer revision', omitOriginId: true, omitStanzaId: true })
+    release.resolve(); await tasks.mock.results[0].value; await drain()
+    expect((await reload('chat')).body).toBe('latest peer revision')
+    expect((await cache.getMessages(otherPeer))[0].body).toBe('other sender content')
+    expect(preview('chat')?.body).toBe('latest peer revision')
+  } finally { release.resolve(); await tasks.mock.results[0].value }
+})
+
+describe('pending live corrections across bounded MAM pages', () => {
+  it.each((['live', 'received', 'sent', 'room'] as const).flatMap(shape =>
+    (['resident', 'cache', 'preview'] as const).flatMap(path => [false, true].flatMap(encrypted =>
+      [false, true].map(replay => ({ shape, path, encrypted, replay }))))))(
+    'preserves MAM C2 against earlier $shape C1 path=$path encrypted=$encrypted replay=$replay', async ({ shape, path, encrypted, replay }) => {
+      setStorageScopeJid(SELF)
+      const kind = shape === 'room' ? 'room' : 'chat'
+      const own = shape === 'sent'
+      const h = harness(kind, own)
+      const base = original(kind, own)
+      await save(kind, base)
+      if (path === 'resident') seed(kind, [base])
+      if (path !== 'cache') seedPreview(kind, base)
+      const manager = (await blockedDecrypt()).manager
+      vi.mocked(manager.decryptArchive).mockRestore()
+      h.deps.getE2EEManager = () => manager
+      const started = deferred(), release = deferred()
+      const decrypt = manager.decryptInbound.bind(manager)
+      vi.spyOn(manager, 'decryptInbound').mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      const c1 = () => {
+        const message = h.stanza({ id: 'c1', body: 'earlier private correction', encrypted: true, to: own ? PEER : SELF })
+        return shape === 'received' || shape === 'sent' ? xml('message', { from: SELF },
+          xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, message))) : message
+      }
+      h.chat.handle(c1()); await started.promise
+      try {
+        await h.archivePages([{ edits: [{ id: 'c2', body: 'newer archive correction', encrypted, at: T2, to: own ? PEER : SELF }] }], true)
+        expect((kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {}))[0].body).toBe('newer archive correction')
+        if (replay) { h.chat.handle(c1()); await tasks.mock.results.at(-1)!.value; await drain() }
+        release.resolve(); await tasks.mock.results[0].value; await drain()
+        await h.archivePages([{ edits: [{ id: 'c1', body: 'earlier private correction', at: T1, to: own ? PEER : SELF }] }], true)
+        const current = await reload(kind)
+        expect(current).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'newer archive correction' })
+        expect(current.correctionRevision?.ids).toContain('stanza:sid-c2')
+        expect(current.correctionRevision?.supersedes).toContain('stanza:sid-c1')
+        if (path !== 'cache') expect(preview(kind)?.body).toBe(current.body)
+        expect(await searchIndex.search('earlier')).toEqual([])
+        expect(await searchIndex.search('newer')).toHaveLength(1)
+        await h.live({ id: 'c2', body: 'newer archive correction', to: own ? PEER : SELF })
+        await h.live({ id: 'c3', body: 'latest live correction', encrypted, to: own ? PEER : SELF })
+        if (encrypted) await tasks.mock.results.at(-1)!.value
+        await drain()
+        expect((await reload(kind)).body).toBe('latest live correction')
+        await h.archivePages([{ edits: [{ id: 'c1', body: 'earlier private correction', at: T1, to: own ? PEER : SELF }] }], true)
+        expect((await reload(kind)).body).toBe('latest live correction')
+      } finally { release.resolve(); await tasks.mock.results[0].value }
+    })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s cache-only failed predecessor write', kind => {
+  it.each(['live', 'archive'].flatMap(mode => [false, true].flatMap(preview => ['abort', 'request'].map(failure => ({ mode, preview, failure })) )))(
+    'retains canonical C2 when failed C1 returns through $mode preview=$preview failure=$failure', async ({ mode, preview: withPreview, failure }) => {
+      setStorageScopeJid(SELF)
+      const h = harness(kind)
+      const base = original(kind)
+      await save(kind, base); seed(kind, [])
+      if (withPreview) seedPreview(kind, base)
+      await searchIndex.indexMessage(base)
+      const c1: Edit = { id: 'c1', body: 'first lost write' }
+      if (failure === 'abort') await abortCorrectionWrite(kind, () => h.receive(c1))
+      else {
+        const put = IDBObjectStore.prototype.put
+        let failed = false
+        const fault = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+          if (!failed && this.name === (kind === 'chat' ? 'messages-canonical' : 'room-messages-canonical')) {
+            failed = true; return this.add(...args)
+          }
+          return put.apply(this, args)
+        })
+        const offset = writes.length
+        try {
+          h.receive(c1)
+          const pending = writes.slice(offset)
+          for (let i = offset; i < writes.length; i++) writes[i] = writes[i].catch(() => {})
+          expect(await Promise.allSettled(pending)).toEqual(expect.arrayContaining([
+            expect.objectContaining({ status: 'rejected', reason: expect.objectContaining({ name: 'ConstraintError' }) }),
+          ]))
+          await drain()
+        } finally { fault.mockRestore() }
+      }
+      const read = () => kind === 'chat' ? cache.getMessages(PEER) : cache.getRoomMessages(ROOM, {})
+      expect(await read()).toMatchObject([{ id: base.id, stanzaId: base.stanzaId, body: base.body }])
+      expect(await read()).toHaveLength(1)
+      expect(await searchIndex.search('first')).toEqual([])
+      await h.live({ id: 'c2', body: 'second current revision' })
+      expect(await read()).toHaveLength(1)
+      expect((await read())[0]).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'second current revision' })
+      if (mode === 'live') await h.live(c1)
+      else await h.archivePages([{ edits: [{ ...c1, at: T1 }] }], true)
+      expect((await reload(kind)).body).toBe('second current revision')
+      if (withPreview) expect(preview(kind)?.body).toBe('second current revision')
+      expect(await searchIndex.search('first')).toEqual([])
+      expect(await searchIndex.search('original')).toEqual([])
+      expect(await searchIndex.search('second')).toHaveLength(1)
+    })
+})
+
+describe.each(['single', 'batch'] as const)('%s room preview hydration ownership', mode => {
+  it.each(['same', 'account', 'roundtrip', 'reset', 'recreate'] as const)('guards read and commit through %s', async change => {
+    setStorageScopeJid(SELF)
+    await save('room', original('room'))
+    const started = deferred(), release = deferred()
+    const read = cache.getRoomMessages
+    vi.spyOn(cache, 'getRoomMessages').mockImplementationOnce(async (...args) => {
+      const rows = await read(...args); started.resolve(); await release.promise; return rows
+    })
+    const work = mode === 'single' ? roomStore.getState().loadPreviewFromCache(ROOM) : roomStore.getState().hydratePreviewsFromCache()
+    await started.promise
+    if (change === 'account' || change === 'roundtrip') {
+      setStorageScopeJid('other@example.test')
+      if (change === 'roundtrip') setStorageScopeJid(SELF)
+    }
+    if (change === 'reset') roomStore.getState().reset()
+    if (change === 'recreate') roomStore.getState().removeRoom(ROOM)
+    if (change !== 'same') roomStore.getState().addRoom(createMockRoom(ROOM, { joined: true, nickname: 'Peer' }))
+    const listener = vi.fn()
+    const unsubscribe = roomStore.subscribe(listener)
+    try {
+      release.resolve()
+      const result = await work
+      if (mode === 'single') expect(result).toEqual(change === 'same' ? expect.objectContaining({ body: 'original text' }) : null)
+      expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe(change === 'same' ? 'original text' : undefined)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage?.body).toBe(change === 'same' ? 'original text' : undefined)
+      expect(listener).toHaveBeenCalledTimes(change === 'same' ? 1 : 0)
+    } finally { release.resolve(); unsubscribe() }
+  })
+})
+
+it.each<Kind>(['chat', 'room'])('retains failed %s predecessor evidence without a missing-target continuation', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind)
+  const base = original(kind)
+  await save(kind, base); seedPreview(kind, base)
+  h.deps.emitSDK = (event, payload) => h.emitSDK(event,
+    event === 'chat:message-updated' || event === 'room:message-updated' ? { ...payload, onCorrectionMissing: undefined } : payload)
+  const c1 = { id: 'c1', body: 'earlier failed correction' }
+  await abortCorrectionWrite(kind, () => h.receive(c1))
+  await h.live({ id: 'c2', body: 'newer durable correction' })
+  const read = () => kind === 'chat' ? cache.getMessages(PEER) : cache.getRoomMessages(ROOM, {})
+  expect(await read()).toHaveLength(1)
+  expect((await read())[0].body).toBe('newer durable correction')
+  await h.archivePages([{ edits: [{ ...c1, at: T1 }] }], true)
+  expect((await reload(kind)).body).toBe('newer durable correction')
+})
+
+it('commits only surviving room previews after a batched read overlaps recreation', async () => {
+  setStorageScopeJid(SELF)
+  const otherRoom = 'other-room@conference.example.test'
+  roomStore.getState().addRoom(createMockRoom(otherRoom, { joined: true }))
+  const other = { ...original('room'), roomJid: otherRoom, from: `${otherRoom}/Peer`, body: 'surviving room content' } as StoredRoomMessage
+  await save('room', original('room'), other)
+  const started = deferred(), release = deferred()
+  const read = cache.getRoomMessages
+  vi.spyOn(cache, 'getRoomMessages').mockImplementation(async (...args) => {
+    const rows = await read(...args)
+    if (args[0] === otherRoom) { started.resolve(); await release.promise }
+    return rows
+  })
+  const work = roomStore.getState().hydratePreviewsFromCache()
+  await started.promise
+  roomStore.getState().removeRoom(ROOM)
+  roomStore.getState().addRoom(createMockRoom(ROOM, { joined: true }))
+  const listener = vi.fn(), unsubscribe = roomStore.subscribe(listener)
+  try {
+    release.resolve(); await work
+    expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toBeUndefined()
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage).toBeUndefined()
+    expect(roomStore.getState().rooms.get(otherRoom)?.lastMessage?.body).toBe('surviving room content')
+    expect(roomStore.getState().roomMeta.get(otherRoom)?.lastMessage?.body).toBe('surviving room content')
+    expect(listener).toHaveBeenCalledTimes(1)
+  } finally { release.resolve(); unsubscribe() }
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s corrections without IndexedDB', kind => {
+  it.each([false, true])('retains received correction, resident original=%s', async hasOriginal => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    if (hasOriginal) seed(kind, [original(kind)])
+    Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+    h.receive({ id: 'no-cache-correction', body: 'visible correction without cache' })
+    for (let i = 0; i < writes.length; i++) writes[i] = writes[i].catch(() => {})
+    await drain()
+    const rows = (kind === 'chat' ? chatStore.getState().messages.get(PEER) : roomStore.getState().messages.get(ROOM)) ?? []
+    expect(rows).toHaveLength(1)
+    expect(rows[0].body).toBe('visible correction without cache')
+    expect(h.events.filter(e => e.event === `${kind}:message`)).toHaveLength(hasOriginal ? 0 : 1)
+  })
+})
+
+describe('overlapping corrections require archive evidence', () => {
+  it.each((['live', 'received', 'sent', 'room'] as const).flatMap(shape =>
+    (['resident', 'cache', 'preview'] as const).flatMap(path =>
+      (['older-page', 'newer-page', 'pending-archive'] as const).map(direction => ({ shape, path, direction })))))(
+    '$shape $path $direction retains incomparable content until archive evidence', async ({ shape, path, direction }) => {
+      setStorageScopeJid(SELF)
+      const kind = shape === 'room' ? 'room' : 'chat', own = shape === 'sent'
+      const h = harness(kind, own), base = original(kind, own)
+      await save(kind, base)
+      if (path === 'resident') seed(kind, [base])
+      if (path !== 'cache') seedPreview(kind, base)
+      const manager = (await blockedDecrypt()).manager
+      vi.mocked(manager.decryptArchive).mockRestore()
+      h.deps.getE2EEManager = () => manager
+      const started = deferred(), release = deferred()
+      const method = direction === 'pending-archive' ? 'decryptArchive' : 'decryptInbound'
+      const decrypt = manager[method].bind(manager)
+      vi.spyOn(manager, method).mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      const first = { id: 'opaque-first', body: 'earlier signed content', to: own ? PEER : SELF }
+      const second = { id: 'opaque-second', body: 'later signed content', to: own ? PEER : SELF }
+      const deliver = (entry: Edit) => {
+        const message = h.stanza(entry)
+        h.chat.handle(shape === 'sent' || shape === 'received' ? xml('message', { from: SELF },
+          xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, message))) : message)
+      }
+      const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      let work: Promise<unknown>
+      if (direction === 'pending-archive') work = h.archive([{ ...first, encrypted: true, at: T1 }])
+      else { deliver({ ...(direction === 'older-page' ? second : first), encrypted: true }); work = tasks.mock.results[0].value }
+      await started.promise
+      try {
+        if (direction === 'pending-archive') { deliver(second); await drain() }
+        else await h.archive([{ ...(direction === 'older-page' ? first : second), at: T1 }])
+        release.resolve(); await work; await drain()
+        const held = await reload(kind)
+        const other = held.correctionRevision?.ids.includes('stanza:sid-opaque-first') ? 'second' : 'first'
+        expect(held.correctionRevision?.supersedes).not.toContain(`stanza:sid-opaque-${other}`)
+        expect(held.correctionAlternatives).toEqual([expect.objectContaining({ body: other === 'first' ? first.body : second.body })])
+        if (direction === 'pending-archive') expect(held.body).toBe(second.body)
+        await h.archivePages([{ edits: [{ ...first, at: T1 }, { ...second, at: T1 }] }], true)
+        const resolved = await reload(kind)
+        expect(resolved).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: second.body })
+        expect(resolved.correctionRevision?.supersedes).toContain('stanza:sid-opaque-first')
+        expect(resolved.correctionAlternatives).toBeUndefined()
+        if (path !== 'cache') expect(preview(kind)?.body).toBe(second.body)
+        expect(await searchIndex.search('earlier')).toEqual([])
+        expect(await searchIndex.search('later')).toHaveLength(1)
+        await h.archive([{ ...first, at: T1 }])
+        expect((await reload(kind)).body).toBe(second.body)
+      } finally { release.resolve(); await work }
+    })
+})
+
+describe('buffered MAM completion ownership', () => {
+  it.each((['chat-preview', 'room-preview', 'room-message'] as const).flatMap(path =>
+    (['same', 'account', 'roundtrip', 'manager', 'transport'] as const).map(change => ({ path, change })) ))(
+    '$path retains ownership through $change', async ({ path, change }) => {
+      setStorageScopeJid(SELF)
+      const kind = path === 'chat-preview' ? 'chat' : 'room'
+      const h = harness(kind)
+      const manager = (await blockedDecrypt()).manager
+      vi.mocked(manager.decryptArchive).mockRestore()
+      h.deps.getE2EEManager = () => manager
+      h.stores.chat.getAllConversations.mockImplementation(() => Array.from(chatStore.getState().conversations.keys(), id => ({ id, messages: [] })))
+      h.stores.chat.updateLastMessagePreview.mockImplementation((...args) => chatStore.getState().updateLastMessagePreview(...args))
+      h.stores.room.updateLastMessagePreview.mockImplementation((...args) => roomStore.getState().updateLastMessagePreview(...args))
+      const started = deferred(), release = deferred()
+      const decrypt = manager.decryptArchive.bind(manager)
+      if (path !== 'room-preview') vi.spyOn(manager, 'decryptArchive').mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      let collector!: (stanza: Element) => void
+      h.deps.registerMAMCollector = (_id, fn) => { collector = fn; return () => {} }
+      h.deps.sendIQ = async iq => {
+        const qid = iq.getChild('query', 'urn:xmpp:mam:2')!.attrs.queryid
+        const message = h.stanza({ id: 'private-preview', body: 'private buffered content', encrypted: path !== 'room-preview' })
+        const replace = message.getChild('replace', 'urn:xmpp:message-correct:0')
+        message.children = message.children.filter(child => child !== replace)
+        collector(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: qid, id: 'private-preview' },
+          xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: T1 }), message))))
+        if (path === 'room-preview') { started.resolve(); await release.promise }
+        return xml('iq', { type: 'result' })
+      }
+      const work = path === 'chat-preview' ? h.mam.refreshConversationPreviews()
+        : path === 'room-preview' ? h.mam.fetchPreviewForRoom(ROOM) : h.mam.fetchRoomMessageById(ROOM, 'private-preview')
+      await started.promise
+      try {
+        if (change === 'account' || change === 'roundtrip') {
+          setStorageScopeJid('other@example.test')
+          if (change === 'roundtrip') setStorageScopeJid(SELF)
+        }
+        if (change === 'manager') h.deps.getE2EEManager = () => null
+        if (change === 'transport') h.deps.getXmpp = () => createMockXmppClient() as unknown as ReturnType<ModuleDependencies['getXmpp']>
+        release.resolve(); const result = await work; await drain()
+        if (path === 'room-message') expect(result).toEqual(change === 'same' ? expect.objectContaining({ body: 'private buffered content' }) : null)
+        else expect(preview(kind)?.body).toBe(change === 'same' ? 'private buffered content' : undefined)
+        if (change !== 'same') {
+          expect(h.events.filter(e => e.event === 'room:message')).toEqual([])
+          expect(await searchIndex.search('private')).toEqual([])
+        }
+      } finally { release.resolve(); await work }
+    })
+})
+
+
+it.each(['account', 'roundtrip', 'manager', 'transport', 'same'] as const)('guards deferred poll verification after %s', async change => {
+  setStorageScopeJid(SELF)
+  const h = harness('room')
+  const release = deferred()
+  const poll = { ...original('room'), poll: { title: 'Lunch?', options: [{ emoji: '1', label: 'Pizza' }], settings: { allowMultiple: false, hideResultsBeforeVote: false } } } as StoredRoomMessage
+  vi.spyOn(h.mam, 'fetchRoomMessageById').mockImplementation(async () => { await release.promise; return poll })
+  h.chat.handle(xml('message', { from: `${ROOM}/Peer`, type: 'groupchat', id: 'close-poll' },
+    xml('body', {}, 'Poll closed'), xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' }),
+    xml('poll-closed', { xmlns: 'urn:fluux:poll:0', 'message-id': 'original' }, xml('title', {}, 'Lunch?'), xml('tally', { emoji: '1', label: 'Pizza', count: '1' }))))
+  await drain()
+  h.events.length = 0
+  if (change === 'account' || change === 'roundtrip') { setStorageScopeJid('other@example.test'); if (change === 'roundtrip') setStorageScopeJid(SELF) }
+  if (change === 'transport') h.deps.getXmpp = () => createMockXmppClient() as unknown as ReturnType<ModuleDependencies['getXmpp']>
+  if (change === 'manager') h.deps.getE2EEManager = () => ({}) as E2EEManager
+  release.resolve()
+  await Promise.resolve(); await Promise.resolve(); await drain()
+  expect(h.events.filter(event => event.event === 'room:message-updated')).toHaveLength(change === 'same' ? 1 : 0)
+})
+
+it.each(['chat', 'archived', 'room'] as const)('does not start queued %s preview queries under a replacement account', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind === 'room' ? 'room' : 'chat')
+  const rooms = [createMockRoom(ROOM, { joined: true, supportsMAM: true }), createMockRoom('other@conference.example.test', { joined: true, supportsMAM: true })]
+  h.stores.room.joinedRooms.mockReturnValue(rooms.map(room => ({ ...room, supportsMAM: true })))
+  const conversations = Array.from(chatStore.getState().conversations.keys(), id => ({ id, messages: [] }))
+  h.stores.chat.getAllConversations.mockReturnValue([...conversations, { ...conversations[0], id: 'other@example.test' }])
+  h.stores.chat.getArchivedConversations.mockReturnValue([...conversations, { ...conversations[0], id: 'other@example.test' }])
+  const started = deferred(), release = deferred()
+  const send = vi.fn(async () => { started.resolve(); await release.promise; return xml('iq', { type: 'result' }) })
+  h.deps.sendIQ = send
+  const work = kind === 'room' ? h.mam.refreshRoomPreviews({ concurrency: 1 }) : kind === 'archived'
+    ? h.mam.refreshArchivedConversationPreviews({ concurrency: 1 }) : h.mam.refreshConversationPreviews({ concurrency: 1 })
+  await started.promise; setStorageScopeJid('other-account@example.test'); release.resolve(); await work
+  expect(send).toHaveBeenCalledTimes(1)
+})
+
+
+it.each(['account', 'roundtrip', 'manager', 'transport', 'same'] as const)('guards room preview query after a %s cache read', async change => {
+  setStorageScopeJid(SELF)
+  const h = harness('room'), started = deferred(), release = deferred()
+  h.stores.room.loadPreviewFromCache.mockImplementation(async () => { started.resolve(); await release.promise; return null })
+  const send = vi.fn(async () => xml('iq', { type: 'result' }))
+  h.deps.sendIQ = send
+  const work = h.mam.fetchPreviewForRoom(ROOM)
+  await started.promise
+  if (change === 'account' || change === 'roundtrip') { setStorageScopeJid('other@example.test'); if (change === 'roundtrip') setStorageScopeJid(SELF) }
+  if (change === 'transport') h.deps.getXmpp = () => createMockXmppClient() as unknown as ReturnType<ModuleDependencies['getXmpp']>
+  if (change === 'manager') h.deps.getE2EEManager = () => ({}) as E2EEManager
+  release.resolve(); await work
+  expect(send).toHaveBeenCalledTimes(change === 'same' ? 1 : 0)
+})
+
+it.each<Kind>(['chat', 'room'])('keeps subsequent %s live progress ahead of an unresolved archive candidate', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind), base = original(kind)
+  await save(kind, base); seedPreview(kind, base)
+  const manager = (await blockedDecrypt()).manager
+  vi.mocked(manager.decryptArchive).mockRestore()
+  h.deps.getE2EEManager = () => manager
+  const started = deferred(), release = deferred(), decrypt = manager.decryptArchive.bind(manager)
+  vi.spyOn(manager, 'decryptArchive').mockImplementationOnce(async (...args) => {
+    started.resolve(); await release.promise; return decrypt(...args)
+  })
+  const first = { id: 'c1', body: 'unresolved archive text', at: T1 }
+  const work = h.archive([{ ...first, encrypted: true }])
+  await started.promise
+  try {
+    await h.live({ id: 'c2', body: 'second live text' })
+    release.resolve(); await work
+    await h.live({ id: 'c3', body: 'third live progress' })
+    expect((await reload(kind)).body).toBe('third live progress')
+    await h.archive([first])
+    expect((await reload(kind)).body).toBe('third live progress')
+    await h.archive([{ id: 'c3', body: 'third live progress', at: T2 }])
+    const resolved = await reload(kind)
+    expect(resolved.body).toBe('third live progress')
+    expect(resolved.correctionAlternatives).toBeUndefined()
+    expect(preview(kind)?.body).toBe('third live progress')
+    expect(await searchIndex.search('unresolved')).toEqual([])
+    expect(await searchIndex.search('progress')).toHaveLength(1)
+  } finally { release.resolve(); await work }
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s buffered archive before IQ completion', kind => {
+  it('retains the current live correction while the earlier archive result is unresolved', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    const started = deferred(), release = deferred()
+    const send = h.deps.sendIQ
+    h.deps.sendIQ = async (...args) => {
+      const response = await send(...args)
+      started.resolve(); await release.promise; return response
+    }
+    const work = h.archive([{ id: 'buffered-c1', body: 'older buffered archive', at: T1 }])
+    await started.promise
+    try {
+      await h.live({ id: 'current-c2', body: 'current live correction' })
+      expect((await reload(kind)).body).toBe('current live correction')
+      release.resolve(); await work; await drain()
+      const current = await reload(kind)
+      expect(current.body).toBe('current live correction')
+      expect(current.correctionRevision?.supersedes).not.toContain('stanza:sid-buffered-c1')
+      expect(current.correctionAlternatives).toEqual([expect.objectContaining({ body: 'older buffered archive' })])
+      await h.archive([{ id: 'current-c2', body: 'current live correction', at: T2 }])
+      expect((await reload(kind)).body).toBe('current live correction')
+    } finally { release.resolve(); await work }
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s archive copy preserves live receipt order', kind => {
+  it.each([false, true])('keeps C2 after live C1 with encrypted=%s while archive C1 is pending', async encrypted => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    const manager = (await blockedDecrypt()).manager
+    vi.mocked(manager.decryptArchive).mockRestore()
+    h.deps.getE2EEManager = () => manager
+    const started = deferred(), release = deferred(), decrypt = manager.decryptArchive.bind(manager)
+    vi.spyOn(manager, 'decryptArchive').mockImplementationOnce(async (...args) => {
+      started.resolve(); await release.promise; return decrypt(...args)
+    })
+    const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+    const c1 = { id: 'shared-c1', body: 'first live revision' }
+    const work = h.archive([{ ...c1, encrypted: true, at: T1 }])
+    await started.promise
+    try {
+      h.receive({ ...c1, encrypted })
+      if (encrypted) await tasks.mock.results.at(-1)!.value
+      await drain()
+      expect((await reload(kind)).body).toBe(c1.body)
+      await h.live({ id: 'later-c2', body: 'second live revision' })
+      expect((await reload(kind)).body).toBe('second live revision')
+      release.resolve(); await work; await drain()
+      expect((await reload(kind)).body).toBe('second live revision')
+      expect(preview(kind)?.body).toBe('second live revision')
+      expect(await searchIndex.search('first')).toEqual([])
+      expect(await searchIndex.search('second')).toHaveLength(1)
+    } finally { release.resolve(); await work }
+  })
+})
+
+
+describe('correction receipts across live and archive copies', () => {
+  it.each((['live', 'received', 'sent', 'room'] as const).flatMap(shape =>
+    (['resident', 'cache', 'preview'] as const).flatMap(path => [false, true].flatMap(encrypted =>
+      (['archive', 'live'] as const).map(first => ({ shape, path, encrypted, first }))))))(
+    '$shape $path preserves live order with $first pending and encrypted=$encrypted copy', async ({ shape, path, encrypted, first }) => {
+      setStorageScopeJid(SELF)
+      const kind = shape === 'room' ? 'room' : 'chat', own = shape === 'sent'
+      const h = harness(kind, own), base = original(kind, own)
+      await save(kind, base)
+      if (path === 'resident') seed(kind, [base])
+      if (path !== 'cache') seedPreview(kind, base)
+      const manager = (await blockedDecrypt()).manager
+      vi.mocked(manager.decryptArchive).mockRestore()
+      h.deps.getE2EEManager = () => manager
+      const started = deferred(), release = deferred()
+      const method = first === 'archive' ? 'decryptArchive' : 'decryptInbound'
+      const decrypt = manager[method].bind(manager)
+      vi.spyOn(manager, method).mockImplementationOnce(async (...args) => {
+        started.resolve(); await release.promise; return decrypt(...args)
+      })
+      const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+      const c1: Edit = { id: 'shared-receipt', body: 'earlier content', to: own ? PEER : SELF }
+      const deliver = async (entry: Edit, wait = true) => {
+        const message = h.stanza(entry)
+        h.chat.handle(shape === 'received' || shape === 'sent' ? xml('message', { from: SELF },
+          xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, message))) : message)
+        if (wait && entry.encrypted) await tasks.mock.results.at(-1)!.value
+        if (wait) await drain()
+      }
+      let work: Promise<unknown>
+      if (first === 'archive') work = h.archive([{ ...c1, encrypted: true, at: T1 }])
+      else { await deliver({ ...c1, encrypted: true }, false); work = tasks.mock.results[0].value }
+      await started.promise
+      try {
+        if (first === 'archive') await deliver({ ...c1, encrypted })
+        else await h.archive([{ ...c1, encrypted, at: T1 }])
+        await deliver({ id: 'second-receipt', body: 'current content', to: c1.to })
+        expect((await reload(kind)).body).toBe('current content')
+        await deliver({ ...c1, encrypted })
+        expect((await reload(kind)).body).toBe('current content')
+        release.resolve(); await work; await drain()
+        expect((await reload(kind)).body).toBe('current content')
+        await deliver({ id: 'third-receipt', body: 'latest content', to: c1.to })
+        await h.archivePages([{ edits: [{ ...c1, at: T1 },
+          { id: 'second-receipt', body: 'current content', to: c1.to, at: T1 },
+          { id: 'third-receipt', body: 'latest content', to: c1.to, at: T1 }] }], true)
+        const current = await reload(kind)
+        expect(current).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'latest content' })
+        expect(current.correctionRevision?.supersedes).toContain('stanza:sid-shared-receipt')
+        expect(current.correctionAlternatives).toBeUndefined()
+        if (path !== 'cache') expect(preview(kind)?.body).toBe(current.body)
+        expect(await searchIndex.search('earlier')).toEqual([])
+        expect(await searchIndex.search('latest')).toHaveLength(1)
+      } finally { release.resolve(); await work }
+    })
+})
+
+it.each<Kind>(['chat', 'room'])('retains a pending %s archive candidate after an outgoing correction', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind, true), base = original(kind, true)
+  await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+  const manager = (await blockedDecrypt()).manager
+  vi.mocked(manager.decryptArchive).mockRestore()
+  h.deps.getE2EEManager = () => manager
+  const started = deferred(), release = deferred(), decrypt = manager.decryptArchive.bind(manager)
+  vi.spyOn(manager, 'decryptArchive').mockImplementationOnce(async (...args) => {
+    started.resolve(); await release.promise; return decrypt(...args)
+  })
+  const work = h.archive([{ id: 'pending-archive', body: 'earlier archive content', at: T1, encrypted: true }])
+  await started.promise
+  try {
+    const id = await h.outgoing('newly sent content')
+    release.resolve(); await work
+    const held = await reload(kind)
+    expect(held).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, body: 'newly sent content' })
+    expect(held.correctionTimestamp).toBeUndefined()
+    expect(held.correctionAlternatives).toEqual([expect.objectContaining({ body: 'earlier archive content' })])
+    expect(held.correctionRevision?.supersedes).not.toContain('stanza:sid-pending-archive')
+    await h.archive([{ id, body: 'newly sent content', at: T2 }])
+    expect((await reload(kind)).correctionAlternatives).toBeUndefined()
+    expect(preview(kind)?.body).toBe('newly sent content')
+    expect(await searchIndex.search('earlier')).toEqual([])
+    expect(await searchIndex.search('newly')).toHaveLength(1)
+  } finally { release.resolve(); await work }
+})
+
+it.each<Kind>(['chat', 'room'])('retains incomparable %s content through full-row cache hydration', async kind => {
+  const base = original(kind)
+  const live: Row = { ...base, body: 'current plaintext', isEdited: true, correctionTimestamp: 900,
+    correctionTimestampSource: 'authored', correctionRevision: { ids: ['stanza:live'], supersedes: [] } }
+  const archive: Row = { ...base, body: 'unresolved plaintext', isEdited: true, correctionTimestamp: 100,
+    correctionTimestampSource: 'authored', correctionRevision: { ids: ['stanza:archive'], supersedes: [], archiveTimestamp: 10 } }
+  await save(kind, live); await save(kind, archive)
+  const held = await reload(kind)
+  expect([held.body, ...held.correctionAlternatives!.map(candidate => candidate.body)].sort()).toEqual(['current plaintext', 'unresolved plaintext'])
+  expect(held.correctionRevision?.supersedes).toEqual([])
+  const h = harness(kind)
+  await h.archive([{ id: 'live', stanzaId: 'live', body: 'current plaintext', at: T2 }])
+  expect((await reload(kind)).body).toBe('current plaintext')
+})
+
+it.each((['live', 'received', 'sent', 'room'] as const).flatMap(shape =>
+  [false, true].flatMap(encrypted => [false, true].map(inMemory => ({ shape, encrypted, inMemory })))))(
+  '$shape replay first seen in the archive cannot gain fresh authority encrypted=$encrypted resident=$inMemory', async ({ shape, encrypted, inMemory }) => {
+    setStorageScopeJid(SELF)
+    const kind = shape === 'room' ? 'room' : 'chat', own = shape === 'sent'
+    const h = harness(kind, own), base = original(kind, own)
+    await save(kind, base); seedPreview(kind, base)
+    if (inMemory) seed(kind, [base])
+    const manager = (await blockedDecrypt()).manager
+    vi.mocked(manager.decryptArchive).mockRestore()
+    h.deps.getE2EEManager = () => manager
+    const started = deferred(), release = deferred(), decrypt = manager.decryptArchive.bind(manager)
+    vi.spyOn(manager, 'decryptArchive').mockImplementationOnce(async (...args) => {
+      started.resolve(); await release.promise; return decrypt(...args)
+    })
+    const tasks = vi.spyOn(h.chat as unknown as { decryptAndReprocess: (...args: unknown[]) => Promise<void> }, 'decryptAndReprocess')
+    const c1: Edit = { id: 'archive-replay', body: 'retained earlier content', to: own ? PEER : SELF }
+    const c2: Edit = { id: 'live-current', body: 'current live content', to: c1.to }
+    const deliver = async (entry: Edit) => {
+      const message = h.stanza(entry)
+      h.chat.handle(shape === 'received' || shape === 'sent' ? xml('message', { from: SELF },
+        xml(shape, { xmlns: 'urn:xmpp:carbons:2' }, xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, message))) : message)
+      if (entry.encrypted) await tasks.mock.results.at(-1)!.value
+      await drain()
+    }
+    const work = h.archive([{ ...c1, encrypted: true, at: T1 }])
+    await started.promise
+    try {
+      await deliver(c2)
+      await deliver({ ...c1, encrypted })
+      const held = await reload(kind)
+      expect(held.body).toBe(c2.body)
+      expect(held.correctionAlternatives).toEqual([expect.objectContaining({ body: c1.body })])
+      expect(held.correctionAlternatives![0].correctionRevision?.supersedes).not.toContain('stanza:sid-live-current')
+      release.resolve(); await work
+      expect((await reload(kind)).body).toBe(c2.body)
+      await h.archive([{ ...c2, at: T2 }])
+      const current = await reload(kind)
+      expect(current).toMatchObject({ body: c2.body, id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp })
+      expect(current.correctionAlternatives).toBeUndefined()
+      expect(preview(kind)?.body).toBe(c2.body)
+      expect(await searchIndex.search('earlier')).toEqual([])
+      expect(await searchIndex.search('current')).toHaveLength(1)
+    } finally { release.resolve(); await work }
+  })
+
+
+describe.each<Kind>(['chat', 'room'])('%s next live edit after completed history', kind => {
+  it('updates the visible message after the previous edit was loaded from a finished archive query', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'known-c1', body: 'previous archived caption', at: T1 }], true)
+    expect((await reload(kind)).body).toBe('previous archived caption')
+    const collectors = new Map<string, (stanza: Element) => void>()
+    h.deps.registerMAMCollector = (id, handler) => { collectors.set(id, handler); return () => { collectors.delete(id) } }
+    h.deps.sendIQ = async iq => {
+      const query = iq.getChild('query', 'urn:xmpp:mam:2')
+      if (!query) throw new Error('Unexpected non-MAM reconciliation request')
+      const queryId = query.attrs.queryid, archiveId = 'sid-fresh-c2'
+      const collector = collectors.get(queryId)
+      if (!collector) throw new Error('MAM reconciliation has no result collector')
+      collector(xml('message', { from: kind === 'room' ? ROOM : SELF },
+        xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: queryId, id: archiveId },
+          xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+            xml('delay', { xmlns: 'urn:xmpp:delay', stamp: T2 }),
+            h.stanza({ id: 'fresh-c2', body: 'fresh live caption' })))))
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, archiveId), xml('last', {}, archiveId))))
+    }
+    await h.live({ id: 'fresh-c2', body: 'fresh live caption' })
+    await vi.waitFor(async () => expect((await reload(kind)).body).toBe('fresh live caption'), { timeout: 1000, interval: 10 })
+    expect(preview(kind)?.body).toBe('fresh live caption')
+    expect(await searchIndex.search('previous')).toEqual([])
+    expect(await searchIndex.search('fresh')).toHaveLength(1)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s correction completion regression', kind => {
+  it.each([false, true])('persists promoted content with its revision, cache-only %s', async cachedOnly => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, cachedOnly ? [] : [base]); seedPreview(kind, base)
+    await h.live({ id: 'c1', body: 'earlier caption', authoredAt: FAST })
+    await h.archive([{ id: 'c2', body: 'selected caption', at: T2, authoredAt: T0 }])
+    if (cachedOnly) seed(kind, [])
+    await h.archive([{ id: 'c1', body: 'earlier caption', at: T1, authoredAt: FAST }])
+    expect(preview(kind)?.body).toBe('selected caption')
+    const row = await reload(kind)
+    expect(row).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp,
+      body: 'selected caption', correctionTimestamp: Date.parse(T0), correctionTimestampSource: 'authored' })
+    expect(row.correctionRevision?.ids).toContain('id:c2')
+    expect(await searchIndex.search('earlier')).toEqual([])
+    expect(await searchIndex.search('selected')).toHaveLength(1)
+  })
+
+  it('keeps current-session observations after reload and old snapshot hydration', async () => {
+    setStorageScopeJid(SELF)
+    let h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.live({ id: 'c1', body: 'first session caption' })
+    const old = await reload(kind)
+    h = harness(kind)
+    seed(kind, [old]); seedPreview(kind, old)
+    await h.live({ id: 'c1', body: 'first session caption' })
+    await save(kind, old)
+    await reload(kind)
+    await h.live({ id: 'c2', body: 'second session caption' })
+    expect((await reload(kind)).body).toBe('second session caption')
+    expect(preview(kind)?.body).toBe('second session caption')
+    expect(await searchIndex.search('first')).toEqual([])
+    expect(await searchIndex.search('second')).toHaveLength(1)
+  })
+
+  it.each([false, true])('recovers promoted ciphertext after unlock, cache-only %s', async cachedOnly => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, cachedOnly ? [] : [base]); seedPreview(kind, base)
+    await h.live({ id: 'c1', body: 'earlier caption' })
+    await h.archive([{ id: 'c2', body: 'locked caption', locked: true, at: T2 }])
+    const manager = (await blockedDecrypt()).manager
+    vi.mocked(manager.decryptArchive).mockRestore()
+    const decryptVerified = manager.decryptArchive.bind(manager)
+    vi.spyOn(manager, 'decryptArchive').mockImplementation(async (...args) => {
+      const result = await decryptVerified(...args)
+      return result && { ...result, securityContext: { ...result.securityContext!, trust: 'verified' as const } }
+    })
+    h.deps.getE2EEManager = () => manager
+    const engine = new DeferredDecryptEngine({ getManager: () => manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    h.deps.recoverCorrection = (...args) => engine.recoverCorrection(...args)
+    await engine.retryPending()
+    if (cachedOnly) seed(kind, [])
+    await h.archive([{ id: 'c1', body: 'earlier caption', at: T1 }])
+    await vi.waitFor(async () => expect((await reload(kind)).body).toBe('recovered'))
+    expect(preview(kind)?.body).toBe('recovered')
+    expect(await searchIndex.search('earlier')).toEqual([])
+    expect(await searchIndex.search('recovered')).toHaveLength(1)
+  })
+})
+
+
+describe.each<Kind>(['chat', 'room'])('%s correction reconciliation lifetime', kind => {
+  it.each(['same', 'retract', 'account', 'roundtrip', 'manager', 'transport', 'failure'] as const)('bounds the query and guards %s completion', async change => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'c1', body: 'previous caption', at: T1 }], true)
+    const collectors = new Map<string, (stanza: Element) => void>()
+    h.deps.registerMAMCollector = (id, collector) => { collectors.set(id, collector); return () => { collectors.delete(id) } }
+    const started = deferred(), release = deferred()
+    const send = vi.fn(async (iq: Element) => {
+      const query = iq.getChild('query', 'urn:xmpp:mam:2')!
+      const fields = query.getChild('x', 'jabber:x:data')!.getChildren('field').map(field => field.attrs.var)
+      expect(fields).toEqual(kind === 'room' ? ['FORM_TYPE'] : ['FORM_TYPE', 'with'])
+      expect(query.getChild('set', 'http://jabber.org/protocol/rsm')?.getChildText('max')).toBe('50')
+      expect(query.getChild('set', 'http://jabber.org/protocol/rsm')?.getChild('before')).toBeDefined()
+      started.resolve(); await release.promise
+      if (change === 'failure') throw new Error('Synthetic archive unavailable')
+      collectors.get(query.attrs.queryid)?.(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: query.attrs.queryid, id: 'sid-c2' },
+        xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: T2 }), h.stanza({ id: 'c2', body: 'current caption' })))))
+      if (change === 'retract') collectors.get(query.attrs.queryid)?.(xml('message', {},
+        xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: query.attrs.queryid, id: 'archive-retraction' },
+          xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: FAST }),
+            xml('message', { from: base.from, to: SELF, type: base.type },
+              xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'sid-c2' }),
+              ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : []))))))
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' }))
+    })
+    h.deps.sendIQ = send
+    await h.live({ id: 'c2', body: 'current caption' })
+    await started.promise
+    await h.live({ id: 'c2', body: 'current caption' })
+    if (change === 'account' || change === 'roundtrip') { setStorageScopeJid('other@example.test'); if (change === 'roundtrip') setStorageScopeJid(SELF) }
+    if (change === 'manager') h.deps.getE2EEManager = () => ({}) as E2EEManager
+    if (change === 'transport') h.deps.getXmpp = () => createMockXmppClient() as unknown as ReturnType<ModuleDependencies['getXmpp']>
+    release.resolve()
+    await vi.waitFor(() => expect(collectors.size).toBe(0))
+    await drain()
+    expect(send).toHaveBeenCalledTimes(1)
+    if (change === 'retract') {
+      expect((await reload(kind)).isRetracted).toBe(true)
+      expect(await searchIndex.search('caption')).toEqual([])
+    } else expect(preview(kind)?.body).toBe(change === 'same' ? 'current caption' : 'previous caption')
+    if (change === 'same') expect((await reload(kind)).body).toBe('current caption')
+  })
+
+  it.each(['unlock', 'locked', 'old-completion', 'newer', 'retract', 'account'] as const)('recovers a queued promoted ciphertext with %s before completion', async change => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seedPreview(kind, base)
+    await h.live({ id: 'c1', body: 'earlier caption' })
+    const first = await reload(kind)
+    seed(kind, [])
+    await h.archive([{ id: 'c2', body: 'locked caption', locked: true, at: T2 }])
+    const manager = (await blockedDecrypt()).manager
+    vi.mocked(manager.decryptArchive).mockRestore()
+    const decryptVerified = manager.decryptArchive.bind(manager)
+    vi.spyOn(manager, 'decryptArchive').mockImplementation(async (...args) => {
+      const result = await decryptVerified(...args)
+      return result && { ...result, securityContext: { ...result.securityContext!, trust: 'verified' as const } }
+    })
+    h.deps.getE2EEManager = () => manager
+    const engine = new DeferredDecryptEngine({ getManager: () => manager, getStores: () => h.stores, getOwnBareJid: () => SELF, cache, updateSearchIndex: searchIndex.updateMessage })
+    h.deps.recoverCorrection = (...args) => engine.recoverCorrection(...args)
+    const started = deferred(), release = deferred()
+    let locked = change === 'locked'
+    vi.spyOn(manager, 'decryptArchive').mockImplementation(async (...args) => { started.resolve(); await release.promise; if (locked) throw new Error('Synthetic key locked'); return decryptVerified(...args).then(result => result && { ...result, securityContext: { ...result.securityContext!, trust: 'verified' as const } }) })
+    seed(kind, [])
+    await h.archive([{ id: 'c1', body: 'earlier caption', at: T1 }])
+    await started.promise
+    if (change === 'old-completion') engine.recoverCorrection(first, () => true, () => { throw new Error('Unexpected stale recovery') })
+    if (change === 'newer') await h.live({ id: 'c3', body: 'newest caption', at: FAST })
+    if (change === 'retract') h.chat.handle(xml('message', { from: base.from, to: SELF, type: base.type },
+      xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'sid-c2' }),
+      ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : [])))
+    if (change === 'account') setStorageScopeJid('other@example.test')
+    release.resolve()
+    await engine.retryPending()
+    if (change === 'locked') {
+      await vi.waitFor(() => expect(vi.mocked(manager.decryptArchive).mock.settledResults.some(result => result.type === 'rejected')).toBe(true))
+      expect((await reload(kind)).body).toBe('locked caption')
+      locked = false
+      await engine.retryPending()
+    }
+    await drain()
+    if (change === 'account') { expect(preview(kind)?.body).not.toBe('recovered'); return }
+    await vi.waitFor(async () => {
+      const row = await reload(kind)
+      if (change === 'retract') expect(row.isRetracted).toBe(true)
+      else expect(row.body).toBe(change === 'newer' ? 'newest caption' : 'recovered')
+    })
+    if (change !== 'unlock' && change !== 'locked' && change !== 'old-completion') expect(await searchIndex.search('recovered')).toEqual([])
+  })
+})
+
+
+it.each<Kind>(['chat', 'room'])('coalesces a third %s live edit into a bounded follow-up query', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind), base = original(kind)
+  await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+  await h.archive([{ id: 'c1', body: 'previous caption', at: T1 }], true)
+  const collectors = new Map<string, (stanza: Element) => void>()
+  h.deps.registerMAMCollector = (id, collector) => { collectors.set(id, collector); return () => { collectors.delete(id) } }
+  const started = deferred(), release = deferred()
+  let requests = 0
+  h.deps.sendIQ = async iq => {
+    const pass = ++requests
+    const queryId = iq.getChild('query', 'urn:xmpp:mam:2')!.attrs.queryid
+    if (pass === 1) { started.resolve(); await release.promise }
+    const id = pass === 1 ? 'c2' : 'c3', body = pass === 1 ? 'second caption' : 'latest caption'
+    collectors.get(queryId)!(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: queryId, id: `sid-${id}` },
+      xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: pass === 1 ? T2 : FAST }), h.stanza({ id, body })))))
+    return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' }))
+  }
+  await h.live({ id: 'c2', body: 'second caption' })
+  await started.promise
+  await h.live({ id: 'c3', body: 'latest caption' })
+  release.resolve()
+  await vi.waitFor(async () => expect((await reload(kind)).body).toBe('latest caption'))
+  expect(requests).toBe(2)
+  expect(preview(kind)?.body).toBe('latest caption')
+  expect(await searchIndex.search('second')).toEqual([])
+  expect(await searchIndex.search('latest')).toHaveLength(1)
+})
+
+describe.each<Kind>(['chat', 'room'])('%s rapid live edits during reconciliation', kind => {
+  it('eventually shows the last edit when new edits arrive during two pending queries', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'previous-c0', body: 'previous archived caption', at: T0 }], true)
+    const collectors = new Map<string, (stanza: Element) => void>()
+    const requests: ReturnType<typeof deferred>[] = []
+    let holdCount = 2, latest = { id: '', body: '', at: T1 }
+    h.deps.registerMAMCollector = (id, handler) => { collectors.set(id, handler); return () => { collectors.delete(id) } }
+    h.deps.sendIQ = async iq => {
+      const query = iq.getChild('query', 'urn:xmpp:mam:2')
+      if (!query) throw new Error('Unexpected non-MAM request')
+      const queryId = query.attrs.queryid, entry = { ...latest }, archiveId = `sid-${entry.id}`
+      const collector = collectors.get(queryId)
+      if (!collector) throw new Error('No MAM collector')
+      collector(xml('message', { from: kind === 'room' ? ROOM : SELF },
+        xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: queryId, id: archiveId },
+          xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: entry.at }),
+            h.stanza({ id: entry.id, body: entry.body })))))
+      const release = deferred(), index = requests.push(release) - 1
+      if (index < holdCount) await release.promise
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, archiveId), xml('last', {}, archiveId))))
+    }
+    const deliver = async (number: number, body: string) => {
+      latest = { id: `burst-c${number}`, body, at: new Date(Date.parse(T1) + number * 1000).toISOString() }
+      await h.live({ id: latest.id, body: latest.body })
+    }
+    try {
+      await deliver(1, 'first burst caption')
+      await vi.waitFor(async () => expect(requests.length > 0 || (await reload(kind)).body === latest.body).toBe(true))
+      if (requests.length === 0) {
+        holdCount = 0
+        await deliver(2, 'second burst caption'); await deliver(3, 'latest burst caption')
+      } else {
+        await deliver(2, 'second burst caption'); requests[0].resolve()
+        await vi.waitFor(async () => expect(requests.length > 1 || (await reload(kind)).body === latest.body).toBe(true))
+        if (requests.length > 1) {
+          await deliver(3, 'latest burst caption'); requests[1].resolve()
+        } else {
+          holdCount = 0; await deliver(3, 'latest burst caption')
+        }
+        holdCount = 0
+      }
+      await vi.waitFor(async () => expect((await reload(kind)).body).toBe('latest burst caption'), { timeout: 1500, interval: 10 })
+      expect(preview(kind)?.body).toBe('latest burst caption')
+      expect(await searchIndex.search('first')).toEqual([])
+      expect(await searchIndex.search('second')).toEqual([])
+      expect(await searchIndex.search('latest')).toHaveLength(1)
+    } finally { holdCount = 0; for (const request of requests) request.resolve(); await drain() }
+  })
+})
+
+function reconciliationArchive(h: ReturnType<typeof harness>, kind: Kind,
+  entries: () => Array<{ id: string; at: string; message: Element }>,
+  beforeResponse: (request: number) => Promise<void> = async () => {}) {
+  const collectors = new Map<string, (stanza: Element) => void>()
+  h.deps.registerMAMCollector = (id, collector) => { collectors.set(id, collector); return () => { collectors.delete(id) } }
+  const send = vi.fn(async (iq: Element) => {
+    const query = iq.getChild('query', 'urn:xmpp:mam:2')!
+    expect(query.attrs.to ?? iq.attrs.to).toBe(kind === 'room' ? ROOM : undefined)
+    const fields = query.getChild('x', 'jabber:x:data')!.getChildren('field')
+    expect(fields.map(field => field.attrs.var)).toEqual(kind === 'room' ? ['FORM_TYPE'] : ['FORM_TYPE', 'with'])
+    if (kind === 'chat') expect(fields[1].getChildText('value')).toBe(PEER)
+    const rsm = query.getChild('set', 'http://jabber.org/protocol/rsm')!
+    const max = Number(rsm.getChildText('max')), before = rsm.getChild('before'), after = rsm.getChildText('after')
+    expect(max).toBeLessThanOrEqual(50)
+    const archive = entries()
+    const cursor = after || before?.getText()
+    const cursorIndex = cursor ? archive.findIndex(entry => entry.id === cursor) : -1
+    if (cursor && cursorIndex < 0) throw new Error('Synthetic unknown archive cursor')
+    const end = before ? (cursor ? cursorIndex : archive.length) : archive.length
+    const start = after ? cursorIndex + 1 : before ? Math.max(0, end - max) : 0
+    const page = archive.slice(start, before ? end : start + max)
+    await beforeResponse(send.mock.calls.length)
+    for (const entry of page) collectors.get(query.attrs.queryid)?.(xml('message', {},
+      xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: query.attrs.queryid, id: entry.id },
+        xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: entry.at }), entry.message))))
+    return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: String(before ? start === 0 : start + page.length === archive.length) },
+      xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, page[0]?.id ?? ''), xml('last', {}, page.at(-1)?.id ?? ''))))
+  })
+  h.deps.sendIQ = send
+  return { send, collectors }
+}
+
+function enableReconciliation(h: ReturnType<typeof harness>, kind: Kind) {
+  if (kind === 'chat') h.stores.connection.getServerInfo.mockReturnValue({ domain: 'example.test', identities: [], features: ['urn:xmpp:mam:2'] })
+  else roomStore.getState().updateRoom(ROOM, { supportsMAM: true })
+}
+
+describe.each<Kind>(['chat', 'room'])('%s scoped reconciliation evidence', kind => {
+  it.each([[false, false, false], [true, false, false], [false, true, false], [true, false, true]])('finds previous-session revision evidence beyond the newest page (equal dates: %s, first: %s, dated: %s)', async (equal, first, dated) => {
+    setStorageScopeJid(SELF)
+    let h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.live({ id: 'old-session', body: 'previous caption', authoredAt: FAST })
+    if (dated) await h.archive([{ id: 'old-session', body: 'previous caption', authoredAt: FAST, at: T1 }])
+    const cached = await reload(kind)
+    const oldSession = cached.correctionRevision?.receiveOrder?.session
+    h = harness(kind)
+    seed(kind, []); seedPreview(kind, cached)
+    enableReconciliation(h, kind)
+    const entries = () => [
+      { id: base.stanzaId!, at: T0, message: xml('message', { id: base.id, from: base.from, to: SELF, type: base.type }, xml('body', {}, base.body)) },
+      ...Array.from({ length: dated ? 160 : 0 }, (_, index) => ({ id: `earlier-${index}`, at: T0,
+        message: xml('message', { from: base.from }, xml('body', {}, 'unrelated message')) })),
+      { id: 'sid-old-session', at: T1, message: h.stanza({ id: 'old-session', body: 'previous caption', authoredAt: FAST }) },
+      ...Array.from({ length: 60 }, (_, index) => ({ id: `filler-${index}`, at: T1,
+        message: xml('message', { id: `filler-${index}`, from: base.from, to: SELF, type: base.type }, xml('body', {}, 'unrelated message')) })),
+      { id: 'sid-new-session', at: equal ? T1 : T2, message: h.stanza({ id: 'new-session', body: 'current caption', authoredAt: T0 }) },
+    ].slice(first ? 1 : 0)
+    const server = reconciliationArchive(h, kind, entries)
+    await h.live({ id: 'new-session', body: 'current caption', authoredAt: T0 })
+    await vi.waitFor(async () => expect((await reload(kind)).body).toBe('current caption'))
+    const row = await reload(kind)
+    expect(row).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp, correctionTimestamp: Date.parse(T0), correctionTimestampSource: 'authored', originalBody: base.body })
+    expect(row.correctionRevision?.receiveOrder?.session).not.toBe(oldSession)
+    expect(row.correctionAlternatives ?? []).toEqual([])
+    expect(preview(kind)?.body).toBe('current caption')
+    expect(await searchIndex.search('previous')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(1)
+    expect(server.send.mock.calls.length).toBeGreaterThan(1)
+    expect(server.send.mock.calls.length).toBeLessThanOrEqual(4)
+    expect(server.collectors.size).toBe(0)
+  })
+
+  it.each([[false, false], [true, false], [false, true], [true, true]])('resolves newly learned retraction aliases (foreign: %s, cache-only: %s)', async (foreign, cacheOnly) => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'c1', body: 'previous caption', at: T1 }], true)
+    if (cacheOnly) seed(kind, [])
+    const server = reconciliationArchive(h, kind, () => [
+      { id: 'new-archive-alias', at: T2, message: h.stanza({ id: 'c2', body: 'current caption', stanzaId: 'new-archive-alias' }) },
+      { id: 'retraction', at: FAST, message: xml('message', { from: foreign && kind === 'chat' ? 'intruder@example.test' : base.from, to: SELF, type: base.type },
+        xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'new-archive-alias' }),
+        ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: foreign ? 'foreign-occupant' : 'peer-occupant' })] : [])) },
+    ])
+    await h.live({ id: 'c2', body: 'current caption', omitStanzaId: true })
+    await vi.waitFor(async () => {
+      const row = await reload(kind)
+      if (foreign) { expect(row.isRetracted).toBeFalsy(); expect(row.body).toBe('current caption') }
+      else { expect(row.isRetracted).toBe(true); expect(row.body).toBe('') }
+    })
+    expect((await reload(kind)).correctionAlternatives ?? []).toEqual([])
+    expect(preview(kind)?.body).toBe(foreign ? 'current caption' : '')
+    expect(await searchIndex.search('caption')).toHaveLength(foreign ? 1 : 0)
+    expect(server.send).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s reconciliation request ownership', kind => {
+  it('serves three different originals arriving during successive queries', async () => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind)
+    const bases = Array.from({ length: 3 }, (_, i) => ({ ...original(kind), id: `original-${i}`, stanzaId: `archive-original-${i}` }))
+    await save(kind, ...bases); seed(kind, bases); seedPreview(kind, bases[2])
+    await h.archive(bases.map((base, i) => ({ id: `previous-${i}`, body: `previous caption ${i}`, at: T1, targetId: base.id })))
+    const latest: Array<{ id: string; at: string; message: Element }> = []
+    const releases = [deferred(), deferred()]
+    const server = reconciliationArchive(h, kind, () => [...latest], async request => {
+      if (request <= releases.length) await releases[request - 1].promise
+    })
+    const deliver = async (index: number) => {
+      const edit = { id: `current-${index}`, body: `current caption ${index}`, targetId: bases[index].id }
+      latest.push({ id: `sid-${edit.id}`, at: T2, message: h.stanza(edit) })
+      await h.live(edit)
+    }
+    try {
+      await deliver(0)
+      await vi.waitFor(() => expect(server.send).toHaveBeenCalledTimes(1))
+      await deliver(1); releases[0].resolve()
+      await vi.waitFor(() => expect(server.send).toHaveBeenCalledTimes(2))
+      await deliver(2); releases[1].resolve()
+      await vi.waitFor(async () => {
+        await drain()
+        const rows = kind === 'chat' ? await cache.getMessages(PEER) : await cache.getRoomMessages(ROOM, {})
+        expect(rows).toHaveLength(3)
+        for (let i = 0; i < 3; i++) expect(rows.find(row => row.id === bases[i].id)?.body).toBe(`current caption ${i}`)
+      })
+      expect(server.send).toHaveBeenCalledTimes(3)
+      expect(server.collectors.size).toBe(0)
+      expect(preview(kind)?.body).toBe('current caption 2')
+      expect(await searchIndex.search('previous')).toEqual([])
+      expect(await searchIndex.search('current')).toHaveLength(3)
+    } finally { releases.forEach(release => release.resolve()); await drain() }
+  })
+
+  it.each(['original-cursor', 'unavailable', 'unsupported', 'budget', 'account', 'roundtrip', 'manager', 'transport'] as const)(
+    'bounds missing-revision requests and handles %s', async outcome => {
+      setStorageScopeJid(SELF)
+      let h = harness(kind)
+      const base = original(kind)
+      await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+      await h.live({ id: 'c1', body: 'previous caption', omitStanzaId: outcome === 'original-cursor' || outcome === 'budget' })
+      const cached = await reload(kind)
+      h = harness(kind)
+      seed(kind, []); seedPreview(kind, cached)
+      if (outcome !== 'unsupported') enableReconciliation(h, kind)
+      const fillers = outcome === 'budget' ? 160 : 60
+      const started = deferred(), release = deferred()
+      const cancelled = ['account', 'roundtrip', 'manager', 'transport'].includes(outcome)
+      const server = reconciliationArchive(h, kind, () => [
+        { id: base.stanzaId!, at: T0, message: xml('message', { id: base.id, from: base.from, to: SELF, type: base.type }, xml('body', {}, base.body)) },
+        ...Array.from({ length: fillers }, (_, index) => ({ id: `filler-${index}`, at: T1, message: xml('message', { from: base.from }, xml('body', {}, 'other')) })),
+        { id: 'sid-c1', at: T1, message: h.stanza({ id: 'c1', body: 'previous caption' }) },
+        ...Array.from({ length: 60 }, (_, index) => ({ id: `later-${index}`, at: T1, message: xml('message', { from: base.from }, xml('body', {}, 'other')) })),
+        { id: 'sid-c2', at: T2, message: h.stanza({ id: 'c2', body: 'current caption' }) },
+      ], async request => {
+        if (request === 2) {
+          if (outcome === 'unavailable') throw new Error('Synthetic archive unavailable')
+          if (cancelled) { started.resolve(); await release.promise }
+        }
+      })
+      try {
+        await h.live({ id: 'c2', body: 'current caption' })
+        if (cancelled) {
+          await started.promise
+          if (outcome === 'account' || outcome === 'roundtrip') { setStorageScopeJid('other@example.test'); if (outcome === 'roundtrip') setStorageScopeJid(SELF) }
+          if (outcome === 'manager') h.deps.getE2EEManager = () => ({}) as E2EEManager
+          if (outcome === 'transport') {
+            const xmpp = createMockXmppClient() as unknown as ReturnType<ModuleDependencies['getXmpp']>
+            h.deps.getXmpp = () => xmpp
+          }
+          release.resolve()
+        }
+        await vi.waitFor(() => expect(server.collectors.size).toBe(0))
+        await drain()
+        if (outcome === 'original-cursor' || outcome === 'budget') {
+          expect((await reload(kind)).body).toBe('current caption')
+          expect(preview(kind)?.body).toBe('current caption')
+          expect(await searchIndex.search('previous')).toEqual([])
+          expect(await searchIndex.search('current')).toHaveLength(1)
+          if (outcome === 'budget') expect(server.send.mock.calls.length).toBeGreaterThan(3)
+        }
+        else {
+          expect(preview(kind)?.body).toBe('previous caption')
+          if (!cancelled) {
+            const row = await reload(kind)
+            expect(row.body).toBe('previous caption')
+            expect(row.correctionAlternatives).toHaveLength(1)
+            const calls = server.send.mock.calls.length
+            await h.live({ id: 'c2', body: 'current caption' })
+            await h.live({ id: 'c2', body: 'current caption' })
+            await drain()
+            expect(server.send).toHaveBeenCalledTimes(calls)
+          }
+        }
+        expect(server.send.mock.calls.length).toBeLessThanOrEqual(outcome === 'unsupported' ? 0 : outcome === 'budget' ? 6 : 4)
+      } finally { release.resolve(); await drain() }
+    })
+})
+
+it.each<Kind>(['chat', 'room'])('serves fresh %s work queued during a failed batch without retrying the failed generation', async kind => {
+  setStorageScopeJid(SELF)
+  const h = harness(kind), base = original(kind)
+  await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+  await h.archive([{ id: 'previous', body: 'previous caption', at: T0 }], true)
+  let latest = { id: 'c1', body: 'second caption' }
+  const started = deferred(), release = deferred()
+  const server = reconciliationArchive(h, kind, () => [{ id: `sid-${latest.id}`, at: T2, message: h.stanza(latest) }], async request => {
+    if (request === 1) { started.resolve(); await release.promise; throw new Error('Synthetic failed first batch') }
+  })
+  try {
+    await h.live(latest); await started.promise
+    latest = { id: 'c2', body: 'latest caption' }
+    await h.live(latest); release.resolve()
+    await vi.waitFor(async () => expect((await reload(kind)).body).toBe('latest caption'))
+    expect(server.send).toHaveBeenCalledTimes(2)
+    await h.live({ id: 'c1', body: 'second caption' })
+    await h.live(latest)
+    expect(server.send).toHaveBeenCalledTimes(2)
+    expect(server.collectors.size).toBe(0)
+    expect((await reload(kind)).body).toBe('latest caption')
+    expect(preview(kind)?.body).toBe('latest caption')
+    expect(await searchIndex.search('second')).toEqual([])
+    expect(await searchIndex.search('latest')).toHaveLength(1)
+  } finally { release.resolve(); await drain() }
+})
+
+it.each((['chat', 'room'] as const).flatMap(kind => [false, true].map(reloadSession => ({ kind, reloadSession }))))('preserves independent completed archive replay provenance for $kind (reload $reloadSession)', async ({ kind, reloadSession }) => {
+  setStorageScopeJid(SELF)
+  let h = harness(kind)
+  const base = original(kind)
+  await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+  await h.archive([{ id: 'completed-c1', body: 'previous caption', at: T1 }], true)
+  if (reloadSession) {
+    const held = await reload(kind)
+    h = harness(kind); seed(kind, [held]); seedPreview(kind, held)
+    enableReconciliation(h, kind)
+  }
+  const sendIQ = h.deps.sendIQ
+  h.deps.sendIQ = async () => { throw new Error('Synthetic archive temporarily unavailable') }
+  await h.live({ id: 'retained-c2', body: 'retained caption' })
+  let row = await reload(kind)
+  expect(row.correctionAlternatives).toEqual(expect.arrayContaining([expect.objectContaining({ body: 'retained caption' })]))
+  await h.live({ id: 'completed-c1', body: 'previous caption' })
+  row = await reload(kind)
+  expect(row.correctionAlternatives).toEqual(expect.arrayContaining([expect.objectContaining({ body: 'retained caption' })]))
+  expect(row.correctionRevision?.supersedes ?? []).not.toContain('id:retained-c2')
+  h.deps.sendIQ = sendIQ
+  await h.archive([{ id: 'retained-c2', body: 'retained caption', at: T2 }])
+  expect((await reload(kind)).body).toBe('retained caption')
+  expect(preview(kind)?.body).toBe('retained caption')
+  expect(await searchIndex.search('previous')).toEqual([])
+  expect(await searchIndex.search('retained')).toHaveLength(1)
+})
+
+
+it.each((['chat', 'room'] as const).flatMap(kind => [false, true].map(reloadSession => ({ kind, reloadSession }))))('preserves independent completed archive replay provenance for alternative owner $kind (reload $reloadSession)', async ({ kind, reloadSession }) => {
+  setStorageScopeJid(SELF)
+  let h = harness(kind)
+  const base = original(kind)
+  await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+  const started = deferred(), release = deferred(), send = h.deps.sendIQ
+  h.deps.sendIQ = async (...args) => {
+    const response = await send(...args)
+    started.resolve(); await release.promise; return response
+  }
+  const work = h.archive([{ id: 'alternative-c1', body: 'previous caption', at: T1 }])
+  await started.promise
+  try {
+    await h.live({ id: 'current-c2', body: 'current caption' })
+    release.resolve(); await work; await drain()
+    let row = await reload(kind)
+    expect(row.body).toBe('current caption')
+    expect(row.correctionAlternatives).toEqual(expect.arrayContaining([expect.objectContaining({ body: 'previous caption' })]))
+    if (reloadSession) {
+      h = harness(kind); seed(kind, [row]); seedPreview(kind, row)
+    }
+    const resumedSend = reloadSession ? h.deps.sendIQ : send
+    h.deps.sendIQ = async () => { throw new Error('Synthetic archive temporarily unavailable') }
+    await h.live({ id: 'alternative-c1', body: 'previous caption' })
+    row = await reload(kind)
+    expect(row.body).toBe('current caption')
+    expect(row.correctionRevision?.supersedes ?? []).not.toContain('id:current-c2')
+    expect(preview(kind)?.body).toBe('current caption')
+    expect(await searchIndex.search('previous')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(1)
+    h.deps.sendIQ = resumedSend
+    await h.archive([{ id: 'current-c2', body: 'current caption', at: T2 }])
+    expect((await reload(kind)).body).toBe('current caption')
+    expect(preview(kind)?.body).toBe('current caption')
+    expect(await searchIndex.search('previous')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(1)
+  } finally { release.resolve(); await work }
+})
+
+it.each<Kind>(['chat', 'room'])('advances an independent absorbed original reconciliation for %s', async kind => {
+  setStorageScopeJid(SELF)
+  const base = { ...original(kind), id: 'z-original', stanzaId: undefined, originId: 'origin-original' }
+  const h = harness(kind, false, base)
+  await save(kind, base)
+  await save(kind, { ...base, id: 'a-canonical', stanzaId: 'archive-original' })
+  const canonical = await reload(kind)
+  expect(canonical.id).toBe('a-canonical')
+  seed(kind, []); seedPreview(kind, canonical)
+  await h.archive([{ id: 'known-c1', body: 'previous caption', at: T1, targetId: base.id }])
+  const previous = await reload(kind)
+  expect(previous.body).toBe('previous caption')
+  seed(kind, []); seedPreview(kind, previous)
+  const server = reconciliationArchive(h, kind, () => [
+    { id: 'archive-original', at: T0, message: xml('message', { id: canonical.id, from: base.from, to: SELF, type: base.type }, xml('body', {}, base.body)) },
+    { id: 'sid-known-c1', at: T1, message: h.stanza({ id: 'known-c1', body: 'previous caption', targetId: base.id }) },
+    { id: 'sid-fresh-c2', at: T2, message: h.stanza({ id: 'fresh-c2', body: 'current caption', targetId: base.id }) },
+  ])
+  await h.live({ id: 'fresh-c2', body: 'current caption', targetId: base.id, omitStanzaId: true })
+  await vi.waitFor(async () => expect((await reload(kind)).body).toBe('current caption'), { timeout: 1500, interval: 10 })
+  const current = await reload(kind)
+  expect(current).toMatchObject({ id: canonical.id, stanzaId: canonical.stanzaId, originId: canonical.originId, timestamp: canonical.timestamp })
+  expect(preview(kind)?.body).toBe('current caption')
+  expect(await searchIndex.search('previous')).toEqual([])
+  expect(await searchIndex.search('current')).toHaveLength(1)
+  expect(server.collectors.size).toBe(0)
+})
+
+describe.each<Kind>(['chat', 'room'])('%s independent reconciliation archive evidence', kind => {
+  it.each([false, true])('handles a newly learned retraction alias, foreign actor %s', async foreign => {
+    setStorageScopeJid(SELF)
+    const h = harness(kind), base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'c1', body: 'previous caption', at: T1 }], true)
+    const collectors = new Map<string, (stanza: Element) => void>()
+    h.deps.registerMAMCollector = (id, cb) => { collectors.set(id, cb); return () => { collectors.delete(id) } }
+    let requests = 0
+    h.deps.sendIQ = async iq => {
+      requests++
+      const qid = iq.getChild('query', 'urn:xmpp:mam:2')!.attrs.queryid, collector = collectors.get(qid)!
+      const from = foreign ? (kind === 'room' ? `${ROOM}/Other` : 'other@example.test') : base.from
+      const entries = [
+        { id: 'new-archive-c2', message: h.stanza({ id: 'c2', body: 'current caption', stanzaId: 'new-archive-c2' }) },
+        { id: 'retraction-signal', message: xml('message', { from, to: SELF, type: base.type },
+          xml('retract', { xmlns: 'urn:xmpp:message-retract:1', id: 'new-archive-c2' }),
+          ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: foreign ? 'other-occupant' : 'peer-occupant' })] : [])) },
+      ]
+      for (const entry of entries) collector(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: qid, id: entry.id },
+        xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: T2 }), entry.message))))
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, entries[0].id), xml('last', {}, entries[1].id))))
+    }
+    await h.live({ id: 'c2', body: 'current caption', omitStanzaId: true })
+    await vi.waitFor(async () => {
+      const row = await reload(kind)
+      if (foreign) { expect(row.isRetracted).not.toBe(true); expect(row.body).toBe('current caption') }
+      else expect(row.isRetracted).toBe(true)
+    }, { timeout: 1500, interval: 10 })
+    expect(requests).toBeGreaterThan(0)
+    expect(await searchIndex.search('previous')).toEqual([])
+    if (foreign) expect(await searchIndex.search('current')).toHaveLength(1)
+    else { expect(await searchIndex.search('current')).toEqual([]); expect(preview(kind)?.isRetracted).toBe(true) }
+  })
+
+  it.each([0, 160])('resolves an undated predecessor outside the latest archive page after reload with %i prior messages', async priorCount => {
+    setStorageScopeJid(SELF)
+    let h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.live({ id: 'older-c1', body: 'previous caption', omitStanzaId: true })
+    const old = await reload(kind)
+    expect(old.correctionRevision?.archiveTimestamp).toBeUndefined()
+    h = harness(kind); seed(kind, [old]); seedPreview(kind, old)
+    await h.archive([], true)
+    const entries: Array<{ id: string; at: string; message: Element }> = [
+      { id: base.stanzaId!, at: T0, message: xml('message', { id: base.id, from: base.from, to: SELF, type: base.type }, xml('body', {}, base.body),
+        xml('stanza-id', { xmlns: 'urn:xmpp:sid:0', by: kind === 'room' ? ROOM : SELF, id: base.stanzaId! }),
+        ...(kind === 'room' ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'peer-occupant' })] : [])) },
+      ...Array.from({ length: priorCount }, (_, i) => ({ id: `prior-noise-${i}`, at: new Date(Date.parse(T0) + 200 * (i + 1)).toISOString(),
+        message: xml('message', { id: `prior-noise-${i}`, from: base.from, to: SELF, type: base.type }, xml('body', {}, `prior noise ${i}`)) })),
+      { id: 'archive-older-c1', at: T1, message: h.stanza({ id: 'older-c1', body: 'previous caption', omitStanzaId: true }) },
+      ...Array.from({ length: 70 }, (_, i) => ({ id: `noise-${i}`, at: new Date(Date.parse(T1) + 1000 * (i + 1)).toISOString(),
+        message: xml('message', { id: `noise-${i}`, from: base.from, to: SELF, type: base.type }, xml('body', {}, `noise ${i}`)) })),
+      { id: 'archive-fresh-c2', at: FAST, message: h.stanza({ id: 'fresh-c2', body: 'current caption', omitStanzaId: true }) },
+    ]
+    const collectors = new Map<string, (stanza: Element) => void>()
+    h.deps.registerMAMCollector = (id, cb) => { collectors.set(id, cb); return () => { collectors.delete(id) } }
+    h.deps.sendIQ = async iq => {
+      const query = iq.getChild('query', 'urn:xmpp:mam:2')!, qid = query.attrs.queryid
+      const fields = query.getChild('x', 'jabber:x:data')!.getChildren('field')
+      for (const field of fields) if (!['FORM_TYPE', 'with', 'start', 'end'].includes(field.attrs.var)) throw new Error(`Unsupported basic MAM field ${field.attrs.var}`)
+      const fieldValue = (name: string) => fields.find(field => field.attrs.var === name)?.getChildText('value')
+      const start = fieldValue('start'), end = fieldValue('end')
+      let candidates = entries.filter(entry => (!start || entry.at >= start) && (!end || entry.at <= end))
+      const rsm = query.getChild('set', 'http://jabber.org/protocol/rsm')
+      const after = rsm?.getChildText('after'), before = rsm?.getChild('before')
+      if (after) { const index = candidates.findIndex(entry => entry.id === after); if (index < 0) throw new Error('Unknown after cursor'); candidates = candidates.slice(index + 1) }
+      if (before?.getText()) { const index = candidates.findIndex(entry => entry.id === before.getText()); if (index < 0) throw new Error('Unknown before cursor'); candidates = candidates.slice(0, index) }
+      const max = Number(rsm?.getChildText('max') ?? 50)
+      const page = before ? candidates.slice(-max) : candidates.slice(0, max)
+      for (const entry of page) collectors.get(qid)!(xml('message', {}, xml('result', { xmlns: 'urn:xmpp:mam:2', queryid: qid, id: entry.id },
+        xml('forwarded', { xmlns: 'urn:xmpp:forward:0' }, xml('delay', { xmlns: 'urn:xmpp:delay', stamp: entry.at }), entry.message))))
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: page.length === candidates.length ? 'true' : 'false' },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' }, xml('first', {}, page[0]?.id ?? ''), xml('last', {}, page.at(-1)?.id ?? ''))))
+    }
+    await h.live({ id: 'fresh-c2', body: 'current caption', omitStanzaId: true })
+    await vi.waitFor(async () => expect((await reload(kind)).body).toBe('current caption'), { timeout: 1500, interval: 10 })
+    expect(preview(kind)?.body).toBe('current caption')
+    expect(await searchIndex.search('previous')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(1)
+  })
+})
+
+describe.each<Kind>(['chat', 'room'])('%s reconciliation traversal termination', kind => {
+  it.each(['complete', 'growth', 'repeated', 'error', 'roundtrip', 'queued'] as const)('preserves finite progress with %s', async outcome => {
+    setStorageScopeJid(SELF)
+    let h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.live({ id: 'c1', body: 'previous caption', omitStanzaId: true })
+    const cached = await reload(kind)
+    h = harness(kind); seed(kind, []); seedPreview(kind, cached)
+    enableReconciliation(h, kind)
+    const filler = (id: string) => ({ id, at: T1, message: xml('message', { id, from: base.from, to: SELF, type: base.type }, xml('body', {}, 'unrelated')) })
+    const archive = [
+      { id: base.stanzaId!, at: T0, message: xml('message', { id: base.id, from: base.from, to: SELF, type: base.type }, xml('body', {}, base.body)) },
+      ...Array.from({ length: 160 }, (_, i) => filler(`before-${i}`)),
+      ...(outcome === 'queued' ? [{ id: 'archive-c1', at: T1, message: h.stanza({ id: 'c1', body: 'previous caption', omitStanzaId: true }) }] : []),
+      ...Array.from({ length: 70 }, (_, i) => filler(`after-${i}`)),
+      { id: 'archive-c2', at: T2, message: h.stanza({ id: 'c2', body: 'current caption', omitStanzaId: true }) },
+    ]
+    const started = deferred(), release = deferred()
+    const server = reconciliationArchive(h, kind, () => [...archive], async request => {
+      if (outcome === 'growth') archive.push(...Array.from({ length: 50 }, (_, i) => filler(`growth-${request}-${i}`)))
+      if (request === 3) {
+        if (outcome === 'error') throw new Error('Synthetic cursor read failed')
+        if (outcome === 'roundtrip' || outcome === 'queued') { started.resolve(); await release.promise }
+      }
+    })
+    const send = h.deps.sendIQ
+    h.deps.sendIQ = async iq => {
+      const response = await send(iq)
+      if (outcome === 'repeated' && server.send.mock.calls.length >= 3) {
+        response.getChild('fin', 'urn:xmpp:mam:2')!.getChild('set', 'http://jabber.org/protocol/rsm')!.getChild('last')!.children = ['before-49']
+      }
+      return response
+    }
+    try {
+      await h.live({ id: 'c2', body: 'current caption', omitStanzaId: true })
+      if (outcome === 'roundtrip' || outcome === 'queued') {
+        await started.promise
+        if (outcome === 'roundtrip') { setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF) }
+        else {
+          archive.push({ id: 'archive-c3', at: FAST, message: h.stanza({ id: 'c3', body: 'latest caption', omitStanzaId: true }) })
+          await h.live({ id: 'c3', body: 'latest caption', omitStanzaId: true })
+        }
+        release.resolve()
+      }
+      await vi.waitFor(() => {
+        expect(server.send.mock.calls.length).toBeGreaterThan(1)
+        expect(server.collectors.size).toBe(0)
+      })
+      await drain()
+      const afters = server.send.mock.calls.map(([iq]) => iq.getChild('query', 'urn:xmpp:mam:2')!.getChild('set', 'http://jabber.org/protocol/rsm')!.getChildText('after')).filter(Boolean)
+      expect(new Set(afters).size).toBe(afters.length)
+      if (outcome === 'queued') {
+        expect((await reload(kind)).body).toBe('latest caption')
+        expect(preview(kind)?.body).toBe('latest caption')
+        expect(await searchIndex.search('latest')).toHaveLength(1)
+        expect(await searchIndex.search('previous')).toEqual([])
+        expect(server.send.mock.calls.length).toBeLessThanOrEqual(7)
+      } else {
+        expect(preview(kind)?.body).toBe('previous caption')
+        if (outcome !== 'roundtrip') {
+          const row = await reload(kind)
+          expect(row.body).toBe('previous caption')
+          expect(row.correctionAlternatives).toEqual(expect.arrayContaining([expect.objectContaining({ body: 'current caption' })]))
+          const calls = server.send.mock.calls.length
+          await h.live({ id: 'c2', body: 'current caption', omitStanzaId: true })
+          expect(server.send).toHaveBeenCalledTimes(calls)
+        }
+        expect(server.send.mock.calls.length).toBe(outcome === 'complete' || outcome === 'growth' ? 6 : 3)
+      }
+    } finally { release.resolve(); await drain() }
+  })
+})
+
+it.each<Kind>(['chat', 'room'])('cancels %s absorbed alias lookup across an account round trip', async kind => {
+  setStorageScopeJid(SELF)
+  const base = { ...original(kind), id: 'z-original', stanzaId: undefined, originId: 'origin-original' }
+  const h = harness(kind, false, base)
+  await save(kind, base); await save(kind, { ...base, id: 'a-canonical', stanzaId: 'archive-original' })
+  await h.archive([{ id: 'c1', body: 'previous caption', at: T1 }])
+  const previous = await reload(kind)
+  seed(kind, []); seedPreview(kind, previous)
+  const server = reconciliationArchive(h, kind, () => [{ id: 'archive-c2', at: T2, message: h.stanza({ id: 'c2', body: 'current caption', omitStanzaId: true }) }])
+  const started = deferred(), release = deferred()
+  const store = kind === 'chat' ? h.stores.chat : h.stores.room
+  const lookup = store.resolveCorrectionReferences.getMockImplementation()!
+  store.resolveCorrectionReferences.mockImplementation(async (...args) => {
+    const references = await lookup(...args)
+    started.resolve(); await release.promise
+    return references
+  })
+  try {
+    await h.live({ id: 'c2', body: 'current caption', omitStanzaId: true })
+    await started.promise
+    setStorageScopeJid('other@example.test'); setStorageScopeJid(SELF)
+    release.resolve()
+    await vi.waitFor(() => expect(server.collectors.size).toBe(0))
+    expect(preview(kind)?.body).toBe('previous caption')
+    expect(server.send).toHaveBeenCalledTimes(1)
+  } finally { release.resolve(); await drain() }
+})
+
+
+it.each((['chat', 'room'] as const).flatMap(kind => [false, true].flatMap(reloadSession =>
+  [false, true].map(cachedOnly => ({ kind, reloadSession, cachedOnly })))))(
+  'keeps genuine live progress after archived replay for $kind reload=$reloadSession cached=$cachedOnly', async ({ kind, reloadSession, cachedOnly }) => {
+    setStorageScopeJid(SELF)
+    let h = harness(kind)
+    const base = original(kind)
+    await save(kind, base); seed(kind, [base]); seedPreview(kind, base)
+    await h.archive([{ id: 'known-c1', body: 'earlier caption', at: T1, authoredAt: FAST }], true)
+    const snapshot = await reload(kind)
+    if (reloadSession) h = harness(kind)
+    seed(kind, cachedOnly ? [] : [snapshot]); seedPreview(kind, snapshot)
+    h.deps.sendIQ = async () => { throw new Error('Synthetic archive temporarily unavailable') }
+    await h.live({ id: 'known-c1', body: 'earlier caption', authoredAt: FAST })
+    await save(kind, snapshot)
+    if (!cachedOnly) await reload(kind)
+    await h.live({ id: 'fresh-c2', body: 'current caption', authoredAt: T0 })
+    const current = await reload(kind)
+    expect(current).toMatchObject({ id: base.id, stanzaId: base.stanzaId, timestamp: base.timestamp,
+      body: 'current caption', correctionTimestamp: Date.parse(T0), correctionTimestampSource: 'authored' })
+    expect(current.correctionAlternatives).toBeUndefined()
+    expect(preview(kind)?.body).toBe(current.body)
+    expect(await searchIndex.search('earlier')).toEqual([])
+    expect(await searchIndex.search('current')).toHaveLength(1)
+    await h.live({ id: 'known-c1', body: 'earlier caption', authoredAt: FAST })
+    expect((await reload(kind)).body).toBe(current.body)
+    await h.live({ id: 'fresh-c3', body: 'latest caption', authoredAt: T1 })
+    expect((await reload(kind)).body).toBe('latest caption')
+    expect(preview(kind)?.body).toBe('latest caption')
+    expect(await searchIndex.search('current')).toEqual([])
+    expect(await searchIndex.search('latest')).toHaveLength(1)
+  })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -218,7 +218,7 @@ describe('messageCache', () => {
     })
 
     await messageCache.getRoomMessages(roomJid)
-    const db = await openDB('fluux-message-cache', 5)
+    const db = await openDB('fluux-message-cache')
     const tx = db.transaction('room-messages-canonical', 'readwrite')
     for (const message of [departed, target, compatible]) {
       await tx.store.put(rrow({
@@ -1328,6 +1328,24 @@ const rrow = (over: Partial<StoredRoomMessage> = {}): StoredRoomMessage => {
 const both = (a: StoredRoomMessage, b: StoredRoomMessage) => [mergeRoomRows(a, b), mergeRoomRows(b, a)]
 
 describe('mergeRoomRows — commutative, associative, field-complete', () => {
+  it('retains incomparable revisions and converges after archive evidence in every save order', () => {
+    const rows = [
+      rrow({ isEdited: true, body: 'zulu', correctionRevision: { ids: ['id:a'], supersedes: ['id:before-a'], afterArchiveTimestamp: 4000 } }),
+      rrow({ isEdited: true, body: 'alpha', correctionRevision: { ids: ['id:b'], supersedes: ['id:before-b'], afterArchiveTimestamp: 1000 } }),
+      rrow({ isEdited: true, body: 'charlie', correctionRevision: { ids: ['id:c'], supersedes: [], archiveTimestamp: 3000 } }),
+    ]
+    const orders = [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]]
+    for (const [a, b, c] of orders) {
+      const held = mergeRoomRows(mergeRoomRows(rows[a], rows[b]), rows[c])
+      expect([held.body, ...(held.correctionAlternatives ?? []).map(candidate => candidate.body)].sort()).toEqual(['alpha', 'zulu'])
+      const resolved = mergeRoomRows(held, rrow({ isEdited: true, body: 'zulu', correctionRevision: {
+        ...rows[0].correctionRevision!, archiveTimestamp: 5000, supersedes: ['id:before-a', 'id:b'], predecessors: [['id:b']],
+      } }))
+      expect(resolved.body).toBe('zulu')
+      expect(resolved.correctionAlternatives).toBeUndefined()
+    }
+  })
+
   it('never downgrades decrypted content, both orders', () => {
     for (const m of both(rrow({ body: 'plaintext' }), rrow({ body: '', unsupportedEncryption: { kind: 'x' } as never }))) expect(m.body).toBe('plaintext')
   })
@@ -2335,7 +2353,7 @@ describe('v5 migration — chat-store canonicalization', () => {
     expect((await messageCache.getRoomMessages(ROOM, {})).map((m) => m.body)).toEqual(['room survives'])
 
     const raw = await openDB(dbName)
-    expect(raw.version).toBe(5)
+    expect(raw.version).toBe(6)
     // Both legacy stores are emptied, not merely bypassed.
     expect(await raw.count('messages' as never)).toBe(0)
     expect(await raw.count('room-messages' as never)).toBe(0)

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -14,7 +14,8 @@ import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 // mutually recursive.
 import type { Message } from '../core/types/chat'
 import type { RoomMessage } from '../core/types/room'
-import { getStorageScopeJid } from './storageScope'
+import { isNoLocalStore, captureContentSource, resolveCorrectionUpdates, compareCorrectionRevisions, canReplaceCorrection, sameCorrection, mergeCorrectionMetadata, correctionContent, type CorrectionUpdates, type MessageImplState } from '../core/types/message-internal'
+import { captureStorageScope, getStorageScopeJid } from './storageScope'
 import {
   archiveIdentityConflict,
   canMergeOccupantSet,
@@ -23,11 +24,15 @@ import {
   chatMessageAuthor,
   extendOccupantComponent,
   identityKeys,
+  correctionReferenceKeys,
+  type MessageActor,
   identityFieldsEqual,
   identityProbes,
   mergeableOccupantCandidates,
   occupantConflict,
   referenceProbes,
+  correctionReferences,
+  type CorrectionReferences,
   roomMessageAuthor,
   roomScope,
   sameLogicalMessage,
@@ -70,7 +75,7 @@ const DB_NAME = 'fluux-message-cache'
 // canonically-keyed store (identityKeys[]/ids[] multiEntry) replaces it; the v5
 // upgrade streams every legacy row through the identity-resolving upsert into it
 // and aborts atomically on failure.
-const DB_VERSION = 5
+const DB_VERSION = 6
 // The canonical chat store (v5+). Keyed by the conversation-qualified canonical key.
 const MESSAGES_STORE = 'messages-canonical'
 // The pre-v5 chat store. Read + cleared by the v5 migration only; never written live.
@@ -84,7 +89,7 @@ const LEGACY_ROOM_MESSAGES_STORE = 'room-messages'
  * Stored message format with timestamps as numbers for efficient indexing.
  */
 export interface StoredMessage
-  extends Omit<Message, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'> {
+  extends Omit<Message, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'>, MessageImplState {
   /** Cache key used as the primary key in IndexedDB. See {@link chatCacheKey}. */
   cacheKey: string
   /** Every chat-scoped identity tier this row is known under (see {@link identityKeys}). */
@@ -105,7 +110,7 @@ export interface StoredMessage
  * Stored room message format with timestamps as numbers for efficient indexing.
  */
 export interface StoredRoomMessage
-  extends Omit<RoomMessage, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'> {
+  extends Omit<RoomMessage, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'>, MessageImplState {
   /** Cache key used as the primary key in IndexedDB. */
   cacheKey: string
   /** Every room-scoped identity tier this row is known under (see {@link identityKeys}). */
@@ -160,6 +165,33 @@ interface MessageCacheSchema extends DBSchema {
 
 let dbPromise: Promise<IDBPDatabase<MessageCacheSchema>> | null = null
 let dbNameForPromise: string | null = null
+
+let failedCorrectionScope = captureStorageScope()
+let failedCorrections = new WeakMap<IDBPDatabase<MessageCacheSchema>, Map<string, MessageImplState>>()
+
+function correctionWrite(db: IDBPDatabase<MessageCacheSchema>, key: string, updates: MessageImplState) {
+  if (!failedCorrectionScope.isCurrent()) {
+    failedCorrectionScope = captureStorageScope()
+    failedCorrections = new WeakMap()
+  }
+  const failures = failedCorrections.get(db) ?? new Map<string, MessageImplState>()
+  failedCorrections.set(db, failures)
+  const pending = failures.get(key)
+  return {
+    metadata: pending ? mergeCorrectionMetadata(updates, pending) : {},
+    failed(message: MessageImplState) {
+      if (!message.correctionRevision) return
+      const metadata = { correctionRevision: message.correctionRevision, correctionStanzaIds: message.correctionStanzaIds }
+      const previous = failures.get(key)
+      failures.set(key, previous && compareCorrectionRevisions(previous, metadata) > 0
+        ? mergeCorrectionMetadata(previous, metadata) : mergeCorrectionMetadata(metadata, previous ?? {}))
+    },
+    completed(message: MessageImplState) {
+      const pending = failures.get(key)
+      if (pending && compareCorrectionRevisions(message, pending) >= 0) failures.delete(key)
+    },
+  }
+}
 
 /**
  * Check if IndexedDB is available in the current environment.
@@ -247,25 +279,23 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
         drain.room = db.objectStoreNames.contains(LEGACY_ROOM_MESSAGES_STORE as never)
       }
 
-      if (drain.chat || drain.room) {
-        // idb does NOT await this callback, and rethrowing would be an unhandled
-        // rejection. Fire the migration and, on ANY failure, explicitly abort the
-        // version-change transaction (which rejects openDB). The transaction stays
-        // alive meanwhile via the migration's chained requests, and openDB resolves
-        // only after it commits. Do not deleteObjectStore here (illegal from the
-        // async continuation) — the migration clear()s the legacy stores instead.
-        migrateStoresToCanonical(transaction, scopeJid, drain).catch((err) => {
-          // Log before aborting: this streaming rewrite of the whole archive is the
-          // riskiest path in the upgrade, and the abort otherwise swallows the cause
-          // silently. Then: aborting rejects openDB (getDB's caller handles that) AND
-          // rejects transaction.done with AbortError; nothing awaits `done`, so attach
-          // a no-op catch first to keep the abort from surfacing as an unhandled
-          // rejection, then abort.
-          console.error('canonical-store migration aborted:', err)
-          transaction.done.catch(() => {})
-          transaction.abort()
-        })
-      }
+      // idb does NOT await this callback, and rethrowing would be an unhandled
+      // rejection. Fire the migration and, on ANY failure, explicitly abort the
+      // version-change transaction (which rejects openDB). The transaction stays
+      // alive meanwhile via the migration's chained requests, and openDB resolves
+      // only after it commits. Do not deleteObjectStore here (illegal from the
+      // async continuation) — the migration clear()s the legacy stores instead.
+      migrateStoresToCanonical(transaction, scopeJid, drain).catch((err) => {
+        // Log before aborting: this streaming rewrite of the whole archive is the
+        // riskiest path in the upgrade, and the abort otherwise swallows the cause
+        // silently. Then: aborting rejects openDB (getDB's caller handles that) AND
+        // rejects transaction.done with AbortError; nothing awaits `done`, so attach
+        // a no-op catch first to keep the abort from surfacing as an unhandled
+        // rejection, then abort.
+        console.error('canonical-store migration aborted:', err)
+        transaction.done.catch(() => {})
+        transaction.abort()
+      })
 
     },
   })
@@ -297,10 +327,11 @@ export function chatCacheKey(m: Pick<Message, 'conversationId' | 'from' | 'id' |
  * Convert a Message to storage format (Date -> number).
  */
 function serializeMessage(message: Message): StoredMessage {
+  const { liveCorrection: _liveCorrection, ...stored } = message as Message & MessageImplState
   return {
-    ...message,
+    ...stored,
     cacheKey: chatCacheKey(message),
-    identityKeys: identityKeys(CHAT_SCOPE, message),
+    identityKeys: [...identityKeys(CHAT_SCOPE, message), ...correctionReferenceKeys(CHAT_SCOPE, message)],
     ids: [message.id],
     timestamp: message.timestamp.getTime(),
     retractedAt: message.retractedAt?.getTime(),
@@ -324,10 +355,11 @@ function deserializeMessage(stored: StoredMessage): Message {
  * Convert a RoomMessage to storage format (Date -> number).
  */
 function serializeRoomMessage(message: RoomMessage): StoredRoomMessage {
+  const { liveCorrection: _liveCorrection, ...stored } = message as RoomMessage & MessageImplState
   return {
-    ...message,
+    ...stored,
     cacheKey: canonicalKey(roomScope(message.roomJid), message),
-    identityKeys: identityKeys(roomScope(message.roomJid), message),
+    identityKeys: [...identityKeys(roomScope(message.roomJid), message), ...correctionReferenceKeys(roomScope(message.roomJid), message)],
     ids: [message.id],
     timestamp: message.timestamp.getTime(),
     retractedAt: message.retractedAt?.getTime(),
@@ -365,6 +397,7 @@ function scrubRetractedContent<T extends StoredMessage | StoredRoomMessage>(row:
   return {
     ...row,
     body: '',
+    correctionAlternatives: undefined,
     originalBody: undefined,
     attachment: undefined,
     linkPreview: undefined,
@@ -455,6 +488,7 @@ export function _setMigrationFaultForTesting(on: boolean): void {
 type RoomIdentityStore = {
   index(name: 'identityKeys'): { getAll(key: string): Promise<StoredRoomMessage[]> }
   index(name: 'ids'): { getAll(key: string): Promise<StoredRoomMessage[]> }
+  index(name: 'roomJid'): { getAll(key: string): Promise<StoredRoomMessage[]> }
 }
 
 /** The minimal room-store surface the identity-resolving upsert needs. */
@@ -474,7 +508,8 @@ async function findRoomRowsByIdentity(
   excludeKey?: string
 ): Promise<StoredRoomMessage[]> {
   const currentKeys = identityKeys(roomScope(m.roomJid), m)
-  const orderedKeys = [...currentKeys, ...m.identityKeys.filter((key) => !currentKeys.includes(key))]
+  const referencePrefix = tierKey(roomScope(m.roomJid), 'correctionStanzaId', '')
+  const orderedKeys = [...currentKeys, ...m.identityKeys.filter((key) => !key.startsWith(referencePrefix) && !currentKeys.includes(key))]
   return findRoomIdentityComponent(
     store.index('identityKeys'),
     m.roomJid,
@@ -557,13 +592,9 @@ async function findRoomRowsByReference(
   reference: string
 ): Promise<{ tier: IdentityTier; authoritative: boolean; candidates: StoredRoomMessage[] } | undefined> {
   for (const probe of referenceProbes<StoredRoomMessage>(reference, 'archive-first')) {
-    const matches = probe.tier === 'fallback'
-      ? await store.index('ids').getAll(reference)
-      : await store.index('identityKeys').getAll(
-          probe.tier === 'stanzaId'
-            ? tierKey(roomScope(roomJid), 'stanzaId', reference)
-            : tierKey(roomScope(roomJid), 'originId', reference)
-        )
+    const matches = probe.tier === 'stanzaId' || probe.tier === 'originId' || probe.tier === 'correctionStanzaId'
+      ? await store.index('identityKeys').getAll(tierKey(roomScope(roomJid), probe.tier, reference))
+      : await store.index('ids').getAll(reference)
     const candidates = matches.filter((row) => row.roomJid === roomJid)
     if (candidates.length > 0) {
       return { tier: probe.tier, authoritative: probe.authoritative, candidates }
@@ -611,7 +642,7 @@ async function upsertRoomRowByIdentity(
 }
 
 /** Minimal cursor view over a legacy store during migration. */
-type LegacyCursor<T> = { value: T; continue(): Promise<LegacyCursor<T> | null> }
+type LegacyCursor<T> = { value: T; continue(): Promise<LegacyCursor<T> | null>; update(value: T): Promise<unknown> }
 /** Minimal legacy-store view: stream every row out, then empty. */
 type LegacyStore<T> = { openCursor(): Promise<LegacyCursor<T> | null>; clear(): Promise<void> }
 /** Minimal version-change transaction view the streaming migration needs. */
@@ -660,6 +691,20 @@ async function migrateStoresToCanonical(
     }
     await legacy.clear()
   }
+  for (const name of [MESSAGES_STORE, ROOM_MESSAGES_STORE] as const) {
+    const store = transaction.objectStore(name) as LegacyStore<StoredMessage | StoredRoomMessage>
+    let cursor = await store.openCursor()
+    while (cursor) {
+      if (migrationFaultForTesting) throw new Error('migration fault (test)')
+      const row = cursor.value
+      const scope = name === MESSAGES_STORE ? CHAT_SCOPE : roomScope((row as StoredRoomMessage).roomJid)
+      const aliases = correctionReferenceKeys(scope, row)
+      if (aliases.some(key => !row.identityKeys.includes(key))) {
+        await cursor.update({ ...row, identityKeys: unionSorted(row.identityKeys, aliases) })
+      }
+      cursor = await cursor.continue()
+    }
+  }
 }
 
 // =============================================================================
@@ -669,6 +714,7 @@ async function migrateStoresToCanonical(
 type ChatIdentityStore = {
   index(name: 'identityKeys'): { getAll(key: string): Promise<StoredMessage[]> }
   index(name: 'ids'): { getAll(key: string): Promise<StoredMessage[]> }
+  index(name: 'conversationId'): { getAll(key: string): Promise<StoredMessage[]> }
 }
 
 /** The read-only chat-store surface a lookup needs. A readonly idb transaction
@@ -705,7 +751,7 @@ async function findChatRowsForTier(
   tier: IdentityTier,
   reference: string
 ): Promise<StoredMessage[]> {
-  const matches = tier === 'stanzaId' || tier === 'originId'
+  const matches = tier === 'stanzaId' || tier === 'originId' || tier === 'correctionStanzaId'
     ? await store.index('identityKeys').getAll(tierKey(CHAT_SCOPE, tier, reference))
     : await store.index('ids').getAll(reference)
   return matches.filter((row) => row.conversationId === conversationId)
@@ -844,59 +890,40 @@ function stableStringify(v: unknown): string {
 type CanonicalRow = Pick<
   StoredRoomMessage,
   | 'cacheKey' | 'identityKeys' | 'ids' | 'timestamp' | 'from' | 'id' | 'body'
-  | 'stanzaId' | 'originId' | 'occupantId' | 'reactions' | 'isEdited'
+  | 'stanzaId' | 'originId' | 'occupantId' | 'reactions' | 'isEdited' | 'correctionTimestamp' | 'correctionTimestampSource' | 'correctionRevision' | 'correctionStanzaIds' | 'correctionAlternatives'
   | 'isRetracted' | 'retractedAt' | 'isModerated' | 'moderatedBy' | 'moderationReason'
   | 'isMention' | 'pollClosed' | 'pollClosedAt' | 'deliveryError'
   | 'encryptedPayload' | 'unsupportedEncryption'
 >
 
 /**
- * The IMMUTABLE content projection — everything EXCEPT the fields merged
- * separately (aliases, timestamp, reactions, retraction, moderation, poll
- * closure, delivery error, cacheKey). The tiebreak must serialize only this,
- * because those excluded fields CHANGE during a merge: an intermediate merged
- * row acquires unioned aliases/reactions and a min timestamp, so serializing the
- * whole row would make contentOwner(merge(a,b), c) differ from
- * contentOwner(a, merge(b,c)) — destroying associativity. The content projection
- * is identical between a merged row and its content-winner, so max over it is
- * genuinely associative.
+ * The fallback tiebreak excludes fields merged independently of content, so
+ * learning aliases, receipts or reactions cannot change it. Revision ordering
+ * is resolved before this fallback; the correction's content date stays with
+ * its body and does not establish revision identity or chronology.
  */
 function contentProjection(m: CanonicalRow): unknown {
   const {
     stanzaId: _s, originId: _o, occupantId: _oi, timestamp: _t, reactions: _r,
-    identityKeys: _ik, ids: _ids,
+    identityKeys: _ik, ids: _ids, correctionStanzaIds: _cs, correctionRevision: _cr, correctionAlternatives: _ca,
     isRetracted: _rt, retractedAt: _ra, isModerated: _m, moderatedBy: _mb, moderationReason: _mr,
     pollClosed: _pc, pollClosedAt: _pca, deliveryError: _de, cacheKey: _ck, ...content
   } = m
   return content
 }
 
-/**
- * Choose the CONTENT-owner row by a strict TOTAL order, so the choice is the same
- * regardless of argument order AND a tie happens only when the rows are identical.
- * Higher decryption rank, then edited, then non-empty body, then — the fix — a
- * stable serialization of the CONTENT PROJECTION (not the whole row), so two rows
- * differing in attachment / poll / reply / encryption metadata still resolve
- * deterministically instead of picking `a`. Serializing the projection rather than
- * the whole row is the LOAD-BEARING invariant for associativity: the fields
- * {@link contentProjection} excludes (aliases, reactions, timestamp, retraction,
- * moderation, poll closure, delivery error) CHANGE during a merge, so a whole-row
- * serialization would make the winner grouping-dependent (see contentProjection).
- */
 function contentOwner<T extends CanonicalRow>(a: T, b: T): T {
-  const ra: number[] = [decryptionRank(a), a.isEdited ? 1 : 0, a.body ? 1 : 0]
-  const rb: number[] = [decryptionRank(b), b.isEdited ? 1 : 0, b.body ? 1 : 0]
+  const correctionOrder = compareCorrectionRevisions(a, b)
+  if (!canReplaceCorrection(b, a, correctionOrder)) return b
+  if (correctionOrder > 0) return a
+  const same = sameCorrection(a, b)
+  const ra: number[] = [a.isEdited ? 1 : 0, decryptionRank(a), same && a.correctionTimestampSource === 'authored' ? 1 : 0, a.body ? 1 : 0]
+  const rb: number[] = [b.isEdited ? 1 : 0, decryptionRank(b), same && b.correctionTimestampSource === 'authored' ? 1 : 0, b.body ? 1 : 0]
   for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) return ra[i] > rb[i] ? a : b
-  // Tiebreak over the IMMUTABLE content only, so max is associative (see contentProjection).
   return stableStringify(contentProjection(a)) <= stableStringify(contentProjection(b)) ? a : b
 }
 
 /**
- * Merge two stored rows that are the same logical message into one. COMMUTATIVE
- * and ASSOCIATIVE. The correlated content block comes from {@link contentOwner}
- * (total order); every other field uses a symmetric operator, so no edit, poll
- * closure, retraction, reaction, moderation, mention, or alias is lost.
- *
  * `rekey` supplies the scope-dependent half — the primary key and the row's own
  * identity aliases — because that is the ONLY thing that differs between the two
  * stores: room keys are namespaced by room JID, chat keys by conversation.
@@ -907,6 +934,10 @@ function mergeCanonicalRows<T extends CanonicalRow>(
   rekey: (row: T) => Pick<CanonicalRow, 'cacheKey' | 'identityKeys'>
 ): T {
   const owner = contentOwner(a, b)
+  const other = owner === a ? b : a
+  const correction = owner.isEdited && other.isEdited && owner.correctionRevision && other.correctionRevision
+    ? resolveCorrectionUpdates(owner, { ...correctionContent(other), correctionAlternatives: other.correctionAlternatives, liveCorrection: false })
+    : mergeCorrectionMetadata(owner, other)
   const aSid = a.stanzaId != null, bSid = b.stanzaId != null
   const timestamp = aSid !== bSid ? (aSid ? a.timestamp : b.timestamp) : Math.min(a.timestamp, b.timestamp)
   const retracted = !!(a.isRetracted || b.isRetracted)
@@ -927,6 +958,7 @@ function mergeCanonicalRows<T extends CanonicalRow>(
   // `...owner`, whichever store's remaining fields T actually has.
   const merged = {
     ...owner,
+    ...correction,
     stanzaId: minStr(a.stanzaId, b.stanzaId),
     originId: minStr(a.originId, b.originId),
     occupantId: minStr(a.occupantId, b.occupantId),
@@ -947,7 +979,7 @@ function mergeCanonicalRows<T extends CanonicalRow>(
 export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
   return mergeCanonicalRows(a, b, (row) => ({
     cacheKey: canonicalKey(roomScope(row.roomJid), row),
-    identityKeys: unionSorted(row.identityKeys, identityKeys(roomScope(row.roomJid), row)),
+    identityKeys: unionSorted(row.identityKeys, [...identityKeys(roomScope(row.roomJid), row), ...correctionReferenceKeys(roomScope(row.roomJid), row)]),
   }))
 }
 
@@ -955,7 +987,7 @@ export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): Store
 export function mergeChatRows(a: StoredMessage, b: StoredMessage): StoredMessage {
   return mergeCanonicalRows(a, b, (row) => ({
     cacheKey: chatCacheKey(row),
-    identityKeys: unionSorted(row.identityKeys, identityKeys(CHAT_SCOPE, row)),
+    identityKeys: unionSorted(row.identityKeys, [...identityKeys(CHAT_SCOPE, row), ...correctionReferenceKeys(CHAT_SCOPE, row)]),
   }))
 }
 
@@ -985,6 +1017,136 @@ async function upsertStoredChatRow(
   await store.put(enforceRetraction(merged, chatScopeOf(merged, scopeJid)))
 }
 
+function reconcileHistoryRow<T extends (StoredMessage | StoredRoomMessage) & CanonicalRow>(page: T, held: T): T {
+  const owner = contentOwner(page, held)
+  const row = {
+    ...page,
+    ...(owner.isEdited || owner !== page ? {
+      body: owner.body,
+      isEdited: owner.isEdited,
+      originalBody: owner.originalBody,
+      attachment: owner.attachment,
+      encryptedPayload: owner.encryptedPayload,
+      unsupportedEncryption: owner.unsupportedEncryption,
+      securityContext: owner.securityContext,
+      correctionTimestamp: owner.correctionTimestamp,
+      correctionTimestampSource: owner.correctionTimestampSource,
+    } : {}),
+    correctionRevision: owner.correctionRevision,
+    ...mergeCorrectionMetadata(owner, owner === page ? held : page),
+    stanzaId: page.stanzaId ?? held.stanzaId,
+    originId: page.originId ?? held.originId,
+    ...('occupantId' in held ? { occupantId: page.occupantId ?? held.occupantId } : {}),
+    ...(held.isRetracted ? { isRetracted: true, retractedAt: minNum(page.retractedAt, held.retractedAt) } : {}),
+    ...('isModerated' in held && held.isModerated ? {
+      isModerated: true,
+      moderatedBy: page.moderatedBy ?? held.moderatedBy,
+      moderationReason: page.moderationReason ?? held.moderationReason,
+    } : {}),
+  } as T
+  return row.isRetracted ? scrubRetractedContent(row) : row
+}
+
+export async function resolveMessagesForIndex(
+  messages: (Message | RoomMessage)[], scopeJid: string | null,
+): Promise<({ message: Message | RoomMessage; cached: boolean } | null)[]> {
+  const db = await getDB(scopeJid)
+  const tx = db.transaction([MESSAGES_STORE, ROOM_MESSAGES_STORE], 'readonly')
+  void tx.done.catch(() => {})
+  const results: ({ message: Message | RoomMessage; cached: boolean } | null)[] = []
+  for (const message of messages) {
+    const incoming = message.type === 'chat' ? serializeMessage(message) : serializeRoomMessage(message)
+    const matches = message.type === 'chat'
+      ? await findChatRowsByIdentity(tx.objectStore(MESSAGES_STORE), incoming as StoredMessage)
+      : await findRoomRowsByIdentity(tx.objectStore(ROOM_MESSAGES_STORE), incoming as StoredRoomMessage)
+    const candidates = matches.filter(row => !archiveIdentityConflict(row, incoming) &&
+      (message.type === 'chat' ? chatMessageAuthor(row, { actorJid: message.from })
+        : roomMessageAuthor(row as StoredRoomMessage, { actorJid: message.from, actorOccupantId: message.occupantId })))
+    if (candidates.length > 1) { results.push(null); continue }
+    const current = candidates[0]
+    const recovery = (message as MessageImplState).contentRecovery
+    if (!current) {
+      results.push(recovery || (message as MessageImplState).correctionHandoff ? null : { message, cached: false })
+      continue
+    }
+    const row = recovery ? { ...current } : reconcileHistoryRow(incoming, current)
+    Object.assign(row, {
+      id: current.id, from: current.from, timestamp: current.timestamp,
+      ...(message.type === 'groupchat' ? { nick: (current as StoredRoomMessage).nick } : {}),
+      ...(isNoLocalStore(message.type === 'chat' ? deserializeMessage(current as StoredMessage) : deserializeRoomMessage(current as StoredRoomMessage)) ? { noLocalStore: true } : {}),
+    })
+    results.push({ message: message.type === 'chat' ? deserializeMessage(row as StoredMessage) : deserializeRoomMessage(row as StoredRoomMessage), cached: true })
+  }
+  await tx.done
+  return results
+}
+
+export async function reconcileChatHistoryMessages(
+  messages: Message[],
+  resident: () => readonly Message[],
+  scopeJid: string | null = getStorageScopeJid(),
+): Promise<Message[]> {
+  let rows = messages.map(serializeMessage)
+  if (rows.length && isIndexedDBAvailable()) {
+    try {
+      const db = await getDB(scopeJid)
+      const tx = db.transaction(MESSAGES_STORE)
+      void tx.done.catch(() => {})
+      for (let i = 0; i < rows.length; i++) {
+        for (const cached of await findChatRowsByIdentity(tx.store, rows[i])) {
+          if (!archiveIdentityConflict(rows[i], cached) && chatMessageAuthor(cached, { actorJid: rows[i].from })) rows[i] = reconcileHistoryRow(rows[i], cached)
+        }
+      }
+      await tx.done
+    } catch {
+      rows = messages.map(serializeMessage)
+    }
+  }
+  const current = resident()
+  return rows.map(row => {
+    for (const message of current) {
+      if (message.conversationId === row.conversationId && chatMessageAuthor(message, { actorJid: row.from }) &&
+          sameLogicalMessage(CHAT_SCOPE, row, message) && !archiveIdentityConflict(row, message)) {
+        row = reconcileHistoryRow(row, serializeMessage(message))
+      }
+    }
+    return deserializeMessage(row)
+  })
+}
+
+export async function reconcileRoomHistoryMessages(
+  messages: RoomMessage[],
+  resident: () => readonly RoomMessage[],
+  scopeJid: string | null = getStorageScopeJid(),
+): Promise<RoomMessage[]> {
+  let rows = messages.map(serializeRoomMessage)
+  if (rows.length && isIndexedDBAvailable()) {
+    try {
+      const db = await getDB(scopeJid)
+      const tx = db.transaction(ROOM_MESSAGES_STORE)
+      void tx.done.catch(() => {})
+      for (let i = 0; i < rows.length; i++) {
+        for (const cached of await findRoomRowsByIdentity(tx.store, rows[i])) {
+          if (!archiveIdentityConflict(rows[i], cached) && roomMessageAuthor(cached, { actorJid: rows[i].from, actorOccupantId: rows[i].occupantId })) rows[i] = reconcileHistoryRow(rows[i], cached)
+        }
+      }
+      await tx.done
+    } catch {
+      rows = messages.map(serializeRoomMessage)
+    }
+  }
+  const current = resident()
+  return rows.map(row => {
+    for (const message of current) {
+      if (message.roomJid === row.roomJid && roomMessageAuthor(message, { actorJid: row.from, actorOccupantId: row.occupantId }) &&
+          sameLogicalMessage(roomScope(row.roomJid), row, message) && !archiveIdentityConflict(row, message)) {
+        row = reconcileHistoryRow(row, serializeRoomMessage(message))
+      }
+    }
+    return deserializeRoomMessage(row)
+  })
+}
+
 /** Insert or merge a message by identity (migration + live/archive write path). */
 async function upsertChatRowByIdentity(
   store: ChatMessageStore,
@@ -1001,47 +1163,14 @@ async function upsertChatRowByIdentity(
 }
 
 /**
- * Put a chat message without ever DEGRADING a higher-quality cache entry.
- *
- * E2EE re-ingestion hazards: a web page reload that yields a *fresh* session
- * runs the background MAM catch-up while the OpenPGP key may still be locked,
- * and a peer toggling their encryption makes history re-arrive as an
- * unsupported fallback. Either way the re-fetched copy is less recoverable
- * than what we already stored, and a blind write would overwrite our decrypted
- * plaintext (or our retriable ciphertext) with a placeholder — leaving the
- * message permanently showing "could not be decrypted" / "not supported".
- *
- * Guard: skip the write when the incoming message is strictly less recoverable
- * than the stored one (see {@link decryptionRank}). Equal-or-better writes
- * upsert normally — decrypted updates, ciphertext refreshes, and the upgrade
- * of a fallback once the real ciphertext arrives.
- */
-async function putChatMessageGuarded(
-  store: ChatMessageStore,
-  message: Message,
-  scopeJid: string | null
-): Promise<void> {
-  const incoming = serializeMessage(message)
-  const matches = await findChatRowsByIdentity(store, incoming)
-  const incomingRank = decryptionRank(message)
-  if (matches[0] && incomingRank < 2 && decryptionRank(matches[0]) > incomingRank) {
-    // Existing entry is more recoverable — don't degrade it.
-    return
-  }
-  await upsertStoredChatRow(store, incoming, matches, scopeJid)
-}
-
-/**
  * Save a chat message to IndexedDB.
- * Upserts - will overwrite if message with same ID exists, EXCEPT it never
- * degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  */
 export async function saveMessageWithResult(message: Message): Promise<boolean> {
   const scopeJid = getStorageScopeJid()
   try {
     const db = await getDB(scopeJid)
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
-    await putChatMessageGuarded(tx.store, message, scopeJid)
+    await upsertChatRowByIdentity(tx.store, message, scopeJid)
     await tx.done
     return true
   } catch (error) {
@@ -1058,7 +1187,6 @@ export async function saveMessage(message: Message): Promise<void> {
 
 /**
  * Save multiple chat messages to IndexedDB in a single transaction.
- * Never degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  *
  * Resolves `true` iff the transaction committed — errors are absorbed (warn)
  * and reported as `false`. Callers advancing durable cursors (gap/coverage
@@ -1075,7 +1203,7 @@ export async function saveMessages(messages: Message[]): Promise<boolean> {
     const store = tx.objectStore(MESSAGES_STORE)
 
     for (const msg of messages) {
-      await putChatMessageGuarded(store, msg, scopeJid)
+      await upsertChatRowByIdentity(store, msg, scopeJid)
     }
     await tx.done
     return true
@@ -1557,6 +1685,123 @@ export async function getTotalRoomMessageCount(): Promise<number> {
 }
 
 /**
+ * The part of an update a cached row may accept.
+ *
+ * A correction update is resolved against the revision the row already holds
+ * (see {@link resolveCorrectionUpdates}), so a write racing a newer revision
+ * contributes its identity aliases without reverting the text. Any other
+ * update passes through untouched.
+ */
+function applicableCorrectionUpdates<T extends CorrectionUpdates>(
+  existing: CorrectionUpdates,
+  updates: T,
+  scopeJid: string | null,
+): T | MessageImplState | undefined {
+  const applicable = resolveCorrectionUpdates(existing, updates, scopeJid)
+  // An emitter may hold fewer aliases than the persisted row. Every correction
+  // adds references, including an id-only update for a superseded revision.
+  return applicable?.correctionStanzaIds
+    ? { ...applicable, correctionStanzaIds: unionSorted(existing.correctionStanzaIds, applicable.correctionStanzaIds) }
+    : applicable
+}
+
+export async function getCorrectionReferences(
+  kind: 'chat' | 'room', conversationId: string, targetId: string, actor: MessageActor,
+  scopeJid: string | null = getStorageScopeJid(),
+): Promise<CorrectionReferences | null | undefined> {
+  if (!isIndexedDBAvailable()) return undefined
+  try {
+    const db = await getDB(scopeJid)
+    if (kind === 'chat') {
+      const resolution = await findChatRowsByReference(db.transaction(MESSAGES_STORE).store, conversationId, targetId)
+      const candidates = resolution?.candidates.filter(row => chatMessageAuthor(row, actor)) ?? []
+      return candidates.length === 1 ? correctionReferences(candidates[0], candidates[0].ids)
+        : candidates.length > 1 || resolution?.authoritative ? null : undefined
+    }
+    const resolution = await findRoomRowsByReference(db.transaction(ROOM_MESSAGES_STORE).store, conversationId, targetId)
+    const candidates = resolution?.candidates.filter(row => roomMessageAuthor(row, actor)) ?? []
+    return candidates.length === 1 ? correctionReferences(candidates[0], candidates[0].ids)
+      : candidates.length > 1 || resolution?.authoritative ? null : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export async function applyChatCorrection(
+  conversationId: string, targetId: string, updates: Partial<Message> & MessageImplState, actor: MessageActor,
+  scopeJid: string | null = getStorageScopeJid(),
+): Promise<(Message & MessageImplState) | null | undefined> {
+  if (!isIndexedDBAvailable()) return undefined
+  const db = await getDB(scopeJid)
+  const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+  const completion = tx.done
+  void completion.catch(() => {})
+  const store = tx.store
+  const resolution = await findChatRowsByReference(store, conversationId, targetId)
+  const existing = resolution?.candidates.find(row => chatMessageAuthor(row, actor))
+  let result: (Message & MessageImplState) | null | undefined = existing || resolution?.authoritative ? null : undefined
+  if (existing) {
+    const write = correctionWrite(db, `${MESSAGES_STORE}:${existing.cacheKey}`, updates)
+    const applicable = applicableCorrectionUpdates(existing, { ...updates, ...write.metadata, originalBody: existing.originalBody ?? existing.body }, scopeJid)
+    if (applicable) {
+      const row = serializeMessage({ ...deserializeMessage(existing), ...applicable })
+      row.cacheKey = existing.cacheKey
+      row.ids = existing.ids
+      row.identityKeys = unionSorted(existing.identityKeys, row.identityKeys)
+      const written = enforceRetraction(row, chatScopeOf(row, scopeJid))
+      try {
+        await store.put(written)
+        await completion
+        write.completed(written)
+      } catch (error) {
+        write.failed(written)
+        throw error
+      }
+      result = { ...deserializeMessage(written), correctionHandoff: captureContentSource(existing, scopeJid) }
+    }
+  }
+  await completion
+  return result
+}
+
+export async function applyRoomCorrection(
+  roomJid: string, targetId: string, updates: Partial<RoomMessage> & MessageImplState, actor: MessageActor,
+  scopeJid: string | null = getStorageScopeJid(),
+): Promise<(RoomMessage & MessageImplState) | null | undefined> {
+  if (!isIndexedDBAvailable()) return undefined
+  const db = await getDB(scopeJid)
+  const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+  const completion = tx.done
+  void completion.catch(() => {})
+  const store = tx.store
+  const resolution = await findRoomRowsByReference(store, roomJid, targetId)
+  const existing = resolution?.candidates.find(row => roomMessageAuthor(row, actor))
+  let result: (RoomMessage & MessageImplState) | null | undefined = existing || resolution?.authoritative ? null : undefined
+  if (existing) {
+    const write = correctionWrite(db, `${ROOM_MESSAGES_STORE}:${existing.cacheKey}`, updates)
+    const applicable = applicableCorrectionUpdates(existing, { ...updates, ...write.metadata, originalBody: existing.originalBody ?? existing.body }, scopeJid)
+    if (applicable) {
+      const row = serializeRoomMessage({ ...deserializeRoomMessage(existing), ...applicable })
+      row.cacheKey = existing.cacheKey
+      row.ids = existing.ids
+      row.identityKeys = unionSorted(existing.identityKeys, row.identityKeys)
+      const written = enforceRetraction(row, roomScopeOf(row, scopeJid))
+      try {
+        await store.put(written)
+        await completion
+        write.completed(written)
+      } catch (error) {
+        write.failed(written)
+        throw error
+      }
+      result = { ...deserializeRoomMessage(written), correctionHandoff: captureContentSource(existing, scopeJid) }
+    }
+  }
+  await completion
+  return result
+}
+
+/**
  * Update specific fields of a message, resolving its conversation- and
  * sender-scoped row through the `ids` alias so a caller holding a pre-merge id
  * still finds it. `expectedCacheKey` selects a previously resolved row exactly
@@ -1574,7 +1819,7 @@ export async function getTotalRoomMessageCount(): Promise<number> {
 export async function updateMessage(
   conversationId: string,
   id: string,
-  updates: Partial<Message>,
+  updates: Partial<Message> & MessageImplState,
   from: string,
   scopeJid: string | null = getStorageScopeJid(),
   expectedCacheKey?: string
@@ -1586,7 +1831,9 @@ export async function updateMessage(
     const existing = await findChatRowById(store, id, conversationId, from, expectedCacheKey)
     if (!existing) { await tx.done; return }
 
-    const updated = { ...deserializeMessage(existing), ...updates } as Message
+    const applicable = applicableCorrectionUpdates(existing, updates, scopeJid)
+    if (!applicable) { await tx.done; return }
+    const updated = { ...deserializeMessage(existing), ...applicable } as Message
     const serialized = serializeMessage(updated)
     // Dates the caller may have passed as epoch millis rather than Date objects.
     serialized.timestamp =
@@ -1599,7 +1846,7 @@ export async function updateMessage(
     // The in-place path requires both unchanged identity fields and an unchanged
     // serialized key. Either kind of change needs the merge/re-key path below.
     if (identityFieldsEqual(updated, existing) && serialized.cacheKey === existing.cacheKey) {
-      serialized.identityKeys = existing.identityKeys // unchanged
+      serialized.identityKeys = unionSorted(existing.identityKeys, serialized.identityKeys)
       serialized.ids = existing.ids
       await store.put(enforceRetraction(serialized, chatScopeOf(serialized, scopeJid)))
     } else {
@@ -2301,7 +2548,7 @@ export async function resolveArchivePosition(
 export async function updateRoomMessage(
   roomJid: string,
   id: string,
-  updates: Partial<RoomMessage>,
+  updates: Partial<RoomMessage> & MessageImplState,
   from?: string,
   scopeJid: string | null = getStorageScopeJid(),
   expectedOwner?: RoomMessage,
@@ -2325,13 +2572,15 @@ export async function updateRoomMessage(
       await tx.done
       return
     }
-    const updated = { ...deserializeRoomMessage(existing), ...updates } as RoomMessage
+    const applicable = applicableCorrectionUpdates(existing, updates, scopeJid)
+    if (!applicable) { await tx.done; return }
+    const updated = { ...deserializeRoomMessage(existing), ...applicable } as RoomMessage
     const serialized = serializeRoomMessage(updated)
     // The in-place path requires both unchanged identity fields and an unchanged
     // serialized key. Either kind of change needs the merge/re-key path below.
     if (identityFieldsEqual(updated, existing) && serialized.cacheKey === existing.cacheKey) {
       const row = serialized
-      row.identityKeys = existing.identityKeys // unchanged
+      row.identityKeys = unionSorted(existing.identityKeys, row.identityKeys)
       row.ids = existing.ids
       await store.put(enforceRetraction(row, roomScopeOf(row, scopeJid)))
     } else {

--- a/packages/fluux-sdk/src/utils/messageIdentity.test.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.test.ts
@@ -119,10 +119,12 @@ describe('resolution policies', () => {
     expect(resolved?.candidates.map(({ message }) => message)).toEqual([a, b])
   })
 
-  it('resolves a correction archive id under client-id-first only', () => {
+  it('resolves a correction archive id under both reference policies', () => {
     const corrected = { from: 'a@b', id: 'm1', correctionStanzaIds: ['C1'] }
     expect(findMessageById([corrected], 'C1')).toBe(corrected)
-    expect(resolveMessageReference([corrected], 'C1', 'archive-first')).toBeUndefined()
+    expect(resolveMessageReference([corrected], 'C1', 'archive-first')).toMatchObject({
+      tier: 'correctionStanzaId', authoritative: true, candidates: [{ message: corrected }],
+    })
   })
 
   it('never lets a spoofable originId shadow a strong-tier match in the lookup map', () => {

--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -70,7 +70,7 @@ export interface IdentityFields {
   /**
    * Archive ids of XEP-0308 corrections applied to this message. A resolution-only
    * tier: other clients may reference a corrected message by its correction's
-   * archive entry. Never contributes a persisted key.
+   * archive entry.
    */
   correctionStanzaIds?: string[]
   /** XEP-0421 occupant-id. Room messages only; see {@link occupantConflict}. */
@@ -108,9 +108,9 @@ export function roomScope(roomJid: string): IdentityScope {
  * `client-id` is not a rung: it is the `client-id-first` policy's single strong
  * pass, matching `id`, `stanzaId` and any correction archive id together.
  */
-export type IdentityTier = 'stanzaId' | 'originId' | 'fallback' | 'client-id'
+export type IdentityTier = 'stanzaId' | 'originId' | 'fallback' | 'client-id' | 'correctionStanzaId'
 
-/** The tiers that contribute a key. `client-id` is resolution-only. */
+/** The tiers that contribute canonical identity keys; reference-only tiers are excluded. */
 export type KeyTier = 'stanzaId' | 'originId' | 'fallback'
 
 /** How to order the ladder when resolving a reference. See the module note. */
@@ -158,9 +158,10 @@ function tierPrefix(scope: IdentityScope): string {
  * The key a single tier contributes, for a value already in hand.
  *
  * Use this to name a tier without a message — revoking a cleared alias, or
- * looking a room up by archive id. Always agrees with {@link identityKeys}.
+ * looking a room up by archive id. Shared by {@link identityKeys} and
+ * {@link correctionReferenceKeys}; a correction key is for reference lookup only.
  */
-export function tierKey(scope: IdentityScope, tier: 'stanzaId' | 'originId', value: string): string {
+export function tierKey(scope: IdentityScope, tier: 'stanzaId' | 'originId' | 'correctionStanzaId', value: string): string {
   return scope.kind === 'room'
     ? `${tierPrefix(scope)}${tier}${S}${value}`
     : `${tier}:${value}`
@@ -195,6 +196,10 @@ export function identityKeys(scope: IdentityScope, m: IdentityFields): string[] 
   if (m.originId) keys.push(tierKey(scope, 'originId', m.originId))
   keys.push(fallbackKey(scope, m))
   return keys
+}
+
+export function correctionReferenceKeys(scope: IdentityScope, message: IdentityFields): string[] {
+  return (message.correctionStanzaIds ?? []).map(id => tierKey(scope, 'correctionStanzaId', id))
 }
 
 /** The durable primary key for the highest tier present. */
@@ -602,6 +607,7 @@ export function referenceProbes<T extends ProbeFields>(
   }
   return [
     { tier: 'stanzaId', authoritative: true, matches: (message) => TIER_MATCHES.stanzaId(message, reference) },
+    { tier: 'correctionStanzaId', authoritative: true, matches: (message) => TIER_MATCHES.correctionStanzaId(message, reference) },
     { tier: 'originId', authoritative: true, matches: (message) => TIER_MATCHES.originId(message, reference) },
     { tier: 'fallback', authoritative: false, matches: (message) => TIER_MATCHES.fallback(message, reference) },
   ]
@@ -623,6 +629,21 @@ export function messageReferences(m: ProbeFields, policy: ResolutionPolicy): str
       ? [m.id, m.stanzaId, ...corrections, m.originId]
       : [m.stanzaId, m.originId, m.id, ...corrections]
   return ordered.filter((reference): reference is string => !!reference)
+}
+
+export interface CorrectionReferences {
+  identity: IdentityFields & { conversationId?: string }
+  references: string[]
+}
+
+export function correctionReferences(
+  message: IdentityFields & { conversationId?: string }, aliases: readonly string[] = [],
+): CorrectionReferences {
+  const { id, from, stanzaId, originId, occupantId, roomJid, conversationId } = message
+  return {
+    identity: { id, from, stanzaId, originId, occupantId, roomJid, conversationId },
+    references: [...new Set([...messageReferences(message, 'archive-first'), ...aliases])],
+  }
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/retractedIdentities.ts
+++ b/packages/fluux-sdk/src/utils/retractedIdentities.ts
@@ -120,13 +120,14 @@ export interface PendingRetractionAlias {
 }
 
 function rawAliasesOf(
-  m: { id: string; stanzaId?: string; originId?: string }
+  m: Pick<IdentityFields, 'id' | 'stanzaId' | 'originId' | 'correctionStanzaIds'>
 ): PendingRetractionAlias[] {
   const aliases = new Map<string, boolean>()
   for (const [reference, authoritative] of [
     [m.id, false],
     [m.stanzaId, true],
     [m.originId, true],
+    ...(m.correctionStanzaIds ?? []).map(id => [id, true] as const),
   ] as const) {
     if (!reference) continue
     const alias = rawAlias(reference)

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
-import { IDBFactory } from 'fake-indexeddb'
+import { IDBFactory, IDBObjectStore } from 'fake-indexeddb'
 import { openDB } from 'idb'
 import type { RoomMessage } from '../core/types'
 import type { StoredMessage } from '../core/types/message-internal'
@@ -24,6 +24,7 @@ import {
   _resetDBForTesting,
 } from './searchIndex'
 import { _resetDBForTesting as _resetMessageCacheDB } from './messageCache'
+import * as messageCache from './messageCache'
 
 // =============================================================================
 // Test helpers
@@ -773,6 +774,109 @@ describe('searchIndex', () => {
   // ===========================================================================
   // backfillFromMessageCache
   // ===========================================================================
+
+  describe.each(['chat', 'room'] as const)('%s coalesced posting mutations', kind => {
+    afterEach(() => { vi.restoreAllMocks() })
+    it('bounds IDB writes for insertion, identical replay and replacement', async () => {
+      const rows = Array.from({ length: 50 }, (_, i) => kind === 'chat'
+        ? createChatMessage('peer@example.com', { id: `m-${i}`, body: 'shared original', timestamp: new Date(i) })
+        : createRoomMessage('room@example.com', { id: `m-${i}`, stanzaId: `archive-${i}`, body: 'shared original', timestamp: new Date(i) }))
+      const saveRows = async (messages: typeof rows) => {
+        if (kind === 'chat') await messageCache.saveMessages(messages as StoredMessage[])
+        else await messageCache.saveRoomMessages(messages as RoomMessage[])
+      }
+      await saveRows(rows)
+      const get = IDBObjectStore.prototype.get, put = IDBObjectStore.prototype.put, remove = IDBObjectStore.prototype.delete
+      let failToken: string | undefined
+      const operations: Array<{ store: string; kind: string; key: unknown }> = []
+      vi.spyOn(IDBObjectStore.prototype, 'get').mockImplementation(function (this: IDBObjectStore, ...args) {
+        operations.push({ store: this.name, kind: 'get', key: args[0] }); return get.apply(this, args)
+      })
+      vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+        operations.push({ store: this.name, kind: 'put', key: args[0].token })
+        if (this.name === 'search-tokens' && args[0].token === failToken) throw new Error('posting write failed')
+        return put.apply(this, args)
+      })
+      vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementation(function (this: IDBObjectStore, ...args) {
+        operations.push({ store: this.name, kind: 'delete', key: args[0] }); return remove.apply(this, args)
+      })
+      await indexMessages(rows)
+      expect(operations.filter(op => op.store === 'search-tokens' && op.kind === 'get')).toHaveLength(2)
+      expect(operations.filter(op => op.store === 'search-tokens' && op.kind === 'put')).toHaveLength(2)
+      expect(await search('original', { limit: 100 })).toHaveLength(50)
+      operations.length = 0
+      await indexMessages(rows); await indexMessages(rows)
+      expect(operations.filter(op => op.store.startsWith('search-') && op.kind !== 'get')).toEqual([])
+      const edited = rows.map(row => ({ ...row, body: 'shared replacement', isEdited: true }))
+      await saveRows(edited)
+      operations.length = 0
+      await indexMessages(edited)
+      expect(operations.filter(op => op.store === 'search-tokens' && op.kind === 'get')).toHaveLength(3)
+      expect(operations.filter(op => op.store === 'search-tokens' && op.kind !== 'get')).toHaveLength(2)
+      expect(await search('original')).toEqual([])
+      expect(await search('replacement', { limit: 100 })).toHaveLength(50)
+      const failedRows = edited.map(row => ({ ...row, body: 'shared failure' }))
+      await saveRows(failedRows)
+      failToken = 'failure'
+      await expect(indexMessages(failedRows)).rejects.toThrow('posting write failed')
+      expect(await search('replacement', { limit: 100 })).toHaveLength(50)
+      expect(await search('failure')).toEqual([])
+      failToken = undefined
+      await indexMessages(failedRows)
+      expect(await search('replacement')).toEqual([])
+      expect(await search('failure', { limit: 100 })).toHaveLength(50)
+    })
+  })
+
+  it('removes an obsolete fallback while retaining an unchanged enriched document', async () => {
+    const original = createRoomMessage('room@example.com', { id: 'original', originId: 'origin', occupantId: 'occupant', body: 'obsolete caption' })
+    const current = { ...original, stanzaId: 'archive-original', body: '', isEdited: true }
+    await indexMessage(original)
+    await indexMessage(current)
+    expect(await search('obsolete')).toHaveLength(1)
+    await messageCache.saveRoomMessages([current])
+    const put = vi.spyOn(IDBObjectStore.prototype, 'put')
+    try {
+      await indexMessages([original, current])
+      expect(put.mock.instances.filter(store => (store as IDBObjectStore).name === 'search-docs')).toHaveLength(0)
+      expect(await search('obsolete')).toEqual([])
+      const db = await openDB('fluux-search-index:test@example.com')
+      try {
+        expect(await db.getAll('search-docs')).toMatchObject([{ stanzaId: current.stanzaId, body: '', tokens: [] }])
+        expect(await db.getAll('search-tokens')).toEqual([])
+      } finally { db.close() }
+    } finally { put.mockRestore() }
+  })
+
+  describe.each(['chat', 'room'] as const)('%s failed search resolution', kind => {
+    it.each(['backfill', 'rebuild'].flatMap(mode => [1, 11].map(failAt => ({ mode, failAt }))))('retries $mode after lookup batch $failAt fails', async ({ mode, failAt }) => {
+      const rows = Array.from({ length: 552 }, (_, i) => kind === 'chat'
+        ? createChatMessage('peer@example.com', { id: `m-${String(i).padStart(3, '0')}`, body: 'searchable fixture', timestamp: new Date(i) })
+        : createRoomMessage('room@example.com', { id: `m-${String(i).padStart(3, '0')}`, body: 'searchable fixture', timestamp: new Date(i) }))
+      if (kind === 'chat') await messageCache.saveMessages(rows as StoredMessage[])
+      else await messageCache.saveRoomMessages(rows as RoomMessage[])
+      const resolve = messageCache.resolveMessagesForIndex
+      let calls = 0
+      const fault = vi.spyOn(messageCache, 'resolveMessagesForIndex').mockImplementation((...args) => {
+        if (++calls === failAt) return Promise.reject(new Error('transient lookup failure'))
+        return resolve(...args)
+      })
+      const progress: number[] = []
+      const operation = mode === 'backfill' ? backfillFromMessageCache() : rebuildSearchIndex(p => progress.push(p.indexed))
+      await expect(operation).rejects.toThrow('transient lookup failure')
+      expect(progress).toEqual(mode === 'rebuild' && failAt === 11 ? [500] : [])
+      const db = await openDB('fluux-search-index:test@example.com')
+      try { expect(await db.get('search-meta', 'backfill-complete')).toBeUndefined() }
+      finally { db.close() }
+      expect(await search('searchable', { limit: 1000 })).toHaveLength(failAt === 11 ? 500 : 0)
+      fault.mockRestore()
+      await closeSearchIndex(); _resetMessageCacheDB()
+      await backfillFromMessageCache()
+      expect(await search('searchable', { limit: 1000 })).toHaveLength(552)
+      setStorageScopeJid('other@example.com')
+      expect(await search('searchable')).toEqual([])
+    })
+  })
 
   describe('backfillFromMessageCache', () => {
     // We need to populate the messageCache IDB directly, then call backfill.

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -13,10 +13,10 @@
  * @module SearchIndex
  */
 
-import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
+import { openDB, type IDBPDatabase, type IDBPTransaction, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { isNoLocalStore } from '../core/types/message-internal'
-import { getStorageScopeJid } from './storageScope'
+import { captureStorageScope, getStorageScopeJid } from './storageScope'
 import {
   chatRetractionAliases,
   roomRetractionAliases,
@@ -41,6 +41,16 @@ const DB_VERSION = 2
 const TOKENS_STORE = 'search-tokens'
 const DOCS_STORE = 'search-docs'
 const META_STORE = 'search-meta'
+const pendingMutations = new Map<string | null, Promise<void>>()
+
+async function mutateIndex(scopeJid: string | null, mutation: () => Promise<void>): Promise<void> {
+  const previous = pendingMutations.get(scopeJid) ?? Promise.resolve()
+  const pending = previous.catch(() => {}).then(mutation)
+  pendingMutations.set(scopeJid, pending)
+  try { await pending } finally {
+    if (pendingMutations.get(scopeJid) === pending) pendingMutations.delete(scopeJid)
+  }
+}
 
 /** Minimum token length to index (skip single characters) */
 const MIN_TOKEN_LENGTH = 2
@@ -472,7 +482,7 @@ function createDocEntry(
     from: message.from,
     timestamp: message.timestamp.getTime(),
     isRoom: message.type === 'groupchat',
-    body: message.body!,
+    body: message.body,
   }
   if (message.stanzaId) doc.stanzaId = message.stanzaId
   if (message.originId) doc.originId = message.originId
@@ -481,6 +491,12 @@ function createDocEntry(
     if (message.occupantId) doc.occupantId = message.occupantId
   }
   return doc
+}
+
+function sameIndexDocument(a: DocEntry, b: DocEntry): boolean {
+  return (Object.keys({ ...a, ...b }) as Array<keyof DocEntry>).every(key => key === 'tokens'
+    ? a.tokens.length === b.tokens.length && a.tokens.every((token, i) => token === b.tokens[i])
+    : a[key] === b[key])
 }
 
 /** The retraction scope a message belongs to. */
@@ -561,7 +577,7 @@ export async function initSearchIndex(scopeJid: string): Promise<void> {
 
 /**
  * Index a single message into the search index.
- * Skips messages with no body, retracted messages, and noLocalStore messages.
+ * Skips retracted messages and noLocalStore messages.
  * Silently returns if IndexedDB is not available.
  */
 export async function indexMessage(
@@ -569,47 +585,10 @@ export async function indexMessage(
   scopeJid: string | null = getStorageScopeJid()
 ): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  if (!message.body || message.isRetracted || isNoLocalStore(message)) return
+  if (message.isRetracted || isNoLocalStore(message)) return
   if (await isRetractedElsewhere(message, scopeJid)) return
 
-  const indexId = getIndexId(message)
-  const tokens = uniqueTokens(message.body)
-  if (tokens.length === 0) return
-
-  const db = await getDB(scopeJid)
-  const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
-  const tokensStore = tx.objectStore(TOKENS_STORE)
-  const docsStore = tx.objectStore(DOCS_STORE)
-
-  // Check if already indexed (idempotent)
-  const existing = await docsStore.get(indexId)
-  if (existing) {
-    await tx.done
-    return
-  }
-
-  const doc = createDocEntry(message, indexId, tokens)
-  if (isKnownRetracted(message, scopeJid)) {
-    await tx.done
-    return
-  }
-  await docsStore.put(doc)
-
-  // Update posting lists for each token
-  for (const token of tokens) {
-    const entry = await tokensStore.get(token)
-    if (entry) {
-      if (!entry.postings.includes(indexId)) {
-        entry.postings.push(indexId)
-        await tokensStore.put(entry)
-      }
-    } else {
-      await tokensStore.put({ token, postings: [indexId] })
-    }
-  }
-
-  await tx.done
-  recordRoomDocumentOwner(indexId, message, scopeJid)
+  await writeIndexBatch([message], scopeJid)
 }
 
 /**
@@ -642,14 +621,14 @@ export async function indexMessages(
   scopeJid: string | null = getStorageScopeJid()
 ): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const candidates = messages.filter((m) => m.body && !m.isRetracted && !isNoLocalStore(m))
+  const candidates = messages.filter((m) => !m.isRetracted && !isNoLocalStore(m))
   const indexable = await rejectRetracted(candidates, options.fromCache === true, scopeJid)
   if (indexable.length === 0) return
 
   // Process in small batches to keep each IDB transaction short-lived
   for (let i = 0; i < indexable.length; i += INDEX_BATCH_SIZE) {
     const batch = indexable.slice(i, i + INDEX_BATCH_SIZE)
-    await indexBatch(batch, scopeJid)
+    await writeIndexBatch(batch, scopeJid)
   }
 }
 
@@ -657,53 +636,69 @@ export async function indexMessages(
  * Index a small batch of messages in a single transaction.
  * Kept small enough that the IDB transaction won't auto-commit.
  */
-async function indexBatch(
+async function writeIndexBatch(
   messages: (Message | RoomMessage)[],
-  scopeJid: string | null
+  scopeJid: string | null,
+  removal?: { message: Message | RoomMessage; identityClosure?: RoomIdentityClosure | ChatIdentityClosure },
 ): Promise<void> {
-  const db = await getDB(scopeJid)
-  const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
-  const tokensStore = tx.objectStore(TOKENS_STORE)
-  const docsStore = tx.objectStore(DOCS_STORE)
-
-  const tokenCache = new Map<string, TokenEntry>()
-  const indexedMessages: Array<{ indexId: string; message: Message | RoomMessage }> = []
-
-  for (const message of messages) {
-    const indexId = getIndexId(message)
-    const tokens = uniqueTokens(message.body!)
-    if (tokens.length === 0) continue
-
-    // Skip if already indexed
-    const existing = await docsStore.get(indexId)
-    if (existing) continue
-
-    const doc = createDocEntry(message, indexId, tokens)
-    if (isKnownRetracted(message, scopeJid)) continue
-    await docsStore.put(doc)
-    indexedMessages.push({ indexId, message })
-
-    for (const token of tokens) {
-      let entry = tokenCache.get(token)
+  await mutateIndex(scopeJid, async () => {
+    const resolved = messages.length ? await messageCache.resolveMessagesForIndex(messages, scopeJid) : []
+    const db = await getDB(scopeJid)
+    const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
+    void tx.done.catch(() => {})
+    const tokensStore = tx.objectStore(TOKENS_STORE)
+    const docsStore = tx.objectStore(DOCS_STORE)
+    const postings = new Map<string, { before: string[]; after: Set<string> }>()
+    const getPostings = async (token: string): Promise<Set<string>> => {
+      let entry = postings.get(token)
       if (!entry) {
-        entry = (await tokensStore.get(token)) || { token, postings: [] }
-        tokenCache.set(token, entry)
+        const before = (await tokensStore.get(token))?.postings ?? []
+        entry = { before, after: new Set(before) }
+        postings.set(token, entry)
       }
-      if (!entry.postings.includes(indexId)) {
-        entry.postings.push(indexId)
+      return entry.after
+    }
+    const indexedMessages = new Map<string, Message | RoomMessage>()
+    const removedIds = new Set<string>()
+    const remove = async (message: Message | RoomMessage, closure?: RoomIdentityClosure | ChatIdentityClosure, source?: Message | RoomMessage, keep?: DocEntry) => {
+      for (const id of await removeMessageEntries(tx, message, scopeJid, getPostings, closure, source, keep)) {
+        removedIds.add(id)
+        indexedMessages.delete(id)
       }
     }
-  }
-
-  // Write all modified token entries
-  for (const entry of tokenCache.values()) {
-    await tokensStore.put(entry)
-  }
-
-  await tx.done
-  for (const indexed of indexedMessages) {
-    recordRoomDocumentOwner(indexed.indexId, indexed.message, scopeJid)
-  }
+    try {
+      if (removal && !messages.length) await remove(removal.message, removal.identityClosure)
+      for (let i = 0; i < resolved.length; i++) {
+        const entry = resolved[i]
+        if (!entry) continue
+        const { message, cached } = entry
+        const indexId = getIndexId(message)
+        const doc = message.isRetracted || isNoLocalStore(message) || isKnownRetracted(message, scopeJid)
+          ? undefined : createDocEntry(message, indexId, uniqueTokens(message.body))
+        if (cached || removal) await remove(message, removal?.identityClosure, messages[i], doc)
+        if (!doc) continue
+        const existing = await docsStore.get(indexId)
+        if (existing) continue
+        await docsStore.put(doc)
+        indexedMessages.set(indexId, message)
+        for (const token of doc.tokens) (await getPostings(token)).add(indexId)
+      }
+      for (const [token, { before, after }] of postings) {
+        if (before.length === after.size && before.every(id => after.has(id))) continue
+        if (after.size) await tokensStore.put({ token, postings: [...after] })
+        else await tokensStore.delete(token)
+      }
+      await tx.done
+    } catch (error) {
+      try { tx.abort() } catch {
+        // An already completed or aborted transaction cannot be aborted again.
+      }
+      await tx.done.catch(() => {})
+      throw error
+    }
+    for (const id of removedIds) roomDocumentOwners.delete(roomOwnerKey(id, scopeJid))
+    for (const [id, message] of indexedMessages) recordRoomDocumentOwner(id, message, scopeJid)
+  })
 }
 
 /**
@@ -716,10 +711,19 @@ export async function removeMessage(
   identityClosure?: RoomIdentityClosure | ChatIdentityClosure
 ): Promise<void> {
   if (!isIndexedDBAvailable()) return
+  await writeIndexBatch([], scopeJid, { message, identityClosure })
+}
 
-  const db = await getDB(scopeJid)
-  const tx = db.transaction([TOKENS_STORE, DOCS_STORE], 'readwrite')
-  const tokensStore = tx.objectStore(TOKENS_STORE)
+async function removeMessageEntries(
+  tx: IDBPTransaction<SearchIndexSchema, ['search-tokens', 'search-docs'], 'readwrite'>,
+  message: Message | RoomMessage,
+  scopeJid: string | null,
+  getPostings: (token: string) => Promise<Set<string>>,
+  identityClosure?: RoomIdentityClosure | ChatIdentityClosure,
+  source?: Message | RoomMessage,
+  keep?: DocEntry,
+): Promise<string[]> {
+  const removedIds: string[] = []
   const docsStore = tx.objectStore(DOCS_STORE)
   const roomIdentityClosure =
     identityClosure && 'identityKeys' in identityClosure ? identityClosure : undefined
@@ -728,10 +732,12 @@ export async function removeMessage(
 
   const drop = async (
     indexId: string,
-    verification: 'chat' | 'chat-closure' | 'room' | 'room-identity' | 'room-closure'
+    verification: 'chat' | 'chat-closure' | 'room' | 'room-identity' | 'room-closure' | 'room-source'
   ): Promise<void> => {
     const doc = await docsStore.get(indexId)
     if (!doc) return
+    if (source && (archiveIdentityConflict(doc, message) || (message.type === 'groupchat' &&
+      !roomMessageAuthor(doc, { actorJid: message.from, actorOccupantId: message.occupantId })))) return
     if (verification === 'chat' && (message.type === 'groupchat' || !docBelongsToChat(doc, message))) return
     // A closure document was written under an id the surviving row absorbed, so
     // its messageId is NOT the survivor's — verify the owner instead.
@@ -740,6 +746,9 @@ export async function removeMessage(
       (message.type === 'groupchat' || !docSharesChatOwner(doc, message))
     ) return
     if (verification === 'room' && (message.type !== 'groupchat' || !docBelongsToRoom(doc, message))) return
+    if (verification === 'room-source' && (!source || !fallbackDocNamesMessage(
+      doc, { ...message, id: source.id, from: source.from }, indexId, scopeJid
+    ))) return
     if (verification === 'room-identity' && !fallbackDocNamesMessage(doc, message, indexId, scopeJid)) return
     if (
       verification === 'room-closure' &&
@@ -753,22 +762,12 @@ export async function removeMessage(
       ))
     ) return
 
-    // Remove from all posting lists
-    for (const token of doc.tokens) {
-      const entry = await tokensStore.get(token)
-      if (entry) {
-        entry.postings = entry.postings.filter((id) => id !== indexId)
-        if (entry.postings.length === 0) {
-          await tokensStore.delete(token)
-        } else {
-          await tokensStore.put(entry)
-        }
-      }
-    }
+    if (keep && sameIndexDocument(doc, keep)) return
+    for (const token of doc.tokens) (await getPostings(token)).delete(indexId)
 
     // Remove the document
     await docsStore.delete(indexId)
-    roomDocumentOwners.delete(roomOwnerKey(indexId, scopeJid))
+    removedIds.push(indexId)
   }
 
   await drop(
@@ -786,12 +785,15 @@ export async function removeMessage(
   for (const fallbackId of getFallbackIndexIds(message)) {
     await drop(fallbackId, 'room-identity')
   }
+  if (source && getIndexId(source) !== getIndexId(message)) {
+    await drop(getIndexId(source), message.type === 'chat' ? 'chat-closure' : 'room-source')
+  }
   if (message.type === 'groupchat' && roomIdentityClosure) {
     const docs = await docsStore.index('conversationId').getAll(message.roomJid)
     for (const doc of docs) await drop(doc.indexId, 'room-closure')
   }
 
-  await tx.done
+  return removedIds
 }
 
 /**
@@ -803,8 +805,9 @@ export async function updateMessage(
   scopeJid: string | null = getStorageScopeJid()
 ): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  await removeMessage(message, scopeJid)
-  await indexMessage(message, scopeJid)
+  const indexable = !message.isRetracted && !isNoLocalStore(message) &&
+    !await isRetractedElsewhere(message, scopeJid)
+  await writeIndexBatch(indexable ? [message] : [], scopeJid, { message })
 }
 
 /**
@@ -951,8 +954,8 @@ const BACKFILL_BATCH_SIZE = 500
 /**
  * Check if the initial backfill from messageCache has been completed.
  */
-async function isBackfillComplete(): Promise<boolean> {
-  const db = await getDB()
+async function isBackfillComplete(scopeJid: string | null): Promise<boolean> {
+  const db = await getDB(scopeJid)
   const entry = await db.get(META_STORE, BACKFILL_KEY)
   return !!entry
 }
@@ -960,8 +963,8 @@ async function isBackfillComplete(): Promise<boolean> {
 /**
  * Mark the backfill as complete so it won't run again.
  */
-async function markBackfillComplete(): Promise<void> {
-  const db = await getDB()
+async function markBackfillComplete(scopeJid: string | null): Promise<void> {
+  const db = await getDB(scopeJid)
   await db.put(META_STORE, { key: BACKFILL_KEY, value: 'true' })
 }
 
@@ -975,22 +978,30 @@ async function markBackfillComplete(): Promise<void> {
 export async function backfillFromMessageCache(): Promise<void> {
   if (!isIndexedDBAvailable()) return
 
-  if (await isBackfillComplete()) return
+  const scope = captureStorageScope()
+  if (await isBackfillComplete(scope.jid)) return
+  scope.assertCurrent()
 
   let chatCount = 0
   let roomCount = 0
 
   await messageCache.iterateAllMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch, { fromCache: true })
+    scope.assertCurrent()
+    await indexMessages(batch, { fromCache: true }, scope.jid)
+    scope.assertCurrent()
     chatCount += batch.length
   })
 
+  scope.assertCurrent()
   await messageCache.iterateAllRoomMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch, { fromCache: true })
+    scope.assertCurrent()
+    await indexMessages(batch, { fromCache: true }, scope.jid)
+    scope.assertCurrent()
     roomCount += batch.length
   })
 
-  await markBackfillComplete()
+  scope.assertCurrent()
+  await markBackfillComplete(scope.jid)
 
   if (chatCount > 0 || roomCount > 0) {
     console.log(`[searchIndex] Backfill complete: indexed ${chatCount} chat + ${roomCount} room messages`)
@@ -1021,15 +1032,9 @@ export async function rebuildSearchIndex(
 ): Promise<number> {
   if (!isIndexedDBAvailable()) return 0
 
-  const scopeJid = getStorageScopeJid()
-  clearRoomDocumentOwners(scopeJid)
-  // Clear existing index data
-  const db = await getDB(scopeJid)
-  const tx = db.transaction([TOKENS_STORE, DOCS_STORE, META_STORE], 'readwrite')
-  await tx.objectStore(TOKENS_STORE).clear()
-  await tx.objectStore(DOCS_STORE).clear()
-  await tx.objectStore(META_STORE).clear()
-  await tx.done
+  const scope = captureStorageScope()
+  await clearIndexData(scope.jid)
+  scope.assertCurrent()
 
   // Count total messages for progress reporting
   const totalMessages =
@@ -1037,20 +1042,27 @@ export async function rebuildSearchIndex(
     (await messageCache.getTotalRoomMessageCount())
 
   let indexed = 0
+  scope.assertCurrent()
 
   await messageCache.iterateAllMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch, { fromCache: true })
+    scope.assertCurrent()
+    await indexMessages(batch, { fromCache: true }, scope.jid)
+    scope.assertCurrent()
     indexed += batch.length
     onProgress?.({ indexed, total: totalMessages })
   })
 
+  scope.assertCurrent()
   await messageCache.iterateAllRoomMessages(BACKFILL_BATCH_SIZE, async (batch) => {
-    await indexMessages(batch, { fromCache: true })
+    scope.assertCurrent()
+    await indexMessages(batch, { fromCache: true }, scope.jid)
+    scope.assertCurrent()
     indexed += batch.length
     onProgress?.({ indexed, total: totalMessages })
   })
 
-  await markBackfillComplete()
+  scope.assertCurrent()
+  await markBackfillComplete(scope.jid)
   return indexed
 }
 
@@ -1064,8 +1076,13 @@ export async function rebuildSearchIndex(
  */
 export async function clearSearchIndex(): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const scopeJid = getStorageScopeJid()
-  try {
+  try { await clearIndexData(getStorageScopeJid()) } catch {
+    // Ignore errors (DB may not exist yet)
+  }
+}
+
+async function clearIndexData(scopeJid: string | null): Promise<void> {
+  await mutateIndex(scopeJid, async () => {
     const db = await getDB(scopeJid)
     const tx = db.transaction([TOKENS_STORE, DOCS_STORE, META_STORE], 'readwrite')
     await tx.objectStore(TOKENS_STORE).clear()
@@ -1073,9 +1090,7 @@ export async function clearSearchIndex(): Promise<void> {
     await tx.objectStore(META_STORE).clear()
     await tx.done
     clearRoomDocumentOwners(scopeJid)
-  } catch {
-    // Ignore errors (DB may not exist yet)
-  }
+  })
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/storageScope.ts
+++ b/packages/fluux-sdk/src/utils/storageScope.ts
@@ -1,6 +1,7 @@
 import { getBareJid } from '../core/jid'
 
 let currentStorageScopeJid: string | null = null
+let storageScopeGeneration = 0
 
 function normalizeScopeJid(jid: string | null | undefined): string | null {
   if (!jid) return null
@@ -20,8 +21,23 @@ export function getStorageScopeJid(): string | null {
  * Returns the normalized bare JID that was stored.
  */
 export function setStorageScopeJid(jid: string | null | undefined): string | null {
-  currentStorageScopeJid = normalizeScopeJid(jid)
+  const next = normalizeScopeJid(jid)
+  if (next !== currentStorageScopeJid) storageScopeGeneration++
+  currentStorageScopeJid = next
   return currentStorageScopeJid
+}
+
+export function captureStorageScope() {
+  const jid = currentStorageScopeJid
+  const generation = storageScopeGeneration
+  const isCurrent = () => generation === storageScopeGeneration
+  return {
+    jid,
+    isCurrent,
+    assertCurrent() {
+      if (!isCurrent()) throw new DOMException('Storage account changed', 'AbortError')
+    },
+  }
 }
 
 /**
@@ -38,5 +54,5 @@ export function buildScopedStorageKey(baseKey: string, jid?: string | null): str
  * @internal
  */
 export function _resetStorageScopeForTesting(): void {
-  currentStorageScopeJid = null
+  setStorageScopeJid(null)
 }


### PR DESCRIPTION
Prevent older archive pages and cache snapshots from restoring superseded message text in chats and rooms. Keep revision ordering separate from signed content dates, preserve correction aliases and retractions, and upgrade the cache index without dropping existing data. When a live edit needs archive evidence, retrieve it automatically through bounded requests that preserve pagination progress.

Keep asynchronous cache, decryption and search updates tied to the initiating account and current revision. Preserve known replay provenance across reloads, repair failed cache writes on replay, keep previews consistent, and remove obsolete fulltext matches while preserving search pagination.
