### PR TITLE
fix: keep history loading visible and recoverable

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import i18n from 'i18next'
+import en from '@/i18n/locales/en.json'
 import { MemoryRouter, NavLink, useLocation, useNavigate } from 'react-router'
 import { ChatLayout } from './ChatLayout'
 import { ROUTER_USE_TRANSITIONS } from '@/config/routerTransitions'
@@ -250,6 +252,7 @@ vi.mock('@fluux/sdk', () => ({
   chatStore: {
     getState: () => ({
       activeConversationId: getMockState().activeConversationId,
+      activationPending: getMockState().chatActivationPending,
       hasConversation: vi.fn(() => false),
       isArchived: vi.fn(() => getMockState().isArchivedResult),
       updateConversationName: vi.fn(),
@@ -263,6 +266,7 @@ vi.mock('@fluux/sdk', () => ({
   roomStore: {
     getState: () => ({
       activeRoomJid: getMockState().activeRoomJid,
+      activationPending: getMockState().roomActivationPending,
       markAsRead: vi.fn(),
       clearFirstNewMessageId: vi.fn(),
       setActiveRoom: mockSetActiveRoom,
@@ -1331,7 +1335,7 @@ describe('ChatLayout - activation gap (no empty-state flash)', () => {
   })
 
   afterEach(() => {
-    setMockState({ chatActivationPending: false, roomActivationPending: false })
+    act(() => setMockState({ chatActivationPending: false, roomActivationPending: false }))
   })
 
   // Regression for the empty-screen flash on rail tab switch: while a hydrating
@@ -1521,6 +1525,46 @@ describe('ChatLayout - mobile pane swap during a hydrating activation', () => {
 
   afterEach(() => {
     setMockState({ chatActivationPending: false, roomActivationPending: false })
+  })
+
+  it.each([
+    ['/messages', 'chatActivationPending', mockActivateConversation],
+    ['/rooms', 'roomActivationPending', mockActivateRoom],
+  ] as const)('explains the pending cache read on %s and lets the user return to the list', async (route, pendingFlag, activate) => {
+    i18n.addResource('en', 'translation', 'chat.loadingMessages', en.chat.loadingMessages)
+    setMockState({ [pendingFlag]: true })
+    activate.mockImplementationOnce(async (id) => {
+      expect(id).toBeNull()
+      setMockState({ [pendingFlag]: false })
+    })
+    render(<ChatLayoutWithRouter initialRoute={route} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(en.chat.loadingMessages)
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    await waitFor(() => expect(activate).toHaveBeenCalledWith(null))
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['/messages', 'chatActivationPending', mockActivateConversation, 'deep-conversation-link'],
+    ['/rooms', 'roomActivationPending', mockActivateRoom, 'deep-room-link'],
+  ] as const)('cancels an unresolved activation on browser Back to %s', async (route, pendingFlag, activate, link) => {
+    activate.mockImplementationOnce(async () => { setMockState({ [pendingFlag]: true }) })
+    activate.mockImplementationOnce(async (id) => {
+      expect(id).toBeNull()
+      setMockState({ [pendingFlag]: false })
+    })
+    render(<ChatLayoutWithProbe initialRoute={route} />)
+    fireEvent.click(screen.getByTestId(link))
+    await waitFor(() => expect(panes().sidebar).toHaveClass('hidden'))
+
+    fireEvent.click(screen.getByTestId('probe-back'))
+
+    await waitFor(() => expect(activate).toHaveBeenCalledWith(null))
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(screen.getByTestId('probe-path')).toHaveTextContent(route)
   })
 
   it('hides the sidebar and shows the hydration surface before the tapped conversation resolves', async () => {

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -47,7 +47,7 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useDeepLink } from '@/hooks/useDeepLink'
 import { saveViewState, getSavedViewState, type ViewStateData } from '@/hooks/useSessionPersistence'
 import { useModalStore } from '@/stores/modalStore'
-import { Server, ShieldOff, MessageCircle, Hash, Users, Search, Settings, Plus, type LucideIcon } from 'lucide-react'
+import { Server, ShieldOff, MessageCircle, Hash, Users, Search, Settings, Plus, ArrowLeft, Loader2, type LucideIcon } from 'lucide-react'
 
 /**
  * ChatLayout wrapper. The actual layout logic is in ChatLayoutContent; modal state
@@ -114,11 +114,24 @@ function GlobalEffects() {
 }
 
 /** Lightweight skeleton fallback for lazy-loaded views to prevent layout shift */
-function ViewLoadingFallback() {
+function ViewLoadingFallback({ onBack }: { onBack?: () => void }) {
+  const { t } = useTranslation()
   return (
     <div className="h-full flex flex-col bg-fluux-chat" data-testid="view-loading-fallback">
-      <div className="h-12 px-4 flex items-center border-b border-fluux-bg" />
-      <div className="flex-1" />
+      <div className="h-12 px-4 flex items-center border-b border-fluux-bg">
+        {onBack && (
+          <button type="button" onClick={onBack} aria-label={t('common.back')}
+            className="size-11 flex items-center justify-center rounded-lg text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-fluux-brand">
+            <ArrowLeft className="size-5 rtl-mirror" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      {onBack ? (
+        <div role="status" className="flex-1 flex flex-col items-center justify-center gap-3 text-fluux-muted">
+          <Loader2 className="size-8 animate-spin text-fluux-brand" aria-hidden="true" />
+          <p>{t('chat.loadingMessages')}</p>
+        </div>
+      ) : <div className="flex-1" />}
     </div>
   )
 }
@@ -442,6 +455,11 @@ function ChatLayoutContent() {
     // entity the handler just cleared (e.g. profile click bouncing back to the
     // conversation).
     if (prev.activeJid === activeJid && prev.sidebarView === sidebarView) return
+    // Navigation can leave a hydration before its active id exists. Cancel the
+    // pending owner as well as the visible selection, so a late cache read
+    // cannot reopen a conversation after the user has left its tab.
+    if (sidebarView !== 'messages' && chatStore.getState().activationPending) void activateConversation(null)
+    if (sidebarView !== 'rooms' && roomStore.getState().activationPending) void activateRoom(null)
     // Leaving the directory view clears the contact profile — without this,
     // browser back from /contacts/:jid keeps showing ContactProfileView while
     // the URL and sidebar already say otherwise (mirror of the directory branch)
@@ -449,13 +467,13 @@ function ChatLayoutContent() {
       setSelectedContactJid(null)
     }
     if (sidebarView === 'messages') {
-      const currentStoreId = chatStore.getState().activeConversationId
-      if (activeJid !== currentStoreId) {
+      const current = chatStore.getState()
+      if (activeJid !== current.activeConversationId || (!activeJid && current.activationPending)) {
         void activateConversation(activeJid)
       }
     } else if (sidebarView === 'rooms') {
-      const currentStoreJid = roomStore.getState().activeRoomJid
-      if (activeJid !== currentStoreJid) {
+      const current = roomStore.getState()
+      if (activeJid !== current.activeRoomJid || (!activeJid && current.activationPending)) {
         void activateRoom(activeJid)
       }
     } else if (sidebarView === 'contacts') {
@@ -775,12 +793,14 @@ function ChatLayoutContent() {
   // Disconnect only happens via explicit user action (menu) or app quit.
 
   const handleChatBack = () => {
-    setActiveConversation(null)
+    hasAutoSelectedRef.current = true
+    void activateConversation(null)
     navigateToMessages(undefined, { replace: true })
   }
 
   const handleRoomBack = () => {
-    setActiveRoom(null)
+    hasAutoSelectedRoomRef.current = true
+    void activateRoom(null)
     navigateToRooms(undefined, { replace: true })
   }
 
@@ -1028,11 +1048,7 @@ function ChatLayoutContent() {
               <SearchContextView onBack={() => searchStore.getState().setPreviewResult(null)} />
             </Suspense>
           ) : activationHoldsMainPane ? (
-            // A hydrating activation is in flight (cache load before the active id
-            // lands). Hold the neutral loading surface — matching the lazy views
-            // above — so switching content tabs doesn't flash the empty-state hero.
-            // This is the surface the mobile pane swap above opens onto.
-            <ViewLoadingFallback />
+            <ViewLoadingFallback onBack={sidebarView === 'rooms' ? handleRoomBack : handleChatBack} />
           ) : (
             <EmptyState
               sidebarView={sidebarView}

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1187,6 +1187,23 @@ describe('chatStore', () => {
       expect(chatStore.getState().activeConversationId).toBeNull()
     })
 
+    it('returns to the list immediately and ignores a cancelled activation when its cache read finishes', async () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      let release: (messages: Message[]) => void = () => {}
+      vi.mocked(messageCache.getMessages).mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const markers = new Map(chatStore.getState().firstNewMessageMarkers)
+      const opening = chatStore.getState().activateConversation('alice@example.com')
+
+      await chatStore.getState().activateConversation(null)
+      expect(chatStore.getState().activationPending).toBe(false)
+      expect(chatStore.getState().activeConversationId).toBeNull()
+
+      release([createMessage('alice@example.com', 'Cached history')])
+      await opening
+      expect(chatStore.getState().activeConversationId).toBeNull()
+      expect(chatStore.getState().firstNewMessageMarkers).toEqual(markers)
+    })
+
     it('activateConversation reloads the window around a pointer deeper than the latest slice', async () => {
       // Arrange: cache holds 300 messages; the latest-100 slice (returned by
       // loadMessagesFromCache) does NOT contain the message the read pointer

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2635,6 +2635,24 @@ describe('roomStore', () => {
       expect(roomStore.getState().activeRoomJid).toBeNull()
     })
 
+    it('returns to the list immediately and ignores a cancelled activation when its cache read finishes', async () => {
+      const roomJid = 'slow@conference.example.com'
+      roomStore.getState().addRoom(createRoom(roomJid))
+      let release: (messages: RoomMessage[]) => void = () => {}
+      vi.mocked(messageCache.getRoomMessages).mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const markers = new Map(roomStore.getState().firstNewMessageMarkers)
+      const opening = roomStore.getState().activateRoom(roomJid)
+
+      await roomStore.getState().activateRoom(null)
+      expect(roomStore.getState().activationPending).toBe(false)
+      expect(roomStore.getState().activeRoomJid).toBeNull()
+
+      release([{ type: 'groupchat', id: 'cached', roomJid, from: `${roomJid}/alice`, nick: 'alice', body: 'Cached history', timestamp: new Date(), isOutgoing: false }])
+      await opening
+      expect(roomStore.getState().activeRoomJid).toBeNull()
+      expect(roomStore.getState().firstNewMessageMarkers).toEqual(markers)
+    })
+
     it('activateRoom reloads the window around a pointer deeper than the latest slice', async () => {
       // Arrange: cache holds 300 messages; the latest-100 slice (returned by
       // loadMessagesFromCache) does NOT contain the message the read pointer names

--- a/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
@@ -122,4 +122,19 @@ describe('version-5 correction alias migration', () => {
     expect(await db.getAll(ROOM_STORE)).toEqual([rows.room])
     db.close()
   })
+
+  it('retries an interrupted upgrade on the next cache read without reloading the app', async () => {
+    const rows = await seedV5()
+    const update = IDBCursor.prototype.update
+    const fault = vi.spyOn(IDBCursor.prototype, 'update').mockImplementationOnce(() => {
+      throw new Error('backfill interrupted')
+    })
+
+    expect(await cache.getMessages(CHAT)).toEqual([])
+    fault.mockRestore()
+    expect(IDBCursor.prototype.update).toBe(update)
+
+    expect(await cache.getMessages(CHAT)).toMatchObject([{ body: rows.chat.body }])
+    expect(await cache.getRoomMessages(ROOM)).toMatchObject([{ body: rows.room.body }])
+  })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -230,7 +230,7 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
   }
 
   dbNameForPromise = targetDbName
-  dbPromise = openDB<MessageCacheSchema>(targetDbName, DB_VERSION, {
+  const opening = openDB<MessageCacheSchema>(targetDbName, DB_VERSION, {
     upgrade(db, _oldVersion, _newVersion, transaction) {
       // Which legacy stores this upgrade has to drain. Both migrations stream through
       // the SAME version-change transaction, so they are fired once, sequentially,
@@ -300,7 +300,16 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
     },
   })
 
-  return dbPromise
+  dbPromise = opening
+  void opening.catch(() => {
+    // An interrupted upgrade must be retryable. A superseded account's failure
+    // must not invalidate the connection opened for the new account.
+    if (dbPromise === opening) {
+      dbPromise = null
+      dbNameForPromise = null
+    }
+  })
+  return opening
 }
 
 // =============================================================================

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -40,6 +40,7 @@ const SUITES = [
   { name: 'scroll', testMatch: 'scroll-invariants.ts' },
   { name: 'composer', testMatch: 'composer-geometry.ts' },
   { name: 'popover', testMatch: 'popover-geometry.ts' },
+  { name: 'history-loading', testMatch: 'history-loading.ts' },
 ] as const
 
 /**

--- a/scripts/history-loading.ts
+++ b/scripts/history-loading.ts
@@ -1,0 +1,96 @@
+import { test, expect, devices } from '@playwright/test'
+import { bootDemo } from './e2e/demoBoot'
+import type { chatStore, roomStore } from '@fluux/sdk'
+
+type DemoWindow = Window & {
+  __chatStore: typeof chatStore
+  __roomStore: typeof roomStore
+  __releaseHistoryRead?: () => void
+  __historyOpening?: Promise<void>
+}
+
+test.use({
+  viewport: devices['iPhone 13'].viewport,
+  userAgent: devices['iPhone 13'].userAgent,
+  isMobile: true,
+  hasTouch: true,
+})
+
+for (const kind of ['chat', 'room'] as const) {
+  for (const action of ['button', 'browser', 'finish', 'tab'] as const) {
+    test(`${kind}: slow cache read handles ${action}`, async ({ page }, testInfo) => {
+      await bootDemo(page, '/demo.html?tutorial=false')
+      await page.locator(`[data-nav="${kind === 'chat' ? 'messages' : 'rooms'}"]`).click()
+      const sidebar = page.getByTestId('sidebar-pane')
+      await expect(sidebar).toBeVisible()
+
+      // Hold the actual SDK activation at its cache boundary; retain the real
+      // token cancellation, routing, store subscriptions and mobile layout.
+      await page.evaluate((entity) => {
+        const w = window as unknown as DemoWindow
+        let release: () => void = () => {}
+        const gate = new Promise<void>(resolve => { release = resolve })
+        if (entity === 'chat') {
+          const read = w.__chatStore.getState().loadMessagesFromCache
+          const activate = w.__chatStore.getState().activateConversation
+          w.__chatStore.setState({
+            loadMessagesFromCache: async (...args) => { await gate; return read(...args) },
+            activateConversation: id => {
+              const opening = activate(id)
+              if (id) w.__historyOpening = opening
+              return opening
+            },
+          })
+          w.__releaseHistoryRead = () => { w.__chatStore.setState({ loadMessagesFromCache: read, activateConversation: activate }); release() }
+        } else {
+          const read = w.__roomStore.getState().loadMessagesFromCache
+          const activate = w.__roomStore.getState().activateRoom
+          w.__roomStore.setState({
+            loadMessagesFromCache: async (...args) => { await gate; return read(...args) },
+            activateRoom: id => {
+              const opening = activate(id)
+              if (id) w.__historyOpening = opening
+              return opening
+            },
+          })
+          w.__releaseHistoryRead = () => { w.__roomStore.setState({ loadMessagesFromCache: read, activateRoom: activate }); release() }
+        }
+      }, kind)
+
+      await sidebar.getByText(kind === 'chat' ? 'Ava Martinez' : 'Team Chat', { exact: true }).click()
+      const main = page.getByRole('main')
+      await expect(main.getByRole('status')).toHaveText('Loading messages...')
+      await expect(sidebar).toBeHidden()
+      await page.screenshot({ path: testInfo.outputPath('history-loading.png') })
+
+      if (action === 'button') await main.getByRole('button', { name: 'Back', exact: true }).click()
+      if (action === 'browser') await page.goBack()
+      if (action === 'tab') {
+        // The navigation rail shares the hidden sidebar on phones. A wider
+        // viewport exposes it while the conversation is still loading.
+        await page.setViewportSize({ width: 1024, height: 844 })
+        await page.locator('[data-nav="contacts"]').click()
+      }
+      if (action !== 'finish') await expect(sidebar).toBeVisible()
+
+      await page.evaluate(async () => {
+        const w = window as unknown as DemoWindow
+        w.__releaseHistoryRead?.()
+        await w.__historyOpening
+      })
+      await expect.poll(() => page.evaluate((entity) => {
+        const w = window as unknown as DemoWindow
+        const state = entity === 'chat' ? w.__chatStore.getState() : w.__roomStore.getState()
+        return state.activationPending
+      }, kind)).toBe(false)
+      if (action === 'finish') {
+        await expect(main.getByRole('status')).toBeHidden()
+        await expect(main.locator('[data-message-id]').first()).toBeVisible()
+      } else {
+        if (action === 'tab') await page.setViewportSize(devices['iPhone 13'].viewport)
+        await expect(sidebar).toBeVisible()
+        await expect(main).toBeHidden()
+      }
+    })
+  }
+}


### PR DESCRIPTION
Slow cache reads now show a loading indicator and a Back button when opening a conversation or room. Back navigation and tab changes cancel the pending activation, so a late read cannot reopen a conversation after the user leaves.

Failed IndexedDB opens are released so the next cache access can retry without reloading the app.
