### PR TITLE
feat: identify Fluux platforms in XMPP resource names

### DIFF
--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -33,6 +33,7 @@ export const changelog: ChangelogEntry[] = [
           'Encryption: a message that cannot be read now says why — a key this device does not have, an invalid signature, or content that could not be parsed — instead of always blaming a missing key',
           'Fluux now tells you when something failed instead of staying silent: older messages that could not be loaded show a marker above the button that retries, and a bookmarked room that could not be rejoined says why — a password is required, the nickname is taken, the room is members-only',
           'Launching after a long absence and opening a conversation are much faster, and Fluux writes far less to local storage while it catches up on history',
+          'Server administrators can identify Fluux and its platform more easily in session metrics: newly generated resource names start with "fluux-w" (web), "fluux-d" (desktop) or "fluux-m" (native mobile). Existing resource names are preserved',
           'Updated dependencies (Rust crates and JavaScript packages)',
         ],
       },

--- a/apps/fluux/src/utils/xmppResource.test.ts
+++ b/apps/fluux/src/utils/xmppResource.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { generateResource, isValidResource } from './xmppResource'
 
+const { nativePlatform } = vi.hoisted(() => ({ nativePlatform: vi.fn(() => 'macos') }))
+vi.mock('@tauri-apps/plugin-os', () => ({ platform: nativePlatform }))
 
 function createStorageMock(): Storage {
   const store: Record<string, string> = {}
@@ -16,9 +18,12 @@ function createStorageMock(): Storage {
 
 describe('xmppResource', () => {
   describe('generateResource', () => {
-    it('should generate a resource with the given prefix and 6-char suffix', () => {
-      const resource = generateResource('web')
-      expect(resource).toMatch(/^web-[a-z0-9]{6}$/)
+    it.each([
+      ['web', 'w'],
+      ['desktop', 'd'],
+      ['mobile', 'm'],
+    ] as const)('should identify %s with fluux-%s and a 5-char suffix', (platform, letter) => {
+      expect(generateResource(platform)).toMatch(new RegExp(`^fluux-${letter}[a-z0-9]{5}$`))
     })
 
     it('should generate unique resources', () => {
@@ -26,13 +31,22 @@ describe('xmppResource', () => {
       expect(resources.size).toBeGreaterThan(1)
     })
 
-    it('should use the provided prefix', () => {
-      expect(generateResource('desktop')).toMatch(/^desktop-/)
-      expect(generateResource('mobile')).toMatch(/^mobile-/)
-    })
   })
 
   describe('isValidResource', () => {
+    it.each(['fluux-wabc12', 'fluux-d00000', 'fluux-mzzzzz'])(
+      'should accept %s', (resource) => {
+        expect(isValidResource(resource)).toBe(true)
+      },
+    )
+
+    it.each([
+      'fluux-w', 'fluux-wabc1', 'fluux-wabc123', 'fluux-xabc12',
+      'fluux-Wabc12', 'Fluux-wabc12', 'fluux-wABC12', 'fluux-wabc!2',
+    ])('should reject malformed resource %s', (resource) => {
+      expect(isValidResource(resource)).toBe(false)
+    })
+
     it('should accept valid web resources', () => {
       expect(isValidResource('web-abc123')).toBe(true)
       expect(isValidResource('web-000000')).toBe(true)
@@ -75,6 +89,7 @@ describe('xmppResource', () => {
     let originalLocalStorage: Storage
 
     beforeEach(async () => {
+      nativePlatform.mockReset().mockReturnValue('macos')
       mockSessionStorage = createStorageMock()
       mockLocalStorage = createStorageMock()
       originalSessionStorage = globalThis.sessionStorage
@@ -110,8 +125,9 @@ describe('xmppResource', () => {
     it('should generate a new web resource when sessionStorage is empty', async () => {
       const getRes = await loadGetResource('web')
       const resource = getRes()
-      expect(resource).toMatch(/^web-[a-z0-9]{6}$/)
+      expect(resource).toMatch(/^fluux-w[a-z0-9]{5}$/)
       expect(mockSessionStorage.setItem).toHaveBeenCalledWith('xmpp-resource', resource)
+      expect(nativePlatform).not.toHaveBeenCalled()
     })
 
     it('should return existing valid web resource from sessionStorage', async () => {
@@ -124,14 +140,14 @@ describe('xmppResource', () => {
       mockSessionStorage.setItem('xmpp-resource', 'web')
       const getRes = await loadGetResource('web')
       const resource = getRes()
-      expect(resource).toMatch(/^web-[a-z0-9]{6}$/)
+      expect(resource).toMatch(/^fluux-w[a-z0-9]{5}$/)
       expect(resource).not.toBe('web')
     })
 
     it('should generate a new desktop resource when localStorage is empty', async () => {
       const getRes = await loadGetResource('desktop')
       const resource = getRes()
-      expect(resource).toMatch(/^desktop-[a-z0-9]{6}$/)
+      expect(resource).toMatch(/^fluux-d[a-z0-9]{5}$/)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('xmpp-resource', resource)
     })
 
@@ -145,8 +161,45 @@ describe('xmppResource', () => {
       mockLocalStorage.setItem('xmpp-resource', 'desktop')
       const getRes = await loadGetResource('desktop')
       const resource = getRes()
-      expect(resource).toMatch(/^desktop-[a-z0-9]{6}$/)
+      expect(resource).toMatch(/^fluux-d[a-z0-9]{5}$/)
       expect(resource).not.toBe('desktop')
+    })
+
+    it.each(['ios', 'android'])('should generate a persistent mobile resource on %s', async (os) => {
+      nativePlatform.mockReturnValue(os)
+      const getRes = await loadGetResource('desktop')
+      const resource = getRes()
+      expect(resource).toMatch(/^fluux-m[a-z0-9]{5}$/)
+      expect(mockLocalStorage.getItem('xmpp-resource')).toBe(resource)
+      expect(getRes()).toBe(resource)
+      expect(mockSessionStorage.length).toBe(0)
+    })
+
+    it.each([
+      ['web', 'fluux-wabc12'],
+      ['desktop', 'fluux-dabc12'],
+      ['desktop', 'fluux-mabc12'],
+    ] as const)('should preserve a stored %s resource %s across reloads', async (shell, resource) => {
+      const storage = shell === 'web' ? mockSessionStorage : mockLocalStorage
+      storage.setItem('xmpp-resource', resource)
+      const getRes = await loadGetResource(shell)
+      expect(getRes()).toBe(resource)
+      vi.resetModules()
+      const getResAfterReload = await loadGetResource(shell)
+      expect(getResAfterReload()).toBe(resource)
+    })
+
+    it('should fall back to desktop when the native OS is unavailable', async () => {
+      nativePlatform.mockImplementation(() => { throw new Error('OS plugin unavailable') })
+      const getRes = await loadGetResource('desktop')
+      expect(getRes()).toMatch(/^fluux-d[a-z0-9]{5}$/)
+    })
+
+    it('should keep the web type in a mobile browser without querying the native OS', async () => {
+      nativePlatform.mockReturnValue('android')
+      const getRes = await loadGetResource('web')
+      expect(getRes()).toMatch(/^fluux-w[a-z0-9]{5}$/)
+      expect(nativePlatform).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/fluux/src/utils/xmppResource.ts
+++ b/apps/fluux/src/utils/xmppResource.ts
@@ -4,8 +4,8 @@
  * The resource is the third part of a JID (user@domain/resource).
  * It identifies a specific client connection.
  *
- * - Desktop (Tauri): Generate a random resource on first launch and persist it
- *   in localStorage. This allows the desktop app to maintain its own session
+ * - Native (Tauri desktop/mobile): Generate a random resource on first launch and persist it
+ *   in localStorage. This allows the native app to maintain its own session
  *   across restarts.
  *
  * - Web: Generate a unique resource per tab/window and persist it in
@@ -14,28 +14,40 @@
  */
 
 import { platform } from '@/platform'
+import { platform as nativePlatform } from '@tauri-apps/plugin-os'
 
 const RESOURCE_KEY = 'xmpp-resource'
 
 /**
- * Generates a random resource identifier with the given prefix.
- * Format: "{prefix}-XXXXXX" where X is alphanumeric
+ * Generates a branded resource: "fluux-{w|d|m}XXXXX", with five random
+ * lowercase alphanumeric characters after the platform letter.
  */
-export function generateResource(prefix: string): string {
+export function generateResource(clientPlatform: 'web' | 'desktop' | 'mobile'): string {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
   let suffix = ''
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 5; i++) {
     suffix += chars.charAt(Math.floor(Math.random() * chars.length))
   }
-  return `${prefix}-${suffix}`
+  return `fluux-${clientPlatform[0]}${suffix}`
 }
 
 /**
- * Validates that a stored resource has the expected format: "{prefix}-XXXXXX".
- * Rejects bare prefixes (e.g. "web", "desktop") that predate the random suffix system.
+ * Accepts branded resources and legacy random resources so a reload can resume
+ * the same session. Bare prefixes lack a unique suffix and must be replaced.
  */
 export function isValidResource(resource: string): boolean {
-  return /^(web|desktop)-[a-z0-9]{6}$/.test(resource)
+  return /^fluux-[wdm][a-z0-9]{5}$/.test(resource)
+    || /^(web|desktop)-[a-z0-9]{6}$/.test(resource)
+}
+
+function getNativeResourcePlatform(): 'desktop' | 'mobile' {
+  try {
+    const os = nativePlatform()
+    return os === 'ios' || os === 'android' ? 'mobile' : 'desktop'
+  } catch {
+    // Match the SDK's desktop fallback when the native OS plugin is unavailable.
+    return 'desktop'
+  }
 }
 
 /**
@@ -49,10 +61,10 @@ export function isValidResource(resource: string): boolean {
  */
 export function getResource(): string {
   if (platform().hasStableInstallIdentity) {
-    // Desktop: Use persistent random resource (survives app restarts)
+    // Native: Use persistent random resource (survives app restarts)
     let resource = localStorage.getItem(RESOURCE_KEY)
     if (!resource || !isValidResource(resource)) {
-      resource = generateResource('desktop')
+      resource = generateResource(getNativeResourcePlatform())
       localStorage.setItem(RESOURCE_KEY, resource)
     }
     return resource


### PR DESCRIPTION
Generate XMPP resources with `fluux-w`, `fluux-d`, or `fluux-m` followed by five random characters, identifying web, desktop, and native mobile clients in server session metrics. Preserve existing resource names and disco/caps identity, and document the change in the 0.17.3 changelog.

Closes #1351.
