### PR TITLE
feat: show local history migration progress

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -31,6 +31,7 @@ const {
     // the pane swap — and the room half would stay unfalsifiable.
     chatActivationPending: false,
     roomActivationPending: false,
+    cacheMigrationProgress: null as { percent: number | null } | null,
     isArchivedResult: false,
     conversations: new Map<string, { id: string }>(),
     rooms: new Map<string, { jid: string; joined: boolean }>(),
@@ -310,6 +311,10 @@ vi.mock('@fluux/sdk/react', async () => {
   // re-render, like the real Zustand subscriptions do.
   const useMockStoreSubscription = () => useSyncExternalStore(subscribeMockState, getMockStateVersion)
   return {
+  useCacheMigration: () => {
+    useMockStoreSubscription()
+    return getMockState().cacheMigrationProgress
+  },
   useChatStore: Object.assign(
     (selector: (state: {
       activeConversationId: string | null;
@@ -1517,6 +1522,7 @@ describe('ChatLayout - mobile pane swap during a hydrating activation', () => {
       activeRoomJid: null,
       chatActivationPending: false,
       roomActivationPending: false,
+      cacheMigrationProgress: null,
       isArchivedResult: false,
       conversations: new Map(),
       rooms: new Map(),
@@ -1524,7 +1530,27 @@ describe('ChatLayout - mobile pane swap during a hydrating activation', () => {
   })
 
   afterEach(() => {
-    setMockState({ chatActivationPending: false, roomActivationPending: false })
+    setMockState({ chatActivationPending: false, roomActivationPending: false, cacheMigrationProgress: null })
+  })
+
+  it.each([
+    ['/messages', 'chatActivationPending'],
+    ['/rooms', 'roomActivationPending'],
+  ] as const)('shows migration progress on %s only while the local history is upgrading', (route, pendingFlag) => {
+    i18n.addResource('en', 'translation', 'chat.updatingLocalHistory', 'Updating local history…')
+    i18n.addResource('en', 'translation', 'chat.loadingMessages', en.chat.loadingMessages)
+    setMockState({ [pendingFlag]: true, cacheMigrationProgress: { percent: null } })
+    render(<ChatLayoutWithRouter initialRoute={route} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Updating local history…')
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    act(() => setMockState({ cacheMigrationProgress: { percent: 45 } }))
+    expect(screen.getByRole('progressbar', { name: 'Updating local history…' })).toHaveAttribute('aria-valuenow', '45')
+    expect(screen.getByText('45%')).toBeInTheDocument()
+
+    act(() => setMockState({ cacheMigrationProgress: null }))
+    expect(screen.getByRole('status')).toHaveTextContent(en.chat.loadingMessages)
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
   })
 
   it.each([

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -31,7 +31,7 @@ import {
 import { getActiveMessageListController } from './conversation/activeMessageListController'
 import { useMessageRequestPreviewStore } from '@/stores/messageRequestPreviewStore'
 // React hook wrappers for reactive subscriptions
-import { useChatStore, useRoomStore, useRosterStore, useConnectionStore, useConsoleStore, useAdminStore, useSearchStore } from '@fluux/sdk/react'
+import { useCacheMigration, useChatStore, useRoomStore, useRosterStore, useConnectionStore, useConsoleStore, useAdminStore, useSearchStore } from '@fluux/sdk/react'
 import { useNotificationBadge } from '@/hooks/useNotificationBadge'
 import { useDesktopNotifications } from '@/hooks/useDesktopNotifications'
 import { useWebPush } from '@/hooks/useWebPush'
@@ -113,6 +113,30 @@ function GlobalEffects() {
   return null
 }
 
+function HistoryLoadingStatus() {
+  const { t, i18n } = useTranslation()
+  const migration = useCacheMigration()
+  const label = t(migration ? 'chat.updatingLocalHistory' : 'chat.loadingMessages')
+  const percent = migration?.percent
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 text-center text-fluux-muted">
+      <Loader2 className="size-8 animate-spin text-fluux-brand" aria-hidden="true" />
+      <p role="status">{label}</p>
+      {percent != null && (
+        <div className="w-64 max-w-full space-y-2">
+          <div role="progressbar" aria-label={label} aria-valuemin={0} aria-valuemax={100} aria-valuenow={percent}
+            className="h-1.5 overflow-hidden rounded-full bg-fluux-bg">
+            <div className="h-full bg-fluux-brand transition-[width] motion-reduce:transition-none" style={{ width: `${percent}%` }} />
+          </div>
+          <p className="text-sm tabular-nums" aria-hidden="true">
+            {new Intl.NumberFormat(i18n.resolvedLanguage, { style: 'percent' }).format(percent / 100)}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 /** Lightweight skeleton fallback for lazy-loaded views to prevent layout shift */
 function ViewLoadingFallback({ onBack }: { onBack?: () => void }) {
   const { t } = useTranslation()
@@ -126,12 +150,7 @@ function ViewLoadingFallback({ onBack }: { onBack?: () => void }) {
           </button>
         )}
       </div>
-      {onBack ? (
-        <div role="status" className="flex-1 flex flex-col items-center justify-center gap-3 text-fluux-muted">
-          <Loader2 className="size-8 animate-spin text-fluux-brand" aria-hidden="true" />
-          <p>{t('chat.loadingMessages')}</p>
-        </div>
-      ) : <div className="flex-1" />}
+      {onBack ? <HistoryLoadingStatus /> : <div className="flex-1" />}
     </div>
   )
 }

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router'
 import { XMPPProvider, E2EEManager, InMemoryStorageBackend, subscribeDiagnostics } from '@fluux/sdk'
 import { DemoClient, setResidentWindowSize } from '@fluux/sdk/demo'
-import { adminStore, chatStore, ignoreStore, roomStore } from '@fluux/sdk/stores'
+import { adminStore, cacheMigrationStore, chatStore, ignoreStore, roomStore } from '@fluux/sdk/stores'
 import { DemoOpenPGPPlugin, DEMO_AVA_FINGERPRINT } from './demo/DemoOpenPGPPlugin'
 import { ThemeProvider } from './providers/ThemeProvider'
 import { useThemeStore } from './stores/themeStore'
@@ -167,6 +167,7 @@ setSessionPassphrase('demo')
 ;(window as any).__adminStore = adminStore
 ;(window as any).__roomStore = roomStore
 ;(window as any).__chatStore = chatStore
+;(window as unknown as { __cacheMigrationStore: typeof cacheMigrationStore }).__cacheMigrationStore = cacheMigrationStore
 ;(window as any).__themeStore = useThemeStore
 ;(window as any).__settingsStore = useSettingsStore
 ;(window as any).__i18n = i18n

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -470,6 +470,7 @@
         "reactWith": "التفاعل بـ {{emoji}}",
         "noMessages": "لا توجد رسائل بعد. قل مرحبًا!",
         "loadingMessages": "جارٍ تحميل الرسائل...",
+        "updatingLocalHistory": "جارٍ تحديث السجل المحلي…",
         "newMessages": "رسائل جديدة",
         "newMessagesCount_zero": "لا رسائل جديدة",
         "newMessagesCount": "رسالة جديدة واحدة",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -468,6 +468,7 @@
         "reactWith": "Адрэагаваць {{emoji}}",
         "noMessages": "Яшчэ няма паведамленняў. Вітаюце!",
         "loadingMessages": "Загрузка паведамленняў...",
+        "updatingLocalHistory": "Абнаўленне лакальнай гісторыі…",
         "newMessages": "Новыя паведамленні",
         "newMessagesCount": "{{displayCount}} новае паведамленне",
         "newMessagesCount_few": "{{displayCount}} новыя паведамленні",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -466,6 +466,7 @@
         "reactWith": "Реагирай с {{emoji}}",
         "noMessages": "Все още няма съобщения. Кажи здравей!",
         "loadingMessages": "Зареждане на съобщения...",
+        "updatingLocalHistory": "Обновяване на локалната история…",
         "newMessages": "Нови съобщения",
         "newMessagesCount": "{{displayCount}} ново съобщение",
         "newMessagesCount_other": "{{displayCount}} нови съобщения",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -469,6 +469,7 @@
         "reactWith": "Reacciona amb {{emoji}}",
         "noMessages": "Encara no hi ha missatges. Digues hola!",
         "loadingMessages": "Carregant missatges...",
+        "updatingLocalHistory": "S’està actualitzant l’historial local…",
         "newMessages": "Missatges nous",
         "newMessagesCount": "{{displayCount}} missatge nou",
         "newMessagesCount_many": "{{displayCount}} de missatges nous",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -470,6 +470,7 @@
         "reactWith": "Reagovat pomocí {{emoji}}",
         "noMessages": "Zatím žádné zprávy. Pozdravte!",
         "loadingMessages": "Načítání zpráv...",
+        "updatingLocalHistory": "Aktualizace místní historie…",
         "newMessages": "Nové zprávy",
         "newMessagesCount": "{{displayCount}} nová zpráva",
         "newMessagesCount_few": "{{displayCount}} nové zprávy",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -466,6 +466,7 @@
         "reactWith": "Reager med {{emoji}}",
         "noMessages": "Ingen beskeder endnu. Sig hej!",
         "loadingMessages": "Indlæser beskeder...",
+        "updatingLocalHistory": "Opdaterer lokal historik…",
         "newMessages": "Nye beskeder",
         "newMessagesCount": "{{displayCount}} ny besked",
         "newMessagesCount_other": "{{displayCount}} nye beskeder",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -468,6 +468,7 @@
         "reactWith": "Mit {{emoji}} reagieren",
         "noMessages": "Noch keine Nachrichten. Sagen Sie Hallo!",
         "loadingMessages": "Nachrichten werden geladen...",
+        "updatingLocalHistory": "Lokaler Verlauf wird aktualisiert…",
         "newMessages": "Neue Nachrichten",
         "newMessagesCount": "{{displayCount}} neue Nachricht",
         "newMessagesCount_other": "{{displayCount}} neue Nachrichten",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -467,6 +467,7 @@
         "reactWith": "Αντίδραση με {{emoji}}",
         "noMessages": "Δεν υπάρχουν μηνύματα ακόμα. Πείτε γεια!",
         "loadingMessages": "Φόρτωση μηνυμάτων...",
+        "updatingLocalHistory": "Ενημέρωση τοπικού ιστορικού…",
         "newMessages": "Νέα μηνύματα",
         "newMessagesCount": "{{displayCount}} νέο μήνυμα",
         "newMessagesCount_other": "{{displayCount}} νέα μηνύματα",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -466,6 +466,7 @@
         "reactWith": "React with {{emoji}}",
         "noMessages": "No messages yet. Say hello!",
         "loadingMessages": "Loading messages...",
+        "updatingLocalHistory": "Updating local history…",
         "newMessages": "New messages",
         "newMessagesCount": "{{displayCount}} new message",
         "newMessagesCount_other": "{{displayCount}} new messages",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -469,6 +469,7 @@
         "reactWith": "Reaccionar con {{emoji}}",
         "noMessages": "Sin mensajes aun. Di hola!",
         "loadingMessages": "Cargando mensajes...",
+        "updatingLocalHistory": "Actualizando el historial local…",
         "newMessages": "Mensajes nuevos",
         "newMessagesCount": "{{displayCount}} mensaje nuevo",
         "newMessagesCount_many": "{{displayCount}} de mensajes nuevos",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -468,6 +468,7 @@
         "reactWith": "Reageeri emotikoniga {{emoji}}",
         "noMessages": "Sõnumeid veel pole. Ütle tere!",
         "loadingMessages": "Sõnumite laadimine...",
+        "updatingLocalHistory": "Kohaliku ajaloo uuendamine…",
         "newMessages": "Uued sõnumid",
         "newMessagesCount": "{{displayCount}} uus sõnum",
         "newMessagesCount_other": "{{displayCount}} uut sõnumit",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -466,6 +466,7 @@
         "reactWith": "Reagoi {{emoji}}",
         "noMessages": "Ei viestejä vielä. Sano hei!",
         "loadingMessages": "Ladataan viestejä...",
+        "updatingLocalHistory": "Päivitetään paikallista historiaa…",
         "newMessages": "Uudet viestit",
         "newMessagesCount": "{{displayCount}} uusi viesti",
         "newMessagesCount_other": "{{displayCount}} uutta viestiä",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -468,6 +468,7 @@
         "reactWith": "Réagir avec {{emoji}}",
         "noMessages": "Aucun message. Dites bonjour !",
         "loadingMessages": "Chargement des messages...",
+        "updatingLocalHistory": "Mise à jour de l’historique local…",
         "newMessages": "Nouveaux messages",
         "newMessagesCount": "{{displayCount}} nouveau message",
         "newMessagesCount_many": "{{displayCount}} de nouveaux messages",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -469,6 +469,7 @@
         "reactWith": "Freagair le {{emoji}}",
         "noMessages": "Níl aon teachtaireachtaí fós. Abair haló!",
         "loadingMessages": "Ag luchtú teachtaireachtaí...",
+        "updatingLocalHistory": "Stair áitiúil á nuashonrú…",
         "newMessages": "Teachtaireachtaí nua",
         "newMessagesCount": "{{displayCount}} teachtaireacht nua",
         "newMessagesCount_two": "{{displayCount}} theachtaireacht nua",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -467,6 +467,7 @@
         "reactWith": "הגב עם {{emoji}}",
         "noMessages": "אין הודעות עדיין. אמור שלום!",
         "loadingMessages": "טוען הודעות...",
+        "updatingLocalHistory": "מעדכן את ההיסטוריה המקומית…",
         "newMessages": "הודעות חדשות",
         "newMessagesCount": "הודעה חדשה אחת",
         "newMessagesCount_two": "2 הודעות חדשות",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -467,6 +467,7 @@
         "reactWith": "Reagiraj s {{emoji}}",
         "noMessages": "Još nema poruka. Reci bok!",
         "loadingMessages": "Učitavanje poruka...",
+        "updatingLocalHistory": "Ažuriranje lokalne povijesti…",
         "newMessages": "Nove poruke",
         "newMessagesCount": "{{displayCount}} nova poruka",
         "newMessagesCount_few": "{{displayCount}} nove poruke",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -466,6 +466,7 @@
         "reactWith": "Reagálás: {{emoji}}",
         "noMessages": "Még nincsenek üzenetek. Köszönjön!",
         "loadingMessages": "Üzenetek betöltése...",
+        "updatingLocalHistory": "Helyi előzmények frissítése…",
         "newMessages": "Új üzenetek",
         "newMessagesCount": "{{displayCount}} új üzenet",
         "newMessagesCount_other": "{{displayCount}} új üzenet",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -466,6 +466,7 @@
         "reactWith": "Bregðast við með {{emoji}}",
         "noMessages": "Engin skilaboð enn. Segðu halló!",
         "loadingMessages": "Hleð skilaboðum...",
+        "updatingLocalHistory": "Uppfæri staðbundna sögu…",
         "newMessages": "Ný skilaboð",
         "newMessagesCount": "{{displayCount}} nýtt skilaboð",
         "newMessagesCount_other": "{{displayCount}} ný skilaboð",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -469,6 +469,7 @@
         "reactWith": "Reagisci con {{emoji}}",
         "noMessages": "Nessun messaggio. Di' ciao!",
         "loadingMessages": "Caricamento messaggi...",
+        "updatingLocalHistory": "Aggiornamento della cronologia locale…",
         "newMessages": "Nuovi messaggi",
         "newMessagesCount": "{{displayCount}} nuovo messaggio",
         "newMessagesCount_many": "{{displayCount}} di nuovi messaggi",

--- a/apps/fluux/src/i18n/locales/ko.json
+++ b/apps/fluux/src/i18n/locales/ko.json
@@ -466,6 +466,7 @@
         "reactWith": "{{emoji}}로 반응",
         "noMessages": "아직 메시지가 없습니다. 인사해보세요!",
         "loadingMessages": "메시지 불러오는 중...",
+        "updatingLocalHistory": "로컬 기록 업데이트 중…",
         "newMessages": "새 메시지",
         "newMessagesCount": "새 메시지 {{displayCount}}개",
         "newMessagesCount_other": "새 메시지 {{displayCount}}개",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -468,6 +468,7 @@
         "reactWith": "Reaguoti su {{emoji}}",
         "noMessages": "Kol kas nėra žinučių. Pasakyk labas!",
         "loadingMessages": "Įkeliamos žinutės...",
+        "updatingLocalHistory": "Atnaujinama vietinė istorija…",
         "newMessages": "Naujos žinutės",
         "newMessagesCount": "{{displayCount}} naujas pranešimas",
         "newMessagesCount_few": "{{displayCount}} nauji pranešimai",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -468,6 +468,7 @@
         "reactWith": "Reaģēt ar {{emoji}}",
         "noMessages": "Vēl nav ziņojumu. Pasaki sveiki!",
         "loadingMessages": "Ielādē ziņojumus...",
+        "updatingLocalHistory": "Notiek lokālās vēstures atjaunināšana…",
         "newMessages": "Jauni ziņojumi",
         "newMessagesCount_zero": "{{displayCount}} jaunu ziņojumu",
         "newMessagesCount": "{{displayCount}} jauns ziņojums",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -471,6 +471,7 @@
         "reactWith": "Reazzjoni b'{{emoji}}",
         "noMessages": "Għad m'hemmx messaġġi. Għid bonġu!",
         "loadingMessages": "Qed jgħabbu l-messaġġi...",
+        "updatingLocalHistory": "Qed tiġi aġġornata l-istorja lokali…",
         "newMessages": "Messaġġi ġodda",
         "newMessagesCount": "{{displayCount}} messaġġ ġdid",
         "newMessagesCount_two": "{{displayCount}} messaġġi ġodda",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -466,6 +466,7 @@
         "reactWith": "Reager med {{emoji}}",
         "noMessages": "Ingen meldinger ennå. Si hei!",
         "loadingMessages": "Laster meldinger...",
+        "updatingLocalHistory": "Oppdaterer lokal historikk…",
         "newMessages": "Nye meldinger",
         "newMessagesCount": "{{displayCount}} ny melding",
         "newMessagesCount_other": "{{displayCount}} nye meldinger",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -466,6 +466,7 @@
         "reactWith": "Reageren met {{emoji}}",
         "noMessages": "Nog geen berichten. Zeg hallo!",
         "loadingMessages": "Berichten laden...",
+        "updatingLocalHistory": "Lokale geschiedenis bijwerken…",
         "newMessages": "Nieuwe berichten",
         "newMessagesCount": "{{displayCount}} nieuw bericht",
         "newMessagesCount_other": "{{displayCount}} nieuwe berichten",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -470,6 +470,7 @@
         "reactWith": "Zareaguj {{emoji}}",
         "noMessages": "Brak wiadomości. Przywitaj się!",
         "loadingMessages": "Ładowanie wiadomości...",
+        "updatingLocalHistory": "Aktualizowanie lokalnej historii…",
         "newMessages": "Nowe wiadomości",
         "newMessagesCount": "{{displayCount}} nowa wiadomość",
         "newMessagesCount_few": "{{displayCount}} nowe wiadomości",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -469,6 +469,7 @@
         "reactWith": "Reagir com {{emoji}}",
         "noMessages": "Ainda não há mensagens. Diga olá!",
         "loadingMessages": "Carregando mensagens...",
+        "updatingLocalHistory": "A atualizar o histórico local…",
         "newMessages": "Novas mensagens",
         "newMessagesCount": "{{displayCount}} mensagem nova",
         "newMessagesCount_many": "{{displayCount}} de mensagens novas",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -469,6 +469,7 @@
         "reactWith": "Reacționează cu {{emoji}}",
         "noMessages": "Niciun mesaj încă. Spune bună!",
         "loadingMessages": "Se încarcă mesajele...",
+        "updatingLocalHistory": "Se actualizează istoricul local…",
         "newMessages": "Mesaje noi",
         "newMessagesCount": "{{displayCount}} mesaj nou",
         "newMessagesCount_few": "{{displayCount}} mesaje noi",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -468,6 +468,7 @@
         "reactWith": "Реагировать {{emoji}}",
         "noMessages": "Пока нет сообщений. Скажите привет!",
         "loadingMessages": "Загрузка сообщений...",
+        "updatingLocalHistory": "Обновление локальной истории…",
         "newMessages": "Новые сообщения",
         "newMessagesCount": "{{displayCount}} новое сообщение",
         "newMessagesCount_few": "{{displayCount}} новых сообщения",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -469,6 +469,7 @@
         "reactWith": "Reagovať s {{emoji}}",
         "noMessages": "Zatiaľ žiadne správy. Povedzte ahoj!",
         "loadingMessages": "Načítavajú sa správy...",
+        "updatingLocalHistory": "Aktualizuje sa miestna história…",
         "newMessages": "Nové správy",
         "newMessagesCount": "{{displayCount}} nová správa",
         "newMessagesCount_few": "{{displayCount}} nové správy",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -470,6 +470,7 @@
         "reactWith": "Odzovi se z {{emoji}}",
         "noMessages": "Še ni sporočil. Pozdravi!",
         "loadingMessages": "Nalaganje sporočil...",
+        "updatingLocalHistory": "Posodabljanje lokalne zgodovine…",
         "newMessages": "Nova sporočila",
         "newMessagesCount": "{{displayCount}} novo sporočilo",
         "newMessagesCount_two": "{{displayCount}} novi sporočili",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -466,6 +466,7 @@
         "reactWith": "Reagera med {{emoji}}",
         "noMessages": "Inga meddelanden ännu. Säg hej!",
         "loadingMessages": "Laddar meddelanden...",
+        "updatingLocalHistory": "Uppdaterar lokal historik…",
         "newMessages": "Nya meddelanden",
         "newMessagesCount": "{{displayCount}} nytt meddelande",
         "newMessagesCount_other": "{{displayCount}} nya meddelanden",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -468,6 +468,7 @@
         "reactWith": "Реагувати {{emoji}}",
         "noMessages": "Ще немає повідомлень. Привітайтеся!",
         "loadingMessages": "Завантаження повідомлень...",
+        "updatingLocalHistory": "Оновлення локальної історії…",
         "newMessages": "Нові повідомлення",
         "newMessagesCount": "{{displayCount}} нове повідомлення",
         "newMessagesCount_few": "{{displayCount}} нових повідомлення",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -466,6 +466,7 @@
         "reactWith": "使用 {{emoji}} 回应",
         "noMessages": "暂无消息。打个招呼吧！",
         "loadingMessages": "正在加载消息…",
+        "updatingLocalHistory": "正在更新本地历史记录…",
         "newMessages": "新消息",
         "newMessagesCount": "{{displayCount}} 条新消息",
         "newMessagesCount_other": "{{displayCount}} 条新消息",

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -189,6 +189,7 @@ export {
 // Vanilla stores (framework-agnostic, for imperative .getState() access)
 export {
   connectionStore,
+  cacheMigrationStore,
   chatStore,
   rosterStore,
   consoleStore,
@@ -198,6 +199,8 @@ export {
   blockingStore,
   searchStore,
 } from './stores'
+
+export type { CacheMigrationProgress, CacheMigrationState } from './stores/cacheMigrationStore'
 
 // React hook wrappers are available from '@fluux/sdk/react':
 // useConnectionStore, useChatStore, useRosterStore, useConsoleStore,

--- a/packages/fluux-sdk/src/react/index.ts
+++ b/packages/fluux-sdk/src/react/index.ts
@@ -101,6 +101,7 @@ export {
 // These are React-bound versions of the vanilla stores
 export {
   useConnectionStore,
+  useCacheMigration,
   useChatStore,
   useRosterStore,
   useConsoleStore,

--- a/packages/fluux-sdk/src/react/storeHooks.ts
+++ b/packages/fluux-sdk/src/react/storeHooks.ts
@@ -8,6 +8,7 @@
  */
 
 import { useStore } from 'zustand'
+import { cacheMigrationStore, type CacheMigrationState } from '../stores/cacheMigrationStore'
 import { connectionStore } from '../stores/connectionStore'
 import { chatStore } from '../stores/chatStore'
 import { rosterStore } from '../stores/rosterStore'
@@ -28,6 +29,13 @@ import type { AdminState } from '../stores/adminStore'
 import type { BlockingState } from '../stores/blockingStore'
 import type { IgnoreState } from '../stores/ignoreStore'
 import type { SearchState } from '../stores/searchStore'
+
+const selectCacheMigration = (state: CacheMigrationState) => state.progress
+
+/** Active local history upgrade, or null during ordinary cache reads. */
+export function useCacheMigration() {
+  return useStore(cacheMigrationStore, selectCacheMigration)
+}
 
 /**
  * React hook for the connection store.

--- a/packages/fluux-sdk/src/stores/cacheMigrationStore.ts
+++ b/packages/fluux-sdk/src/stores/cacheMigrationStore.ts
@@ -1,0 +1,42 @@
+import { createStore } from 'zustand/vanilla'
+
+/** Progress of a local message-cache upgrade; null percent means preparation. */
+export interface CacheMigrationProgress {
+  /** Percentage of the canonical-row scan, capped at 99 until the upgrade commits. */
+  percent: number | null
+}
+
+export interface CacheMigrationState {
+  /** Null outside an upgrade, including ordinary reads and first-time cache creation. */
+  progress: CacheMigrationProgress | null
+}
+
+/** Transient status for the current account's local message-cache migration. */
+export const cacheMigrationStore = createStore<CacheMigrationState>(() => ({ progress: null }))
+
+let generation = 0
+
+/** @internal An account change invalidates progress from the previous cache. */
+export function resetCacheMigration(): void {
+  generation++
+  if (cacheMigrationStore.getState().progress) cacheMigrationStore.setState({ progress: null })
+}
+
+/** @internal Owned by one IndexedDB open request, through commit or failure. */
+export function beginCacheMigration() {
+  const owner = ++generation
+  cacheMigrationStore.setState({ progress: { percent: null } })
+  return {
+    report(processed: number, total: number) {
+      if (owner !== generation) return
+      // The row scan is not a commit: reserve completion until openDB resolves.
+      const percent = total > 0 ? Math.min(99, Math.floor(processed * 100 / total)) : 99
+      if (cacheMigrationStore.getState().progress?.percent !== percent) {
+        cacheMigrationStore.setState({ progress: { percent } })
+      }
+    },
+    finish() {
+      if (owner === generation) resetCacheMigration()
+    },
+  }
+}

--- a/packages/fluux-sdk/src/stores/index.ts
+++ b/packages/fluux-sdk/src/stores/index.ts
@@ -41,6 +41,9 @@
 export { connectionStore } from './connectionStore'
 export type { ConnectionState } from './connectionStore'
 
+export { cacheMigrationStore } from './cacheMigrationStore'
+export type { CacheMigrationProgress, CacheMigrationState } from './cacheMigrationStore'
+
 export { chatStore } from './chatStore'
 export type { ChatState } from './chatStore'
 export { chatSelectors } from './chatSelectors'

--- a/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.aliasMigration.test.ts
@@ -5,9 +5,10 @@ import { openDB } from 'idb'
 import * as cache from './messageCache'
 import * as searchIndex from './searchIndex'
 import { CHAT_SCOPE, correctionReferenceKeys, identityKeys, roomScope } from './messageIdentity'
-import { _resetStorageScopeForTesting } from './storageScope'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
 import { _clearRetractedIdentitiesForTesting } from './retractedIdentities'
 import { retractUnresidentChatTarget, retractUnresidentRoomTarget } from '../stores/shared/retractionStorage'
+import { cacheMigrationStore } from '../stores/cacheMigrationStore'
 
 const DB_NAME = 'fluux-message-cache'
 const CHAT = 'peer@example.test'
@@ -67,6 +68,54 @@ afterEach(async () => {
 })
 
 describe('version-5 correction alias migration', () => {
+  it('reports real migration progress until commit, then stays idle on subsequent opens', async () => {
+    await seedV5()
+    const progress: Array<number | null | 'idle'> = []
+    const unsubscribe = cacheMigrationStore.subscribe(({ progress: value }) => {
+      progress.push(value ? value.percent : 'idle')
+    })
+    try {
+      await cache.getMessages(CHAT)
+      expect(progress).toEqual([null, 0, 50, 99, 'idle'])
+      const db = await openDB(DB_NAME)
+      expect(db.version).toBe(6)
+      db.close()
+      progress.length = 0
+      cache._resetDBForTesting()
+      await cache.getRoomMessages(ROOM)
+      expect(progress).toEqual([])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('does not announce migration when creating an empty cache', async () => {
+    const states: unknown[] = []
+    const unsubscribe = cacheMigrationStore.subscribe(state => { states.push(state.progress) })
+    try {
+      await cache.getMessages(CHAT)
+      expect(states).toEqual([])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('stops publishing an old account migration after the storage scope changes', async () => {
+    await seedV5()
+    const progress: Array<number | null | 'idle'> = []
+    const unsubscribe = cacheMigrationStore.subscribe(({ progress: value }) => {
+      progress.push(value ? value.percent : 'idle')
+      if (value?.percent === 0) setStorageScopeJid('other@example.test')
+    })
+    try {
+      await cache.getMessages(CHAT)
+      expect(progress).toEqual([null, 0, 'idle'])
+      expect(cacheMigrationStore.getState().progress).toBeNull()
+    } finally {
+      unsubscribe()
+    }
+  })
+
   it('preserves every row and key, then resolves and retracts cached correction aliases', async () => {
     const rows = await seedV5()
     expect((await cache.findChatRetractionTargets(CHAT, 'older-alias'))?.candidates).toHaveLength(1)
@@ -108,6 +157,8 @@ describe('version-5 correction alias migration', () => {
 
   it('rolls back both stores if alias backfill fails after its first update', async () => {
     const rows = await seedV5()
+    const progress: unknown[] = []
+    const unsubscribe = cacheMigrationStore.subscribe(state => { progress.push(state.progress) })
     const update = IDBCursor.prototype.update
     let updates = 0
     const fault = vi.spyOn(IDBCursor.prototype, 'update').mockImplementation(function (this: IDBCursor, value) {
@@ -115,6 +166,10 @@ describe('version-5 correction alias migration', () => {
       return update.call(this, value)
     })
     await cache.findChatRetractionTargets(CHAT, 'older-alias')
+    unsubscribe()
+    expect(progress).toContainEqual({ percent: 0 })
+    expect(progress.at(-1)).toBeNull()
+    expect(cacheMigrationStore.getState().progress).toBeNull()
     fault.mockRestore()
     const db = await openDB(DB_NAME)
     expect(db.version).toBe(5)

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -8,6 +8,7 @@
  */
 
 import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
+import { beginCacheMigration, resetCacheMigration } from '../stores/cacheMigrationStore'
 // Imported from the declaring modules rather than the `core/types` barrel:
 // the barrel also re-exports the store-binding port, which names
 // `GetMessagesOptions` from this file, so going through it would make the two
@@ -230,8 +231,13 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
   }
 
   dbNameForPromise = targetDbName
+  const scope = captureStorageScope()
+  let migration: ReturnType<typeof beginCacheMigration> | undefined
   const opening = openDB<MessageCacheSchema>(targetDbName, DB_VERSION, {
-    upgrade(db, _oldVersion, _newVersion, transaction) {
+    upgrade(db, oldVersion, _newVersion, transaction) {
+      if (oldVersion > 0 && scope.isCurrent() && scope.jid === scopeJid) {
+        migration = beginCacheMigration()
+      }
       // Which legacy stores this upgrade has to drain. Both migrations stream through
       // the SAME version-change transaction, so they are fired once, sequentially,
       // below: two concurrent cursor walks over one transaction would interleave
@@ -285,7 +291,7 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
       // alive meanwhile via the migration's chained requests, and openDB resolves
       // only after it commits. Do not deleteObjectStore here (illegal from the
       // async continuation) — the migration clear()s the legacy stores instead.
-      migrateStoresToCanonical(transaction, scopeJid, drain).catch((err) => {
+      migrateStoresToCanonical(transaction, scopeJid, drain, migration?.report).catch((err) => {
         // Log before aborting: this streaming rewrite of the whole archive is the
         // riskiest path in the upgrade, and the abort otherwise swallows the cause
         // silently. Then: aborting rejects openDB (getDB's caller handles that) AND
@@ -301,7 +307,8 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
   })
 
   dbPromise = opening
-  void opening.catch(() => {
+  void opening.then(() => migration?.finish(), () => {
+    migration?.finish()
     // An interrupted upgrade must be retryable. A superseded account's failure
     // must not invalidate the connection opened for the new account.
     if (dbPromise === opening) {
@@ -653,7 +660,7 @@ async function upsertRoomRowByIdentity(
 /** Minimal cursor view over a legacy store during migration. */
 type LegacyCursor<T> = { value: T; continue(): Promise<LegacyCursor<T> | null>; update(value: T): Promise<unknown> }
 /** Minimal legacy-store view: stream every row out, then empty. */
-type LegacyStore<T> = { openCursor(): Promise<LegacyCursor<T> | null>; clear(): Promise<void> }
+type LegacyStore<T> = { openCursor(): Promise<LegacyCursor<T> | null>; clear(): Promise<void>; count(): Promise<number> }
 /** Minimal version-change transaction view the streaming migration needs. */
 type MigrationTransaction = { objectStore(name: string): unknown }
 
@@ -676,7 +683,8 @@ type MigrationTransaction = { objectStore(name: string): unknown }
 async function migrateStoresToCanonical(
   transaction: MigrationTransaction,
   scopeJid: string | null,
-  drain: { chat: boolean; room: boolean }
+  drain: { chat: boolean; room: boolean },
+  report?: (processed: number, total: number) => void
 ): Promise<void> {
   if (drain.room) {
     const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE) as LegacyStore<StoredRoomMessage>
@@ -700,7 +708,14 @@ async function migrateStoresToCanonical(
     }
     await legacy.clear()
   }
-  for (const name of [MESSAGES_STORE, ROOM_MESSAGES_STORE] as const) {
+  const stores = [MESSAGES_STORE, ROOM_MESSAGES_STORE] as const
+  // Count after canonicalization: legacy rows may have merged by identity.
+  const total = report ? (await Promise.all(stores.map(name =>
+    (transaction.objectStore(name) as LegacyStore<StoredMessage>).count()
+  ))).reduce((sum, count) => sum + count, 0) : 0
+  let processed = 0
+  report?.(processed, total)
+  for (const name of stores) {
     const store = transaction.objectStore(name) as LegacyStore<StoredMessage | StoredRoomMessage>
     let cursor = await store.openCursor()
     while (cursor) {
@@ -711,6 +726,7 @@ async function migrateStoresToCanonical(
       if (aliases.some(key => !row.identityKeys.includes(key))) {
         await cursor.update({ ...row, identityKeys: unionSorted(row.identityKeys, aliases) })
       }
+      report?.(++processed, total)
       cursor = await cursor.continue()
     }
   }
@@ -2879,6 +2895,7 @@ export function isMessageCacheAvailable(): boolean {
 export function _resetDBForTesting(): void {
   dbPromise = null
   dbNameForPromise = null
+  resetCacheMigration()
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/storageScope.ts
+++ b/packages/fluux-sdk/src/utils/storageScope.ts
@@ -1,4 +1,5 @@
 import { getBareJid } from '../core/jid'
+import { resetCacheMigration } from '../stores/cacheMigrationStore'
 
 let currentStorageScopeJid: string | null = null
 let storageScopeGeneration = 0
@@ -22,7 +23,10 @@ export function getStorageScopeJid(): string | null {
  */
 export function setStorageScopeJid(jid: string | null | undefined): string | null {
   const next = normalizeScopeJid(jid)
-  if (next !== currentStorageScopeJid) storageScopeGeneration++
+  if (next !== currentStorageScopeJid) {
+    storageScopeGeneration++
+    resetCacheMigration()
+  }
   currentStorageScopeJid = next
   return currentStorageScopeJid
 }

--- a/scripts/history-loading.ts
+++ b/scripts/history-loading.ts
@@ -1,12 +1,63 @@
 import { test, expect, devices } from '@playwright/test'
 import { bootDemo } from './e2e/demoBoot'
-import type { chatStore, roomStore } from '@fluux/sdk'
+import type { cacheMigrationStore, chatStore, roomStore } from '@fluux/sdk'
 
 type DemoWindow = Window & {
   __chatStore: typeof chatStore
   __roomStore: typeof roomStore
+  __cacheMigrationStore: typeof cacheMigrationStore
+  __i18n: { changeLanguage(language: string): Promise<unknown> }
   __releaseHistoryRead?: () => void
   __historyOpening?: Promise<void>
+}
+
+for (const kind of ['chat', 'room'] as const) {
+  test(`${kind}: local migration progress stays readable on desktop and mobile`, async ({ page }, testInfo) => {
+    await bootDemo(page, '/demo.html?tutorial=false')
+    await page.locator(`[data-nav="${kind === 'chat' ? 'messages' : 'rooms'}"]`).click()
+    await page.evaluate(entity => {
+      const w = window as unknown as DemoWindow
+      if (entity === 'chat') w.__chatStore.setState({ activeConversationId: null, activationPending: true })
+      else w.__roomStore.setState({ activeRoomJid: null, activationPending: true })
+      w.__cacheMigrationStore.setState({ progress: { percent: null } })
+    }, kind)
+    const main = page.getByRole('main')
+    await expect(main.getByRole('status')).toHaveText('Updating local history…')
+    await expect(main.getByRole('progressbar')).toHaveCount(0)
+    await page.evaluate(() => {
+      (window as unknown as DemoWindow).__cacheMigrationStore.setState({ progress: { percent: 45 } })
+    })
+    for (const width of [1106, 390]) {
+      await page.setViewportSize({ width, height: 844 })
+      const bar = main.getByRole('progressbar', { name: 'Updating local history…' })
+      await expect(bar).toBeVisible()
+      await expect(bar).toHaveAttribute('aria-valuenow', '45')
+      await expect(main.getByText('45%')).toBeVisible()
+      const bounds = await bar.boundingBox()
+      expect(bounds!.x).toBeGreaterThanOrEqual(0)
+      expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(width)
+      await page.screenshot({ path: testInfo.outputPath(`migration-${width}.png`) })
+    }
+    await page.evaluate(async () => {
+      await (window as unknown as DemoWindow).__i18n.changeLanguage('fr')
+    })
+    await expect(main.getByRole('status')).toHaveText('Mise à jour de l’historique local…')
+    await expect(main.getByText(/45\s*%/)).toBeVisible()
+    await page.screenshot({ path: testInfo.outputPath('migration-fr-mobile.png') })
+    await page.setViewportSize({ width: 1106, height: 786 })
+    await page.screenshot({ path: testInfo.outputPath('migration-fr-desktop.png') })
+    await page.setViewportSize(devices['iPhone 13'].viewport)
+    await page.evaluate(async () => {
+      await (window as unknown as DemoWindow).__i18n.changeLanguage('en')
+    })
+    await page.evaluate(() => {
+      (window as unknown as DemoWindow).__cacheMigrationStore.setState({ progress: null })
+    })
+    await expect(main.getByRole('status')).toHaveText('Loading messages...')
+    await expect(main.getByRole('progressbar')).toHaveCount(0)
+    await main.getByRole('button', { name: 'Back', exact: true }).click()
+    await expect(page.getByTestId('sidebar-pane')).toBeVisible()
+  })
 }
 
 test.use({


### PR DESCRIPTION
Show “Updating local history…” and a progress bar while the local message cache is upgraded after an app update. Progress reflects the canonical message scan, clears when the upgrade commits or fails, and cannot leak across account changes.

The new message is translated into all 34 supported languages and appears only during a cache migration.
