### PR TITLE
fix(profile): keep vCard timeout negatives out of persistent cache

### DIFF
--- a/apps/fluux/src/components/conversation/UserInfoPopover.test.tsx
+++ b/apps/fluux/src/components/conversation/UserInfoPopover.test.tsx
@@ -6,11 +6,12 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
-import { UserInfoPopover, _profileDetailsCacheForTesting } from './UserInfoPopover'
+import { UserInfoPopover } from './UserInfoPopover'
 import type { ProfileDetails } from '@fluux/sdk'
 
 // Track the mock fetchProfileDetails function
 const mockFetchProfileDetails = vi.fn<(jid: string) => Promise<ProfileDetails | null>>()
+const mockClient = { profile: { fetchProfileDetails: mockFetchProfileDetails } }
 
 // Override the useXMPP mock for this test file
 vi.mock('@fluux/sdk', async (importOriginal) => {
@@ -18,7 +19,7 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
   return {
     ...actual,
     useXMPP: () => ({
-      client: { profile: { fetchProfileDetails: mockFetchProfileDetails } },
+      client: mockClient,
       sendRawXml: vi.fn(),
       onStanza: vi.fn(() => vi.fn()),
       on: vi.fn(() => vi.fn()),
@@ -33,8 +34,6 @@ vi.mock('@fluux/sdk', async (importOriginal) => {
 describe('UserInfoPopover', () => {
   beforeEach(() => {
     mockFetchProfileDetails.mockReset()
-    // Clear the module-level details cache between tests
-    _profileDetailsCacheForTesting.clear()
   })
 
   it('should render trigger element', () => {
@@ -45,6 +44,35 @@ describe('UserInfoPopover', () => {
     )
 
     expect(screen.getByText('Alice')).toBeInTheDocument()
+  })
+
+  it.each(['empty', 'rejected', 'populated'])(
+    'asks the SDK again when reopening a previously %s profile', async outcome => {
+      if (outcome === 'rejected') mockFetchProfileDetails.mockRejectedValueOnce(new Error('Timeout'))
+      else mockFetchProfileDetails.mockResolvedValueOnce(outcome === 'populated' ? { fullName: 'Old Name' } : null)
+      render(<UserInfoPopover jid="alice@example.com"><span>Open profile</span></UserInfoPopover>)
+      await act(async () => { fireEvent.click(screen.getByText('Open profile')) })
+      expect(mockFetchProfileDetails).toHaveBeenCalledTimes(1)
+      fireEvent.click(screen.getByText('Open profile'))
+      mockFetchProfileDetails.mockResolvedValueOnce({ fullName: 'Recovered Name' })
+      await act(async () => { fireEvent.click(screen.getByText('Open profile')) })
+      expect(screen.getByText('Recovered Name')).toBeInTheDocument()
+      expect(screen.queryByText('Old Name')).not.toBeInTheDocument()
+      expect(mockFetchProfileDetails).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('clears previous details while a replacement profile is pending', async () => {
+    mockFetchProfileDetails.mockResolvedValueOnce({ fullName: 'Alice Smith' })
+    const view = render(<UserInfoPopover occupantJid="room@example.com/alice"><span>Open profile</span></UserInfoPopover>)
+    await act(async () => { fireEvent.click(screen.getByText('Open profile')) })
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    let reply!: (details: ProfileDetails) => void
+    mockFetchProfileDetails.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+    view.rerender(<UserInfoPopover occupantJid="room@example.com/bob"><span>Open profile</span></UserInfoPopover>)
+    expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument()
+    await act(async () => { reply({ fullName: 'Bob Smith' }) })
+    expect(screen.getByText('Bob Smith')).toBeInTheDocument()
   })
 
   it('should show JID when popover is opened', () => {

--- a/apps/fluux/src/components/conversation/UserInfoPopover.tsx
+++ b/apps/fluux/src/components/conversation/UserInfoPopover.tsx
@@ -69,12 +69,6 @@ function getDeviceIcon(clientName: string) {
   return <HelpCircle className="size-3" />
 }
 
-// Cache the details across popover opens to avoid redundant fetches
-const profileDetailsCache = new Map<string, ProfileDetails | null>()
-
-/** @internal Exported for testing only */
-export const _profileDetailsCacheForTesting = profileDetailsCache
-
 export function UserInfoPopover({ contact, jid, occupantJid, role, affiliation, children, className = '' }: UserInfoPopoverProps) {
   const { t } = useTranslation()
   const { client } = useXMPP()
@@ -115,22 +109,15 @@ export function UserInfoPopover({ contact, jid, occupantJid, role, affiliation, 
     const targetJid = contact?.jid || jid || occupantJid
     if (!targetJid) return
 
-    // Check cache first
-    if (profileDetailsCache.has(targetJid)) {
-      setDetails(profileDetailsCache.get(targetJid) ?? null)
-      return
-    }
-
     let cancelled = false
+    setDetails(null)
     setDetailsLoading(true)
     client.profile.fetchProfileDetails(targetJid).then((result) => {
       if (cancelled) return
-      profileDetailsCache.set(targetJid, result)
       setDetails(result)
       setDetailsLoading(false)
     }).catch(() => {
       if (cancelled) return
-      profileDetailsCache.set(targetJid, null)
       setDetailsLoading(false)
     })
 

--- a/apps/fluux/src/hooks/useSessionPersistence.avatar.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.avatar.test.tsx
@@ -1,26 +1,26 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
-import { IDBFactory } from 'fake-indexeddb'
-import { XMPPClient } from '../../../../packages/fluux-sdk/src/core/XMPPClient'
-import { Connection } from '../../../../packages/fluux-sdk/src/core/modules/Connection'
-import { connectionStore } from '../../../../packages/fluux-sdk/src/stores/connectionStore'
-import * as avatarCache from '../../../../packages/fluux-sdk/src/utils/avatarCache'
+import { IDBFactory, IDBObjectStore } from 'fake-indexeddb'
+import { XMPPClient } from '@fluux/sdk/core'
+import { connectionStore } from '@fluux/sdk/stores'
+import { XMPPProvider } from '@fluux/sdk/react'
+import { clearAllAvatarData, revokeAllBlobUrls } from '@fluux/sdk/cache'
+import { xml, type Element } from '@fluux/sdk/xmpp'
 import { saveSession, useSessionPersistence } from './useSessionPersistence'
 
-const context = vi.hoisted(() => ({ client: null as unknown as XMPPClient }))
-
-vi.mock('../../../../packages/fluux-sdk/src/provider', () => ({ useXMPPContext: () => context }))
-vi.mock('@fluux/sdk', async () => ({
-  connectionStore: (await import('../../../../packages/fluux-sdk/src/stores/connectionStore')).connectionStore,
-  useConnectionActions: (await import('../../../../packages/fluux-sdk/src/hooks/useConnectionActions')).useConnectionActions,
-  useXMPPContext: () => context,
-  ...(await import('../../../../packages/fluux-sdk/src/core/jid')),
-  hasFastToken: () => false,
-  deleteFastToken: vi.fn(),
-}))
-vi.mock('@fluux/sdk/react', async () => {
-  const { useConnectionStore, useRosterStore } = await import('../../../../packages/fluux-sdk/src/react/storeHooks')
-  return { useConnectionStore, useRosterStore }
+vi.mock('@fluux/sdk', async () => {
+  const { connectionStore } = await import('@fluux/sdk/stores')
+  const { useConnectionActions, useXMPPContext } = await import('@fluux/sdk/react')
+  const { getBareJid, getDomain } = await import('@fluux/sdk/core')
+  return { connectionStore, useConnectionActions, useXMPPContext, getBareJid, getDomain,
+    hasFastToken: () => false, deleteFastToken: vi.fn() }
+})
+vi.mock('@fluux/sdk/react', async importOriginal => {
+  // This integration exercises the real provider, actions and store subscriptions.
+  const { XMPPProvider, useConnectionActions, useXMPPContext, useConnectionStore, useRosterStore } =
+    await importOriginal<typeof import('@fluux/sdk/react')>()
+  return { XMPPProvider, useConnectionActions, useXMPPContext, useConnectionStore, useRosterStore }
 })
 vi.mock('@/platform', () => ({ platform: () => ({
   hasNativeConnectionKeepalive: true, nativeKeychain: true, hasStableInstallIdentity: true,
@@ -32,23 +32,37 @@ const HASH = 'saved-own-avatar'
 describe('cached own avatar during session reload', () => {
   let finishTransport: () => void
   let releaseCache: () => void
-  let onConnectionSuccess: Parameters<Connection['setConnectionSuccessHandler']>[0]
+  let onConnectionSuccess: Parameters<XMPPClient['connection']['setConnectionSuccessHandler']>[0]
   let client: XMPPClient
   let cachedUrl: string
+
+  beforeAll(() => { vi.stubGlobal('indexedDB', new IDBFactory()) })
+  afterAll(() => { vi.unstubAllGlobals() })
 
   beforeEach(async () => {
     localStorage.clear()
     sessionStorage.clear()
     connectionStore.setState({ status: 'disconnected', jid: null, ownAvatar: null, ownAvatarHash: null })
-    globalThis.indexedDB = new IDBFactory()
-    cachedUrl = await avatarCache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
-    const handler = vi.spyOn(Connection.prototype, 'setConnectionSuccessHandler')
+    await clearAllAvatarData()
     class ReloadClient extends XMPPClient {
       protected override async sendStanza(): Promise<void> {}
+      protected override async sendIQ(): Promise<Element> {
+        return xml('iq', { type: 'result' },
+          xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+            xml('items', { node: 'urn:xmpp:avatar:data' },
+              xml('item', { id: HASH }, xml('data', { xmlns: 'urn:xmpp:avatar:data' }, 'aW1hZ2U=')))))
+      }
     }
+    const probe = new ReloadClient({ debug: false })
+    const connectionPrototype = Object.getPrototypeOf(probe.connection) as XMPPClient['connection']
+    probe.destroy()
+    const handler = vi.spyOn(connectionPrototype, 'setConnectionSuccessHandler')
     client = new ReloadClient({ debug: false })
-    context.client = client
     onConnectionSuccess = handler.mock.calls.at(-1)![0]
+    await client.profile.fetchAvatarData(OWN, HASH)
+    revokeAllBlobUrls()
+    cachedUrl = 'blob:saved-avatar'
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue(cachedUrl)
     finishTransport = () => {}
     vi.spyOn(client.connection, 'connect')
       .mockImplementationOnce(() => new Promise<void>(resolve => { finishTransport = resolve }))
@@ -59,11 +73,18 @@ describe('cached own avatar during session reload', () => {
     vi.spyOn(client.profile, 'refreshAllAvatarBlobUrls')
     vi.spyOn(client.profile, 'fetchOwnProfile')
     vi.spyOn(client.profile, 'restoreOwnAvatarFromCache')
-    const getCachedAvatar = avatarCache.getCachedAvatar
-    const delayedRead = new Promise<void>(resolve => { releaseCache = resolve })
-    vi.spyOn(avatarCache, 'getCachedAvatar').mockImplementation(async hash => {
-      await delayedRead
-      return getCachedAvatar(hash)
+    releaseCache = undefined as unknown as () => void
+    const get = IDBObjectStore.prototype.get
+    vi.spyOn(IDBObjectStore.prototype, 'get').mockImplementation(function (this: IDBObjectStore, key) {
+      const request = get.call(this, key)
+      if (this.name === 'avatars' && key === HASH) {
+        request.addEventListener('success', event => {
+          const complete = request.onsuccess
+          request.onsuccess = null
+          releaseCache = () => { complete?.call(request, event) }
+        })
+      }
+      return request
     })
     saveSession(OWN, 'password', 'wss://example.com/ws')
     sessionStorage.setItem(`xmpp-profile:${OWN}`, JSON.stringify({ ownAvatarHash: HASH }))
@@ -82,9 +103,11 @@ describe('cached own avatar during session reload', () => {
     const claim = path === 'claim granted' ? async () => true
       : path === 'claim failure' ? async () => { throw new Error('Claim unavailable') }
       : undefined
-    renderHook(() => useSessionPersistence(claim))
+    renderHook(() => useSessionPersistence(claim), {
+      wrapper: ({ children }: { children: ReactNode }) => <XMPPProvider client={client}>{children}</XMPPProvider>,
+    })
     await waitFor(() => expect(client.connection.connect).toHaveBeenCalledTimes(1))
-    await waitFor(() => expect(avatarCache.getCachedAvatar).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(releaseCache).toBeTypeOf('function'))
     await act(async () => {
       await onConnectionSuccess(true, undefined, 1_000)
       finishTransport()

--- a/apps/fluux/src/hooks/useSessionPersistence.avatar.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.avatar.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { IDBFactory } from 'fake-indexeddb'
+import { XMPPClient } from '../../../../packages/fluux-sdk/src/core/XMPPClient'
+import { Connection } from '../../../../packages/fluux-sdk/src/core/modules/Connection'
+import { connectionStore } from '../../../../packages/fluux-sdk/src/stores/connectionStore'
+import * as avatarCache from '../../../../packages/fluux-sdk/src/utils/avatarCache'
+import { saveSession, useSessionPersistence } from './useSessionPersistence'
+
+const context = vi.hoisted(() => ({ client: null as unknown as XMPPClient }))
+
+vi.mock('../../../../packages/fluux-sdk/src/provider', () => ({ useXMPPContext: () => context }))
+vi.mock('@fluux/sdk', async () => ({
+  connectionStore: (await import('../../../../packages/fluux-sdk/src/stores/connectionStore')).connectionStore,
+  useConnectionActions: (await import('../../../../packages/fluux-sdk/src/hooks/useConnectionActions')).useConnectionActions,
+  useXMPPContext: () => context,
+  ...(await import('../../../../packages/fluux-sdk/src/core/jid')),
+  hasFastToken: () => false,
+  deleteFastToken: vi.fn(),
+}))
+vi.mock('@fluux/sdk/react', async () => {
+  const { useConnectionStore, useRosterStore } = await import('../../../../packages/fluux-sdk/src/react/storeHooks')
+  return { useConnectionStore, useRosterStore }
+})
+vi.mock('@/platform', () => ({ platform: () => ({
+  hasNativeConnectionKeepalive: true, nativeKeychain: true, hasStableInstallIdentity: true,
+}) }))
+
+const OWN = 'me@example.com'
+const HASH = 'saved-own-avatar'
+
+describe('cached own avatar during session reload', () => {
+  let finishTransport: () => void
+  let releaseCache: () => void
+  let onConnectionSuccess: Parameters<Connection['setConnectionSuccessHandler']>[0]
+  let client: XMPPClient
+  let cachedUrl: string
+
+  beforeEach(async () => {
+    localStorage.clear()
+    sessionStorage.clear()
+    connectionStore.setState({ status: 'disconnected', jid: null, ownAvatar: null, ownAvatarHash: null })
+    globalThis.indexedDB = new IDBFactory()
+    cachedUrl = await avatarCache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+    const handler = vi.spyOn(Connection.prototype, 'setConnectionSuccessHandler')
+    class ReloadClient extends XMPPClient {
+      protected override async sendStanza(): Promise<void> {}
+    }
+    client = new ReloadClient({ debug: false })
+    context.client = client
+    onConnectionSuccess = handler.mock.calls.at(-1)![0]
+    finishTransport = () => {}
+    vi.spyOn(client.connection, 'connect')
+      .mockImplementationOnce(() => new Promise<void>(resolve => { finishTransport = resolve }))
+      .mockResolvedValue(undefined)
+    vi.spyOn(client.contacts, 'sendInitialPresence').mockResolvedValue(undefined)
+    vi.spyOn(client.contacts, 'sendPresenceProbes').mockResolvedValue(undefined)
+    vi.spyOn(client.admin, 'discoverAdminCommands').mockResolvedValue(undefined)
+    vi.spyOn(client.profile, 'refreshAllAvatarBlobUrls')
+    vi.spyOn(client.profile, 'fetchOwnProfile')
+    vi.spyOn(client.profile, 'restoreOwnAvatarFromCache')
+    const getCachedAvatar = avatarCache.getCachedAvatar
+    const delayedRead = new Promise<void>(resolve => { releaseCache = resolve })
+    vi.spyOn(avatarCache, 'getCachedAvatar').mockImplementation(async hash => {
+      await delayedRead
+      return getCachedAvatar(hash)
+    })
+    saveSession(OWN, 'password', 'wss://example.com/ws')
+    sessionStorage.setItem(`xmpp-profile:${OWN}`, JSON.stringify({ ownAvatarHash: HASH }))
+    localStorage.setItem(`fluux:cache-marker:${OWN}`, 'present')
+  })
+
+  afterEach(() => {
+    cleanup()
+    releaseCache?.()
+    finishTransport?.()
+    client?.destroy()
+    vi.restoreAllMocks()
+  })
+
+  async function resume(path: string) {
+    const claim = path === 'claim granted' ? async () => true
+      : path === 'claim failure' ? async () => { throw new Error('Claim unavailable') }
+      : undefined
+    renderHook(() => useSessionPersistence(claim))
+    await waitFor(() => expect(client.connection.connect).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(avatarCache.getCachedAvatar).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await onConnectionSuccess(true, undefined, 1_000)
+      finishTransport()
+    })
+    expect(client.profile.refreshAllAvatarBlobUrls).not.toHaveBeenCalled()
+    expect(client.profile.fetchOwnProfile).not.toHaveBeenCalled()
+    expect(connectionStore.getState().ownAvatar).toBeNull()
+  }
+
+  async function finishCachedRestore() {
+    await act(async () => {
+      releaseCache()
+      await vi.mocked(client.profile.restoreOwnAvatarFromCache).mock.results[0].value
+    })
+  }
+
+  it.each(['native reload', 'claim granted', 'claim failure'])(
+    'restores the saved avatar after a short SM resume through %s', async path => {
+      await resume(path)
+      await finishCachedRestore()
+      expect(connectionStore.getState().jid).toBe(OWN)
+      expect(connectionStore.getState().ownAvatar).toBe(cachedUrl)
+      expect(connectionStore.getState().ownAvatarHash).toBe(HASH)
+      expect(client.profile.refreshAllAvatarBlobUrls).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects the delayed saved avatar after a real account switch', async () => {
+    await resume('native reload')
+    await act(async () => {
+      await client.connect({ jid: 'next@example.com', password: 'password', server: 'wss://example.com/ws' })
+      connectionStore.getState().setOwnAvatar('blob:next-account', 'next-hash')
+    })
+    await finishCachedRestore()
+    expect(connectionStore.getState().jid).toBe('next@example.com')
+    expect(connectionStore.getState().ownAvatar).toBe('blob:next-account')
+    expect(connectionStore.getState().ownAvatarHash).toBe('next-hash')
+  })
+})

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -424,12 +424,6 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         if (savedProfile.ownNickname) {
           setOwnNickname(savedProfile.ownNickname)
         }
-        if (savedProfile.ownAvatarHash) {
-          // Restore avatar blob URL from IndexedDB cache
-          restoreOwnAvatarFromCache(savedProfile.ownAvatarHash).catch(() => {
-            // Avatar not in cache, will be fetched on next fresh connect
-          })
-        }
       }
 
       // Restore own resources (other connected devices)
@@ -462,6 +456,21 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
       const autoRetry = true
       const serverOptions = getConnectionServerOptions(session.jid, session.server)
 
+      const reconnect = () => {
+        const pending = connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos })
+        if (savedProfile?.ownAvatarHash) {
+          // Restore avatar blob URL from IndexedDB cache
+          restoreOwnAvatarFromCache(savedProfile.ownAvatarHash).catch(() => {
+            // Avatar not in cache, will be fetched on next fresh connect
+          })
+        }
+        pending.catch((err) => {
+          console.log('[Auth] Reconnection failed:', err?.message || err)
+          clearSession()
+          isResumptionRef.current = false
+        })
+      }
+
       // Check if another tab already holds this JID (web only)
       if (claimConnection) {
         claimConnection(session.jid).then((canConnect) => {
@@ -470,28 +479,15 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
             isResumptionRef.current = false
             return
           }
-          connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
-            console.log('[Auth] Reconnection failed:', err?.message || err)
-            clearSession()
-            isResumptionRef.current = false
-          })
+          reconnect()
         }).catch(() => {
           // Claim check failed, try connecting anyway
-          connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
-            console.log('[Auth] Reconnection failed:', err?.message || err)
-            clearSession()
-            isResumptionRef.current = false
-          })
+          reconnect()
         })
         return
       }
 
-      connect({ jid: session.jid, password: session.password, ...serverOptions, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
-        console.log('[Auth] Reconnection failed:', err?.message || err)
-        // If auto-reconnect fails, clear session
-        clearSession()
-        isResumptionRef.current = false
-      })
+      reconnect()
       return
     }
 

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1860,6 +1860,7 @@ describe('XMPPClient', () => {
 
       // Emit avatarMetadataUpdate (simulating what PubSub.ts or Roster.ts would emit)
       ;(xmppClient as any).emit('avatarMetadataUpdate', 'contact@example.com', 'abc123hash')
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(fetchAvatarDataSpy).toHaveBeenCalledWith('contact@example.com', 'abc123hash')
     })
@@ -1935,6 +1936,7 @@ describe('XMPPClient', () => {
 
       // Emit occupantAvatarUpdate (simulating what MUC.ts would emit)
       ;(xmppClient as any).emit('occupantAvatarUpdate', 'room@conference.example.com', 'TestUser', 'abc123hash', 'realuser@example.com')
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(fetchOccupantAvatarSpy).toHaveBeenCalledWith(
         'room@conference.example.com',
@@ -1945,7 +1947,7 @@ describe('XMPPClient', () => {
       )
     })
 
-    it('threads the room-scoped occupant-id into avatar persistence', () => {
+    it('threads the room-scoped occupant-id into avatar persistence', async () => {
       const occupants = new Map()
       occupants.set('TestUser', {
         nick: 'TestUser',
@@ -1974,6 +1976,7 @@ describe('XMPPClient', () => {
         undefined,
         'opaque-occ-id',
       )
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(fetchOccupantAvatarSpy).toHaveBeenCalledWith(
         'room@conference.example.com',
@@ -2006,6 +2009,7 @@ describe('XMPPClient', () => {
 
       // Emit occupantAvatarUpdate with same hash
       ;(xmppClient as any).emit('occupantAvatarUpdate', 'room@conference.example.com', 'TestUser', 'abc123hash', 'realuser@example.com')
+      await vi.advanceTimersByTimeAsync(0)
 
       // Should skip fetch since hash matches and avatar exists
       expect(fetchOccupantAvatarSpy).not.toHaveBeenCalled()
@@ -2033,6 +2037,7 @@ describe('XMPPClient', () => {
 
       // Emit occupantAvatarUpdate with new hash
       ;(xmppClient as any).emit('occupantAvatarUpdate', 'room@conference.example.com', 'TestUser', 'newhash456', 'realuser@example.com')
+      await vi.advanceTimersByTimeAsync(0)
 
       // Should fetch since hash changed
       expect(fetchOccupantAvatarSpy).toHaveBeenCalledWith(

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -812,8 +812,8 @@ export class XMPPClient {
 
       // Listen for MUC occupant avatar updates (XEP-0398)
       // Emitted by MUC module when an occupant's presence contains vcard-temp:x:update
-      this.onInternal('occupantAvatarUpdate', async (roomJid, nick, hash, realJid, occupantId) => {
-        await this.profile.clearVCardNegativeCache(`${roomJid}/${nick}`, realJid)
+      this.onInternal('occupantAvatarUpdate', async (roomJid, nick, hash, realJid, occupantId, invalidationJid) => {
+        await this.profile.clearVCardNegativeCache(`${roomJid}/${nick}`, invalidationJid ?? realJid)
         // Only fetch if the avatar hash changed to avoid re-downloading on every presence
         const room = this.stores?.room.getRoom(roomJid)
         const occupant = room?.occupants.get(nick)

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -401,12 +401,8 @@ export class XMPPClient {
    */
   private sdkEventHandlers: Map<keyof SDKEvents, Set<SDKEventHandler<keyof SDKEvents>>> = new Map()
 
-  /**
-   * Tracks contacts we've already checked for XEP-0084 (PEP) avatars.
-   * Prevents repeated queries when a contact has empty XEP-0153 photo
-   * but no XEP-0084 avatar either. Cleared on disconnect.
-   */
-  private xep0084AvatarChecked: Set<string> = new Set()
+  private pendingContactAvatarChecks: Set<string> = new Set()
+
 
   /**
    * MAM query collectors registry.
@@ -816,7 +812,9 @@ export class XMPPClient {
 
       // Listen for MUC occupant avatar updates (XEP-0398)
       // Emitted by MUC module when an occupant's presence contains vcard-temp:x:update
-      this.onInternal('occupantAvatarUpdate', (roomJid, nick, hash, realJid, occupantId) => {
+      this.onInternal('occupantAvatarUpdate', async (roomJid, nick, hash, realJid, occupantId) => {
+        await this.profile.clearVCardNegativeCache(`${roomJid}/${nick}`)
+        if (realJid) await this.profile.clearVCardNegativeCache(getBareJid(realJid))
         // Only fetch if the avatar hash changed to avoid re-downloading on every presence
         const room = this.stores?.room.getRoom(roomJid)
         const occupant = room?.occupants.get(nick)
@@ -835,8 +833,9 @@ export class XMPPClient {
 
       // Listen for avatar metadata updates (XEP-0084)
       // Emitted by PubSub module for real events or Roster for vcard-temp:x:update
-      this.onInternal('avatarMetadataUpdate', (jid, hash) => {
+      this.onInternal('avatarMetadataUpdate', async (jid, hash) => {
         if (hash) {
+          await this.profile.clearVCardNegativeCache(getBareJid(jid))
           // Skip if contact already has this avatar hash with a loaded avatar
           const contact = this.stores?.roster.getContact(jid)
           if (contact?.avatarHash === hash && contact?.avatar) {
@@ -852,14 +851,20 @@ export class XMPPClient {
       // Listen for contacts missing XEP-0153 avatar (empty <photo/> in presence)
       // These contacts may use XEP-0084 (PEP) avatars instead (like Conversations)
       this.onInternal('contactMissingXep0153Avatar', (jid) => {
-        // Only fetch if:
-        // 1. Contact doesn't already have an avatar
-        // 2. We haven't already checked this contact this session (prevents overfetching)
         const contact = this.stores?.roster.getContact(jid)
-        if (!contact?.avatar && !contact?.avatarHash && !this.xep0084AvatarChecked.has(jid)) {
-          this.xep0084AvatarChecked.add(jid)
-          this.profile.fetchContactAvatarMetadata(jid).catch(() => {})
+        if (!contact?.avatar && !contact?.avatarHash && !this.pendingContactAvatarChecks.has(jid)) {
+          this.pendingContactAvatarChecks.add(jid)
+          this.profile.fetchContactAvatarMetadata(jid).finally(() => {
+            this.pendingContactAvatarChecks.delete(jid)
+          }).catch(() => {})
         }
+      })
+
+      this.subscribe('room:occupant-left', ({ roomJid, nick }) => {
+        this.profile.invalidateOccupantProfiles(roomJid, nick)
+      })
+      this.subscribe('room:joined', ({ roomJid, joined }) => {
+        if (!joined) this.profile.invalidateOccupantProfiles(roomJid)
       })
 
       // Restore cached avatar hashes for offline contacts when roster loads
@@ -1138,7 +1143,7 @@ export class XMPPClient {
     const accountJid = this.currentJid ? getBareJid(this.currentJid) : null
     this.currentJid = null
     // Clear session-scoped tracking data
-    this.xep0084AvatarChecked.clear()
+    this.pendingContactAvatarChecks.clear()
     this.#internal.entityTime.clearCache()
     this.#internal.lastActivity.clearCache()
     if (options.invalidateFastToken && accountJid) {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -866,6 +866,9 @@ export class XMPPClient {
       this.subscribe('room:joined', ({ roomJid, joined }) => {
         if (!joined) this.profile.invalidateOccupantProfiles(roomJid)
       })
+      this.subscribe('room:updated', ({ roomJid, updates }) => {
+        if (updates.occupants) this.profile.invalidateOccupantProfiles(roomJid)
+      })
 
       // Restore cached avatar hashes for offline contacts when roster loads
       this.onInternal('rosterLoaded', () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -832,9 +832,10 @@ export class XMPPClient {
 
       // Listen for avatar metadata updates (XEP-0084)
       // Emitted by PubSub module for real events or Roster for vcard-temp:x:update
-      this.onInternal('avatarMetadataUpdate', async (jid, hash) => {
+      this.onInternal('avatarMetadataUpdate', async (jid, hash, ownPresence) => {
         if (hash) {
           await this.profile.clearVCardNegativeCache(getBareJid(jid))
+          if (ownPresence) return
           // Skip if contact already has this avatar hash with a loaded avatar
           const contact = this.stores?.roster.getContact(jid)
           if (contact?.avatarHash === hash && contact?.avatar) {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -813,8 +813,7 @@ export class XMPPClient {
       // Listen for MUC occupant avatar updates (XEP-0398)
       // Emitted by MUC module when an occupant's presence contains vcard-temp:x:update
       this.onInternal('occupantAvatarUpdate', async (roomJid, nick, hash, realJid, occupantId) => {
-        await this.profile.clearVCardNegativeCache(`${roomJid}/${nick}`)
-        if (realJid) await this.profile.clearVCardNegativeCache(getBareJid(realJid))
+        await this.profile.clearVCardNegativeCache(`${roomJid}/${nick}`, realJid)
         // Only fetch if the avatar hash changed to avoid re-downloading on every presence
         const room = this.stores?.room.getRoom(roomJid)
         const occupant = room?.occupants.get(nick)

--- a/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
@@ -297,7 +297,7 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
   })
 
   describe('occupant avatar dedup on presence update', () => {
-    it('does not emit occupantAvatarUpdate when occupant already has same hash and avatar', () => {
+    it('emits occupantAvatarUpdate when occupant already has same hash and avatar', () => {
       const existingOccupants = new Map()
       existingOccupants.set('TestUser', {
         nick: 'TestUser',
@@ -345,13 +345,13 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
 
       muc.handle(presence)
 
-      // Should NOT emit occupantAvatarUpdate because hash hasn't changed and avatar exists
-      expect(mockEmit).not.toHaveBeenCalledWith(
+      expect(mockEmit).toHaveBeenCalledWith(
         'occupantAvatarUpdate',
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything()
+        'room@conference.example.org',
+        'TestUser',
+        'abc123avatarhash',
+        undefined,
+        undefined,
       )
     })
 

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -353,6 +353,7 @@ export class MUC extends BaseModule {
     }
 
     if (isSelf) {
+      const avatarRealJid = realJid ?? this.deps.getCurrentJid() ?? undefined
       // Nick change confirmed (XEP-0045 §7.6): the server echoes our new nick as a
       // self-presence. We never left the room, so update our occupant + nickname and
       // add the renamed occupant WITHOUT the full join completion (no MAM refetch,
@@ -363,7 +364,7 @@ export class MUC extends BaseModule {
         this.deps.emitSDK('room:self-occupant', { roomJid, occupant })
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
         if (avatarHash) {
-          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
+          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, avatarRealJid, occupantId)
         }
         return
       }
@@ -458,7 +459,7 @@ export class MUC extends BaseModule {
 
       // XEP-0398: Trigger avatar fetch if occupant has avatar hash (skip self - we use own avatar)
       if (avatarHash) {
-        this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
+        this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, avatarRealJid, occupantId)
       }
     } else {
       // Check if room is in joining state - buffer occupants to reduce re-renders

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -353,7 +353,7 @@ export class MUC extends BaseModule {
     }
 
     if (isSelf) {
-      const avatarRealJid = realJid ?? this.deps.getCurrentJid() ?? undefined
+      const invalidationJid = realJid ?? this.deps.getCurrentJid() ?? undefined
       // Nick change confirmed (XEP-0045 §7.6): the server echoes our new nick as a
       // self-presence. We never left the room, so update our occupant + nickname and
       // add the renamed occupant WITHOUT the full join completion (no MAM refetch,
@@ -364,7 +364,7 @@ export class MUC extends BaseModule {
         this.deps.emitSDK('room:self-occupant', { roomJid, occupant })
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
         if (avatarHash) {
-          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, avatarRealJid, occupantId)
+          this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId, invalidationJid)
         }
         return
       }
@@ -459,7 +459,7 @@ export class MUC extends BaseModule {
 
       // XEP-0398: Trigger avatar fetch if occupant has avatar hash (skip self - we use own avatar)
       if (avatarHash) {
-        this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, avatarRealJid, occupantId)
+        this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId, invalidationJid)
       }
     } else {
       // Check if room is in joining state - buffer occupants to reduce re-renders
@@ -475,7 +475,7 @@ export class MUC extends BaseModule {
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
 
         if (avatarHash) {
-          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
+          this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId)
         }
       }
     }
@@ -493,15 +493,6 @@ export class MUC extends BaseModule {
     }
   }
 
-  private emitOccupantAvatarUpdate(
-    roomJid: string,
-    nick: string,
-    avatarHash: string,
-    realJid?: string,
-    occupantId?: string,
-  ): void {
-    this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId)
-  }
 
   /**
    * Get the in-flight join's outcome deferred, creating one if none is pending.
@@ -665,7 +656,7 @@ export class MUC extends BaseModule {
       // XEP-0398: Trigger avatar fetch for all occupants with avatar hashes
       for (const occupant of occupants) {
         if (occupant.avatarHash) {
-          this.emitOccupantAvatarUpdate(
+          this.deps.emit('occupantAvatarUpdate',
             roomJid,
             occupant.nick,
             occupant.avatarHash,

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -473,13 +473,8 @@ export class MUC extends BaseModule {
         // SDK event only - binding calls store.addOccupant
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
 
-        // XEP-0398: Trigger avatar fetch if occupant has avatar hash
-        // Only emit if hash changed from what we already have
         if (avatarHash) {
-          const existing = room?.occupants.get(nick)
-          if (existing?.avatarHash !== avatarHash || !existing?.avatar) {
-            this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
-          }
+          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
         }
       }
     }

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -71,6 +71,7 @@ vi.mock('../../utils/avatarCache', () => ({
   refreshAllBlobUrls: vi.fn().mockResolvedValue(new Map()),
   // Negative cache functions
   hasNoAvatar: vi.fn().mockResolvedValue(false),
+  getNoAvatarWriteToken: vi.fn().mockReturnValue(Symbol.for('avatar-test')),
   markNoAvatar: vi.fn().mockResolvedValue(undefined),
   clearNoAvatar: vi.fn().mockResolvedValue(undefined),
   // PEP-forbidden domain cache functions
@@ -1270,7 +1271,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchVCardAvatar('nophoto@example.com')
 
         // Should mark the JID as having no avatar
-        expect(markNoAvatar).toHaveBeenCalledWith('nophoto@example.com', 'contact', 'definitive')
+        expect(markNoAvatar).toHaveBeenCalledWith('nophoto@example.com', 'contact', 'definitive', Symbol.for('avatar-test'))
       })
 
       it('should clear negative cache when vCard photo is found', async () => {
@@ -1371,7 +1372,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchContactAvatarMetadata('noavatar@example.com')
 
         // Should mark the JID as having no avatar (via vCard fallback path)
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive', Symbol.for('avatar-test'))
       })
 
       it('should clear negative cache when XEP-0084 avatar is found', async () => {
@@ -1605,7 +1606,7 @@ describe('XMPPClient Own Avatar', () => {
         )
 
         // Should mark the realJid as no-avatar due to forbidden errors
-        expect(markNoAvatar).toHaveBeenCalledWith('private@example.com', 'contact', 'transient')
+        expect(markNoAvatar).toHaveBeenCalledWith('private@example.com', 'contact', 'transient', Symbol.for('avatar-test'))
       })
 
       it('should cache empty vCard response after forbidden XEP-0084', async () => {
@@ -1636,7 +1637,7 @@ describe('XMPPClient Own Avatar', () => {
         )
 
         // Should mark as no-avatar due to empty vCard
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive', Symbol.for('avatar-test'))
       })
 
       it('should clear negative cache when avatar is successfully fetched', async () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -6,7 +6,7 @@
  * - Proper two-step process: fetch metadata first to get hash, then fetch data
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { XMPPClient, getInternalSurfaceForTesting, bindStoresForTesting } from '../XMPPClient'
+import { XMPPClient, bindStoresForTesting } from '../XMPPClient'
 import type { Room, RoomOccupant } from '../types/room'
 import {
   createMockXmppClient,
@@ -685,7 +685,7 @@ describe('XMPPClient Own Avatar', () => {
       expect(hasVcardCall).toBe(false)
     })
 
-    it('should emit avatarMetadataUpdate event when avatar found', async () => {
+    it('should deliver the avatar before metadata fetching completes', async () => {
       // Clear any calls from connection setup
       mockXmppClientInstance.iqCaller.request.mockClear()
 
@@ -721,29 +721,18 @@ describe('XMPPClient Own Avatar', () => {
         },
       ])
 
-      // Mock subsequent fetchAvatarData to prevent unhandled promise
-      mockXmppClientInstance.iqCaller.request
-        .mockResolvedValueOnce(metadataResponse)
-        .mockRejectedValue(new Error('not found'))
-
-      // Track emitted events
-      const emittedEvents: Array<{ jid: string; hash: string | null }> = []
-      // `avatarMetadataUpdate` is an internal signal, deliberately absent from
-      // the public `on` surface. Reaching the bus directly is the point here:
-      // this asserts what the module emits, not what a consumer can subscribe to.
-      const bus = getInternalSurfaceForTesting(xmppClient) as unknown as {
-        on: (event: 'avatarMetadataUpdate', handler: (jid: string, hash: string | null) => void) => () => void
-      }
-      bus.on('avatarMetadataUpdate', (jid, hash) => {
-        emittedEvents.push({ jid, hash })
-      })
+      const { getCachedAvatar } = await import('../../utils/avatarCache')
+      vi.mocked(getCachedAvatar).mockResolvedValueOnce('blob:contact-avatar')
+      mockXmppClientInstance.iqCaller.request.mockResolvedValueOnce(metadataResponse)
+      const onAvatar = vi.fn()
+      xmppClient.subscribe('contacts:avatar', onAvatar)
 
       await xmppClient.profile.fetchContactAvatarMetadata('contact@example.com')
 
-      // Should emit event with the hash
-      expect(emittedEvents).toContainEqual({
+      expect(onAvatar).toHaveBeenCalledWith({
         jid: 'contact@example.com',
-        hash: 'contact-avatar-hash',
+        avatar: 'blob:contact-avatar',
+        avatarHash: 'contact-avatar-hash',
       })
     })
   })

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -1281,7 +1281,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchVCardAvatar('nophoto@example.com')
 
         // Should mark the JID as having no avatar
-        expect(markNoAvatar).toHaveBeenCalledWith('nophoto@example.com', 'contact')
+        expect(markNoAvatar).toHaveBeenCalledWith('nophoto@example.com', 'contact', 'definitive')
       })
 
       it('should clear negative cache when vCard photo is found', async () => {
@@ -1382,7 +1382,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchContactAvatarMetadata('noavatar@example.com')
 
         // Should mark the JID as having no avatar (via vCard fallback path)
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive')
       })
 
       it('should clear negative cache when XEP-0084 avatar is found', async () => {
@@ -1481,7 +1481,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchRoomAvatar('noavatar@conference.example.com')
 
         // Should mark the room JID as having no avatar
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@conference.example.com', 'room')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@conference.example.com', 'room', 'definitive')
       })
 
       it('should mark room JID in negative cache on item-not-found error', async () => {
@@ -1496,7 +1496,7 @@ describe('XMPPClient Own Avatar', () => {
         await xmppClient.profile.fetchRoomAvatar('noavatar@conference.example.com')
 
         // Should mark the room JID as having no avatar
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@conference.example.com', 'room')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@conference.example.com', 'room', 'definitive')
       })
 
       it('should clear negative cache when room avatar is found', async () => {
@@ -1616,7 +1616,7 @@ describe('XMPPClient Own Avatar', () => {
         )
 
         // Should mark the realJid as no-avatar due to forbidden errors
-        expect(markNoAvatar).toHaveBeenCalledWith('private@example.com', 'contact')
+        expect(markNoAvatar).toHaveBeenCalledWith('private@example.com', 'contact', 'transient')
       })
 
       it('should cache empty vCard response after forbidden XEP-0084', async () => {
@@ -1647,7 +1647,7 @@ describe('XMPPClient Own Avatar', () => {
         )
 
         // Should mark as no-avatar due to empty vCard
-        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact')
+        expect(markNoAvatar).toHaveBeenCalledWith('noavatar@example.com', 'contact', 'definitive')
       })
 
       it('should clear negative cache when avatar is successfully fetched', async () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.profileDetails.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.profileDetails.test.ts
@@ -222,6 +222,8 @@ describe('XMPPClient fetchOwnProfileDetails', () => {
     xmppClient = new XMPPClient({ debug: false })
     bindStoresForTesting(xmppClient, mockStores)
     emitSDKSpy = vi.spyOn(xmppClient, 'emitSDK')
+    // Each test supplies its reply after connecting; startup must not seed this cache.
+    vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue(undefined)
 
     const connectPromise = xmppClient.connect({
       jid: 'user@example.com',

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -63,6 +63,22 @@ import {
 /** XEP-0172 and the appearance node each keep a single current value. */
 const CURRENT_ITEM_ID = 'current'
 
+const PROFILE_REFRESH_MS = 5 * 60 * 1000
+const VCARD_ABSENCE_TTL_MS = 24 * 60 * 60 * 1000
+
+function isDefinitiveVCardError(error: unknown): boolean {
+  // iqCaller exposes the error stanza's condition. Free-form error text is
+  // not a server response and cannot justify a durable negative cache entry.
+  const condition = (error as { condition?: unknown } | null)?.condition
+  return condition === 'service-unavailable' || condition === 'feature-not-implemented'
+    || condition === 'item-not-found'
+}
+
+interface CachedProfileDetails {
+  promise: Promise<ProfileDetails | null>
+  expiresAt: number
+}
+
 /** What the appearance node stores. `mode` is required; the rest are optional. */
 export interface AppearanceSettings {
   mode: string
@@ -160,6 +176,8 @@ export class Profile extends BaseModule {
   private readonly appearanceNode: PepNode<AppearanceSettings>
   private readonly avatarDataNode: PepNode<string>
   private readonly avatarMetadataNode: PepNode<AvatarMetadata | null>
+  private readonly profileDetailsCache = new Map<string, CachedProfileDetails>()
+  private profileCacheAccount: string | null = null
 
   constructor(deps: ModuleDependencies) {
     super(deps)
@@ -208,6 +226,9 @@ export class Profile extends BaseModule {
    */
   async fetchAvatarData(jid: string, hash: string): Promise<void> {
     const bareJid = getBareJid(jid)
+    // Both XEP-0153 presence and XEP-0084 notifications arrive with a hash.
+    // This evidence overrides a negative even if the image is already cached.
+    await this.clearVCardNegativeCache(bareJid)
 
     // Check if we already have this avatar cached
     const cachedUrl = await getCachedAvatar(hash)
@@ -268,7 +289,7 @@ export class Profile extends BaseModule {
     }
 
     // Found an avatar - clear any negative cache entry
-    await clearNoAvatar(bareJid)
+    await this.clearVCardNegativeCache(bareJid)
     // Emit the same event that XEP-0153 would emit, so existing
     // avatar fetching logic handles it consistently
     this.deps.emit('avatarMetadataUpdate', bareJid, hash)
@@ -280,11 +301,41 @@ export class Profile extends BaseModule {
    *
    * Carried over XEP-0054 vcard-temp. For a room occupant in an anonymous
    * room, pass the full occupant JID (room@conf/nick).
+   * Concurrent reads share one query. Results and failures are cached in memory:
+   * five minutes for populated profiles or ambiguous failures, 24 hours for
+   * empty profiles or explicit absence. Avatar announcements invalidate the cache.
    *
    * @param jid - The bare JID or full occupant JID to query
    * @returns The fields the server returned, or null if the query failed
    */
   async fetchProfileDetails(jid: string): Promise<ProfileDetails | null> {
+    const account = this.deps.getCurrentJid()
+    const bareAccount = account ? getBareJid(account) : null
+    if (this.profileCacheAccount !== bareAccount) {
+      this.profileDetailsCache.clear()
+      this.profileCacheAccount = bareAccount
+    }
+    for (const [key, entry] of this.profileDetailsCache) {
+      if (entry.expiresAt <= Date.now()) this.profileDetailsCache.delete(key)
+    }
+    // The full occupant JID is the query target; different nicks are not the room.
+    let entry = this.profileDetailsCache.get(jid)
+    if (!entry) {
+      const pending: CachedProfileDetails = {
+        expiresAt: Infinity,
+        promise: this.queryProfileDetails(jid).then(({ details, ttlMs }) => {
+          pending.expiresAt = Date.now() + ttlMs
+          return details
+        }),
+      }
+      this.profileDetailsCache.set(jid, pending)
+      entry = pending
+    }
+    const details = await entry.promise
+    return details ? { ...details } : null
+  }
+
+  private async queryProfileDetails(jid: string): Promise<{ details: ProfileDetails | null; ttlMs: number }> {
     const iq = xml('iq', { type: 'get', to: jid, id: `vcard_${generateUUID()}` },
       xml('vCard', { xmlns: NS_VCARD_TEMP })
     )
@@ -292,7 +343,9 @@ export class Profile extends BaseModule {
     try {
       const result = await this.deps.sendIQ(iq)
       const vcard = result.getChild('vCard', NS_VCARD_TEMP)
-      if (!vcard) return null
+      if (!vcard) return { details: null, ttlMs: VCARD_ABSENCE_TTL_MS }
+
+      if (vcard.getChild('PHOTO')?.getChildText('BINVAL')) await clearNoAvatar(jid)
 
       const fullName = vcard.getChildText('FN') || undefined
       const org = vcard.getChild('ORG')?.getChildText('ORGNAME') || undefined
@@ -301,12 +354,17 @@ export class Profile extends BaseModule {
       const country = adr?.getChildText('CTRY') || undefined
 
       // Return null if no fields were found
-      if (!fullName && !org && !email && !country) return null
+      if (!fullName && !org && !email && !country) return { details: null, ttlMs: VCARD_ABSENCE_TTL_MS }
 
-      return { fullName, org, email, country }
-    } catch {
-      return null
+      return { details: { fullName, org, email, country }, ttlMs: PROFILE_REFRESH_MS }
+    } catch (error) {
+      return { details: null, ttlMs: isDefinitiveVCardError(error) ? VCARD_ABSENCE_TTL_MS : PROFILE_REFRESH_MS }
     }
+  }
+
+  private async clearVCardNegativeCache(jid: string): Promise<void> {
+    this.profileDetailsCache.delete(jid)
+    await clearNoAvatar(jid)
   }
 
   async fetchVCardAvatar(jid: string): Promise<void> {
@@ -332,14 +390,13 @@ export class Profile extends BaseModule {
         const avatarUrl = `data:${type};base64,${binval.replace(/\s/g, '')}`
         this.updateAvatar(bareJid, avatarUrl, null)
         // Clear negative cache since we found an avatar
-        await clearNoAvatar(bareJid)
+        await this.clearVCardNegativeCache(bareJid)
       } else {
         // vCard exists but has no photo - mark as no avatar
         await markNoAvatar(bareJid, 'contact')
       }
-    } catch {
-      // vCard query failed - mark as no avatar for now
-      await markNoAvatar(bareJid, 'contact')
+    } catch (error) {
+      await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient')
     }
   }
 
@@ -372,6 +429,9 @@ export class Profile extends BaseModule {
       return
     }
 
+    await this.clearVCardNegativeCache(`${roomJid}/${nick}`)
+    if (realJid) await this.clearVCardNegativeCache(getBareJid(realJid))
+
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
     if (cachedUrl) {
@@ -391,11 +451,6 @@ export class Profile extends BaseModule {
     // If we have a real JID, try to fetch from their PEP or vCard
     if (realJid) {
       const bareJid = getBareJid(realJid)
-      // The presence advertises an avatar hash, which is a positive signal
-      // that the user now has an avatar. Clear any stale negative cache entry
-      // (they may have been marked as "no avatar" from a previous session).
-      await clearNoAvatar(bareJid)
-
       const data = (await this.readContactAvatarNode(
         this.avatarDataNode, bareJid, { itemId: avatarHash },
       ))[0]
@@ -691,6 +746,7 @@ export class Profile extends BaseModule {
       xml('vCard', { xmlns: NS_VCARD_TEMP }, ...children)
     )
     await this.deps.sendIQ(setIq)
+    this.profileDetailsCache.delete(bareJid)
     this.deps.emitSDK('connection:own-profile', { details: info })
   }
 

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -65,16 +65,11 @@ import {
 /** XEP-0172 and the appearance node each keep a single current value. */
 const CURRENT_ITEM_ID = 'current'
 
-type ProfilePublicationEvent = 'connection:own-avatar' | 'contacts:avatar'
-  | 'room:occupant-avatar' | 'connection:own-profile'
-type ProfileCompletion = {
-  [K in ProfilePublicationEvent]: {
-    event: K
-    payload: SDKEvents[K]
-    realJid?: string
-    replaceProfile?: boolean
-  }
-}[ProfilePublicationEvent]
+type ProfileCompletion =
+  | { event: 'connection:own-avatar'; payload: SDKEvents['connection:own-avatar']; accountJid: string | null }
+  | { event: 'connection:own-profile'; payload: SDKEvents['connection:own-profile']; accountJid: string | null; replaceProfile?: boolean }
+  | { event: 'contacts:avatar'; payload: SDKEvents['contacts:avatar'] }
+  | { event: 'room:occupant-avatar'; payload: SDKEvents['room:occupant-avatar']; realJid?: string }
   | { event: 'avatar:evidence'; payload: { jid: string; realJid?: string } }
   | { event: 'profile:photo'; payload: { jid: string } }
 
@@ -392,7 +387,12 @@ export class Profile extends BaseModule {
   private async completeProfileUpdate(update: ProfileCompletion): Promise<void> {
     const identities: string[] = []
     let positiveAvatar = false
-    const currentJid = this.deps.getCurrentJid()
+    const isCurrentAccount = () => {
+      const currentJid = this.deps.getCurrentJid()
+      return !('accountJid' in update)
+        || update.accountJid === (currentJid ? getBareJid(currentJid) : null)
+    }
+    if (!isCurrentAccount()) return
     switch (update.event) {
       case 'avatar:evidence':
         identities.push(update.payload.jid)
@@ -404,7 +404,7 @@ export class Profile extends BaseModule {
         positiveAvatar = true
         break
       case 'connection:own-avatar':
-        if (currentJid) identities.push(getBareJid(currentJid))
+        if (update.accountJid) identities.push(update.accountJid)
         positiveAvatar = Boolean(update.payload.avatar || update.payload.hash)
         break
       case 'contacts:avatar':
@@ -427,7 +427,7 @@ export class Profile extends BaseModule {
         break
       }
       case 'connection:own-profile':
-        if (update.replaceProfile && currentJid) this.profileDetailsCache.delete(getBareJid(currentJid))
+        if (update.replaceProfile && update.accountJid) this.profileDetailsCache.delete(update.accountJid)
         break
     }
 
@@ -444,6 +444,8 @@ export class Profile extends BaseModule {
       }
     }
 
+    // IndexedDB invalidation can yield while the user switches accounts.
+    if (!isCurrentAccount()) return
     if (update.event !== 'avatar:evidence' && update.event !== 'profile:photo') {
       this.deps.emitSDK(update.event, update.payload)
     }
@@ -702,7 +704,7 @@ export class Profile extends BaseModule {
     const currentJid = this.deps.getCurrentJid()
 
     if (bareJid === getBareJid(currentJid ?? '')) {
-      await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar, hash } })
+      await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid: bareJid, payload: { avatar, hash } })
     } else {
       await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid: bareJid, avatar, avatarHash: hash ?? undefined } })
     }
@@ -768,7 +770,7 @@ export class Profile extends BaseModule {
 
     const bareJid = getBareJid(currentJid)
     const details = await this.fetchProfileDetails(bareJid)
-    await this.completeProfileUpdate({ event: 'connection:own-profile', payload: { details } })
+    await this.completeProfileUpdate({ event: 'connection:own-profile', accountJid: bareJid, payload: { details } })
     return details
   }
 
@@ -826,7 +828,7 @@ export class Profile extends BaseModule {
       xml('vCard', { xmlns: NS_VCARD_TEMP }, ...children)
     )
     await this.deps.sendIQ(setIq)
-    await this.completeProfileUpdate({ event: 'connection:own-profile', payload: { details: info }, replaceProfile: true })
+    await this.completeProfileUpdate({ event: 'connection:own-profile', accountJid: bareJid, payload: { details: info }, replaceProfile: true })
   }
 
   /**
@@ -876,7 +878,7 @@ export class Profile extends BaseModule {
 
     const cachedUrl = await getCachedAvatar(meta.hash)
     if (cachedUrl) {
-      await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: cachedUrl, hash: meta.hash } })
+      await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid: bareJid, payload: { avatar: cachedUrl, hash: meta.hash } })
       return
     }
 
@@ -888,10 +890,12 @@ export class Profile extends BaseModule {
     const sniffedType = sniffImageMimeType(base64) ?? meta.mimeType ?? 'image/png'
     const blobUrl = await cacheAvatar(meta.hash, base64, sniffedType)
     await saveAvatarHash(bareJid, meta.hash, 'contact')
-    await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: blobUrl, hash: meta.hash } })
+    await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid: bareJid, payload: { avatar: blobUrl, hash: meta.hash } })
   }
 
   async publishOwnAvatar(imageData: string, mimeType: string, _width: number, _height: number): Promise<void> {
+    const currentJid = this.deps.getCurrentJid()
+    const accountJid = currentJid ? getBareJid(currentJid) : null
     const base64Data = imageData.split(',')[1] || imageData
     const hash = generateUUID() // Should ideally be SHA-1 of data
 
@@ -904,16 +908,18 @@ export class Profile extends BaseModule {
       bytes: Math.round(base64Data.length * 0.75),
     })
 
-    await this.updateAvatar(this.deps.getCurrentJid()!, imageData, hash)
+    await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid, payload: { avatar: imageData, hash } })
   }
 
   async clearOwnAvatar(): Promise<void> {
+    const currentJid = this.deps.getCurrentJid()
+    const accountJid = currentJid ? getBareJid(currentJid) : null
     // XEP-0084 §4.2 disables an avatar by publishing a `<metadata/>` with no
     // `<info/>`, not by publishing a bare `<item/>`: peers drop the avatar they
     // hold on reading the empty element, and an item with no payload carries
     // nothing for them to read.
     await this.avatarMetadataNode.publish(CURRENT_ITEM_ID, null)
-    await this.updateAvatar(this.deps.getCurrentJid()!, null, null)
+    await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid, payload: { avatar: null, hash: null } })
   }
 
   async setRoomAvatar(roomJid: string, imageData: string, _mimeType: string): Promise<void> {
@@ -956,10 +962,12 @@ export class Profile extends BaseModule {
   }
 
   async restoreOwnAvatarFromCache(avatarHash: string): Promise<boolean> {
+    const currentJid = this.deps.getCurrentJid()
+    const accountJid = currentJid ? getBareJid(currentJid) : null
     try {
       const cachedUrl = await getCachedAvatar(avatarHash)
       if (cachedUrl) {
-        await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: cachedUrl, hash: avatarHash } })
+        await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid, payload: { avatar: cachedUrl, hash: avatarHash } })
         return true
       }
     } catch (error) {
@@ -1082,7 +1090,7 @@ export class Profile extends BaseModule {
           // roster:avatar. Without this the own avatar's blob URL — revoked by
           // refreshAllBlobUrls — is never re-pointed and renders as a fallback.
           if (ownBareJid && mapping.jid === ownBareJid) {
-            await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: url, hash: mapping.hash } })
+            await this.completeProfileUpdate({ event: 'connection:own-avatar', accountJid: ownBareJid, payload: { avatar: url, hash: mapping.hash } })
             continue
           }
           const contact = this.deps.stores?.roster.getContact(mapping.jid)

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -2,8 +2,9 @@ import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { BaseModule, type ModuleDependencies } from './BaseModule'
 import { PepNode, type PepCodec, type PepGetOptions, type PublishOptions } from './PepNode'
-import { getBareJid, getLocalPart, getDomain } from '../jid'
+import { getBareJid, getLocalPart, getDomain, getResource } from '../jid'
 import type { ProfileDetails } from '../types/roster'
+import type { RoomOccupant } from '../types/room'
 import { generateUUID } from '../../utils/uuid'
 import {
   getCachedAvatar,
@@ -77,6 +78,9 @@ function isDefinitiveVCardError(error: unknown): boolean {
 interface CachedProfileDetails {
   promise: Promise<ProfileDetails | null>
   expiresAt: number
+  negative?: boolean
+  negativeInvalidated?: boolean
+  occupant?: RoomOccupant
 }
 
 /** What the appearance node stores. `mode` is required; the rest are optional. */
@@ -303,7 +307,7 @@ export class Profile extends BaseModule {
    * room, pass the full occupant JID (room@conf/nick).
    * Concurrent reads share one query. Results and failures are cached in memory:
    * five minutes for populated profiles or ambiguous failures, 24 hours for
-   * empty profiles or explicit absence. Avatar announcements invalidate the cache.
+   * empty profiles or explicit absence. Avatar announcements invalidate negative results.
    *
    * @param jid - The bare JID or full occupant JID to query
    * @returns The fields the server returned, or null if the query failed
@@ -320,11 +324,20 @@ export class Profile extends BaseModule {
     }
     // The full occupant JID is the query target; different nicks are not the room.
     let entry = this.profileDetailsCache.get(jid)
+    if (entry && !this.isProfileOccupantCurrent(jid, entry)) {
+      this.profileDetailsCache.delete(jid)
+      entry = undefined
+    }
     if (!entry) {
       const pending: CachedProfileDetails = {
         expiresAt: Infinity,
+        occupant: this.getProfileOccupant(jid),
         promise: this.queryProfileDetails(jid).then(({ details, ttlMs }) => {
           pending.expiresAt = Date.now() + ttlMs
+          pending.negative = details === null
+          if (pending.negative && pending.negativeInvalidated && this.profileDetailsCache.get(jid) === pending) {
+            this.profileDetailsCache.delete(jid)
+          }
           return details
         }),
       }
@@ -332,6 +345,7 @@ export class Profile extends BaseModule {
       entry = pending
     }
     const details = await entry.promise
+    if (this.profileDetailsCache.get(jid) !== entry || !this.isProfileOccupantCurrent(jid, entry)) return null
     return details ? { ...details } : null
   }
 
@@ -362,9 +376,33 @@ export class Profile extends BaseModule {
     }
   }
 
-  private async clearVCardNegativeCache(jid: string): Promise<void> {
-    this.profileDetailsCache.delete(jid)
+  async clearVCardNegativeCache(jid: string): Promise<void> {
+    const entry = this.profileDetailsCache.get(jid)
+    if (entry?.negative) this.profileDetailsCache.delete(jid)
+    else if (entry && entry.negative === undefined) entry.negativeInvalidated = true
     await clearNoAvatar(jid)
+  }
+
+  invalidateOccupantProfiles(roomJid: string, nick?: string): void {
+    if (nick !== undefined) {
+      this.profileDetailsCache.delete(`${roomJid}/${nick}`)
+    } else {
+      for (const jid of this.profileDetailsCache.keys()) {
+        if (jid.startsWith(`${roomJid}/`)) this.profileDetailsCache.delete(jid)
+      }
+    }
+  }
+
+  private getProfileOccupant(jid: string): RoomOccupant | undefined {
+    const nick = getResource(jid)
+    return nick ? this.deps.stores?.room.getRoom(getBareJid(jid))?.occupants.get(nick) : undefined
+  }
+
+  private isProfileOccupantCurrent(jid: string, entry: CachedProfileDetails): boolean {
+    const occupant = this.getProfileOccupant(jid)
+    return Boolean(occupant) === Boolean(entry.occupant)
+      && occupant?.occupantId === entry.occupant?.occupantId
+      && occupant?.jid === entry.occupant?.jid
   }
 
   async fetchVCardAvatar(jid: string): Promise<void> {
@@ -393,7 +431,7 @@ export class Profile extends BaseModule {
         await this.clearVCardNegativeCache(bareJid)
       } else {
         // vCard exists but has no photo - mark as no avatar
-        await markNoAvatar(bareJid, 'contact')
+        await markNoAvatar(bareJid, 'contact', 'definitive')
       }
     } catch (error) {
       await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient')
@@ -505,11 +543,10 @@ export class Profile extends BaseModule {
           return
         } else {
           // vCard exists but no photo - mark as no avatar
-          await markNoAvatar(bareJid, 'contact')
+          await markNoAvatar(bareJid, 'contact', 'definitive')
         }
-      } catch {
-        // vCard fetch failed - mark as no avatar
-        await markNoAvatar(bareJid, 'contact')
+      } catch (error) {
+        await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient')
       }
       return
     }
@@ -602,14 +639,14 @@ export class Profile extends BaseModule {
         })
       } else {
         // vCard exists but has no photo - mark as no avatar
-        await markNoAvatar(bareJid, 'room')
+        await markNoAvatar(bareJid, 'room', 'definitive')
       }
     } catch (err) {
       // item-not-found is expected when a room has no avatar set
       const isNotFound = err instanceof Error && err.message.includes('item-not-found')
       if (isNotFound) {
         // Room definitively has no avatar - cache this
-        await markNoAvatar(bareJid, 'room')
+        await markNoAvatar(bareJid, 'room', 'definitive')
       } else {
         // Network or other error - don't cache, might succeed next time
         console.error('Failed to fetch room avatar:', err)

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -19,6 +19,7 @@ import {
   seedRoomOccupantAvatarHashes,
   hasNoAvatar,
   markNoAvatar,
+  getNoAvatarWriteToken,
   clearNoAvatar,
   refreshAllBlobUrls,
   isPepForbiddenDomain,
@@ -67,10 +68,10 @@ const CURRENT_ITEM_ID = 'current'
 
 type ProfileCompletion =
   | { event: 'connection:own-avatar'; payload: SDKEvents['connection:own-avatar']; accountJid: string | null }
-  | { event: 'connection:own-profile'; payload: SDKEvents['connection:own-profile']; accountJid: string | null; replaceProfile?: boolean }
+  | { event: 'connection:own-profile'; payload: SDKEvents['connection:own-profile']; accountJid: string | null; replaceProfile?: boolean; hasPhoto?: boolean }
   | { event: 'contacts:avatar'; payload: SDKEvents['contacts:avatar'] }
   | { event: 'room:occupant-avatar'; payload: SDKEvents['room:occupant-avatar']; realJid?: string }
-  | { event: 'avatar:evidence'; payload: { jid: string; realJid?: string } }
+  | { event: 'avatar:evidence'; payload: { jid: string; realJid?: string }; accountJid?: string }
   | { event: 'profile:photo'; payload: { jid: string } }
 
 const PROFILE_REFRESH_MS = 5 * 60 * 1000
@@ -243,6 +244,7 @@ export class Profile extends BaseModule {
     // This evidence overrides a negative even if the image is already cached.
     await this.clearVCardNegativeCache(bareJid)
 
+    const token = getNoAvatarWriteToken(bareJid)
     let avatarUrl = await getCachedAvatar(hash)
     if (!avatarUrl) {
       const data = (await this.readContactAvatarNode(
@@ -250,7 +252,7 @@ export class Profile extends BaseModule {
       ))[0]
 
       if (!data) {
-        await this.fetchVCardAvatar(bareJid)
+        await this.fetchVCardAvatarWithToken(bareJid, token)
         return
       }
 
@@ -274,6 +276,7 @@ export class Profile extends BaseModule {
    */
   async fetchContactAvatarMetadata(jid: string): Promise<string | null> {
     const bareJid = getBareJid(jid)
+    const token = getNoAvatarWriteToken(bareJid)
 
     // Check negative cache first - skip if we recently confirmed no avatar
     if (await hasNoAvatar(bareJid)) {
@@ -289,7 +292,7 @@ export class Profile extends BaseModule {
     if (!hash) {
       // No avatar via XEP-0084, or the server would not say — either way, fall
       // back to vCard-temp (XEP-0054).
-      await this.fetchVCardAvatar(bareJid)
+      await this.fetchVCardAvatarWithToken(bareJid, token)
       return null
     }
 
@@ -427,6 +430,8 @@ export class Profile extends BaseModule {
         break
       }
       case 'connection:own-profile':
+        if (update.accountJid) identities.push(update.accountJid)
+        positiveAvatar = Boolean(update.hasPhoto)
         if (update.replaceProfile && update.accountJid) this.profileDetailsCache.delete(update.accountJid)
         break
     }
@@ -475,7 +480,10 @@ export class Profile extends BaseModule {
 
   async fetchVCardAvatar(jid: string): Promise<void> {
     const bareJid = getBareJid(jid)
+    await this.fetchVCardAvatarWithToken(bareJid, getNoAvatarWriteToken(bareJid))
+  }
 
+  private async fetchVCardAvatarWithToken(bareJid: string, token: symbol): Promise<void> {
     // Check negative cache first - skip if we recently confirmed no avatar
     if (await hasNoAvatar(bareJid)) {
       return
@@ -497,10 +505,10 @@ export class Profile extends BaseModule {
         await this.updateAvatar(bareJid, avatarUrl, null)
       } else {
         // vCard exists but has no photo - mark as no avatar
-        await markNoAvatar(bareJid, 'contact', 'definitive')
+        await markNoAvatar(bareJid, 'contact', 'definitive', token)
       }
     } catch (error) {
-      await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient')
+      await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient', token)
     }
   }
 
@@ -534,6 +542,7 @@ export class Profile extends BaseModule {
     }
 
     await this.clearVCardNegativeCache(`${roomJid}/${nick}`, realJid)
+    const token = realJid ? getNoAvatarWriteToken(getBareJid(realJid)) : undefined
 
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
@@ -579,10 +588,10 @@ export class Profile extends BaseModule {
           return
         } else {
           // vCard exists but no photo - mark as no avatar
-          await markNoAvatar(bareJid, 'contact', 'definitive')
+          await markNoAvatar(bareJid, 'contact', 'definitive', token)
         }
       } catch (error) {
-        await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient')
+        await markNoAvatar(bareJid, 'contact', isDefinitiveVCardError(error) ? 'definitive' : 'transient', token)
       }
       return
     }
@@ -793,6 +802,9 @@ export class Profile extends BaseModule {
       )
       const result = await this.deps.sendIQ(getIq)
       existingVCardEl = result.getChild('vCard', NS_VCARD_TEMP) ?? null
+      if (existingVCardEl?.getChild('PHOTO')?.getChildText('BINVAL')) {
+        await this.completeProfileUpdate({ event: 'avatar:evidence', accountJid: bareJid, payload: { jid: bareJid } })
+      }
     } catch {
       // No existing vCard, we'll create a fresh one
     }
@@ -828,7 +840,9 @@ export class Profile extends BaseModule {
       xml('vCard', { xmlns: NS_VCARD_TEMP }, ...children)
     )
     await this.deps.sendIQ(setIq)
-    await this.completeProfileUpdate({ event: 'connection:own-profile', accountJid: bareJid, payload: { details: info }, replaceProfile: true })
+    await this.completeProfileUpdate({ event: 'connection:own-profile', accountJid: bareJid, payload: { details: info }, replaceProfile: true,
+      hasPhoto: Boolean(existingVCardEl?.getChild('PHOTO')?.getChildText('BINVAL')),
+    })
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -4,6 +4,7 @@ import { BaseModule, type ModuleDependencies } from './BaseModule'
 import { PepNode, type PepCodec, type PepGetOptions, type PublishOptions } from './PepNode'
 import { getBareJid, getLocalPart, getDomain, getResource } from '../jid'
 import type { ProfileDetails } from '../types/roster'
+import type { SDKEvents } from '../types'
 import type { RoomOccupant } from '../types/room'
 import { generateUUID } from '../../utils/uuid'
 import {
@@ -63,6 +64,19 @@ import {
  */
 /** XEP-0172 and the appearance node each keep a single current value. */
 const CURRENT_ITEM_ID = 'current'
+
+type ProfilePublicationEvent = 'connection:own-avatar' | 'contacts:avatar'
+  | 'room:occupant-avatar' | 'connection:own-profile'
+type ProfileCompletion = {
+  [K in ProfilePublicationEvent]: {
+    event: K
+    payload: SDKEvents[K]
+    realJid?: string
+    replaceProfile?: boolean
+  }
+}[ProfilePublicationEvent]
+  | { event: 'avatar:evidence'; payload: { jid: string; realJid?: string } }
+  | { event: 'profile:photo'; payload: { jid: string } }
 
 const PROFILE_REFRESH_MS = 5 * 60 * 1000
 const VCARD_ABSENCE_TTL_MS = 24 * 60 * 60 * 1000
@@ -250,8 +264,7 @@ export class Profile extends BaseModule {
       avatarUrl = await cacheAvatar(hash, data, mimeType)
       await saveAvatarHash(bareJid, hash, 'contact')
     }
-    await this.clearVCardNegativeCache(bareJid)
-    this.updateAvatar(bareJid, avatarUrl, hash)
+    await this.updateAvatar(bareJid, avatarUrl, hash)
   }
 
   /**
@@ -348,7 +361,9 @@ export class Profile extends BaseModule {
       const vcard = result.getChild('vCard', NS_VCARD_TEMP)
       if (!vcard) return { details: null, ttlMs: VCARD_ABSENCE_TTL_MS }
 
-      if (vcard.getChild('PHOTO')?.getChildText('BINVAL')) await clearNoAvatar(jid)
+      if (vcard.getChild('PHOTO')?.getChildText('BINVAL')) {
+        await this.completeProfileUpdate({ event: 'profile:photo', payload: { jid } })
+      }
 
       const fullName = vcard.getChildText('FN') || undefined
       const org = vcard.getChild('ORG')?.getChildText('ORGNAME') || undefined
@@ -365,11 +380,73 @@ export class Profile extends BaseModule {
     }
   }
 
-  async clearVCardNegativeCache(jid: string): Promise<void> {
-    const entry = this.profileDetailsCache.get(jid)
-    if (entry?.negative) this.profileDetailsCache.delete(jid)
-    else if (entry && entry.negative === undefined) entry.negativeInvalidated = true
-    await clearNoAvatar(jid)
+  async clearVCardNegativeCache(jid: string, realJid?: string): Promise<void> {
+    await this.completeProfileUpdate({ event: 'avatar:evidence', payload: { jid, realJid } })
+  }
+
+  /**
+   * Positive avatar evidence and profile/avatar publication share this boundary.
+   * Announcements enter before download deduplication; completions enter again
+   * because a negative profile query can finish while image data is in flight.
+   */
+  private async completeProfileUpdate(update: ProfileCompletion): Promise<void> {
+    const identities: string[] = []
+    let positiveAvatar = false
+    const currentJid = this.deps.getCurrentJid()
+    switch (update.event) {
+      case 'avatar:evidence':
+        identities.push(update.payload.jid)
+        if (update.payload.realJid) identities.push(getBareJid(update.payload.realJid))
+        positiveAvatar = true
+        break
+      case 'profile:photo':
+        identities.push(update.payload.jid)
+        positiveAvatar = true
+        break
+      case 'connection:own-avatar':
+        if (currentJid) identities.push(getBareJid(currentJid))
+        positiveAvatar = Boolean(update.payload.avatar || update.payload.hash)
+        break
+      case 'contacts:avatar':
+        identities.push(getBareJid(update.payload.jid))
+        positiveAvatar = Boolean(update.payload.avatar || update.payload.avatarHash)
+        break
+      case 'room:occupant-avatar': {
+        const { roomJid, nick, occupantId } = update.payload
+        const occupant = nick ? this.deps.stores?.room.getRoom(roomJid)?.occupants.get(nick) : undefined
+        // A restored stable identity must not invalidate the profile of a reused nick.
+        const sameOccupant = !occupantId || !occupant?.occupantId || occupantId === occupant.occupantId
+        if (nick && sameOccupant) {
+          identities.push(`${roomJid}/${nick}`)
+          const realJid = update.realJid ?? occupant?.jid
+          if (realJid) identities.push(getBareJid(realJid))
+        } else if (update.realJid) {
+          identities.push(getBareJid(update.realJid))
+        }
+        positiveAvatar = Boolean(update.payload.avatar || update.payload.avatarHash)
+        break
+      }
+      case 'connection:own-profile':
+        if (update.replaceProfile && currentJid) this.profileDetailsCache.delete(getBareJid(currentJid))
+        break
+    }
+
+    if (positiveAvatar) {
+      for (const jid of new Set(identities)) {
+        // A profile response already supplies the authoritative details (even
+        // empty ones); its PHOTO must not invalidate that same pending result.
+        if (update.event !== 'profile:photo') {
+          const entry = this.profileDetailsCache.get(jid)
+          if (entry?.negative) this.profileDetailsCache.delete(jid)
+          else if (entry && entry.negative === undefined) entry.negativeInvalidated = true
+        }
+        await clearNoAvatar(jid)
+      }
+    }
+
+    if (update.event !== 'avatar:evidence' && update.event !== 'profile:photo') {
+      this.deps.emitSDK(update.event, update.payload)
+    }
   }
 
   invalidateOccupantProfiles(roomJid: string, nick?: string): void {
@@ -415,9 +492,7 @@ export class Profile extends BaseModule {
 
       if (binval) {
         const avatarUrl = `data:${type};base64,${binval.replace(/\s/g, '')}`
-        this.updateAvatar(bareJid, avatarUrl, null)
-        // Clear negative cache since we found an avatar
-        await this.clearVCardNegativeCache(bareJid)
+        await this.updateAvatar(bareJid, avatarUrl, null)
       } else {
         // vCard exists but has no photo - mark as no avatar
         await markNoAvatar(bareJid, 'contact', 'definitive')
@@ -456,8 +531,7 @@ export class Profile extends BaseModule {
       return
     }
 
-    await this.clearVCardNegativeCache(`${roomJid}/${nick}`)
-    if (realJid) await this.clearVCardNegativeCache(getBareJid(realJid))
+    await this.clearVCardNegativeCache(`${roomJid}/${nick}`, realJid)
 
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
@@ -542,15 +616,13 @@ export class Profile extends BaseModule {
     occupantId?: string,
   ): Promise<void> {
     if (occupantId) await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
-    await this.clearVCardNegativeCache(`${roomJid}/${nick}`)
-    if (realJid) await this.clearVCardNegativeCache(getBareJid(realJid))
-    this.deps.emitSDK('room:occupant-avatar', {
+    await this.completeProfileUpdate({ event: 'room:occupant-avatar', payload: {
       roomJid,
       nick,
       ...(occupantId && { occupantId }),
       avatar,
       avatarHash,
-    })
+    }, realJid })
   }
 
   /**
@@ -625,14 +697,14 @@ export class Profile extends BaseModule {
     }
   }
 
-  private updateAvatar(jid: string, avatar: string | null, hash: string | null): void {
+  private async updateAvatar(jid: string, avatar: string | null, hash: string | null): Promise<void> {
     const bareJid = getBareJid(jid)
     const currentJid = this.deps.getCurrentJid()
 
     if (bareJid === getBareJid(currentJid ?? '')) {
-      this.deps.emitSDK('connection:own-avatar', { avatar, hash })
+      await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar, hash } })
     } else {
-      this.deps.emitSDK('contacts:avatar', { jid: bareJid, avatar, avatarHash: hash ?? undefined })
+      await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid: bareJid, avatar, avatarHash: hash ?? undefined } })
     }
   }
 
@@ -696,7 +768,7 @@ export class Profile extends BaseModule {
 
     const bareJid = getBareJid(currentJid)
     const details = await this.fetchProfileDetails(bareJid)
-    this.deps.emitSDK('connection:own-profile', { details })
+    await this.completeProfileUpdate({ event: 'connection:own-profile', payload: { details } })
     return details
   }
 
@@ -754,8 +826,7 @@ export class Profile extends BaseModule {
       xml('vCard', { xmlns: NS_VCARD_TEMP }, ...children)
     )
     await this.deps.sendIQ(setIq)
-    this.profileDetailsCache.delete(bareJid)
-    this.deps.emitSDK('connection:own-profile', { details: info })
+    await this.completeProfileUpdate({ event: 'connection:own-profile', payload: { details: info }, replaceProfile: true })
   }
 
   /**
@@ -801,10 +872,11 @@ export class Profile extends BaseModule {
     const meta = (await this.avatarMetadataNode.getOr([], { maxItems: 1 }))[0]
     // `null` is a published "no avatar"; either way there is nothing to fetch.
     if (!meta) return
+    await this.completeProfileUpdate({ event: 'avatar:evidence', payload: { jid: bareJid } })
 
     const cachedUrl = await getCachedAvatar(meta.hash)
     if (cachedUrl) {
-      this.deps.emitSDK('connection:own-avatar', { avatar: cachedUrl, hash: meta.hash })
+      await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: cachedUrl, hash: meta.hash } })
       return
     }
 
@@ -816,7 +888,7 @@ export class Profile extends BaseModule {
     const sniffedType = sniffImageMimeType(base64) ?? meta.mimeType ?? 'image/png'
     const blobUrl = await cacheAvatar(meta.hash, base64, sniffedType)
     await saveAvatarHash(bareJid, meta.hash, 'contact')
-    this.deps.emitSDK('connection:own-avatar', { avatar: blobUrl, hash: meta.hash })
+    await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: blobUrl, hash: meta.hash } })
   }
 
   async publishOwnAvatar(imageData: string, mimeType: string, _width: number, _height: number): Promise<void> {
@@ -832,7 +904,7 @@ export class Profile extends BaseModule {
       bytes: Math.round(base64Data.length * 0.75),
     })
 
-    this.updateAvatar(this.deps.getCurrentJid()!, imageData, hash)
+    await this.updateAvatar(this.deps.getCurrentJid()!, imageData, hash)
   }
 
   async clearOwnAvatar(): Promise<void> {
@@ -841,7 +913,7 @@ export class Profile extends BaseModule {
     // hold on reading the empty element, and an item with no payload carries
     // nothing for them to read.
     await this.avatarMetadataNode.publish(CURRENT_ITEM_ID, null)
-    this.updateAvatar(this.deps.getCurrentJid()!, null, null)
+    await this.updateAvatar(this.deps.getCurrentJid()!, null, null)
   }
 
   async setRoomAvatar(roomJid: string, imageData: string, _mimeType: string): Promise<void> {
@@ -874,7 +946,7 @@ export class Profile extends BaseModule {
     try {
       const cachedUrl = await getCachedAvatar(avatarHash)
       if (cachedUrl) {
-        this.deps.emitSDK('contacts:avatar', { jid, avatar: cachedUrl, avatarHash })
+        await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid, avatar: cachedUrl, avatarHash } })
         return true
       }
     } catch (error) {
@@ -887,7 +959,7 @@ export class Profile extends BaseModule {
     try {
       const cachedUrl = await getCachedAvatar(avatarHash)
       if (cachedUrl) {
-        this.deps.emitSDK('connection:own-avatar', { avatar: cachedUrl, hash: avatarHash })
+        await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: cachedUrl, hash: avatarHash } })
         return true
       }
     } catch (error) {
@@ -936,10 +1008,10 @@ export class Profile extends BaseModule {
         if (contact && !contact.avatarHash) {
           const cachedUrl = await getCachedAvatar(mapping.hash)
           if (cachedUrl) {
-            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: cachedUrl, avatarHash: mapping.hash })
+            await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid: mapping.jid, avatar: cachedUrl, avatarHash: mapping.hash } })
           } else {
             // At least set the hash so we can try fetching later
-            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: null, avatarHash: mapping.hash })
+            await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid: mapping.jid, avatar: null, avatarHash: mapping.hash } })
           }
         }
       }
@@ -1010,12 +1082,12 @@ export class Profile extends BaseModule {
           // roster:avatar. Without this the own avatar's blob URL — revoked by
           // refreshAllBlobUrls — is never re-pointed and renders as a fallback.
           if (ownBareJid && mapping.jid === ownBareJid) {
-            this.deps.emitSDK('connection:own-avatar', { avatar: url, hash: mapping.hash })
+            await this.completeProfileUpdate({ event: 'connection:own-avatar', payload: { avatar: url, hash: mapping.hash } })
             continue
           }
           const contact = this.deps.stores?.roster.getContact(mapping.jid)
           if (contact) {
-            this.deps.emitSDK('contacts:avatar', { jid: mapping.jid, avatar: url, avatarHash: mapping.hash })
+            await this.completeProfileUpdate({ event: 'contacts:avatar', payload: { jid: mapping.jid, avatar: url, avatarHash: mapping.hash } })
           }
         } else if (mapping.type === 'room') {
           const room = this.deps.stores?.room.getRoom(mapping.jid)
@@ -1043,7 +1115,7 @@ export class Profile extends BaseModule {
         const url = freshUrls.get(contact.avatarHash)
         if (url) {
           if (contact.avatar !== url) {
-            this.updateAvatar(contact.jid, url, contact.avatarHash)
+            await this.updateAvatar(contact.jid, url, contact.avatarHash)
           }
         } else if (!contact.avatar || contact.avatar.startsWith('blob:')) {
           // Only refetch contacts whose current pointer is empty or a revoked
@@ -1065,13 +1137,13 @@ export class Profile extends BaseModule {
           if (!occupant.avatarHash) continue
           const url = freshUrls.get(occupant.avatarHash)
           if (!url) continue
-          this.deps.emitSDK('room:occupant-avatar', {
+          await this.completeProfileUpdate({ event: 'room:occupant-avatar', payload: {
             roomJid: room.jid,
             nick: occupant.nick,
             ...(occupant.occupantId && { occupantId: occupant.occupantId }),
             avatar: url,
             avatarHash: occupant.avatarHash,
-          })
+          } })
         }
 
         // Re-point offline XEP-0421 identities too. They are absent from the
@@ -1088,13 +1160,13 @@ export class Profile extends BaseModule {
           const url = freshUrls.get(hash)
           if (!url) continue
           const nick = room.occupantIdToNick?.get(occupantId)
-          this.deps.emitSDK('room:occupant-avatar', {
+          await this.completeProfileUpdate({ event: 'room:occupant-avatar', payload: {
             roomJid: room.jid,
             ...(nick && { nick }),
             occupantId,
             avatar: url,
             avatarHash: hash,
-          })
+          } })
         }
       }
     } catch (error) {
@@ -1123,13 +1195,13 @@ export class Profile extends BaseModule {
 
         const cachedUrl = await getCachedAvatar(hash)
         if (cachedUrl) {
-          this.deps.emitSDK('room:occupant-avatar', {
+          await this.completeProfileUpdate({ event: 'room:occupant-avatar', payload: {
             roomJid,
             nick,
             ...(occupant.occupantId && { occupantId: occupant.occupantId }),
             avatar: cachedUrl,
             avatarHash: hash,
-          })
+          } })
         }
       }
 
@@ -1144,13 +1216,13 @@ export class Profile extends BaseModule {
           const cachedUrl = await getCachedAvatar(hash)
           if (!cachedUrl) continue
           const nick = room.occupantIdToNick?.get(occupantId)
-          this.deps.emitSDK('room:occupant-avatar', {
+          await this.completeProfileUpdate({ event: 'room:occupant-avatar', payload: {
             roomJid,
             ...(nick && { nick }),
             occupantId,
             avatar: cachedUrl,
             avatarHash: hash,
-          })
+          } })
         }
       }
     } catch {

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -234,31 +234,24 @@ export class Profile extends BaseModule {
     // This evidence overrides a negative even if the image is already cached.
     await this.clearVCardNegativeCache(bareJid)
 
-    // Check if we already have this avatar cached
-    const cachedUrl = await getCachedAvatar(hash)
-    if (cachedUrl) {
-      this.updateAvatar(bareJid, cachedUrl, hash)
-      return
+    let avatarUrl = await getCachedAvatar(hash)
+    if (!avatarUrl) {
+      const data = (await this.readContactAvatarNode(
+        this.avatarDataNode, bareJid, { itemId: hash },
+      ))[0]
+
+      if (!data) {
+        await this.fetchVCardAvatar(bareJid)
+        return
+      }
+
+      // XEP-0084 data responses carry no MIME type; sniff animated formats too.
+      const mimeType = sniffImageMimeType(data) ?? 'image/png'
+      avatarUrl = await cacheAvatar(hash, data, mimeType)
+      await saveAvatarHash(bareJid, hash, 'contact')
     }
-
-    const data = (await this.readContactAvatarNode(
-      this.avatarDataNode, bareJid, { itemId: hash },
-    ))[0]
-
-    if (!data) {
-      await this.fetchVCardAvatar(bareJid)
-      return
-    }
-
-    // XEP-0084 data responses carry no MIME type, so sniff the bytes rather
-    // than assume PNG — otherwise animated GIF/WebP/APNG avatars get a Blob
-    // typed image/png and any consumer trusting blob.type is misled.
-    const mimeType = sniffImageMimeType(data) ?? 'image/png'
-    const blobUrl = await cacheAvatar(hash, data, mimeType)
-    await saveAvatarHash(bareJid, hash, 'contact')
-    this.updateAvatar(bareJid, blobUrl, hash)
-    // Clear negative cache since we found an avatar
-    await clearNoAvatar(bareJid)
+    await this.clearVCardNegativeCache(bareJid)
+    this.updateAvatar(bareJid, avatarUrl, hash)
   }
 
   /**
@@ -292,11 +285,7 @@ export class Profile extends BaseModule {
       return null
     }
 
-    // Found an avatar - clear any negative cache entry
-    await this.clearVCardNegativeCache(bareJid)
-    // Emit the same event that XEP-0153 would emit, so existing
-    // avatar fetching logic handles it consistently
-    this.deps.emit('avatarMetadataUpdate', bareJid, hash)
+    await this.fetchAvatarData(bareJid, hash)
     return hash
   }
 
@@ -473,16 +462,7 @@ export class Profile extends BaseModule {
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
     if (cachedUrl) {
-      if (occupantId) {
-        await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
-      }
-      this.deps.emitSDK('room:occupant-avatar', {
-        roomJid,
-        nick,
-        ...(occupantId && { occupantId }),
-        avatar: cachedUrl,
-        avatarHash,
-      })
+      await this.updateOccupantAvatar(roomJid, nick, cachedUrl, avatarHash, realJid, occupantId)
       return
     }
 
@@ -498,19 +478,9 @@ export class Profile extends BaseModule {
         // avatars aren't cached as image/png (see fetchAvatarData).
         const mimeType = sniffImageMimeType(data) ?? 'image/png'
         const blobUrl = await cacheAvatar(avatarHash, data, mimeType)
-        await clearNoAvatar(bareJid)
         // Persist JID→hash mapping so we can restore from cache on next session
         await saveAvatarHash(bareJid, avatarHash, 'contact')
-        if (occupantId) {
-          await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
-        }
-        this.deps.emitSDK('room:occupant-avatar', {
-          roomJid,
-          nick,
-          ...(occupantId && { occupantId }),
-          avatar: blobUrl,
-          avatarHash,
-        })
+        await this.updateOccupantAvatar(roomJid, nick, blobUrl, avatarHash, realJid, occupantId)
         return
       }
 
@@ -527,19 +497,9 @@ export class Profile extends BaseModule {
           const mimeType = photo?.getChildText('TYPE') || 'image/png'
           const base64 = binval.replace(/\s/g, '')
           const blobUrl = await cacheAvatar(avatarHash, base64, mimeType)
-          await clearNoAvatar(bareJid)
           // Persist JID→hash mapping so we can restore from cache on next session
           await saveAvatarHash(bareJid, avatarHash, 'contact')
-          if (occupantId) {
-            await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
-          }
-          this.deps.emitSDK('room:occupant-avatar', {
-            roomJid,
-            nick,
-            ...(occupantId && { occupantId }),
-            avatar: blobUrl,
-            avatarHash,
-          })
+          await this.updateOccupantAvatar(roomJid, nick, blobUrl, avatarHash, realJid, occupantId)
           return
         } else {
           // vCard exists but no photo - mark as no avatar
@@ -566,20 +526,31 @@ export class Profile extends BaseModule {
         const mimeType = photo?.getChildText('TYPE') || 'image/png'
         const base64 = binval.replace(/\s/g, '')
         const blobUrl = await cacheAvatar(avatarHash, base64, mimeType)
-        if (occupantId) {
-          await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
-        }
-        this.deps.emitSDK('room:occupant-avatar', {
-          roomJid,
-          nick,
-          ...(occupantId && { occupantId }),
-          avatar: blobUrl,
-          avatarHash,
-        })
+        await this.updateOccupantAvatar(roomJid, nick, blobUrl, avatarHash, realJid, occupantId)
       }
     } catch {
       // Silently fail - avatar fetch failed or occupant has no avatar
     }
+  }
+
+  private async updateOccupantAvatar(
+    roomJid: string,
+    nick: string,
+    avatar: string,
+    avatarHash: string,
+    realJid?: string,
+    occupantId?: string,
+  ): Promise<void> {
+    if (occupantId) await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
+    await this.clearVCardNegativeCache(`${roomJid}/${nick}`)
+    if (realJid) await this.clearVCardNegativeCache(getBareJid(realJid))
+    this.deps.emitSDK('room:occupant-avatar', {
+      roomJid,
+      nick,
+      ...(occupantId && { occupantId }),
+      avatar,
+      avatarHash,
+    })
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -278,7 +278,7 @@ export class Profile extends BaseModule {
     const bareJid = getBareJid(jid)
     const token = getNoAvatarWriteToken(bareJid)
 
-    // Check negative cache first - skip if we recently confirmed no avatar
+    // Both confirmed absence and transient backoff suppress this query.
     if (await hasNoAvatar(bareJid)) {
       return null
     }
@@ -308,6 +308,8 @@ export class Profile extends BaseModule {
    * Concurrent reads share one query. Results and failures are cached in memory:
    * five minutes for populated profiles or ambiguous failures, 24 hours for
    * empty profiles or explicit absence. Avatar announcements invalidate negative results.
+   * All outcomes are memory-only, including definitive absence: the first read
+   * after an application restart queries the server again.
    *
    * @param jid - The bare JID or full occupant JID to query
    * @returns The fields the server returned, or null if the query failed
@@ -484,7 +486,7 @@ export class Profile extends BaseModule {
   }
 
   private async fetchVCardAvatarWithToken(bareJid: string, token: symbol): Promise<void> {
-    // Check negative cache first - skip if we recently confirmed no avatar
+    // Both confirmed absence and transient backoff suppress this query.
     if (await hasNoAvatar(bareJid)) {
       return
     }

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardCache.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardCache.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { xml, type Element } from '@xmpp/client'
+import { IDBFactory } from 'fake-indexeddb'
+import { createPresenceReader } from '../presenceReader'
+import type { ModuleDependencies } from './BaseModule'
+import type { Profile } from './Profile'
+
+const JID = 'alice@example.com'
+const MINUTE = 60_000
+const DAY = 24 * 60 * MINUTE
+const card = (...children: Element[]) => xml('iq', { type: 'result' },
+  xml('vCard', { xmlns: 'vcard-temp' }, ...children))
+const namedCard = () => card(xml('FN', {}, 'Alice'))
+const photoCard = () => card(xml('PHOTO', {}, xml('BINVAL', {}, 'aW1hZ2U=')))
+const stanzaError = (condition: string) => Object.assign(new Error(condition), { condition })
+
+// Keep IndexedDB across module reloads: a restart must discard only volatile state.
+async function loadProfile(deps: ModuleDependencies) {
+  vi.resetModules()
+  const { Profile } = await import('./Profile')
+  const cache = await import('../../utils/avatarCache')
+  return { profile: new Profile(deps), cache }
+}
+
+describe('vCard cache outcomes', () => {
+  let deps: ModuleDependencies
+  let sendIQ: ReturnType<typeof vi.fn<ModuleDependencies['sendIQ']>>
+  let profile: Profile
+  let cache: typeof import('../../utils/avatarCache')
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-09-09T12:00:00Z'))
+    globalThis.indexedDB = new IDBFactory()
+    sendIQ = vi.fn<ModuleDependencies['sendIQ']>()
+    deps = {
+      stores: null, presence: createPresenceReader(), sendStanza: async () => {}, sendIQ,
+      getCurrentJid: () => 'me@example.com/device', emit: vi.fn(), emitSDK: vi.fn(), getXmpp: () => null,
+    }
+    ;({ profile, cache } = await loadProfile(deps))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('retries an avatar after five minutes of timeout backoff', async () => {
+    sendIQ.mockRejectedValueOnce(new Error('Timeout')).mockResolvedValue(photoCard())
+    await profile.fetchVCardAvatar(JID)
+    await profile.fetchVCardAvatar(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+    vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+    await profile.fetchVCardAvatar(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+    expect(deps.emitSDK).toHaveBeenCalledWith('contacts:avatar', expect.objectContaining({ jid: JID }))
+    expect(await cache.hasNoAvatar(JID)).toBe(false)
+  })
+
+  it('does not retain an avatar timeout after a module reload', async () => {
+    sendIQ.mockRejectedValueOnce(new Error('Timeout')).mockResolvedValue(photoCard())
+    await profile.fetchVCardAvatar(JID)
+    expect(await cache.hasNoAvatar(JID)).toBe(true)
+    ;({ profile, cache } = await loadProfile(deps))
+    expect(await cache.hasNoAvatar(JID)).toBe(false)
+    await profile.fetchVCardAvatar(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  it('retains a returned vCard without PHOTO after reload until its 24-hour expiry', async () => {
+    sendIQ.mockResolvedValue(card())
+    await profile.fetchVCardAvatar(JID)
+    ;({ profile, cache } = await loadProfile(deps))
+    expect(await cache.hasNoAvatar(JID)).toBe(true)
+    vi.setSystemTime(Date.now() + DAY - 1)
+    await profile.fetchVCardAvatar(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+    vi.setSystemTime(Date.now() + 2)
+    await profile.fetchVCardAvatar(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+    'retains an explicit %s avatar refusal after reload for 24 hours', async (condition) => {
+      sendIQ.mockRejectedValue(stanzaError(condition))
+      await profile.fetchVCardAvatar(JID)
+      ;({ profile, cache } = await loadProfile(deps))
+      expect(await cache.hasNoAvatar(JID)).toBe(true)
+      vi.setSystemTime(Date.now() + DAY - 1)
+      await profile.fetchVCardAvatar(JID)
+      expect(sendIQ).toHaveBeenCalledTimes(1)
+      vi.setSystemTime(Date.now() + 2)
+      await profile.fetchVCardAvatar(JID)
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it.each([new Error('Network disconnected'), stanzaError('remote-server-timeout'), new Error('service-unavailable')])(
+    'does not persist an ambiguous avatar failure: %s', async (error) => {
+      sendIQ.mockRejectedValue(error)
+      await profile.fetchVCardAvatar(JID)
+      ;({ profile, cache } = await loadProfile(deps))
+      expect(await cache.hasNoAvatar(JID)).toBe(false)
+    },
+  )
+
+  it('shares pending profile queries, caches the result and refreshes after five minutes', async () => {
+    let reply!: (value: Element) => void
+    sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+    const first = profile.fetchProfileDetails(JID)
+    const second = profile.fetchProfileDetails(JID)
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+    reply(namedCard())
+    expect(await first).toMatchObject({ fullName: 'Alice' })
+    expect(await second).toMatchObject({ fullName: 'Alice' })
+    expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+    vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+    sendIQ.mockResolvedValue(card(xml('FN', {}, 'Updated')))
+    expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Updated' })
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['empty', 'missing', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+    'caches definitive profile absence (%s) for 24 hours', async (outcome) => {
+      if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+      else if (outcome === 'missing') sendIQ.mockResolvedValue(xml('iq', { type: 'result' }))
+      else sendIQ.mockRejectedValue(stanzaError(outcome))
+      expect(await profile.fetchProfileDetails(JID)).toBeNull()
+      vi.setSystemTime(Date.now() + DAY - 1)
+      expect(await profile.fetchProfileDetails(JID)).toBeNull()
+      expect(sendIQ).toHaveBeenCalledTimes(1)
+      vi.setSystemTime(Date.now() + 2)
+      sendIQ.mockResolvedValue(namedCard())
+      expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('backs off profile timeouts for five minutes and retries after reload', async () => {
+    sendIQ.mockRejectedValue(new Error('Timeout'))
+    expect(await profile.fetchProfileDetails(JID)).toBeNull()
+    expect(await profile.fetchProfileDetails(JID)).toBeNull()
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+    vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+    expect(await profile.fetchProfileDetails(JID)).toBeNull()
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+    ;({ profile, cache } = await loadProfile(deps))
+    sendIQ.mockResolvedValue(namedCard())
+    expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+    expect(sendIQ).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps full occupant JIDs distinct from each other and the room', async () => {
+    sendIQ.mockImplementation(async iq => card(xml('FN', {}, iq.attrs.to)))
+    const jids = ['room@conf.example/alice', 'room@conf.example/bob', 'room@conf.example']
+    for (const jid of jids) expect(await profile.fetchProfileDetails(jid)).toMatchObject({ fullName: jid })
+    for (const jid of jids) expect(await profile.fetchProfileDetails(jid)).toMatchObject({ fullName: jid })
+    expect(sendIQ.mock.calls.map(([iq]) => iq.attrs.to)).toEqual(jids)
+  })
+
+  it('refreshes cached own details after publication', async () => {
+    const ownJid = 'me@example.com'
+    sendIQ.mockResolvedValue(namedCard())
+    expect(await profile.fetchProfileDetails(ownJid)).toMatchObject({ fullName: 'Alice' })
+    await profile.publishOwnProfileDetails({ fullName: 'New Name' })
+    sendIQ.mockResolvedValue(card(xml('FN', {}, 'New Name')))
+    expect(await profile.fetchProfileDetails(ownJid)).toMatchObject({ fullName: 'New Name' })
+  })
+
+  it('does not reuse profile details across accounts', async () => {
+    sendIQ.mockResolvedValue(namedCard())
+    await profile.fetchProfileDetails(JID)
+    deps.getCurrentJid = () => 'another@example.com/device'
+    sendIQ.mockResolvedValue(card(xml('FN', {}, 'Visible to another account')))
+    expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Visible to another account' })
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  describe.each(['timeout', 'no-photo', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+    'positive evidence after %s', (outcome) => {
+      async function seedNegative() {
+        if (outcome === 'no-photo') sendIQ.mockResolvedValue(card())
+        else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : stanzaError(outcome))
+        await profile.fetchVCardAvatar(JID)
+        await profile.fetchProfileDetails(JID)
+        expect(await cache.hasNoAvatar(JID)).toBe(true)
+        sendIQ.mockClear()
+      }
+
+      it.each(['presence', 'metadata'])(
+        'clears both caches on %s even when the image is already cached', async (source) => {
+          await seedNegative()
+          await cache.cacheAvatar('known-hash', 'aW1hZ2U=', 'image/png')
+          const fetches: Promise<void>[] = []
+          deps.emit = vi.fn((event, ...args) => {
+            if (event === 'avatarMetadataUpdate') {
+              const [jid, hash] = args as [string, string]
+              fetches.push(profile.fetchAvatarData(jid, hash))
+            }
+          })
+          if (source === 'presence') {
+            const { Roster } = await import('./Roster')
+            new Roster(deps).handle(xml('presence', { from: `${JID}/phone` },
+              xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, 'known-hash'))))
+          } else {
+            const { PubSub } = await import('./PubSub')
+            new PubSub(deps).handle(xml('message', { from: JID },
+              xml('event', { xmlns: 'http://jabber.org/protocol/pubsub#event' },
+                xml('items', { node: 'urn:xmpp:avatar:metadata' },
+                  xml('item', { id: 'known-hash' },
+                    xml('metadata', { xmlns: 'urn:xmpp:avatar:metadata' },
+                      xml('info', { id: 'known-hash', type: 'image/png' })))))))
+          }
+          expect(fetches).toHaveLength(1)
+          await Promise.all(fetches)
+          expect(await cache.hasNoAvatar(JID)).toBe(false)
+          sendIQ.mockResolvedValue(namedCard())
+          expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+          expect(sendIQ).toHaveBeenCalledTimes(1)
+      })
+
+      it('clears both caches on occupant presence even when the image is already cached', async () => {
+        await seedNegative()
+        await cache.cacheAvatar('known-hash', 'aW1hZ2U=', 'image/png')
+        await profile.fetchOccupantAvatar('room@conf.example', 'alice', 'known-hash', `${JID}/phone`)
+        expect(await cache.hasNoAvatar(JID)).toBe(false)
+        sendIQ.mockResolvedValue(namedCard())
+        expect(await profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+      })
+
+      it('allows vCard fallback immediately after a contact hash when PEP cannot answer', async () => {
+        await seedNegative()
+        sendIQ.mockRejectedValueOnce(new Error('Timeout')).mockResolvedValue(photoCard())
+        await profile.fetchAvatarData(JID, 'new-hash')
+        expect(sendIQ).toHaveBeenCalledTimes(2)
+        expect(await cache.hasNoAvatar(JID)).toBe(false)
+        expect(deps.emitSDK).toHaveBeenCalledWith('contacts:avatar', expect.objectContaining({ jid: JID }))
+      })
+    },
+  )
+})

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -29,6 +29,7 @@ describe('vCard cache through avatar dispatchers', () => {
   let internal: ReturnType<typeof import('../XMPPClient')['getInternalSurfaceForTesting']>
   let sendIQ: MockInstance<XMPPClient['sendIQ']>
   let occupants: Map<string, RoomOccupant>
+  let joined: boolean
 
   beforeEach(async () => {
     vi.resetModules()
@@ -38,14 +39,18 @@ describe('vCard cache through avatar dispatchers', () => {
     const { XMPPClient, bindStoresForTesting, getInternalSurfaceForTesting } = await import('../XMPPClient')
     const { createMockStores } = await import('../test-utils')
     cache = await import('../../utils/avatarCache')
-    client = new XMPPClient({ debug: false })
+    class TestClient extends XMPPClient {
+      protected override async sendStanza(): Promise<void> {}
+    }
+    client = new TestClient({ debug: false })
+    joined = true
     const stores = createMockStores()
     occupants = new Map([['guest', {
       nick: 'guest', affiliation: 'member', role: 'participant',
       jid: `${JID}/phone`, avatarHash: HASH, avatar: 'blob:loaded', occupantId: 'alice-id',
     }]])
     stores.room.getRoom.mockImplementation(jid => jid === ROOM ? {
-      jid: ROOM, name: 'Room', nickname: 'me', joined: true, isBookmarked: false,
+      jid: ROOM, name: 'Room', nickname: 'me', joined, isBookmarked: false,
       occupants, unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>(),
     } : undefined)
     stores.roster.getContact.mockImplementation(jid => jid === JID ? {
@@ -230,5 +235,88 @@ describe('vCard cache through avatar dispatchers', () => {
     sendIQ.mockResolvedValue(namedCard('Bob'))
     expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Bob' })
     expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  describe('rejoin and avatar completion', () => {
+    const dataReply = () => xml('iq', { type: 'result' },
+      xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+        xml('items', { node: 'urn:xmpp:avatar:data' },
+          xml('item', { id: HASH }, xml('data', { xmlns: 'urn:xmpp:avatar:data' }, 'aW1hZ2U=')))))
+
+    it.each(['positive', 'negative', 'pending'])(
+      'discards %s anonymous occupant details on a fresh room rejoin', async outcome => {
+        occupants.set('guest', { nick: 'guest', affiliation: 'member', role: 'participant' })
+        let reply!: (value: Element) => void
+        if (outcome === 'pending') sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+        else sendIQ.mockResolvedValueOnce(outcome === 'positive' ? namedCard() : card())
+        const first = client.profile.fetchProfileDetails(OCCUPANT)
+        if (outcome !== 'pending') await first
+        joined = false
+        vi.spyOn(client.rooms, 'queryRoomFeatures').mockResolvedValue(null)
+        await client.rooms.joinRoom(ROOM, 'me')
+        occupants.set('guest', { nick: 'guest', affiliation: 'member', role: 'participant' })
+        sendIQ.mockResolvedValue(namedCard('Bob'))
+        const replacement = client.profile.fetchProfileDetails(OCCUPANT)
+        expect(sendIQ).toHaveBeenCalledTimes(2)
+        expect(await replacement).toMatchObject({ fullName: 'Bob' })
+        if (outcome === 'pending') {
+          reply(namedCard())
+          expect(await first).toBeNull()
+        }
+        expect(sendIQ).toHaveBeenCalledTimes(2)
+      },
+    )
+
+    describe.each(['contact PEP', 'occupant PEP', 'occupant vCard', 'anonymous vCard'])(
+      '%s success', route => {
+        it.each(['timeout', 'empty', 'service-unavailable'])(
+          'lifts a %s profile negative created during the download', async outcome => {
+            let reply!: (value: Element) => void
+            if (route === 'occupant vCard') sendIQ.mockResolvedValueOnce(xml('iq', { type: 'result' }))
+            sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+            const download = route === 'contact PEP'
+              ? client.profile.fetchAvatarData(JID, HASH)
+              : client.profile.fetchOccupantAvatar(ROOM, 'guest', HASH,
+                route === 'anonymous vCard' ? undefined : JID)
+            await vi.waitFor(() => expect(sendIQ).toHaveBeenCalledTimes(route === 'occupant vCard' ? 2 : 1))
+            if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+            else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : error(outcome))
+            const targets = route === 'contact PEP' ? [JID]
+              : route === 'anonymous vCard' ? [OCCUPANT] : [JID, OCCUPANT]
+            for (const target of targets) expect(await client.profile.fetchProfileDetails(target)).toBeNull()
+            reply(route.includes('PEP') ? dataReply()
+              : card(xml('PHOTO', {}, xml('BINVAL', {}, 'aW1hZ2U='))))
+            await download
+            sendIQ.mockResolvedValue(namedCard('Recovered'))
+            for (const target of targets) {
+              expect(await client.profile.fetchProfileDetails(target)).toMatchObject({ fullName: 'Recovered' })
+            }
+          },
+        )
+      },
+    )
+
+    it('shares empty-photo contact checks until the avatar download completes', async () => {
+      const { bindStoresForTesting } = await import('../XMPPClient')
+      const { createMockStores } = await import('../test-utils')
+      bindStoresForTesting(client, createMockStores())
+      const metadata = xml('iq', { type: 'result' },
+        xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+          xml('items', { node: 'urn:xmpp:avatar:metadata' },
+            xml('item', { id: HASH }, xml('metadata', { xmlns: 'urn:xmpp:avatar:metadata' },
+              xml('info', { id: HASH, type: 'image/png' }))))))
+      let reply!: (value: Element) => void
+      sendIQ.mockResolvedValueOnce(metadata)
+        .mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+        .mockResolvedValue(metadata)
+      const fetchMetadata = vi.spyOn(client.profile, 'fetchContactAvatarMetadata')
+      client.contacts.handle(contactPresence(''))
+      await vi.waitFor(() => expect(sendIQ).toHaveBeenCalledTimes(2))
+      client.contacts.handle(contactPresence(''))
+      expect(fetchMetadata).toHaveBeenCalledTimes(1)
+      reply(dataReply())
+      await fetchMetadata.mock.results[0].value
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -54,6 +54,7 @@ describe('vCard cache through avatar dispatchers', () => {
     client = new TestClient()
     joined = true
     const stores = createMockStores()
+    stores.connection.getJid.mockReturnValue(`${OWN}/desktop`)
     occupants = new Map([['guest', {
       nick: 'guest', affiliation: 'member', role: 'participant',
       jid: `${JID}/phone`, avatarHash: HASH, avatar: 'blob:loaded', occupantId: 'alice-id',
@@ -75,6 +76,7 @@ describe('vCard cache through avatar dispatchers', () => {
     client.destroy()
     vi.useRealTimers()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   async function dispatchOccupantFallback() {
@@ -490,6 +492,187 @@ describe('vCard cache through avatar dispatchers', () => {
       },
     )
 
+  })
+
+  describe('review regressions', () => {
+    const photoCard = () => card(xml('PHOTO', {}, xml('BINVAL', {}, 'aW1hZ2U=')))
+    const dataReply = () => xml('iq', { type: 'result' },
+      xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+        xml('items', { node: 'urn:xmpp:avatar:data' },
+          xml('item', { id: 'positive-hash' },
+            xml('data', { xmlns: 'urn:xmpp:avatar:data' }, 'aW1hZ2U=')))))
+
+    it.each(['timeout', 'empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+      'lifts a %s negative after another own resource announces a hash', async outcome => {
+        if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+        else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : error(outcome))
+        await client.profile.fetchVCardAvatar(OWN)
+        expect(await client.profile.fetchOwnProfileDetails()).toBeNull()
+        await client.profile.fetchProfileDetails(JID)
+        await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+        sendIQ.mockClear().mockResolvedValue(namedCard('Recovered'))
+        const fetch = vi.spyOn(client.profile, 'fetchAvatarData')
+        client.contacts.handle(xml('presence', { from: `${OWN}/phone` },
+          xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, HASH))))
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+        await fetch.mock.results[0].value
+        expect(await cache.hasNoAvatar(OWN)).toBe(false)
+        expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
+        expect(await client.profile.fetchProfileDetails(JID)).toBeNull()
+        expect(sendIQ).toHaveBeenCalledTimes(1)
+      },
+    )
+
+    it.each(['join', 'nick change'])(
+      'lifts own negatives on MUC self %s without a disclosed JID', async route => {
+        occupants.set('guest', {
+          nick: 'guest', affiliation: 'member', role: 'participant',
+          avatarHash: HASH, avatar: 'blob:loaded', occupantId: 'self-id',
+        })
+        vi.spyOn(client.profile, 'fetchRoomAvatar').mockResolvedValue()
+        vi.spyOn(client.rooms, 'setBookmark').mockResolvedValue()
+        sendIQ.mockResolvedValue(card())
+        for (const jid of [OWN, OCCUPANT]) {
+          await client.profile.fetchProfileDetails(jid)
+          await cache.markNoAvatar(jid, 'contact', 'definitive')
+        }
+        const changeNick = route === 'nick change' ? client.rooms.changeNick(ROOM, 'guest') : undefined
+        client.rooms.handle(xml('presence', { from: OCCUPANT },
+          xml('x', { xmlns: 'http://jabber.org/protocol/muc#user' },
+            xml('item', { affiliation: 'member', role: 'participant' }), xml('status', { code: '110' })),
+          xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, HASH)),
+          xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'self-id' })))
+        await changeNick
+        await vi.waitFor(async () => expect(await cache.hasNoAvatar(OCCUPANT)).toBe(false))
+        await vi.waitFor(async () => expect(await cache.hasNoAvatar(OWN)).toBe(false))
+        sendIQ.mockClear().mockResolvedValue(namedCard('Recovered'))
+        expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
+        expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Recovered' })
+        expect(sendIQ).toHaveBeenCalledTimes(2)
+      },
+    )
+
+    describe.each(['contact vCard', 'contact PEP fallback', 'occupant vCard', 'occupant PEP fallback'])(
+      '%s started before positive evidence', route => {
+        it.each(['timeout', 'empty', 'service-unavailable'])(
+          'does not restore a late %s avatar negative', async outcome => {
+            let resolve!: (value: Element) => void
+            let reject!: (reason: Error) => void
+            if (route === 'occupant vCard') sendIQ.mockResolvedValueOnce(xml('iq', { type: 'result' }))
+            sendIQ.mockImplementationOnce(() => new Promise((res, rej) => { resolve = res; reject = rej }))
+            const stale = route === 'contact vCard' ? client.profile.fetchVCardAvatar(JID)
+              : route === 'contact PEP fallback' ? client.profile.fetchContactAvatarMetadata(JID)
+              : client.profile.fetchOccupantAvatar(ROOM, 'guest', HASH, `${JID}/phone`, 'alice-id')
+            await vi.waitFor(() => expect(resolve).toBeTypeOf('function'))
+            sendIQ.mockResolvedValue(dataReply())
+            const fetch = vi.spyOn(client.profile, 'fetchAvatarData')
+            const published = vi.fn()
+            client.subscribe('contacts:avatar', published)
+            internal.pubsub.handle(xml('message', { from: JID },
+              xml('event', { xmlns: 'http://jabber.org/protocol/pubsub#event' },
+                xml('items', { node: 'urn:xmpp:avatar:metadata' },
+                  xml('item', { id: 'positive-hash' },
+                    xml('metadata', { xmlns: 'urn:xmpp:avatar:metadata' },
+                      xml('info', { id: 'positive-hash', type: 'image/png' })))))))
+            await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+            await fetch.mock.results[0].value
+            expect(published).toHaveBeenCalledWith(expect.objectContaining({ avatarHash: 'positive-hash' }))
+            expect(await cache.hasNoAvatar(JID)).toBe(false)
+            const failure = outcome === 'timeout' ? new Error('Timeout') : error(outcome)
+            if (route.endsWith('PEP fallback')) {
+              if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+              else sendIQ.mockRejectedValue(failure)
+              resolve(xml('iq', { type: 'result' }))
+            } else if (outcome === 'empty') resolve(card())
+            else reject(failure)
+            await stale
+            expect(await cache.hasNoAvatar(JID)).toBe(false)
+            vi.resetModules()
+            const restartedCache = await import('../../utils/avatarCache')
+            expect(await restartedCache.hasNoAvatar(JID)).toBe(false)
+          },
+        )
+      },
+    )
+
+    describe.each(['unavailable', 'open failure'])(
+      'IndexedDB %s', storage => {
+        it.each(['empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+          'suppresses repeated empty-photo queries for definitive %s absence', async outcome => {
+            const { bindStoresForTesting } = await import('../XMPPClient')
+            const { createMockStores } = await import('../test-utils')
+            bindStoresForTesting(client, createMockStores())
+            if (storage === 'unavailable') vi.stubGlobal('indexedDB', undefined)
+            else {
+              vi.spyOn(indexedDB, 'open').mockImplementation(() => { throw new Error('Storage unavailable') })
+              vi.spyOn(console, 'warn').mockImplementation(() => {})
+            }
+            sendIQ.mockImplementation(async iq => {
+              if (!iq.getChild('vCard') || outcome === 'empty') return card()
+              throw error(outcome)
+            })
+            const fetch = vi.spyOn(client.profile, 'fetchContactAvatarMetadata')
+            const dispatch = async () => {
+              const count = fetch.mock.calls.length
+              client.contacts.handle(contactPresence(''))
+              expect(fetch).toHaveBeenCalledTimes(count + 1)
+              await fetch.mock.results.at(-1)!.value
+            }
+            await dispatch()
+            expect(sendIQ).toHaveBeenCalledTimes(2)
+            vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+            await dispatch()
+            expect(sendIQ).toHaveBeenCalledTimes(2)
+            vi.setSystemTime(Date.now() + 24 * 60 * MINUTE)
+            await dispatch()
+            expect(sendIQ).toHaveBeenCalledTimes(4)
+            await client.profile.clearVCardNegativeCache(JID)
+            await dispatch()
+            expect(sendIQ).toHaveBeenCalledTimes(6)
+          },
+        )
+      },
+    )
+
+    it('does not restore a negative when storage fails after positive evidence', async () => {
+      let failOpen!: () => void
+      vi.spyOn(indexedDB, 'open').mockImplementation(() => {
+        const request = {
+          error: new Error('Storage unavailable'), onerror: null as null | (() => void),
+        }
+        failOpen = () => request.onerror?.()
+        return request as unknown as IDBOpenDBRequest
+      })
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mark = cache.markNoAvatar(JID, 'contact', 'definitive')
+      const evidence = client.profile.clearVCardNegativeCache(JID)
+      failOpen()
+      await Promise.all([mark, evidence])
+      expect(await cache.hasNoAvatar(JID)).toBe(false)
+    })
+
+    it.each(['preservation read', 'publication completion'])(
+      'lifts avatar negatives through own-profile %s with PHOTO', async stage => {
+        await cache.markNoAvatar(OWN, 'contact', 'definitive')
+        sendIQ.mockResolvedValueOnce(card())
+        expect(await client.profile.fetchOwnProfileDetails()).toBeNull()
+        let resolve!: (value: Element) => void
+        let reject!: (reason: Error) => void
+        sendIQ.mockResolvedValueOnce(photoCard())
+          .mockImplementationOnce(() => new Promise((res, rej) => { resolve = res; reject = rej }))
+        const publication = client.profile.publishOwnProfileDetails({ fullName: 'Recovered' })
+        const settled = publication.catch(reason => reason)
+        await vi.waitFor(() => expect(resolve).toBeTypeOf('function'))
+        if (stage === 'publication completion') {
+          await cache.markNoAvatar(OWN, 'contact', 'definitive')
+          resolve(xml('iq', { type: 'result' }))
+        } else reject(new Error('Publication failed'))
+        await settled
+        expect(await cache.hasNoAvatar(OWN)).toBe(false)
+        sendIQ.mockResolvedValue(namedCard('Recovered'))
+        expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
+      },
+    )
   })
 
 })

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -503,25 +503,52 @@ describe('vCard cache through avatar dispatchers', () => {
             xml('data', { xmlns: 'urn:xmpp:avatar:data' }, 'aW1hZ2U=')))))
 
     it.each(['timeout', 'empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
-      'lifts a %s negative after another own resource announces a hash', async outcome => {
+      'invalidates %s negatives without repeated own-presence avatar queries', async outcome => {
+        sendIQ.mockResolvedValueOnce(photoCard())
+        await client.profile.fetchVCardAvatar(OWN)
         if (outcome === 'empty') sendIQ.mockResolvedValue(card())
         else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : error(outcome))
         await client.profile.fetchVCardAvatar(OWN)
         expect(await client.profile.fetchOwnProfileDetails()).toBeNull()
         await client.profile.fetchProfileDetails(JID)
-        await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
-        sendIQ.mockClear().mockResolvedValue(namedCard('Recovered'))
+        sendIQ.mockClear().mockImplementation(async iq => iq.getChild('vCard')
+          ? card(xml('FN', {}, 'Recovered'), xml('PHOTO', {}, xml('BINVAL', {}, 'aW1hZ2U=')))
+          : xml('iq', { type: 'result' }))
         const fetch = vi.spyOn(client.profile, 'fetchAvatarData')
-        client.contacts.handle(xml('presence', { from: `${OWN}/phone` },
-          xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, HASH))))
-        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
-        await fetch.mock.results[0].value
-        expect(await cache.hasNoAvatar(OWN)).toBe(false)
+        const evidence = vi.spyOn(client.profile, 'clearVCardNegativeCache')
+        for (let repeat = 0; repeat < 3; repeat++) {
+          client.contacts.handle(xml('presence', { from: `${OWN}/phone` },
+            xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, HASH))))
+          await vi.waitFor(async () => expect(await cache.hasNoAvatar(OWN)).toBe(false))
+          await evidence.mock.results.at(-1)!.value
+          await Promise.resolve()
+          await Promise.all(fetch.mock.results.map(result => result.value))
+          expect(sendIQ).not.toHaveBeenCalled()
+          expect(fetch).not.toHaveBeenCalled()
+        }
         expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
         expect(await client.profile.fetchProfileDetails(JID)).toBeNull()
         expect(sendIQ).toHaveBeenCalledTimes(1)
       },
     )
+
+    it('still downloads ordinary-contact presence avatars through the vCard fallback', async () => {
+      sendIQ.mockRejectedValue(error('service-unavailable'))
+      await client.profile.fetchVCardAvatar(JID)
+      await client.profile.fetchProfileDetails(JID)
+      sendIQ.mockClear().mockImplementation(async iq => iq.getChild('vCard')
+        ? photoCard() : xml('iq', { type: 'result' }))
+      const updated = vi.fn()
+      client.subscribe('contacts:avatar', updated)
+      client.contacts.handle(contactPresence('new-contact-hash'))
+      await vi.waitFor(() => expect(updated).toHaveBeenCalledWith(expect.objectContaining({
+        jid: JID, avatar: 'data:image/png;base64,aW1hZ2U=',
+      })))
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+      expect(await cache.hasNoAvatar(JID)).toBe(false)
+      sendIQ.mockResolvedValue(namedCard('Recovered'))
+      expect(await client.profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Recovered' })
+    })
 
     it.each(['join', 'nick change'])(
       'lifts own negatives on MUC self %s without a disclosed JID', async route => {

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -4,6 +4,7 @@ import { IDBFactory } from 'fake-indexeddb'
 import type { XMPPClient } from '../XMPPClient'
 import type { RoomOccupant } from '../types/room'
 
+const OWN = 'me@example.com'
 const JID = 'alice@example.com'
 const ROOM = 'room@conference.example.com'
 const OCCUPANT = `${ROOM}/guest`
@@ -32,17 +33,23 @@ describe('vCard cache through avatar dispatchers', () => {
   let joined: boolean
 
   beforeEach(async () => {
+    const { createMockStores } = await import('../test-utils')
+    // test-utils registers an XML mock; these dispatcher tests inspect real stanzas.
+    vi.doUnmock('@xmpp/client')
     vi.resetModules()
     vi.useFakeTimers({ toFake: ['Date'] })
     vi.setSystemTime(new Date('2026-09-09T12:00:00Z'))
     globalThis.indexedDB = new IDBFactory()
     const { XMPPClient, bindStoresForTesting, getInternalSurfaceForTesting } = await import('../XMPPClient')
-    const { createMockStores } = await import('../test-utils')
     cache = await import('../../utils/avatarCache')
     class TestClient extends XMPPClient {
+      constructor() {
+        super({ debug: false })
+        this.currentJid = `${OWN}/desktop`
+      }
       protected override async sendStanza(): Promise<void> {}
     }
-    client = new TestClient({ debug: false })
+    client = new TestClient()
     joined = true
     const stores = createMockStores()
     occupants = new Map([['guest', {
@@ -319,4 +326,112 @@ describe('vCard cache through avatar dispatchers', () => {
       expect(sendIQ).toHaveBeenCalledTimes(2)
     })
   })
+
+  describe('shared positive profile/avatar boundary', () => {
+    const metadataReply = () => xml('iq', { type: 'result' },
+      xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+        xml('items', { node: 'urn:xmpp:avatar:metadata' },
+          xml('item', { id: HASH }, xml('metadata', { xmlns: 'urn:xmpp:avatar:metadata' },
+            xml('info', { id: HASH, type: 'image/png' }))))))
+    const dataReply = () => xml('iq', { type: 'result' },
+      xml('pubsub', { xmlns: 'http://jabber.org/protocol/pubsub' },
+        xml('items', { node: 'urn:xmpp:avatar:data' },
+          xml('item', { id: HASH }, xml('data', { xmlns: 'urn:xmpp:avatar:data' }, 'aW1hZ2U=')))))
+
+    describe.each(['cached', 'downloaded'])(
+      'own %s avatar at startup', route => {
+        it.each(['timeout', 'empty', 'service-unavailable'])(
+          'lifts a %s own-profile negative after concurrent startup queries', async outcome => {
+            if (route === 'cached') await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+            let release!: (value: Element) => void
+            let profileQueries = 0
+            let recovered = false
+            sendIQ.mockImplementation(async iq => {
+              if (iq.getChild('vCard')) {
+                profileQueries++
+                if (recovered) return namedCard('Recovered')
+                if (outcome === 'empty') return card()
+                throw outcome === 'timeout' ? new Error('Timeout') : error(outcome)
+              }
+              const node = iq.getChild('pubsub')?.getChild('items')?.attrs.node
+              if (node === 'urn:xmpp:avatar:metadata') {
+                if (route === 'cached') return new Promise(resolve => { release = resolve })
+                return metadataReply()
+              }
+              if (node === 'urn:xmpp:avatar:data') return new Promise(resolve => { release = resolve })
+              return xml('iq', { type: 'result' })
+            })
+            const startup = client.profile.fetchOwnProfile()
+            await vi.waitFor(() => expect(release).toBeTypeOf('function'))
+            expect(await client.profile.fetchProfileDetails(OWN)).toBeNull()
+            const queriesBeforeAvatar = profileQueries
+            expect(await client.profile.fetchProfileDetails(OWN)).toBeNull()
+            expect(profileQueries).toBe(queriesBeforeAvatar)
+            await cache.markNoAvatar(OWN, 'contact', outcome === 'timeout' ? 'transient' : 'definitive')
+            release(route === 'cached' ? metadataReply() : dataReply())
+            await startup
+            recovered = true
+            expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
+            expect(profileQueries).toBe(queriesBeforeAvatar + 1)
+            expect(await cache.hasNoAvatar(OWN)).toBe(false)
+          },
+        )
+      },
+    )
+
+    it.each(['own restore', 'contact restore', 'contact hashes', 'occupant restore',
+      'stable occupant restore', 'own refresh', 'contact refresh', 'occupant refresh'])(
+      'invalidates only the publishing identities through %s', async route => {
+        // fake-indexeddb's cloned happy-dom Blob is not a native URL Blob.
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:restored')
+        const { bindStoresForTesting } = await import('../XMPPClient')
+        const { createMockStores } = await import('../test-utils')
+        const stores = createMockStores()
+        const occupant: RoomOccupant = {
+          nick: 'guest', affiliation: 'member', role: 'participant',
+          jid: `${JID}/phone`, avatarHash: HASH, occupantId: 'alice-id',
+        }
+        const room = {
+          jid: ROOM, name: 'Room', nickname: 'me', joined: true, isBookmarked: false,
+          occupants: new Map([['guest', occupant]]),
+          occupantIdToNick: new Map([['alice-id', 'guest']]),
+          unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>(),
+        }
+        stores.room.getRoom.mockImplementation(jid => jid === ROOM ? room : undefined)
+        if (route === 'occupant refresh') stores.room.joinedRooms.mockReturnValue([room])
+        stores.roster.getContact.mockImplementation(jid => jid === JID ? {
+          jid: JID, name: 'Alice', subscription: 'both', presence: 'online',
+        } : undefined)
+        bindStoresForTesting(client, stores)
+        await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+        if (route === 'own refresh') await cache.saveAvatarHash(OWN, HASH, 'contact')
+        else if (route === 'stable occupant restore') await cache.saveRoomOccupantAvatarHash(ROOM, 'alice-id', HASH)
+        else if (!route.includes('own')) await cache.saveAvatarHash(JID, HASH, 'contact')
+        const targets = route.includes('own') ? [OWN]
+          : route.includes('occupant') ? [JID, OCCUPANT] : [JID]
+        const identities = [OWN, JID, OCCUPANT, ROOM, 'other@example.com', 'other@conference.example.com/guest']
+        sendIQ.mockRejectedValue(error('service-unavailable'))
+        for (const jid of identities) {
+          expect(await client.profile.fetchProfileDetails(jid)).toBeNull()
+          await cache.markNoAvatar(jid, 'contact', 'definitive')
+        }
+        sendIQ.mockClear().mockResolvedValue(namedCard('Recovered'))
+        if (route === 'own restore') expect(await client.profile.restoreOwnAvatarFromCache(HASH)).toBe(true)
+        else if (route === 'contact restore') expect(await client.profile.restoreContactAvatarFromCache(`${JID}/phone`, HASH)).toBe(true)
+        else if (route === 'contact hashes') await client.profile.restoreAllContactAvatarHashes()
+        else if (route.endsWith('restore')) await client.profile.restoreOccupantAvatarsFromCache(ROOM)
+        else await client.profile.refreshAllAvatarBlobUrls()
+        expect(sendIQ).not.toHaveBeenCalled()
+        for (const jid of identities) {
+          const details = await client.profile.fetchProfileDetails(jid)
+          if (targets.includes(jid)) expect(details).toMatchObject({ fullName: 'Recovered' })
+          else expect(details).toBeNull()
+          expect(await cache.hasNoAvatar(jid)).toBe(!targets.includes(jid))
+        }
+        expect(sendIQ).toHaveBeenCalledTimes(targets.length)
+      },
+    )
+
+  })
+
 })

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -31,6 +31,7 @@ describe('vCard cache through avatar dispatchers', () => {
   let sendIQ: MockInstance<XMPPClient['sendIQ']>
   let occupants: Map<string, RoomOccupant>
   let joined: boolean
+  let switchAccount: (jid: string) => void
 
   beforeEach(async () => {
     const { createMockStores } = await import('../test-utils')
@@ -46,6 +47,7 @@ describe('vCard cache through avatar dispatchers', () => {
       constructor() {
         super({ debug: false })
         this.currentJid = `${OWN}/desktop`
+        switchAccount = jid => { this.currentJid = jid }
       }
       protected override async sendStanza(): Promise<void> {}
     }
@@ -429,6 +431,62 @@ describe('vCard cache through avatar dispatchers', () => {
           expect(await cache.hasNoAvatar(jid)).toBe(!targets.includes(jid))
         }
         expect(sendIQ).toHaveBeenCalledTimes(targets.length)
+      },
+    )
+
+    it.each(['avatar cache', 'avatar download', 'avatar publication', 'avatar removal', 'profile publication',
+      'profile fetch', 'avatar restoration'])(
+      'rejects a late own %s completion after the account changes', async route => {
+        const nextAccount = 'next@example.com'
+        let release!: () => void
+        let started!: () => void
+        const pendingStarted = new Promise<void>(resolve => { started = resolve })
+        const hold = (reply: Element) => new Promise<Element>(resolve => {
+          release = () => resolve(reply)
+          started()
+        })
+        if (route === 'avatar cache') await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+        if (route === 'avatar restoration') {
+          vi.spyOn(cache, 'getCachedAvatar').mockImplementationOnce(() => new Promise(resolve => {
+            release = () => resolve('blob:restored')
+            started()
+          }))
+        }
+        sendIQ.mockImplementation(async iq => {
+          if (iq.attrs.to === nextAccount) throw error('service-unavailable')
+          if (iq.getChild('vCard')) {
+            if (route === 'profile fetch' || iq.attrs.type === 'set') return hold(namedCard('Previous account'))
+            return namedCard('Previous account')
+          }
+          const itemsNode = iq.getChild('pubsub')?.getChild('items')?.attrs.node
+          if (itemsNode === 'urn:xmpp:avatar:metadata') {
+            return route === 'avatar cache' ? hold(metadataReply()) : metadataReply()
+          }
+          if (itemsNode === 'urn:xmpp:avatar:data') return hold(dataReply())
+          const publishNode = iq.getChild('pubsub')?.getChild('publish')?.attrs.node
+          if (publishNode === 'urn:xmpp:avatar:metadata') return hold(xml('iq', { type: 'result' }))
+          return xml('iq', { type: 'result' })
+        })
+        const ownUpdate = vi.fn()
+        client.subscribe('connection:own-avatar', ownUpdate)
+        client.subscribe('connection:own-profile', ownUpdate)
+        const pending = route === 'avatar restoration' ? client.profile.restoreOwnAvatarFromCache(HASH)
+          : route === 'avatar removal' ? client.profile.clearOwnAvatar()
+          : route === 'profile fetch' ? client.profile.fetchOwnProfileDetails()
+          : route === 'profile publication' ? client.profile.publishOwnProfileDetails({ fullName: 'Previous account' })
+          : route === 'avatar publication' ? client.profile.publishOwnAvatar('data:image/png;base64,aW1hZ2U=', 'image/png', 1, 1)
+          : client.profile.fetchOwnAvatar()
+        await pendingStarted
+        switchAccount(`${nextAccount}/desktop`)
+        expect(await client.profile.fetchProfileDetails(nextAccount)).toBeNull()
+        await cache.markNoAvatar(nextAccount, 'contact', 'definitive')
+        release()
+        await pending
+        expect(await cache.hasNoAvatar(nextAccount)).toBe(true)
+        const count = sendIQ.mock.calls.length
+        expect(await client.profile.fetchProfileDetails(nextAccount)).toBeNull()
+        expect(sendIQ).toHaveBeenCalledTimes(count)
+        expect(ownUpdate).not.toHaveBeenCalled()
       },
     )
 

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import { xml, type Element } from '@xmpp/client'
+import { IDBFactory } from 'fake-indexeddb'
+import type { XMPPClient } from '../XMPPClient'
+import type { RoomOccupant } from '../types/room'
+
+const JID = 'alice@example.com'
+const ROOM = 'room@conference.example.com'
+const OCCUPANT = `${ROOM}/guest`
+const HASH = 'known-hash'
+const MINUTE = 60_000
+const card = (...children: Element[]) => xml('iq', { type: 'result' },
+  xml('vCard', { xmlns: 'vcard-temp' }, ...children))
+const namedCard = (name = 'Alice') => card(xml('FN', {}, name))
+const error = (condition: string) => Object.assign(new Error(condition), { condition })
+const contactPresence = (hash: string) => xml('presence', { from: `${JID}/phone` },
+  xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, hash)))
+const occupantPresence = (options: { hash?: string; unavailable?: boolean; self?: boolean; id?: string } = {}) =>
+  xml('presence', { from: OCCUPANT, ...(options.unavailable && { type: 'unavailable' }) },
+    xml('x', { xmlns: 'http://jabber.org/protocol/muc#user' },
+      xml('item', { affiliation: 'member', role: 'participant', jid: `${JID}/phone` }),
+      ...(options.self ? [xml('status', { code: '110' })] : [])),
+    ...(options.hash ? [xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, options.hash))] : []),
+    ...(options.id ? [xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: options.id })] : []))
+
+describe('vCard cache through avatar dispatchers', () => {
+  let client: XMPPClient
+  let cache: typeof import('../../utils/avatarCache')
+  let internal: ReturnType<typeof import('../XMPPClient')['getInternalSurfaceForTesting']>
+  let sendIQ: MockInstance<XMPPClient['sendIQ']>
+  let occupants: Map<string, RoomOccupant>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-09-09T12:00:00Z'))
+    globalThis.indexedDB = new IDBFactory()
+    const { XMPPClient, bindStoresForTesting, getInternalSurfaceForTesting } = await import('../XMPPClient')
+    const { createMockStores } = await import('../test-utils')
+    cache = await import('../../utils/avatarCache')
+    client = new XMPPClient({ debug: false })
+    const stores = createMockStores()
+    occupants = new Map([['guest', {
+      nick: 'guest', affiliation: 'member', role: 'participant',
+      jid: `${JID}/phone`, avatarHash: HASH, avatar: 'blob:loaded', occupantId: 'alice-id',
+    }]])
+    stores.room.getRoom.mockImplementation(jid => jid === ROOM ? {
+      jid: ROOM, name: 'Room', nickname: 'me', joined: true, isBookmarked: false,
+      occupants, unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>(),
+    } : undefined)
+    stores.roster.getContact.mockImplementation(jid => jid === JID ? {
+      jid: JID, name: 'Alice', subscription: 'both', presence: 'online',
+      avatarHash: HASH, avatar: 'blob:loaded',
+    } : undefined)
+    bindStoresForTesting(client, stores)
+    internal = getInternalSurfaceForTesting(client)
+    sendIQ = vi.spyOn(client, 'sendIQ')
+  })
+
+  afterEach(() => {
+    client.destroy()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  async function dispatchOccupantFallback() {
+    const fetch = vi.spyOn(client.profile, 'fetchOccupantAvatar')
+    const count = fetch.mock.calls.length
+    client.rooms.handle(occupantPresence({ hash: 'new-hash', id: 'alice-id' }))
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(count + 1))
+    await fetch.mock.results.at(-1)!.value
+  }
+
+  it('keeps occupant fallback timeouts volatile with five-minute backoff', async () => {
+    sendIQ.mockRejectedValue(new Error('Timeout'))
+    await dispatchOccupantFallback()
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+    expect(await cache.hasNoAvatar(JID)).toBe(true)
+    vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+    expect(await cache.hasNoAvatar(JID)).toBe(false)
+    await dispatchOccupantFallback()
+    expect(await cache.hasNoAvatar(JID)).toBe(true)
+    vi.resetModules()
+    const restartedCache = await import('../../utils/avatarCache')
+    expect(await restartedCache.hasNoAvatar(JID)).toBe(false)
+  })
+
+  it.each(['empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+    'persists definitive occupant fallback absence: %s', async outcome => {
+      sendIQ.mockRejectedValueOnce(new Error('Timeout'))
+      if (outcome === 'empty') sendIQ.mockResolvedValueOnce(card())
+      else sendIQ.mockRejectedValueOnce(error(outcome))
+      await dispatchOccupantFallback()
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+      vi.resetModules()
+      const restartedCache = await import('../../utils/avatarCache')
+      expect(await restartedCache.hasNoAvatar(JID)).toBe(true)
+      vi.setSystemTime(Date.now() + 24 * 60 * MINUTE + 1)
+      expect(await restartedCache.hasNoAvatar(JID)).toBe(false)
+    },
+  )
+
+  describe.each(['timeout', 'empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+    'cached negative %s', outcome => {
+      it.each(['presence', 'metadata', 'occupant'])(
+        'invalidates before loaded-hash deduplication through %s', async source => {
+          if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+          else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : error(outcome))
+          await client.profile.fetchVCardAvatar(JID)
+          await client.profile.fetchProfileDetails(JID)
+          await client.profile.fetchProfileDetails(OCCUPANT)
+          await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+          sendIQ.mockClear().mockResolvedValue(namedCard())
+          if (source === 'presence') client.contacts.handle(contactPresence(HASH))
+          else if (source === 'occupant') client.rooms.handle(occupantPresence({ hash: HASH, id: 'alice-id' }))
+          else internal.pubsub.handle(xml('message', { from: JID },
+            xml('event', { xmlns: 'http://jabber.org/protocol/pubsub#event' },
+              xml('items', { node: 'urn:xmpp:avatar:metadata' },
+                xml('item', { id: HASH }, xml('metadata', { xmlns: 'urn:xmpp:avatar:metadata' },
+                  xml('info', { id: HASH, type: 'image/png' })))))))
+          await vi.waitFor(async () => expect(await cache.hasNoAvatar(JID)).toBe(false))
+          expect(sendIQ).not.toHaveBeenCalled()
+          expect(await client.profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+          if (source === 'occupant') {
+            expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Alice' })
+          }
+          expect(sendIQ).toHaveBeenCalledTimes(source === 'occupant' ? 2 : 1)
+        },
+      )
+    },
+  )
+
+  it('retries empty-photo contact presence after timeout backoff expires', async () => {
+    const { bindStoresForTesting } = await import('../XMPPClient')
+    const { createMockStores } = await import('../test-utils')
+    bindStoresForTesting(client, createMockStores())
+    sendIQ.mockRejectedValue(new Error('Timeout'))
+    const fetchMetadata = vi.spyOn(client.profile, 'fetchContactAvatarMetadata')
+    const dispatch = async () => {
+      client.contacts.handle(contactPresence(''))
+      await vi.waitFor(() => expect(fetchMetadata).toHaveBeenCalled())
+      await fetchMetadata.mock.results.at(-1)!.value
+    }
+    await dispatch()
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+    await dispatch()
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+    vi.setSystemTime(Date.now() + 5 * MINUTE + 1)
+    sendIQ.mockResolvedValue(card(xml('PHOTO', {}, xml('BINVAL', {}, 'aW1hZ2U='))))
+    await dispatch()
+    expect(sendIQ).toHaveBeenCalledTimes(4)
+    expect(await cache.hasNoAvatar(JID)).toBe(false)
+  })
+
+  it('shares concurrent empty-photo presence checks while the query is pending', async () => {
+    const { bindStoresForTesting } = await import('../XMPPClient')
+    const { createMockStores } = await import('../test-utils')
+    bindStoresForTesting(client, createMockStores())
+    let reply!: (value: Element) => void
+    sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+    const fetchMetadata = vi.spyOn(client.profile, 'fetchContactAvatarMetadata')
+    client.contacts.handle(contactPresence(''))
+    await vi.waitFor(() => expect(sendIQ).toHaveBeenCalledTimes(1))
+    client.contacts.handle(contactPresence(''))
+    expect(fetchMetadata).toHaveBeenCalledTimes(1)
+    sendIQ.mockResolvedValue(card())
+    reply(xml('iq', { type: 'result' }))
+    await fetchMetadata.mock.results[0].value
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves populated profile results when another room announces the cached avatar', async () => {
+    sendIQ.mockResolvedValue(namedCard())
+    await client.profile.fetchProfileDetails(JID)
+    await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+    await client.profile.fetchOccupantAvatar(ROOM, 'guest', HASH, JID)
+    expect(await client.profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+    expect(sendIQ).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['positive', 'negative'])(
+    'shares pending %s profile queries across avatar evidence', async outcome => {
+      let reply!: (value: Element) => void
+      sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+      const first = client.profile.fetchProfileDetails(JID)
+      await cache.cacheAvatar(HASH, 'aW1hZ2U=', 'image/png')
+      await client.profile.fetchOccupantAvatar(ROOM, 'guest', HASH, JID)
+      const second = client.profile.fetchProfileDetails(JID)
+      expect(sendIQ).toHaveBeenCalledTimes(1)
+      reply(outcome === 'positive' ? namedCard() : card())
+      expect(await second).toEqual(await first)
+      sendIQ.mockResolvedValue(namedCard())
+      expect(await client.profile.fetchProfileDetails(JID)).toMatchObject({ fullName: 'Alice' })
+      expect(sendIQ).toHaveBeenCalledTimes(outcome === 'positive' ? 1 : 2)
+    },
+  )
+
+  it.each(['positive', 'negative', 'pending'])(
+    'discards %s occupant details after departure and nick reuse', async outcome => {
+      let reply!: (value: Element) => void
+      if (outcome === 'pending') sendIQ.mockImplementationOnce(() => new Promise(resolve => { reply = resolve }))
+      else sendIQ.mockResolvedValueOnce(outcome === 'positive' ? namedCard() : card())
+      const first = client.profile.fetchProfileDetails(OCCUPANT)
+      if (outcome !== 'pending') await first
+      client.rooms.handle(occupantPresence({ unavailable: true }))
+      client.rooms.handle(occupantPresence())
+      sendIQ.mockResolvedValue(namedCard('Bob'))
+      expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Bob' })
+      if (outcome === 'pending') {
+        reply(namedCard())
+        expect(await first).toBeNull()
+      }
+      expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Bob' })
+      expect(sendIQ).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('discards occupant details when the local user leaves the room', async () => {
+    sendIQ.mockResolvedValueOnce(namedCard())
+    await client.profile.fetchProfileDetails(OCCUPANT)
+    client.rooms.handle(occupantPresence({ unavailable: true, self: true }))
+    sendIQ.mockResolvedValue(namedCard('Bob'))
+    expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Bob' })
+  })
+
+  it.each(['occupantId', 'jid'] as const)('detects a replaced occupant by %s without departure', async field => {
+    sendIQ.mockResolvedValueOnce(namedCard())
+    await client.profile.fetchProfileDetails(OCCUPANT)
+    occupants.set('guest', { ...occupants.get('guest')!, [field]: 'bob' })
+    sendIQ.mockResolvedValue(namedCard('Bob'))
+    expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Bob' })
+    expect(sendIQ).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.vcardDispatch.test.ts
@@ -31,6 +31,7 @@ describe('vCard cache through avatar dispatchers', () => {
   let sendIQ: MockInstance<XMPPClient['sendIQ']>
   let occupants: Map<string, RoomOccupant>
   let joined: boolean
+  let privacyOptions: { disableOccupantAvatarsInAnonymousRooms?: boolean }
   let switchAccount: (jid: string) => void
 
   beforeEach(async () => {
@@ -43,9 +44,10 @@ describe('vCard cache through avatar dispatchers', () => {
     globalThis.indexedDB = new IDBFactory()
     const { XMPPClient, bindStoresForTesting, getInternalSurfaceForTesting } = await import('../XMPPClient')
     cache = await import('../../utils/avatarCache')
+    privacyOptions = {}
     class TestClient extends XMPPClient {
       constructor() {
-        super({ debug: false })
+        super({ debug: false, privacyOptions })
         this.currentJid = `${OWN}/desktop`
         switchAccount = jid => { this.currentJid = jid }
       }
@@ -578,6 +580,78 @@ describe('vCard cache through avatar dispatchers', () => {
         expect(sendIQ).toHaveBeenCalledTimes(2)
       },
     )
+
+    describe.each(['join', 'nick change'])('self-MUC %s avatar identity', route => {
+      async function seedNegatives(outcome: string) {
+        occupants.clear()
+        vi.spyOn(client.profile, 'fetchRoomAvatar').mockResolvedValue()
+        vi.spyOn(client.rooms, 'setBookmark').mockResolvedValue()
+        if (outcome === 'empty') sendIQ.mockResolvedValue(card())
+        else sendIQ.mockRejectedValue(outcome === 'timeout' ? new Error('Timeout') : error(outcome))
+        for (const jid of [OWN, OCCUPANT]) {
+          expect(await client.profile.fetchProfileDetails(jid)).toBeNull()
+          await cache.markNoAvatar(jid, 'contact', outcome === 'timeout' ? 'transient' : 'definitive')
+          expect(await cache.hasNoAvatar(jid)).toBe(true)
+        }
+        sendIQ.mockClear().mockImplementation(async iq => iq.getChild('vCard')
+          ? photoCard() : xml('iq', { type: 'result' }))
+      }
+
+      async function announce(realJid?: string) {
+        const fetch = vi.spyOn(client.profile, 'fetchOccupantAvatar')
+        const changeNick = route === 'nick change' ? client.rooms.changeNick(ROOM, 'guest') : undefined
+        client.rooms.handle(xml('presence', { from: OCCUPANT },
+          xml('x', { xmlns: 'http://jabber.org/protocol/muc#user' },
+            xml('item', { affiliation: 'member', role: 'participant', ...(realJid && { jid: realJid }) }),
+            xml('status', { code: '110' })),
+          xml('x', { xmlns: 'vcard-temp:x:update' }, xml('photo', {}, HASH)),
+          xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'self-id' })))
+        await changeNick
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+        await fetch.mock.results[0].value
+      }
+
+      async function expectRecoveredProfiles() {
+        for (const jid of [OWN, OCCUPANT]) expect(await cache.hasNoAvatar(jid)).toBe(false)
+        sendIQ.mockClear().mockResolvedValue(namedCard('Recovered'))
+        expect(await client.profile.fetchOwnProfileDetails()).toMatchObject({ fullName: 'Recovered' })
+        expect(await client.profile.fetchProfileDetails(OCCUPANT)).toMatchObject({ fullName: 'Recovered' })
+        expect(sendIQ).toHaveBeenCalledTimes(2)
+      }
+
+      it.each(['timeout', 'empty', 'service-unavailable', 'feature-not-implemented', 'item-not-found'])(
+        'invalidates %s negatives without anonymous avatar requests when disabled', async outcome => {
+          privacyOptions.disableOccupantAvatarsInAnonymousRooms = true
+          await seedNegatives(outcome)
+          const updated = vi.fn()
+          client.subscribe('room:occupant-avatar', updated)
+          await announce()
+          expect(sendIQ).not.toHaveBeenCalled()
+          expect(updated).not.toHaveBeenCalled()
+          await expectRecoveredProfiles()
+        },
+      )
+
+      it.each(['anonymous', 'disclosed'])(
+        'preserves the original %s avatar request target when permitted', async identity => {
+          privacyOptions.disableOccupantAvatarsInAnonymousRooms = identity === 'disclosed'
+          await seedNegatives('service-unavailable')
+          const updated = vi.fn()
+          client.subscribe('room:occupant-avatar', updated)
+          await announce(identity === 'disclosed' ? `${OWN}/phone` : undefined)
+          expect(sendIQ.mock.calls.map(([iq]) => ({
+            to: iq.attrs.to, vcard: Boolean(iq.getChild('vCard', 'vcard-temp')),
+          }))).toEqual(identity === 'disclosed'
+            ? [{ to: OWN, vcard: false }, { to: OWN, vcard: true }]
+            : [{ to: OCCUPANT, vcard: true }])
+          expect(updated).toHaveBeenCalledWith(expect.objectContaining({
+            roomJid: ROOM, nick: 'guest', occupantId: 'self-id', avatarHash: HASH,
+            avatar: expect.any(String),
+          }))
+          await expectRecoveredProfiles()
+        },
+      )
+    })
 
     describe.each(['contact vCard', 'contact PEP fallback', 'occupant vCard', 'occupant PEP fallback'])(
       '%s started before positive evidence', route => {

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -696,7 +696,7 @@ describe('XMPPClient Roster', () => {
       expect(missingAvatarCalls[0]).toEqual(['contactMissingXep0153Avatar', 'contact@example.com'])
     })
 
-    it('should NOT emit avatarMetadataUpdate when contact already has the same avatar hash', async () => {
+    it('should emit avatarMetadataUpdate when contact already has the same avatar hash', async () => {
       await connectClient()
 
       const emitSpy = vi.spyOn(xmppClient as any, 'emit')
@@ -727,7 +727,7 @@ describe('XMPPClient Roster', () => {
       mockXmppClientInstance._emit('stanza', presenceWithSameHash)
 
       const avatarCalls = emitSpy.mock.calls.filter(call => call[0] === 'avatarMetadataUpdate')
-      expect(avatarCalls.length).toBe(0)
+      expect(avatarCalls).toEqual([['avatarMetadataUpdate', 'contact@example.com', 'abc123avatarhash']])
     })
 
     it('should emit avatarMetadataUpdate when contact avatar hash changes', async () => {

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -764,7 +764,7 @@ describe('XMPPClient Roster', () => {
       expect(avatarCalls[0]).toEqual(['avatarMetadataUpdate', 'contact@example.com', 'new-hash-456'])
     })
 
-    it('should NOT emit avatarMetadataUpdate for self-presence with photo hash', async () => {
+    it('should emit avatarMetadataUpdate for self-presence with photo hash', async () => {
       await connectClient()
 
       // Set up the mock to return the connected JID (needed for self-presence detection)
@@ -772,7 +772,6 @@ describe('XMPPClient Roster', () => {
 
       const emitSpy = vi.spyOn(xmppClient as any, 'emit')
 
-      // Self-presence (from our own JID but different resource) - should be ignored
       const selfPresenceWithAvatar = createMockElement('presence', {
         from: 'user@example.com/otherdevice',
       }, [
@@ -787,9 +786,8 @@ describe('XMPPClient Roster', () => {
 
       mockXmppClientInstance._emit('stanza', selfPresenceWithAvatar)
 
-      // Should NOT emit for self-presence
       const avatarCalls = emitSpy.mock.calls.filter(call => call[0] === 'avatarMetadataUpdate')
-      expect(avatarCalls.length).toBe(0)
+      expect(avatarCalls).toEqual([['avatarMetadataUpdate', 'user@example.com', 'myavatarhash']])
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -764,7 +764,7 @@ describe('XMPPClient Roster', () => {
       expect(avatarCalls[0]).toEqual(['avatarMetadataUpdate', 'contact@example.com', 'new-hash-456'])
     })
 
-    it('should emit avatarMetadataUpdate for self-presence with photo hash', async () => {
+    it('should mark self-presence avatar evidence without requesting a download', async () => {
       await connectClient()
 
       // Set up the mock to return the connected JID (needed for self-presence detection)
@@ -787,7 +787,7 @@ describe('XMPPClient Roster', () => {
       mockXmppClientInstance._emit('stanza', selfPresenceWithAvatar)
 
       const avatarCalls = emitSpy.mock.calls.filter(call => call[0] === 'avatarMetadataUpdate')
-      expect(avatarCalls).toEqual([['avatarMetadataUpdate', 'user@example.com', 'myavatarhash']])
+      expect(avatarCalls).toEqual([['avatarMetadataUpdate', 'user@example.com', 'myavatarhash', true]])
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -280,15 +280,13 @@ export class Roster extends BaseModule {
             updates: { avatarFromPresence: true, avatar: undefined, avatarHash: undefined },
           })
         }
+      } else if (photo) {
+        this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
       } else if (!isSelfPresence) {
-        if (photo) {
-          this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
-        } else {
-          // Contact has empty <photo/> in XEP-0153 - they may use XEP-0084 instead
-          // Clients like Conversations publish avatars via XEP-0084 (PEP) only.
-          // Emit event to trigger XEP-0084 metadata fetch as fallback.
-          this.deps.emit('contactMissingXep0153Avatar', bareFrom)
-        }
+        // Contact has empty <photo/> in XEP-0153 - they may use XEP-0084 instead
+        // Clients like Conversations publish avatars via XEP-0084 (PEP) only.
+        // Emit event to trigger XEP-0084 metadata fetch as fallback.
+        this.deps.emit('contactMissingXep0153Avatar', bareFrom)
       }
     } else if (isRoomPresence) {
       // Room presence WITHOUT vcard-temp:x:update means room doesn't advertise avatar

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -281,7 +281,8 @@ export class Roster extends BaseModule {
           })
         }
       } else if (photo) {
-        this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
+        if (isSelfPresence) this.deps.emit('avatarMetadataUpdate', bareFrom, photo, true)
+        else this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
       } else if (!isSelfPresence) {
         // Contact has empty <photo/> in XEP-0153 - they may use XEP-0084 instead
         // Clients like Conversations publish avatars via XEP-0084 (PEP) only.

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -282,12 +282,7 @@ export class Roster extends BaseModule {
         }
       } else if (!isSelfPresence) {
         if (photo) {
-          // Contact has XEP-0153 avatar hash - emit if hash changed OR avatar blob is missing
-          // (blob can be missing when hash was restored from cache but blob was evicted)
-          const contact = this.deps.stores?.roster.getContact(bareFrom)
-          if (contact?.avatarHash !== photo || !contact?.avatar) {
-            this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
-          }
+          this.deps.emit('avatarMetadataUpdate', bareFrom, photo)
         } else {
           // Contact has empty <photo/> in XEP-0153 - they may use XEP-0084 instead
           // Clients like Conversations publish avatars via XEP-0084 (PEP) only.

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -85,7 +85,7 @@ export interface InternalClientEvents {
   /** Room avatar updated */
   roomAvatarUpdate: (roomJid: string, photoHash: string) => void
   /** MUC occupant avatar hash received (XEP-0398) */
-  occupantAvatarUpdate: (roomJid: string, nick: string, hash: string, realJid?: string, occupantId?: string) => void
+  occupantAvatarUpdate: (roomJid: string, nick: string, hash: string, realJid?: string, occupantId?: string, invalidationJid?: string) => void
   /** Roster (contact list) fully loaded from server */
   rosterLoaded: () => void
 }

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -77,7 +77,7 @@ export interface XMPPClientEvents {
  */
 export interface InternalClientEvents {
   /** Avatar metadata update received (XEP-0084) - hash is null when avatar removed */
-  avatarMetadataUpdate: (jid: string, hash: string | null) => void
+  avatarMetadataUpdate: (jid: string, hash: string | null, ownPresence?: boolean) => void
   /** Contact presence has empty XEP-0153 photo - may use XEP-0084 instead */
   contactMissingXep0153Avatar: (jid: string) => void
   /** Successfully joined a MUC room */

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -596,7 +596,7 @@ export async function hasNoAvatar(jid: string, ttlMs: number = NO_AVATAR_TTL_MS)
 export async function markNoAvatar(
   jid: string,
   type: AvatarEntityType,
-  outcome: 'definitive' | 'transient' = 'definitive',
+  outcome: 'definitive' | 'transient',
 ): Promise<void> {
   if (outcome === 'transient') {
     avatarRetryAfter.set(jid, Date.now() + AVATAR_RETRY_TTL_MS)

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -23,6 +23,7 @@ const AVATAR_RETRY_TTL_MS = 5 * 60 * 1000
 // A missing reply is not evidence of a missing avatar. Retry backoff must
 // disappear on reload, even when the durable no-avatar store survives.
 const avatarRetryAfter = new Map<string, number>()
+const noAvatarWriteTokens = new Map<string, symbol>()
 
 /**
  * Default TTL for PEP-forbidden domain cache entries (7 days in milliseconds).
@@ -586,6 +587,15 @@ export async function hasNoAvatar(jid: string, ttlMs: number = NO_AVATAR_TTL_MS)
   }
 }
 
+export function getNoAvatarWriteToken(jid: string): symbol {
+  let token = noAvatarWriteTokens.get(jid)
+  if (!token) {
+    token = Symbol()
+    noAvatarWriteTokens.set(jid, token)
+  }
+  return token
+}
+
 /**
  * Record confirmed avatar absence or a transient query failure.
  *
@@ -597,14 +607,18 @@ export async function markNoAvatar(
   jid: string,
   type: AvatarEntityType,
   outcome: 'definitive' | 'transient',
+  token = getNoAvatarWriteToken(jid),
 ): Promise<void> {
+  if (noAvatarWriteTokens.get(jid) !== token) return
   if (outcome === 'transient') {
     avatarRetryAfter.set(jid, Date.now() + AVATAR_RETRY_TTL_MS)
     return
   }
   avatarRetryAfter.delete(jid)
+  const expiresAt = Date.now() + NO_AVATAR_TTL_MS
   try {
     const db = await getDB()
+    if (noAvatarWriteTokens.get(jid) !== token) return
     await new Promise<void>((resolve, reject) => {
       const transaction = db.transaction(NO_AVATAR_STORE_NAME, 'readwrite')
       const store = transaction.objectStore(NO_AVATAR_STORE_NAME)
@@ -619,6 +633,7 @@ export async function markNoAvatar(
       request.onsuccess = () => resolve()
     })
   } catch (error) {
+    if (noAvatarWriteTokens.get(jid) === token) avatarRetryAfter.set(jid, expiresAt)
     // Only log if IndexedDB is available (skip in test environments)
     if (isIndexedDBAvailable()) {
       console.warn('Failed to mark JID as no-avatar:', error)
@@ -633,6 +648,7 @@ export async function markNoAvatar(
  * @param jid - The JID to remove from the cache
  */
 export async function clearNoAvatar(jid: string): Promise<void> {
+  noAvatarWriteTokens.delete(jid)
   avatarRetryAfter.delete(jid)
   try {
     const db = await getDB()
@@ -656,6 +672,7 @@ export async function clearNoAvatar(jid: string): Promise<void> {
  * Clear all no-avatar entries
  */
 export async function clearAllNoAvatarEntries(): Promise<void> {
+  noAvatarWriteTokens.clear()
   avatarRetryAfter.clear()
   try {
     const db = await getDB()

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -18,6 +18,11 @@ const PEP_FORBIDDEN_STORE_NAME = 'pep-forbidden-domains'
  * After this time, we'll re-check if the JID has an avatar
  */
 const NO_AVATAR_TTL_MS = 24 * 60 * 60 * 1000
+const AVATAR_RETRY_TTL_MS = 5 * 60 * 1000
+
+// A missing reply is not evidence of a missing avatar. Retry backoff must
+// disappear on reload, even when the durable no-avatar store survives.
+const avatarRetryAfter = new Map<string, number>()
 
 /**
  * Default TTL for PEP-forbidden domain cache entries (7 days in milliseconds).
@@ -534,13 +539,18 @@ export async function clearAllAvatarHashes(): Promise<void> {
 // =============================================================================
 
 /**
- * Check if a JID is known to have no avatar (negative cache)
- * Returns true if the JID was recently checked and found to have no avatar
+ * Check whether avatar queries should wait for a negative cache entry to expire.
+ * Includes confirmed absence and short, volatile backoff after a failed query.
  *
  * @param jid - The JID to check
  * @param ttlMs - Time-to-live in milliseconds (default: 24 hours)
  */
 export async function hasNoAvatar(jid: string, ttlMs: number = NO_AVATAR_TTL_MS): Promise<boolean> {
+  const retryAfter = avatarRetryAfter.get(jid)
+  if (retryAfter !== undefined) {
+    if (Date.now() < retryAfter) return true
+    avatarRetryAfter.delete(jid)
+  }
   try {
     const db = await getDB()
     return new Promise((resolve, reject) => {
@@ -577,13 +587,22 @@ export async function hasNoAvatar(jid: string, ttlMs: number = NO_AVATAR_TTL_MS)
 }
 
 /**
- * Mark a JID as having no avatar (negative cache)
- * This prevents repeated queries for JIDs without avatars
+ * Record confirmed avatar absence or a transient query failure.
  *
- * @param jid - The JID that has no avatar
+ * @param jid - The queried JID
  * @param type - Whether this is a 'contact' or 'room'
+ * @param outcome - Only definitive absence is persisted; transient failures back off in memory
  */
-export async function markNoAvatar(jid: string, type: AvatarEntityType): Promise<void> {
+export async function markNoAvatar(
+  jid: string,
+  type: AvatarEntityType,
+  outcome: 'definitive' | 'transient' = 'definitive',
+): Promise<void> {
+  if (outcome === 'transient') {
+    avatarRetryAfter.set(jid, Date.now() + AVATAR_RETRY_TTL_MS)
+    return
+  }
+  avatarRetryAfter.delete(jid)
   try {
     const db = await getDB()
     await new Promise<void>((resolve, reject) => {
@@ -614,6 +633,7 @@ export async function markNoAvatar(jid: string, type: AvatarEntityType): Promise
  * @param jid - The JID to remove from the cache
  */
 export async function clearNoAvatar(jid: string): Promise<void> {
+  avatarRetryAfter.delete(jid)
   try {
     const db = await getDB()
     await new Promise<void>((resolve, reject) => {
@@ -636,6 +656,7 @@ export async function clearNoAvatar(jid: string): Promise<void> {
  * Clear all no-avatar entries
  */
 export async function clearAllNoAvatarEntries(): Promise<void> {
+  avatarRetryAfter.clear()
   try {
     const db = await getDB()
     await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Fixes https://github.com/processone/fluux-messenger/issues/1358.

A vCard timeout could be recorded as “no avatar” for 24 hours on disk, while profile details had no SDK cache. This restores the intended failure handling: lack of a reply is not evidence of no avatar. Timeouts and other transient failures now use a five-minute backoff in memory; confirmed missing photos and explicit unsupported/not-found responses retain the 24-hour persistent avatar cache. A timeout-derived negative never survives an application restart. Positive avatar evidence clears every category of negative and prevents older failures from reinstating it. Profile reads share in-flight requests and cached results. Invalidation preserves existing download eligibility, including own-resource presence suppression and anonymous-room avatar privacy.