### PR TITLE
docs(changelog): refresh 0.17.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Fluux Messenger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.3] - 2026-09-07
+## [0.17.3] - 2026-09-09
 
 ### Added
 
@@ -19,32 +19,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Group chats: a room row tooltip now tells you how many messages are unread, and the unread dot and mention badge moved after the timestamp so they line up down the list
 - Encryption: a message that cannot be read now says why — a key this device does not have, an invalid signature, or content that could not be parsed — instead of always blaming a missing key
 - Fluux now tells you when something failed instead of staying silent: older messages that could not be loaded show a marker above the button that retries, and a bookmarked room that could not be rejoined says why — a password is required, the nickname is taken, the room is members-only
-- Launching after a long absence and opening a conversation are much faster, and Fluux writes far less to local storage while it catches up on history
-- Updated dependencies (Rust crates and JavaScript packages)
+- Opening a conversation now shows a loading indicator and lets you go back while history loads. When an app update needs to upgrade your local history, a progress bar shows how far it has got
+- Launching after a long absence and opening a conversation are faster, and Fluux writes less to local storage while it catches up on history. Upgrading local history after an app update is also faster for large archives
+- Server administrators can identify Fluux and its platform more easily in session metrics: newly generated resource names start with "fluux-w" (web), "fluux-d" (desktop) or "fluux-m" (native mobile). Existing resource names are preserved
 
 ### Fixed
 
 - Your read position now reaches your other devices in the cases where it used to stall: after you reply in a one-to-one chat, in a conversation with nothing currently loaded, and after a first attempt that did not go through. Other clients stop showing a stale "New messages" line and an inflated unread badge
 - A conversation whose oldest messages have been removed from the server archive no longer freezes your read position: Fluux could stop publishing it altogether, leaving your other devices months behind
-- The "New messages" line no longer comes back every time you reopen a conversation you have already read through
+- The "New messages" line no longer comes back every time you reopen a conversation you have already read through, and your read position no longer moves backwards when the last message you read is missing from the loaded history
 - A conversation or room no longer keeps an unread badge that reading cannot clear, with no new messages to explain it
 - A read position arriving from another device is no longer discarded when it cannot yet be ordered against your own; it is applied once the conversation is opened
 - Group chats: a room read elsewhere no longer shows zero unread and no read marker while other XMPP clients show both
 - The conversation stops jumping and drifting: closing an image or a dialog with Escape keeps your place, a late-arriving older message no longer pushes a scrolled-up reader backwards in time, returning to a room lands on the position you left, opening a room whose read position predates the loaded history no longer strands you at the oldest message, and Home works right after opening a conversation
-- The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send
+- The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send. Deleting text in the composer also keeps your place, whether you are at the bottom or reading older messages
 - The typing indicator no longer covers messages, and its label wraps to two lines instead of being cut off
 - One-to-one messages you sent from another device while this one was asleep now come back in the order you sent them, instead of after the replies you have already read
+- One-to-one messages no longer overwrite each other in local history when another client reuses a message identifier, and deleting one message no longer removes an unrelated one
+- Edited messages keep their latest text when you load older history or restart Fluux, in both chats and rooms. Conversation previews and search results also reflect the current text
 - Group chats: a room whose archive starts near the bottom of your local cache no longer claims "Beginning of conversation" and refuses to load older messages
 - Group chats: after a reconnect, a joined room no longer sits inert in the sidebar with no preview and no timestamp, and history no longer loads in two visible phases on mobile and the web app
 - Group chats: joining a password-protected room now asks for the password wherever you join from — the sidebar, an invitation, or Browse Rooms — and remembers it for next time
 - Group chats: hat management stops waiting sooner when the room service does not reply, explains when the command timed out, reports the server's reason when available, and deleting a hat no longer appears to revert on ejabberd 26.01-26.04
 - Group chats: messages keep the right avatar after their author leaves the room or the app restarts
+- A slow or failed profile lookup no longer leaves an avatar missing for a day or profile details stuck empty for the rest of the session
 - Group chats: joining a busy room no longer announces its recent history as new arrivals
 - Encryption: OpenPGP keys generated by Fluux can now be imported by Gajim, existing keys are repaired when you unlock them, and Fluux no longer removes your other clients' keys from the shared key list
 - Encryption: re-publishing an unchanged key no longer locks encryption behind a reconcile warning, a backup check that could not complete is no longer reported as "no backup", a backup that fails to re-publish during key rotation is now surfaced, and the backup dialog's Copy and Regenerate buttons no longer publish the key behind your back
 - Encryption: OMEMO session-setup messages no longer show up as empty bubbles with unread badges in builds without OMEMO support
 - Encryption: saving an image from the lightbox or its context menu no longer writes the raw encrypted file to disk
 - A retracted message no longer leaves a stray "This message has been retracted" bubble next to its tombstone
+- macOS: repeated notifications from the same contact or room keep their avatar
 - Desktop (Windows and Linux): clicking a notification while Fluux is running now restores the window and opens the conversation and message it came from, and notification failures are recorded in the log
 - Linux: the notification settings button opens the right panel on Cinnamon, KDE, XFCE, Budgie and LXQt instead of doing nothing
 - Desktop: quitting from the system tray no longer reconnects on the way out, the window can be resized narrow enough to reach the single-pane layout, and the log file is named so Windows can open it

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,32 +12,37 @@
 - Group chats: a room row tooltip now tells you how many messages are unread, and the unread dot and mention badge moved after the timestamp so they line up down the list
 - Encryption: a message that cannot be read now says why — a key this device does not have, an invalid signature, or content that could not be parsed — instead of always blaming a missing key
 - Fluux now tells you when something failed instead of staying silent: older messages that could not be loaded show a marker above the button that retries, and a bookmarked room that could not be rejoined says why — a password is required, the nickname is taken, the room is members-only
-- Launching after a long absence and opening a conversation are much faster, and Fluux writes far less to local storage while it catches up on history
-- Updated dependencies (Rust crates and JavaScript packages)
+- Opening a conversation now shows a loading indicator and lets you go back while history loads. When an app update needs to upgrade your local history, a progress bar shows how far it has got
+- Launching after a long absence and opening a conversation are faster, and Fluux writes less to local storage while it catches up on history. Upgrading local history after an app update is also faster for large archives
+- Server administrators can identify Fluux and its platform more easily in session metrics: newly generated resource names start with "fluux-w" (web), "fluux-d" (desktop) or "fluux-m" (native mobile). Existing resource names are preserved
 
 ### Fixed
 
 - Your read position now reaches your other devices in the cases where it used to stall: after you reply in a one-to-one chat, in a conversation with nothing currently loaded, and after a first attempt that did not go through. Other clients stop showing a stale "New messages" line and an inflated unread badge
 - A conversation whose oldest messages have been removed from the server archive no longer freezes your read position: Fluux could stop publishing it altogether, leaving your other devices months behind
-- The "New messages" line no longer comes back every time you reopen a conversation you have already read through
+- The "New messages" line no longer comes back every time you reopen a conversation you have already read through, and your read position no longer moves backwards when the last message you read is missing from the loaded history
 - A conversation or room no longer keeps an unread badge that reading cannot clear, with no new messages to explain it
 - A read position arriving from another device is no longer discarded when it cannot yet be ordered against your own; it is applied once the conversation is opened
 - Group chats: a room read elsewhere no longer shows zero unread and no read marker while other XMPP clients show both
 - The conversation stops jumping and drifting: closing an image or a dialog with Escape keeps your place, a late-arriving older message no longer pushes a scrolled-up reader backwards in time, returning to a room lands on the position you left, opening a room whose read position predates the loaded history no longer strands you at the oldest message, and Home works right after opening a conversation
-- The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send
+- The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send. Deleting text in the composer also keeps your place, whether you are at the bottom or reading older messages
 - The typing indicator no longer covers messages, and its label wraps to two lines instead of being cut off
 - One-to-one messages you sent from another device while this one was asleep now come back in the order you sent them, instead of after the replies you have already read
+- One-to-one messages no longer overwrite each other in local history when another client reuses a message identifier, and deleting one message no longer removes an unrelated one
+- Edited messages keep their latest text when you load older history or restart Fluux, in both chats and rooms. Conversation previews and search results also reflect the current text
 - Group chats: a room whose archive starts near the bottom of your local cache no longer claims "Beginning of conversation" and refuses to load older messages
 - Group chats: after a reconnect, a joined room no longer sits inert in the sidebar with no preview and no timestamp, and history no longer loads in two visible phases on mobile and the web app
 - Group chats: joining a password-protected room now asks for the password wherever you join from — the sidebar, an invitation, or Browse Rooms — and remembers it for next time
 - Group chats: hat management stops waiting sooner when the room service does not reply, explains when the command timed out, reports the server's reason when available, and deleting a hat no longer appears to revert on ejabberd 26.01-26.04
 - Group chats: messages keep the right avatar after their author leaves the room or the app restarts
+- A slow or failed profile lookup no longer leaves an avatar missing for a day or profile details stuck empty for the rest of the session
 - Group chats: joining a busy room no longer announces its recent history as new arrivals
 - Encryption: OpenPGP keys generated by Fluux can now be imported by Gajim, existing keys are repaired when you unlock them, and Fluux no longer removes your other clients' keys from the shared key list
 - Encryption: re-publishing an unchanged key no longer locks encryption behind a reconcile warning, a backup check that could not complete is no longer reported as "no backup", a backup that fails to re-publish during key rotation is now surfaced, and the backup dialog's Copy and Regenerate buttons no longer publish the key behind your back
 - Encryption: OMEMO session-setup messages no longer show up as empty bubbles with unread badges in builds without OMEMO support
 - Encryption: saving an image from the lightbox or its context menu no longer writes the raw encrypted file to disk
 - A retracted message no longer leaves a stray "This message has been retracted" bubble next to its tombstone
+- macOS: repeated notifications from the same contact or room keep their avatar
 - Desktop (Windows and Linux): clicking a notification while Fluux is running now restores the window and opens the conversation and message it came from, and notification failures are recorded in the log
 - Linux: the notification settings button opens the right panel on Cinnamon, KDE, XFCE, Budgie and LXQt instead of doing nothing
 - Desktop: quitting from the system tray no longer reconnects on the way out, the window can be resized narrow enough to reach the single-pane layout, and the log file is named so Windows can open it

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -15,7 +15,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '0.17.3',
-    date: '2026-09-07',
+    date: '2026-09-09',
     sections: [
       {
         type: 'added',
@@ -32,9 +32,9 @@ export const changelog: ChangelogEntry[] = [
           'Group chats: a room row tooltip now tells you how many messages are unread, and the unread dot and mention badge moved after the timestamp so they line up down the list',
           'Encryption: a message that cannot be read now says why — a key this device does not have, an invalid signature, or content that could not be parsed — instead of always blaming a missing key',
           'Fluux now tells you when something failed instead of staying silent: older messages that could not be loaded show a marker above the button that retries, and a bookmarked room that could not be rejoined says why — a password is required, the nickname is taken, the room is members-only',
-          'Launching after a long absence and opening a conversation are much faster, and Fluux writes far less to local storage while it catches up on history',
+          'Opening a conversation now shows a loading indicator and lets you go back while history loads. When an app update needs to upgrade your local history, a progress bar shows how far it has got',
+          'Launching after a long absence and opening a conversation are faster, and Fluux writes less to local storage while it catches up on history. Upgrading local history after an app update is also faster for large archives',
           'Server administrators can identify Fluux and its platform more easily in session metrics: newly generated resource names start with "fluux-w" (web), "fluux-d" (desktop) or "fluux-m" (native mobile). Existing resource names are preserved',
-          'Updated dependencies (Rust crates and JavaScript packages)',
         ],
       },
       {
@@ -42,19 +42,22 @@ export const changelog: ChangelogEntry[] = [
         items: [
           'Your read position now reaches your other devices in the cases where it used to stall: after you reply in a one-to-one chat, in a conversation with nothing currently loaded, and after a first attempt that did not go through. Other clients stop showing a stale "New messages" line and an inflated unread badge',
           'A conversation whose oldest messages have been removed from the server archive no longer freezes your read position: Fluux could stop publishing it altogether, leaving your other devices months behind',
-          'The "New messages" line no longer comes back every time you reopen a conversation you have already read through',
+          'The "New messages" line no longer comes back every time you reopen a conversation you have already read through, and your read position no longer moves backwards when the last message you read is missing from the loaded history',
           'A conversation or room no longer keeps an unread badge that reading cannot clear, with no new messages to explain it',
           'A read position arriving from another device is no longer discarded when it cannot yet be ordered against your own; it is applied once the conversation is opened',
           'Group chats: a room read elsewhere no longer shows zero unread and no read marker while other XMPP clients show both',
           'The conversation stops jumping and drifting: closing an image or a dialog with Escape keeps your place, a late-arriving older message no longer pushes a scrolled-up reader backwards in time, returning to a room lands on the position you left, opening a room whose read position predates the loaded history no longer strands you at the oldest message, and Home works right after opening a conversation',
-          'The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send',
+          'The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send. Deleting text in the composer also keeps your place, whether you are at the bottom or reading older messages',
           'The typing indicator no longer covers messages, and its label wraps to two lines instead of being cut off',
           'One-to-one messages you sent from another device while this one was asleep now come back in the order you sent them, instead of after the replies you have already read',
+          'One-to-one messages no longer overwrite each other in local history when another client reuses a message identifier, and deleting one message no longer removes an unrelated one',
+          'Edited messages keep their latest text when you load older history or restart Fluux, in both chats and rooms. Conversation previews and search results also reflect the current text',
           'Group chats: a room whose archive starts near the bottom of your local cache no longer claims "Beginning of conversation" and refuses to load older messages',
           'Group chats: after a reconnect, a joined room no longer sits inert in the sidebar with no preview and no timestamp, and history no longer loads in two visible phases on mobile and the web app',
           'Group chats: joining a password-protected room now asks for the password wherever you join from — the sidebar, an invitation, or Browse Rooms — and remembers it for next time',
           'Group chats: hat management stops waiting sooner when the room service does not reply, explains when the command timed out, reports the server\'s reason when available, and deleting a hat no longer appears to revert on ejabberd 26.01-26.04',
           'Group chats: messages keep the right avatar after their author leaves the room or the app restarts',
+          'A slow or failed profile lookup no longer leaves an avatar missing for a day or profile details stuck empty for the rest of the session',
           'Group chats: joining a busy room no longer announces its recent history as new arrivals',
           'Encryption: OpenPGP keys generated by Fluux can now be imported by Gajim, existing keys are repaired when you unlock them, and Fluux no longer removes your other clients\' keys from the shared key list',
           'Encryption: re-publishing an unchanged key no longer locks encryption behind a reconcile warning, a backup check that could not complete is no longer reported as "no backup", a backup that fails to re-publish during key rotation is now surfaced, and the backup dialog\'s Copy and Regenerate buttons no longer publish the key behind your back',

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -7,29 +7,34 @@ fluux-messenger (0.17.3-1) unstable; urgency=medium
   * Group chats: a room row tooltip now tells you how many messages are unread, and the unread dot and mention badge moved after the timestamp so they line up down the list
   * Encryption: a message that cannot be read now says why — a key this device does not have, an invalid signature, or content that could not be parsed — instead of always blaming a missing key
   * Fluux now tells you when something failed instead of staying silent: older messages that could not be loaded show a marker above the button that retries, and a bookmarked room that could not be rejoined says why — a password is required, the nickname is taken, the room is members-only
-  * Launching after a long absence and opening a conversation are much faster, and Fluux writes far less to local storage while it catches up on history
-  * Updated dependencies (Rust crates and JavaScript packages)
+  * Opening a conversation now shows a loading indicator and lets you go back while history loads. When an app update needs to upgrade your local history, a progress bar shows how far it has got
+  * Launching after a long absence and opening a conversation are faster, and Fluux writes less to local storage while it catches up on history. Upgrading local history after an app update is also faster for large archives
+  * Server administrators can identify Fluux and its platform more easily in session metrics: newly generated resource names start with "fluux-w" (web), "fluux-d" (desktop) or "fluux-m" (native mobile). Existing resource names are preserved
   * Your read position now reaches your other devices in the cases where it used to stall: after you reply in a one-to-one chat, in a conversation with nothing currently loaded, and after a first attempt that did not go through. Other clients stop showing a stale "New messages" line and an inflated unread badge
   * A conversation whose oldest messages have been removed from the server archive no longer freezes your read position: Fluux could stop publishing it altogether, leaving your other devices months behind
-  * The "New messages" line no longer comes back every time you reopen a conversation you have already read through
+  * The "New messages" line no longer comes back every time you reopen a conversation you have already read through, and your read position no longer moves backwards when the last message you read is missing from the loaded history
   * A conversation or room no longer keeps an unread badge that reading cannot clear, with no new messages to explain it
   * A read position arriving from another device is no longer discarded when it cannot yet be ordered against your own; it is applied once the conversation is opened
   * Group chats: a room read elsewhere no longer shows zero unread and no read marker while other XMPP clients show both
   * The conversation stops jumping and drifting: closing an image or a dialog with Escape keeps your place, a late-arriving older message no longer pushes a scrolled-up reader backwards in time, returning to a room lands on the position you left, opening a room whose read position predates the loaded history no longer strands you at the oldest message, and Home works right after opening a conversation
-  * The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send
+  * The view stays on the newest message when a late link preview, reaction or attachment makes the last message taller, and when the composer collapses back to one line after you send. Deleting text in the composer also keeps your place, whether you are at the bottom or reading older messages
   * The typing indicator no longer covers messages, and its label wraps to two lines instead of being cut off
   * One-to-one messages you sent from another device while this one was asleep now come back in the order you sent them, instead of after the replies you have already read
+  * One-to-one messages no longer overwrite each other in local history when another client reuses a message identifier, and deleting one message no longer removes an unrelated one
+  * Edited messages keep their latest text when you load older history or restart Fluux, in both chats and rooms. Conversation previews and search results also reflect the current text
   * Group chats: a room whose archive starts near the bottom of your local cache no longer claims "Beginning of conversation" and refuses to load older messages
   * Group chats: after a reconnect, a joined room no longer sits inert in the sidebar with no preview and no timestamp, and history no longer loads in two visible phases on mobile and the web app
   * Group chats: joining a password-protected room now asks for the password wherever you join from — the sidebar, an invitation, or Browse Rooms — and remembers it for next time
   * Group chats: hat management stops waiting sooner when the room service does not reply, explains when the command timed out, reports the server's reason when available, and deleting a hat no longer appears to revert on ejabberd 26.01-26.04
   * Group chats: messages keep the right avatar after their author leaves the room or the app restarts
+  * A slow or failed profile lookup no longer leaves an avatar missing for a day or profile details stuck empty for the rest of the session
   * Group chats: joining a busy room no longer announces its recent history as new arrivals
   * Encryption: OpenPGP keys generated by Fluux can now be imported by Gajim, existing keys are repaired when you unlock them, and Fluux no longer removes your other clients' keys from the shared key list
   * Encryption: re-publishing an unchanged key no longer locks encryption behind a reconcile warning, a backup check that could not complete is no longer reported as "no backup", a backup that fails to re-publish during key rotation is now surfaced, and the backup dialog's Copy and Regenerate buttons no longer publish the key behind your back
   * Encryption: OMEMO session-setup messages no longer show up as empty bubbles with unread badges in builds without OMEMO support
   * Encryption: saving an image from the lightbox or its context menu no longer writes the raw encrypted file to disk
   * A retracted message no longer leaves a stray "This message has been retracted" bubble next to its tombstone
+  * macOS: repeated notifications from the same contact or room keep their avatar
   * Desktop (Windows and Linux): clicking a notification while Fluux is running now restores the window and opens the conversation and message it came from, and notification failures are recorded in the log
   * Linux: the notification settings button opens the right panel on Cinnamon, KDE, XFCE, Budgie and LXQt instead of doing nothing
   * Desktop: quitting from the system tray no longer reconnects on the way out, the window can be resized narrow enough to reach the single-pane layout, and the log file is named so Windows can open it
@@ -48,4 +53,4 @@ fluux-messenger (0.17.3-1) unstable; urgency=medium
   * Fluux now asks your server where to connect before falling back to its own list of known addresses, so an account on a server whose address changed is no longer locked out. If you were affected and had typed an address into the advanced server field, clear it once and Fluux will find the server on its own
   * A password containing accented or non-Latin characters is now sent to the server exactly as you typed it, so accounts that were refused with "invalid username or password" can sign in
 
- -- ProcessOne <contact@process-one.net>  Mon, 07 Sep 2026 12:00:00 +0000
+ -- ProcessOne <contact@process-one.net>  Wed, 09 Sep 2026 12:00:00 +0000

--- a/packaging/flatpak/com.processone.fluux.metainfo.xml
+++ b/packaging/flatpak/com.processone.fluux.metainfo.xml
@@ -91,7 +91,7 @@
   </content_rating>
 
   <releases>
-    <release version="0.17.3" date="2026-09-07">
+    <release version="0.17.3" date="2026-09-09">
       <description>
         <p>See release notes for details.</p>
       </description>


### PR DESCRIPTION
Refresh the 0.17.3 release notes with the latest history-loading, message-cache, profile, and read-position improvements. Synchronize the generated changelogs and packaging metadata with the September 9 date.
