### PR TITLE
fix(sidebar): keep room unread dots circular

### DIFF
--- a/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
@@ -138,7 +138,7 @@ describe('RoomItem tooltip', () => {
 })
 
 describe('RoomItem unread indicators', () => {
-  it('renders a larger dot after the timestamp at the fixed metadata edge', () => {
+  it('renders a circular dot after the timestamp at the fixed metadata edge', () => {
     const { container } = renderRoom(makeRoom({
       unreadCount: 37,
       mentionsCount: 0,
@@ -161,7 +161,8 @@ describe('RoomItem unread indicators', () => {
     expect(timestamp).not.toBeNull()
     expect(dot).not.toBeNull()
     expect(timestamp.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    expect(dot.className).toContain('size-3')
+    expect(dot.className).toContain('size-2.5')
+    expect(dot.className).toContain('rounded-full')
   })
 
   it('renders the mention-count badge after the timestamp in the same metadata slot', () => {

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -471,7 +471,7 @@ export const RoomItem = memo(function RoomItem({
                   second bubble). */}
               {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
                 <div
-                  className={`size-3 rounded-full flex-shrink-0 ${
+                  className={`size-2.5 rounded-full flex-shrink-0 ${
                     roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
                   }`}
                 />


### PR DESCRIPTION
Use the same 10 px circular geometry as the icon rail for room unread indicators, avoiding the slightly elongated rendering at small scale. Strengthen the existing sidebar regression to pin both the dot size and full rounding.