### PR TITLE
docs(sdk): correct the version that superseded the legacy MDS payload

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -180,7 +180,7 @@ export function setupMdsSideEffects(
   }
 
   /**
-   * Republish a legacy-format marker (pre-0.18 payload) in XEP-0490 format so
+   * Republish a legacy-format marker (pre-0.17.1 payload) in XEP-0490 format so
    * other clients can read it. Best-effort; the value is already correct
    * locally and on the node, only its shape is wrong.
    */
@@ -938,7 +938,7 @@ export function setupMdsSideEffects(
         // once the bookmark lands. A genuine 1:1 JID also lands in the else
         // branch and simply never drains — cleared on the next seed.
         //
-        // Legacy-format items (pre-0.18 payload) are additionally republished
+        // Legacy-format items (pre-0.17.1 payload) are additionally republished
         // in spec format once the JID can be classified (`by` differs for
         // rooms vs 1:1): known rooms and known 1:1 entities migrate here;
         // stashed room markers migrate when their bookmark drains below. A

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -11,7 +11,7 @@ export interface DisplayedMarker {
   /** XEP-0359 stanza-id of the last displayed message. */
   stanzaId: string
   /**
-   * True when the item was published in the pre-0.18 Fluux payload (a bare
+   * True when the item was published in the pre-0.17.1 Fluux payload (a bare
    * XEP-0333 `<displayed/>` instead of the XEP-0490 wrapper). Other clients
    * cannot read that shape — the consumer should republish it in spec format.
    */
@@ -26,7 +26,7 @@ export type DisplayedMarkerFetchResult =
  * Parse the `<items/>` of an MDS node into markers.
  * Accepts the XEP-0490 payload (`<displayed xmlns='urn:xmpp:mds:displayed:0'>`
  * wrapping a XEP-0359 `<stanza-id/>`) and, as a migration fallback, the
- * pre-0.18 Fluux payload (a bare XEP-0333 `<displayed id=…/>`), flagged
+ * pre-0.17.1 Fluux payload (a bare XEP-0333 `<displayed id=…/>`), flagged
  * `legacy`. Items with neither shape are skipped.
  * Exported so PubSub can reuse it for incoming `+notify` events.
  */

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -118,8 +118,9 @@ const appearanceCodec: PepCodec<AppearanceSettings> = {
   decode: (item) => {
     const appearance = item.getChild('appearance', NS_APPEARANCE)
     if (!appearance) return undefined
-    // `theme` is the pre-0.18 name for `mode`, still read so an upgrade keeps
-    // the user's choice. Publishing only ever writes `mode`.
+    // Appearance items published before the first public release name this
+    // element `theme`. Both spellings are read so an upgrade keeps the user's
+    // choice; publishing only ever writes `mode`.
     const mode = appearance.getChildText('mode') || appearance.getChildText('theme')
     if (!mode) return undefined
     const settings: AppearanceSettings = { mode }

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -300,7 +300,7 @@ describe('PubSub Module', () => {
       })
     })
 
-    it('emits read:displayed-synced for legacy pre-0.18 Fluux payloads (migration read path)', async () => {
+    it('emits read:displayed-synced for legacy pre-0.17.1 Fluux payloads (migration read path)', async () => {
       await connectClient()
 
       mockXmppClientInstance._emit('stanza', mdsEvent('user@example.com', [


### PR DESCRIPTION
Four comments named 0.18 as the boundary for the pre-spec XEP-0490 marker payload. The spec payload actually shipped in 0.17.1 (#854), so the comments over-reported by three releases which builds can still hold a legacy item on their MDS node.

The appearance codec's `theme` fallback carried the same "pre-0.18" phrasing, but `mode` and the `theme` fallback read were introduced together in the repository's root commit — no released version ever published `theme`, so that comment now states the constraint without citing a version.

Comment text only; no behaviour change.