### PR TITLE
ci(windows): keep the release building when code signing is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # The release signs Windows artifacts through a PowerShell hook the Tauri
+      # bundler invokes per file. Whether a signing failure stops the build is a
+      # policy the hook alone enforces, and no other job runs it.
+      - name: Windows signing hook honours its policy
+        shell: pwsh
+        run: apps/fluux/src-tauri/sign-windows.test.ps1
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,19 @@ jobs:
           projectPath: apps/fluux
           args: --config src-tauri/tauri.release-signing.conf.json
 
+      # The bundler discards the sign hook's output, so the hook keeps its own
+      # log. It is the only account of why an artifact went out unsigned.
+      - name: Windows signing log
+        if: always()
+        shell: pwsh
+        run: |
+          $log = "apps/fluux/src-tauri/target/windows-signing.log"
+          if (Test-Path -LiteralPath $log) {
+            Get-Content -LiteralPath $log
+          } else {
+            Write-Host "The signing hook produced no log; it was never invoked."
+          }
+
       - name: Check Windows Authenticode signatures
         shell: powershell
         run: apps/fluux/src-tauri/verify-windows-signatures.ps1

--- a/apps/fluux/src-tauri/sign-windows.ps1
+++ b/apps/fluux/src-tauri/sign-windows.ps1
@@ -5,7 +5,22 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+# WINDOWS_CODE_SIGNING_REQUIRED is the single switch deciding what an
+# unavailable signing service costs: "true" stops the release, anything else
+# ships the artifact unsigned. Every failure below routes through the one
+# handler at the bottom of this file so that no unanticipated error can escape
+# that policy.
 $signingRequired = $env:WINDOWS_CODE_SIGNING_REQUIRED -eq "true"
+
+# The Tauri bundler runs this file as a per-artifact sign command and discards
+# its stdout and stderr, so nothing written to the host reaches the CI log.
+# Diagnostics are appended to a log file the workflow prints after the build.
+$logPath = if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_LOG)) {
+    Join-Path $PSScriptRoot "target/windows-signing.log"
+} else {
+    $env:WINDOWS_SIGNING_LOG
+}
 
 $requiredEnvironmentVariables = @(
     "AZURE_TENANT_ID",
@@ -16,77 +31,122 @@ $requiredEnvironmentVariables = @(
     "AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE"
 )
 
-$missingEnvironmentVariables = @(
-    $requiredEnvironmentVariables | Where-Object {
-        [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
-    }
-)
+function Write-SigningLog {
+    param([string]$Message)
 
-if ($missingEnvironmentVariables.Count -gt 0) {
-    $message = "Windows code signing is unavailable because these environment variables are missing: $($missingEnvironmentVariables -join ', ')."
-    if ($signingRequired) {
-        throw $message
-    }
+    $line = "[{0}] {1}" -f (Get-Date -Format "o"), $Message
+    Write-Host $line
 
-    Write-Warning "$message Continuing without an Authenticode signature."
-    exit 0
+    try {
+        $directory = Split-Path -Parent $logPath
+        if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+        Add-Content -LiteralPath $logPath -Value $line
+    } catch {
+        # An unwritable log must never be the reason a build fails.
+    }
 }
 
-$resolvedPath = (Resolve-Path -LiteralPath $FilePath).Path
+function Invoke-Signing {
+    param([string]$Path)
 
-Write-Host "Signing $resolvedPath with Azure Artifact Signing"
-& artifact-signing-cli `
-    -e $env:AZURE_SIGNING_ENDPOINT `
-    -a $env:AZURE_ARTIFACT_SIGNING_ACCOUNT `
-    -c $env:AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE `
-    -d "Fluux Messenger" `
-    $resolvedPath
-
-if ($LASTEXITCODE -ne 0) {
-    $message = "Azure Artifact Signing failed for '$resolvedPath' with exit code $LASTEXITCODE."
-    if ($signingRequired) {
-        throw $message
+    $missingEnvironmentVariables = @(
+        $requiredEnvironmentVariables | Where-Object {
+            [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+        }
+    )
+    if ($missingEnvironmentVariables.Count -gt 0) {
+        throw "Windows code signing is unavailable because these environment variables are missing: $($missingEnvironmentVariables -join ', ')."
     }
 
-    $failedSignature = Get-AuthenticodeSignature -LiteralPath $resolvedPath
-    if ($failedSignature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
-        throw "$message The failed attempt left a non-valid signature ($($failedSignature.Status)); refusing to package the file."
+    $cli = @(Get-Command "artifact-signing-cli" -CommandType Application -ErrorAction SilentlyContinue)
+    if ($cli.Count -eq 0) {
+        throw "artifact-signing-cli was not found on PATH."
     }
 
-    Write-Warning "$message Continuing without an Authenticode signature."
-    exit 0
+    Write-SigningLog "Signing $Path with Azure Artifact Signing"
+
+    # The CLI reports progress and failures on stderr. Windows PowerShell turns
+    # a native command's stderr into error records whenever its output is
+    # redirected, which under `Stop` aborts the script before its exit code can
+    # be read — so judge the call by its exit code alone.
+    $output = $null
+    $exitCode = $null
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & $cli[0].Source `
+            -e $env:AZURE_SIGNING_ENDPOINT `
+            -a $env:AZURE_ARTIFACT_SIGNING_ACCOUNT `
+            -c $env:AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE `
+            -d "Fluux Messenger" `
+            $Path 2>&1
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+
+    if ($output) {
+        Write-SigningLog "artifact-signing-cli said:`n$(($output | Out-String).TrimEnd())"
+    }
+
+    if ($exitCode -ne 0) {
+        throw "Azure Artifact Signing failed for '$Path' with exit code $exitCode."
+    }
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $Path
+    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+        throw "Authenticode verification failed for '$Path': $($signature.Status) ($($signature.StatusMessage))"
+    }
+    if ($null -eq $signature.SignerCertificate) {
+        throw "No Authenticode signer certificate was found for '$Path'."
+    }
+    if ($null -eq $signature.TimeStamperCertificate) {
+        throw "No Authenticode timestamp was found for '$Path'."
+    }
+
+    Write-SigningLog "Verified Authenticode signature: $Path"
+    Write-SigningLog "  Signer: $($signature.SignerCertificate.Subject)"
+    Write-SigningLog "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
+    Write-SigningLog "  Timestamp authority: $($signature.TimeStamperCertificate.Subject)"
 }
 
-$signature = Get-AuthenticodeSignature -LiteralPath $resolvedPath
-if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
-    $message = "Authenticode verification failed for '$resolvedPath': $($signature.Status) ($($signature.StatusMessage))"
-    if ($signingRequired) {
-        throw $message
-    }
+function Get-ResidualSignatureStatus {
+    param([string]$Path)
 
-    Write-Warning "$message Continuing with the produced file."
-    exit 0
-}
-if ($null -eq $signature.SignerCertificate) {
-    $message = "No Authenticode signer certificate was found for '$resolvedPath'."
-    if ($signingRequired) {
-        throw $message
+    try {
+        return (Get-AuthenticodeSignature -LiteralPath $Path).Status
+    } catch {
+        return $null
     }
-
-    Write-Warning "$message Continuing with the produced file."
-    exit 0
-}
-if ($null -eq $signature.TimeStamperCertificate) {
-    $message = "No Authenticode timestamp was found for '$resolvedPath'."
-    if ($signingRequired) {
-        throw $message
-    }
-
-    Write-Warning "$message Continuing with the produced file."
-    exit 0
 }
 
-Write-Host "Verified Authenticode signature: $resolvedPath"
-Write-Host "  Signer: $($signature.SignerCertificate.Subject)"
-Write-Host "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
-Write-Host "  Timestamp authority: $($signature.TimeStamperCertificate.Subject)"
+$exitCode = 0
+try {
+    Invoke-Signing -Path (Resolve-Path -LiteralPath $FilePath).Path
+} catch {
+    $reason = $_.Exception.Message
+
+    if ($signingRequired) {
+        Write-SigningLog "$reason Windows code signing is required, so the build stops here."
+        $exitCode = 1
+    } else {
+        # Windows treats a broken signature as tampering, which is worse than no
+        # signature at all. An attempt that left one behind is not something the
+        # fallback may ship.
+        $residualStatus = Get-ResidualSignatureStatus -Path $FilePath
+        $residualIsUsable = $null -eq $residualStatus -or
+            $residualStatus -eq [System.Management.Automation.SignatureStatus]::NotSigned -or
+            $residualStatus -eq [System.Management.Automation.SignatureStatus]::Valid
+
+        if ($residualIsUsable) {
+            Write-SigningLog "$reason Continuing without an Authenticode signature."
+        } else {
+            Write-SigningLog "$reason The attempt left a $residualStatus signature behind; refusing to package the file."
+            $exitCode = 1
+        }
+    }
+}
+
+exit $exitCode

--- a/apps/fluux/src-tauri/sign-windows.test.ps1
+++ b/apps/fluux/src-tauri/sign-windows.test.ps1
@@ -242,10 +242,16 @@ try {
     Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
 }
 
+Write-Host ""
+
 if ($script:failures.Count -gt 0) {
-    Write-Host ""
-    throw "$($script:failures.Count) Windows signing hook case(s) failed: $($script:failures -join '; ')"
+    Write-Host "$($script:failures.Count) Windows signing hook case(s) failed: $($script:failures -join '; ')"
+    exit 1
 }
 
-Write-Host ""
 Write-Host "Windows signing hook honours WINDOWS_CODE_SIGNING_REQUIRED in every failure mode."
+
+# Each case ran the hook as a child process, so $LASTEXITCODE still carries the
+# exit code of the last one, and the cases that must stop a build leave it at 1.
+# The CI shell exits on that value unless this script sets its own.
+exit 0

--- a/apps/fluux/src-tauri/sign-windows.test.ps1
+++ b/apps/fluux/src-tauri/sign-windows.test.ps1
@@ -1,0 +1,251 @@
+#!/usr/bin/env pwsh
+#
+# Regression tests for sign-windows.ps1.
+#
+# Windows code signing is optional: WINDOWS_CODE_SIGNING_REQUIRED decides
+# whether a signing failure stops the release or only leaves the artifact
+# unsigned. These tests pin that contract for the failure modes the hook can
+# actually meet — absent credentials, an absent CLI, a CLI that fails, and a CLI
+# that reports success without producing a signature.
+#
+# The bundler runs the hook as `powershell.exe -File ... "%1"` with stdout and
+# stderr piped into the bundler. That exact combination — Windows PowerShell,
+# not pwsh, with redirected output — is what turns a native command's stderr
+# into an error record, so the tests reproduce it rather than calling the hook
+# in-process, where the hazard does not exist.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$signScript = Join-Path $PSScriptRoot "sign-windows.ps1"
+$windowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+
+$azureCredentials = @{
+    AZURE_TENANT_ID                            = "00000000-0000-0000-0000-000000000000"
+    AZURE_CLIENT_ID                            = "00000000-0000-0000-0000-000000000001"
+    AZURE_CLIENT_SECRET                        = "test-secret"
+    AZURE_SIGNING_ENDPOINT                     = "https://wus.codesigning.azure.net"
+    AZURE_ARTIFACT_SIGNING_ACCOUNT             = "test-account"
+    AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE = "test-profile"
+}
+
+$script:failures = @()
+
+function New-Sandbox {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("fluux-sign-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    return $root
+}
+
+function New-UnsignedArtifact {
+    param([string]$Root)
+
+    # Get-AuthenticodeSignature reports NotSigned for an unsigned PowerShell
+    # script just as it does for an unsigned binary, so a .ps1 stands in for the
+    # bundled executable without committing a PE fixture.
+    $path = Join-Path $Root "artifact.ps1"
+    Set-Content -LiteralPath $path -Value "# unsigned test artifact"
+    return $path
+}
+
+function New-FakeSigningCli {
+    param(
+        [string]$Root,
+        [int]$ExitCode,
+        [switch]$WriteStderr
+    )
+
+    $binDirectory = Join-Path $Root "bin"
+    New-Item -ItemType Directory -Path $binDirectory -Force | Out-Null
+
+    $lines = @("@echo off")
+    if ($WriteStderr) {
+        $lines += "echo AADSTS7000222: The provided client secret keys for app are expired. 1>&2"
+    }
+    $lines += "exit /b $ExitCode"
+    Set-Content -LiteralPath (Join-Path $binDirectory "artifact-signing-cli.cmd") -Value $lines
+
+    return $binDirectory
+}
+
+function Invoke-SignHook {
+    param(
+        [string]$ArtifactPath,
+        [string]$LogPath,
+        [hashtable]$Environment,
+        [string]$SearchPath
+    )
+
+    $names = @($azureCredentials.Keys) + @("WINDOWS_CODE_SIGNING_REQUIRED", "WINDOWS_SIGNING_LOG", "PATH")
+    $saved = @{}
+    foreach ($name in $names) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name)
+    }
+
+    try {
+        foreach ($name in $names) {
+            [Environment]::SetEnvironmentVariable($name, $null)
+        }
+        foreach ($name in $Environment.Keys) {
+            [Environment]::SetEnvironmentVariable($name, $Environment[$name])
+        }
+        [Environment]::SetEnvironmentVariable("WINDOWS_SIGNING_LOG", $LogPath)
+        [Environment]::SetEnvironmentVariable("PATH", $SearchPath)
+
+        # Merging stderr is what the bundler does, and under `Stop` the merge
+        # would abort this test the way it aborts the hook. Judge the child by
+        # its exit code instead.
+        $previousPreference = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $output = & $windowsPowerShell -NoLogo -NoProfile -NonInteractive `
+                -ExecutionPolicy Bypass -File $signScript $ArtifactPath 2>&1
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousPreference
+        }
+
+        $log = if (Test-Path -LiteralPath $LogPath) {
+            (Get-Content -LiteralPath $LogPath -Raw)
+        } else {
+            ""
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output   = ($output | Out-String)
+            Log      = $log
+        }
+    } finally {
+        foreach ($name in $names) {
+            [Environment]::SetEnvironmentVariable($name, $saved[$name])
+        }
+    }
+}
+
+function Assert-Case {
+    param(
+        [string]$Name,
+        [pscustomobject]$Result,
+        [switch]$ExpectSuccess,
+        [string]$ExpectLogMatch
+    )
+
+    $problems = @()
+
+    if ($ExpectSuccess) {
+        if ($Result.ExitCode -ne 0) {
+            $problems += "expected exit code 0, got $($Result.ExitCode)"
+        }
+    } elseif ($Result.ExitCode -eq 0) {
+        $problems += "expected a non-zero exit code, got 0"
+    }
+
+    if ($ExpectLogMatch -and $Result.Log -notmatch [regex]::Escape($ExpectLogMatch)) {
+        $problems += "expected the signing log to mention '$ExpectLogMatch'"
+    }
+
+    if ($problems.Count -eq 0) {
+        Write-Host "  PASS  $Name"
+        return
+    }
+
+    Write-Host "  FAIL  $Name"
+    foreach ($problem in $problems) {
+        Write-Host "        $problem"
+    }
+    if ($Result.Log) {
+        Write-Host "        --- signing log ---"
+        foreach ($line in ($Result.Log -split "`r?`n")) {
+            if ($line) { Write-Host "        $line" }
+        }
+    }
+    if ($Result.Output) {
+        Write-Host "        --- hook output ---"
+        foreach ($line in ($Result.Output -split "`r?`n")) {
+            if ($line) { Write-Host "        $line" }
+        }
+    }
+    $script:failures += $Name
+}
+
+function Get-BaseSearchPath {
+    return (Join-Path $env:SystemRoot "System32") + ";" + $env:SystemRoot
+}
+
+$sandbox = New-Sandbox
+try {
+    $basePath = Get-BaseSearchPath
+    $case = 0
+
+    function New-Case {
+        param([string]$Label)
+        $script:case++
+        $root = Join-Path $sandbox "case$script:case"
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        Write-Host $Label
+        return [pscustomobject]@{
+            Artifact = (New-UnsignedArtifact -Root $root)
+            Log      = (Join-Path $root "windows-signing.log")
+            Root     = $root
+        }
+    }
+
+    # --- Credentials absent ---------------------------------------------------
+
+    $context = New-Case "Azure credentials absent"
+    Assert-Case -Name "signing optional -> the artifact is bundled unsigned" -ExpectSuccess `
+        -ExpectLogMatch "environment variables are missing" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $basePath -Environment @{ WINDOWS_CODE_SIGNING_REQUIRED = "false" })
+
+    Assert-Case -Name "signing required -> the build stops" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $basePath -Environment @{ WINDOWS_CODE_SIGNING_REQUIRED = "true" })
+
+    # --- CLI absent from PATH -------------------------------------------------
+
+    $context = New-Case "artifact-signing-cli absent from PATH"
+    Assert-Case -Name "signing optional -> the artifact is bundled unsigned" -ExpectSuccess `
+        -ExpectLogMatch "artifact-signing-cli" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $basePath -Environment ($azureCredentials + @{ WINDOWS_CODE_SIGNING_REQUIRED = "false" }))
+
+    # --- CLI fails, as an expired client secret makes it fail ------------------
+
+    $context = New-Case "artifact-signing-cli fails and reports on stderr"
+    $cliPath = (New-FakeSigningCli -Root $context.Root -ExitCode 1 -WriteStderr) + ";" + $basePath
+
+    Assert-Case -Name "signing optional -> the artifact is bundled unsigned" -ExpectSuccess `
+        -ExpectLogMatch "exit code 1" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $cliPath -Environment ($azureCredentials + @{ WINDOWS_CODE_SIGNING_REQUIRED = "false" }))
+
+    Assert-Case -Name "signing required -> the build stops" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $cliPath -Environment ($azureCredentials + @{ WINDOWS_CODE_SIGNING_REQUIRED = "true" }))
+
+    # --- CLI succeeds without producing a signature ---------------------------
+
+    $context = New-Case "artifact-signing-cli succeeds but leaves the artifact unsigned"
+    $cliPath = (New-FakeSigningCli -Root $context.Root -ExitCode 0) + ";" + $basePath
+
+    Assert-Case -Name "signing optional -> the artifact is bundled unsigned" -ExpectSuccess `
+        -ExpectLogMatch "NotSigned" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $cliPath -Environment ($azureCredentials + @{ WINDOWS_CODE_SIGNING_REQUIRED = "false" }))
+
+    Assert-Case -Name "signing required -> the build stops" `
+        -Result (Invoke-SignHook -ArtifactPath $context.Artifact -LogPath $context.Log `
+            -SearchPath $cliPath -Environment ($azureCredentials + @{ WINDOWS_CODE_SIGNING_REQUIRED = "true" }))
+} finally {
+    Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:failures.Count -gt 0) {
+    Write-Host ""
+    throw "$($script:failures.Count) Windows signing hook case(s) failed: $($script:failures -join '; ')"
+}
+
+Write-Host ""
+Write-Host "Windows signing hook honours WINDOWS_CODE_SIGNING_REQUIRED in every failure mode."


### PR DESCRIPTION
The Windows release job fails whenever the signing hook meets an error it does not anticipate, even though `WINDOWS_CODE_SIGNING_REQUIRED` is false and the hook is meant to fall back to an unsigned artifact. That is what stopped v0.17.3 after every other platform had already published.

Every failure now routes through a single handler that applies the policy, so an absent CLI, an unresolvable path or a failing signature check all leave the build running when signing is optional. An attempt that leaves a broken signature behind stays fatal: Windows reads that as tampering.

The bundler discards the hook's output, which is why the last failure left no account of itself. The hook now writes a log the release workflow prints.

A suite on the Windows CI runner exercises the hook the way the bundler does and pins the contract in each failure mode.