### PR TITLE
fix(read-state): separate counting anchors from MAM cursors

### DIFF
--- a/docs/MAM_CATCHUP.md
+++ b/docs/MAM_CATCHUP.md
@@ -127,10 +127,20 @@ Chains after the preview refresh completes.
   resume cursor is the preferred bottom; a timestamp-resumed walk instead uses
   the oldest persistable archive id returned by that whole walk. An incomplete
   walk never seeds coverage.
-- Coverage is committed only after the messages and archive-id backfills that
-  make its bottom resolvable are durable. For a timestamp-resumed bootstrap,
-  the unread recount then runs against that committed coverage, including when
-  the conversation is active.
+- Coverage keeps raw MAM `bottomId` / `topId` cursors for pagination, including
+  cursors that name bodyless signals. Its separate `countBottomId` names a
+  persistable message from the same contiguous walk. `null` means the walk has
+  no materialized counting anchor yet; legacy records without the field still
+  resolve their raw bottom through the cache.
+- Coverage changes wait for the walk's cache writes to succeed, then trigger
+  an unread recount, including for the active conversation. Signal-only walks
+  retain their pagination cursors but cannot certify an unread count.
+- A completed forward catch-up can also repair an unusable counting anchor,
+  even when it returns no messages. The replacement must resolve from that
+  walk's resume cursor or persistable extent; an unrelated cached message is
+  not proof of continuity. Repair rebases coverage conservatively and never
+  moves the read pointer. Bounded repair queries and walks carrying message
+  modifications cannot certify coverage without a durability proof.
 - For an inactive entity whose XEP-0490 read marker is still unresolved, a
   second phase walks backward from the live-edge window toward that marker. A
   page cap, an active-entity bail, a missing or non-advancing cursor, and a

--- a/packages/fluux-sdk/src/core/modules/MAM.coverage.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.coverage.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { xml, type Element } from '@xmpp/client'
+import { MAM } from './MAM'
+import type { ModuleDependencies } from './BaseModule'
+import { createMockStores } from '../test-utils'
+import { createPresenceReader } from '../presenceReader'
+import type { SDKEventSource } from '../types/eventSource'
+import type { SDKEvents } from '../types/sdk-events'
+import type { Message, RoomMessage } from '../types'
+import { createStoreBindings, type StoreRefs } from '../../bindings/storeBindings'
+import { roomStore, _resetRoomReadStateForTesting } from '../../stores/roomStore'
+import { chatStore } from '../../stores/chatStore'
+import { connectionStore } from '../../stores/connectionStore'
+import { ignoreStore } from '../../stores/ignoreStore'
+import { makeReadPointer } from '../../stores/shared/readPointer'
+import * as coverageTools from '../../stores/shared/mamCoverage'
+import type { CoverageRecord } from '../../stores/shared/mamCoverage'
+import { _resetStorageScopeForTesting } from '../../utils/storageScope'
+import * as cache from '../../utils/messageCache'
+import { MAM_BACKWARD_SIGNAL_RETRY_PAGES } from '../../utils/mamCatchUpUtils'
+
+const NS = 'urn:xmpp:mam:2'
+const ROOM = 'room@conference.example.test'
+const PEER = 'peer@example.test'
+const SELF = 'me@example.test'
+type Kind = 'room' | 'chat'
+type Entry = { id: string; at: number; body?: string; reaction?: boolean }
+type Page = { entries: Entry[]; complete?: boolean }
+const first: Entry = { id: 'first', at: 2000, body: 'First message' }
+const latest: Entry = { id: 'latest', at: 3000, body: 'Latest message' }
+const receipt: Entry = { id: 'receipt', at: 1000 }
+let unbind: (() => void) | undefined
+
+beforeEach(() => {
+  _resetStorageScopeForTesting()
+  cache._resetDBForTesting()
+  globalThis.indexedDB = new IDBFactory()
+  roomStore.getState().reset()
+  _resetRoomReadStateForTesting()
+  chatStore.getState().reset()
+  connectionStore.setState({ windowVisible: true })
+})
+
+afterEach(() => {
+  unbind?.()
+  vi.restoreAllMocks()
+})
+
+function harness(kind: Kind) {
+  const id = kind === 'room' ? ROOM : PEER
+  const row = (entry: Entry): Message | RoomMessage => {
+    const common = { id: entry.id, stanzaId: `archive-${entry.id}`, body: entry.body ?? '',
+      timestamp: new Date(entry.at), isOutgoing: false }
+    return kind === 'room'
+      ? { ...common, type: 'groupchat', roomJid: ROOM, from: `${ROOM}/peer`, nick: 'peer' }
+      : { ...common, type: 'chat', conversationId: PEER, from: PEER }
+  }
+  if (kind === 'room') {
+    roomStore.getState().addRoom({ jid: ROOM, name: 'Room', nickname: 'me', joined: true,
+      isBookmarked: true, occupants: new Map(), unreadCount: 1, mentionsCount: 0, typingUsers: new Set() })
+    roomStore.setState(state => ({ activeRoomJid: ROOM,
+      roomMeta: new Map(state.roomMeta).set(ROOM, { ...state.roomMeta.get(ROOM)!,
+        unreadCount: 1, readPointer: makeReadPointer(row(first), 'room') }) }))
+  } else {
+    chatStore.getState().addConversation({ id: PEER, name: 'Peer', type: 'chat', unreadCount: 1 })
+    chatStore.setState(state => ({ activeConversationId: PEER,
+      conversationMeta: new Map(state.conversationMeta).set(PEER, { ...state.conversationMeta.get(PEER)!,
+        unreadCount: 1, readPointer: makeReadPointer(row(first), 'chat') }) }))
+  }
+  const listeners = new Map<keyof SDKEvents, (payload: never) => void>()
+  const source: SDKEventSource = {
+    subscribe(event, handler) {
+      listeners.set(event, handler as (payload: never) => void)
+      return () => { listeners.delete(event) }
+    },
+  }
+  unbind = createStoreBindings(source, () => ({ room: roomStore.getState(), chat: chatStore.getState(),
+    ignore: ignoreStore.getState(), console: { addEvent() {} } }) as unknown as StoreRefs)
+  const stores = createMockStores()
+  stores.room.getRoom.mockImplementation(jid => roomStore.getState().getRoom(jid))
+  stores.room.getRoomCoverage.mockImplementation(jid => roomStore.getState().getRoomCoverage(jid))
+  stores.chat.getConversationCoverage.mockImplementation(jid => chatStore.getState().getConversationCoverage(jid))
+  const collectors = new Map<string, (stanza: Element) => void>()
+  let pages: Page[] = []
+  const sent: Element[] = []
+  const deps: ModuleDependencies = {
+    stores, presence: createPresenceReader(), getCurrentJid: () => SELF, getXmpp: () => null,
+    getE2EEManager: () => null, sendStanza: async () => {}, emit: () => {},
+    emitSDK: (event, payload) => listeners.get(event)?.(payload as never),
+    registerMAMCollector: (queryId, collector) => {
+      collectors.set(queryId, collector)
+      return () => { collectors.delete(queryId) }
+    },
+    sendIQ: async iq => {
+      sent.push(iq)
+      const page = pages.shift()
+      if (!page) throw new Error('Unexpected archive request')
+      const queryId = iq.getChild('query', NS)!.attrs.queryid
+      for (const entry of page.entries) {
+        collectors.get(queryId)!(xml('message', { from: kind === 'room' ? ROOM : SELF },
+          xml('result', { xmlns: NS, queryid: queryId, id: `archive-${entry.id}` },
+            xml('forwarded', { xmlns: 'urn:xmpp:forward:0' },
+              xml('delay', { xmlns: 'urn:xmpp:delay', stamp: new Date(entry.at).toISOString() }),
+              xml('message', { xmlns: 'jabber:client', from: row(entry).from, to: SELF,
+                type: kind === 'room' ? 'groupchat' : 'chat', id: entry.id },
+              ...(entry.body ? [xml('body', {}, entry.body)]
+                : entry.reaction ? [xml('reactions', { xmlns: 'urn:xmpp:reactions:0', id: 'archive-latest' }, xml('reaction', {}, '👍'))]
+                : [xml('received', { xmlns: 'urn:xmpp:chat-markers:0', id: 'acknowledged-message' })]))))))
+      }
+      return xml('iq', { type: 'result' }, xml('fin', { xmlns: NS, complete: String(page.complete ?? false) },
+        xml('set', { xmlns: 'http://jabber.org/protocol/rsm' },
+          ...(page.entries.length ? [xml('first', {}, `archive-${page.entries[0].id}`),
+            xml('last', {}, `archive-${page.entries.at(-1)!.id}`)] : []))))
+    },
+  }
+  const mam = new MAM(deps)
+  return {
+    id, row, sent,
+    coverage: () => kind === 'room' ? roomStore.getState().getRoomCoverage(id) : chatStore.getState().getConversationCoverage(id),
+    restoreCoverage(record?: CoverageRecord) {
+      const coverage = coverageTools.deserializeCoverage(coverageTools.serializeCoverage(new Map(record ? [[id, record]] : [])))
+      if (kind === 'room') roomStore.setState({ roomCoverage: coverage })
+      else chatStore.setState({ conversationCoverage: coverage })
+    },
+    restoreUnread(unreadCount: number) {
+      if (kind === 'room') roomStore.setState(state => ({ roomMeta: new Map(state.roomMeta)
+        .set(id, { ...state.roomMeta.get(id)!, unreadCount }),
+        rooms: new Map(state.rooms).set(id, { ...state.rooms.get(id)!, unreadCount }) }))
+      else chatStore.setState(state => ({ conversationMeta: new Map(state.conversationMeta)
+        .set(id, { ...state.conversationMeta.get(id)!, unreadCount }) }))
+    },
+    recount: () => kind === 'room' ? roomStore.getState().recomputeUnreadForRoom(id, { allowActive: true })
+      : chatStore.getState().recomputeUnreadForConversation(id, { allowActive: true }),
+    count: () => kind === 'room' ? roomStore.getState().getRoom(id)?.unreadCount : chatStore.getState().conversationMeta.get(id)?.unreadCount,
+    pointer: () => kind === 'room' ? roomStore.getState().roomMeta.get(id)?.readPointer : chatStore.getState().conversationMeta.get(id)?.readPointer,
+    read: (entry: Entry) => kind === 'room' ? roomStore.getState().advanceReadPointer(id, { id: entry.id })
+      : chatStore.getState().advanceReadPointer(id, { id: entry.id }),
+    async query(nextPages: Page[], options: { before?: string; after?: string; start?: string; preserveGapMarker?: boolean } = { before: '' }) {
+      pages = [...nextPages]
+      return kind === 'room' ? mam.queryRoomArchive({ roomJid: id, ...options }) : mam.queryArchive({ with: id, ...options })
+    },
+    async cached(entry: Entry) {
+      return kind === 'room' ? cache.getRoomMessageByStanzaId(id, `archive-${entry.id}`)
+        : cache.getMessageByStanzaId(id, `archive-${entry.id}`)
+    },
+  }
+}
+
+describe.each(['room', 'chat'] as const)('%s coverage through MAM and durable store bindings', kind => {
+  it('clears unread when the first archive entry is a receipt without a cache row', async () => {
+    const h = harness(kind)
+    const result = await h.query([{ entries: [receipt, first, latest] }])
+    expect(result.messages.map(message => message.id)).toEqual(['first', 'latest'])
+    await vi.waitFor(() => expect(h.coverage()?.bottomId).toBe('archive-receipt'))
+    expect(await h.cached(receipt)).toBeNull()
+    expect(await h.cached(first)).not.toBeNull()
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    expect(h.pointer()).toEqual(makeReadPointer(h.row(latest), kind))
+    expect(h.coverage()?.bottomId).toBe('archive-receipt')
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it.each([
+    { name: 'already discarded coverage', record: undefined },
+    { name: 'legacy coverage on a receipt', record: { bottomId: 'archive-receipt', topId: 'archive-latest' } },
+    { name: 'a signal-only coverage record', record: { bottomId: 'archive-receipt', countBottomId: null } },
+  ])('recovers $name on an empty completed catch-up without advancing the pointer', async ({ record }) => {
+    const h = harness(kind)
+    await h.query([{ entries: [receipt, first, latest] }])
+    await vi.waitFor(() => expect(h.coverage()).toBeDefined())
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    const pointer = h.pointer()
+    h.restoreCoverage(record)
+    h.restoreUnread(1)
+    cache._resetDBForTesting()
+    await h.query([{ entries: [], complete: true }], { after: 'archive-latest' })
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    expect(h.pointer()).toBe(pointer)
+    expect(h.sent).toHaveLength(2)
+    expect(await h.cached(receipt)).toBeNull()
+    expect(h.coverage()?.bottomId).toBe('archive-latest')
+  })
+
+  it('retains signal-only pagination across reload and anchors counting when the next walk reaches messages', async () => {
+    const h = harness(kind)
+    const pages = Array.from({ length: MAM_BACKWARD_SIGNAL_RETRY_PAGES }, (_, index) => ({ entries: [
+      { id: `receipt-${MAM_BACKWARD_SIGNAL_RETRY_PAGES - index}`, at: 9000 - index * 1000 },
+    ] }))
+    const empty = await h.query(pages)
+    expect(empty.messages).toEqual([])
+    const record = h.coverage()!
+    expect(record.bottomId).toBe('archive-receipt-1')
+    expect(record.topId).toBe(`archive-receipt-${MAM_BACKWARD_SIGNAL_RETRY_PAGES}`)
+    expect(h.count()).toBe(1)
+    h.restoreCoverage(record)
+    cache._resetDBForTesting()
+    await h.query([pages[0], { entries: [first, latest] }])
+    const lastQuery = h.sent.at(-1)!.getChild('query', NS)!
+    expect(lastQuery.getChild('set', 'http://jabber.org/protocol/rsm')!.getChildText('before')).toBe(record.bottomId)
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    expect(h.pointer()).toEqual(makeReadPointer(h.row(latest), kind))
+    expect(h.sent).toHaveLength(MAM_BACKWARD_SIGNAL_RETRY_PAGES + 2)
+  })
+
+  it('waits for the archive write before certifying the materialized anchor and recounting', async () => {
+    const h = harness(kind)
+    let release!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    if (kind === 'room') {
+      const save = cache.saveRoomMessages
+      vi.spyOn(cache, 'saveRoomMessages').mockImplementationOnce(async messages => { await gate; return save(messages) })
+    } else {
+      const save = cache.saveMessages
+      vi.spyOn(cache, 'saveMessages').mockImplementationOnce(async messages => { await gate; return save(messages) })
+    }
+    await h.query([{ entries: [receipt, first, latest] }])
+    h.read(latest)
+    const pointer = h.pointer()
+    await h.recount()
+    expect(h.count()).toBe(1)
+    expect(h.coverage()).toBeUndefined()
+    expect(await h.cached(first)).toBeNull()
+    release()
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    expect(h.coverage()?.bottomId).toBe('archive-receipt')
+    expect(h.pointer()).toBe(pointer)
+  })
+
+  it('does not certify a page whose cache write failed', async () => {
+    const h = harness(kind)
+    if (kind === 'room') vi.spyOn(cache, 'saveRoomMessages').mockResolvedValueOnce(false)
+    else vi.spyOn(cache, 'saveMessages').mockResolvedValueOnce(false)
+    await h.query([{ entries: [receipt, first, latest], complete: true }], { start: new Date(0).toISOString() })
+    h.read(latest)
+    await h.recount()
+    expect(h.count()).toBe(1)
+    expect(h.coverage()).toBeUndefined()
+    expect(await h.cached(first)).toBeNull()
+    expect(h.pointer()).toEqual(makeReadPointer(h.row(latest), kind))
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it('does not let a stale anchor lookup discard a newly materialized counting anchor', async () => {
+    const h = harness(kind)
+    await h.query([{ entries: [receipt, first, latest] }])
+    await vi.waitFor(() => expect(h.coverage()).toBeDefined())
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    h.restoreCoverage({ bottomId: 'archive-receipt' })
+    h.restoreUnread(1)
+    let release!: () => void
+    let started!: () => void
+    const pending = new Promise<void>(resolve => { started = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+    vi.spyOn(cache, 'resolveArchivePosition').mockImplementationOnce(async () => {
+      started()
+      await gate
+      return null
+    })
+    const recount = h.recount()
+    await pending
+    h.restoreCoverage({ bottomId: 'archive-receipt', countBottomId: 'archive-first' })
+    release()
+    await recount
+    expect(h.coverage()?.bottomId).toBe('archive-receipt')
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+  })
+
+  it.each(['modifications', 'bounded repair'] as const)('does not certify a %s walk without a durability proof', async guard => {
+    const h = harness(kind)
+    await h.query([{ entries: [receipt, first, latest] }])
+    await vi.waitFor(() => expect(h.coverage()).toBeDefined())
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+    h.restoreCoverage({ bottomId: 'archive-receipt', countBottomId: null })
+    h.restoreUnread(1)
+    const recovery = vi.spyOn(coverageTools, 'recoverCoverageForCounting')
+    await h.query([{ entries: guard === 'modifications' ? [{ id: 'reaction', at: 4000, reaction: true }] : [], complete: true }],
+      { after: 'archive-latest', preserveGapMarker: guard === 'bounded repair' })
+    await Promise.all(recovery.mock.results.map(result => result.value))
+    await h.recount()
+    expect(h.coverage()?.bottomId).toBe('archive-receipt')
+    expect(h.count()).toBe(1)
+    expect(h.sent).toHaveLength(2)
+  })
+
+  it('does not use an older cached island to repair coverage short of the read pointer', async () => {
+    const h = harness(kind)
+    await h.query([{ entries: [receipt, first, latest] }])
+    await vi.waitFor(() => expect(h.coverage()).toBeDefined())
+    h.restoreCoverage({ bottomId: 'archive-receipt' })
+    h.restoreUnread(7)
+    const pointer = h.pointer()
+    await h.query([{ entries: [], complete: true }], { after: 'archive-latest' })
+    await vi.waitFor(() => expect(h.coverage()?.bottomId).toBe('archive-latest'))
+    await h.recount()
+    expect(h.count()).toBe(7)
+    expect(h.pointer()).toBe(pointer)
+    expect(await h.cached(first)).not.toBeNull()
+    h.read(latest)
+    await vi.waitFor(() => expect(h.count()).toBe(0))
+  })
+})

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -298,6 +298,10 @@ export interface CoverageRecord {
   /** Archive id of the NEWEST entry seen by the fetch-latest walk that
    *  established this record (page-1 page.last). */
   topId?: string
+  /** Oldest persisted message proven contiguous with live for unread counting.
+   *  null means the walk has no materialized anchor; absent on legacy records,
+   *  whose bottomId must still be checked against the cache. */
+  countBottomId?: string | null
 }
 
 /**

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -1828,7 +1828,7 @@ describe('chatStore — `start`-filtered catch-up bootstraps coverage from its w
     catchUp(true)
     await settle()
 
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id', countBottomId: 'own-archive-id' })
 
     // Nothing sits after the pointer, so the seeded count of 4 converges to 0 with
     // no further prodding — the merge re-derives once its record commits.
@@ -1906,7 +1906,7 @@ describe('chatStore — `start`-filtered catch-up bootstraps coverage from its w
     catchUp(true)
     await settle()
 
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'own-archive-id', countBottomId: 'own-archive-id' })
     await vi.waitFor(() => {
       expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
     }, { timeout: 2000 })

--- a/packages/fluux-sdk/src/stores/chatStore.persist.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.persist.test.ts
@@ -262,17 +262,17 @@ describe('chat gap/coverage structural durability', () => {
     seedConversation(CID)
 
     createCoverage(CID, 'deep-old', 'top-1')
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1', countBottomId: null })
 
     refreshCoverageTop(CID, 'deep-old', 'top-2') // throttled → window OPEN
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-2' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-2', countBottomId: null })
 
     chatStore.getState().mergeMAMMessages(
       CID, [], { first: 'new-shallow' }, true, 'backward', true, false, { sawCoverageTop: false }
     )
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
 
-    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow' })
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
   })
 
   /**
@@ -297,16 +297,16 @@ describe('chat gap/coverage structural durability', () => {
 
     bootstrapCoverage(CID, 'edge-1')
     bootstrapCoverage(CID2, 'edge-2')
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'edge-1' })
-    expect(chatStore.getState().getConversationCoverage(CID2)).toEqual({ bottomId: 'edge-2' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'edge-1', countBottomId: 'edge-1' })
+    expect(chatStore.getState().getConversationCoverage(CID2)).toEqual({ bottomId: 'edge-2', countBottomId: 'edge-2' })
 
     // Under #1133's "bottomId changed → force-flush" this is 3.
     expect(writeCount()).toBe(1)
     expect(coverageOnDisk().size).toBe(0)
 
     flush()
-    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'edge-1' })
-    expect(coverageOnDisk().get(CID2)).toEqual({ bottomId: 'edge-2' })
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'edge-1', countBottomId: 'edge-1' })
+    expect(coverageOnDisk().get(CID2)).toEqual({ bottomId: 'edge-2', countBottomId: 'edge-2' })
   })
 
   /**
@@ -322,11 +322,11 @@ describe('chat gap/coverage structural durability', () => {
 
     deepenCoverage(CID, 'deep-0', 'deep-1')
     deepenCoverage(CID, 'deep-1', 'deep-2')
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1', countBottomId: null })
 
     expect(writeCount()).toBe(1) // 3 under #1133
     flush()
-    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1', countBottomId: null })
   })
 
   /**
@@ -346,7 +346,7 @@ describe('chat gap/coverage structural durability', () => {
   it('persists a DEFERRED coverage replacement that was coalesced into an open window', async () => {
     seedConversation(CID)
     createCoverage(CID, 'deep-old', 'top-1') // creation → throttled, window OPEN
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1', countBottomId: null })
     // The window is open and nothing coverage-related has reached disk, so the
     // ordinary throttled path demonstrably would NOT persist what follows.
     expect(coverageOnDisk().has(CID)).toBe(false)
@@ -360,13 +360,13 @@ describe('chat gap/coverage structural durability', () => {
       CID, stored, { first: 'new-shallow' }, true, 'backward', true, false, { sawCoverageTop: false }
     )
     // Deliberately still the old record: the transition has NOT applied yet.
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1', countBottomId: null })
 
     // Drain the save chain's microtasks WITHOUT advancing the throttle timer.
     for (let i = 0; i < 10; i++) await Promise.resolve()
-    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow' })
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow', countBottomId: 'new-shallow' })
 
-    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow' })
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow', countBottomId: 'new-shallow' })
   })
 
   it('persists a coverage REMOVAL that was coalesced into an open window', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -57,6 +57,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
 
 // Import the mocked module for assertions
 import * as messageCache from '../utils/messageCache'
+import { exactPosition } from './shared/readState'
 
 /**
  * The durable half of a retraction resolves the identity ladder before it writes,
@@ -623,20 +624,23 @@ describe('chatStore', () => {
     it('fetch-latest establishes the coverage record and it survives resetMAMStates (fresh session)', async () => {
       chatStore.getState().addConversation(createConversation(cid))
       const m = { ...createMessage(cid, 'm1'), id: 'm1', stanzaId: 'sid-1', timestamp: new Date('2026-07-15T00:00:00Z') }
-      chatStore.getState().mergeMAMMessages(cid, [m], { first: 'sid-1', last: 'sid-1' }, false, 'backward', true, false,
-        { initialBefore: '', fetchLatestTopId: 'sid-1' })
-      await vi.waitFor(() => {
-        expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1' })
-      })
-      chatStore.getState().resetMAMStates()
-      expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1' })
+      const lookup = vi.spyOn(messageCache, 'resolveArchivePosition').mockResolvedValue(exactPosition(m, 'chat'))
+      try {
+        chatStore.getState().mergeMAMMessages(cid, [m], { first: 'sid-1', last: 'sid-1' }, false, 'backward', true, false,
+          { initialBefore: '', fetchLatestTopId: 'sid-1' })
+        await vi.waitFor(() => {
+          expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1', countBottomId: 'sid-1' })
+        })
+        chatStore.getState().resetMAMStates()
+        expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1', countBottomId: 'sid-1' })
+      } finally { lookup.mockRestore() }
     })
 
     it('signal-only give-up (zero messages) records coverage immediately (nothing to persist)', () => {
       chatStore.getState().addConversation(createConversation(cid))
       chatStore.getState().mergeMAMMessages(cid, [], { first: 'p5-first', last: 'p5-last' }, false, 'backward', true, false,
         { initialBefore: '', fetchLatestTopId: 'p1-last' })
-      expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'p5-first', topId: 'p1-last' })
+      expect(chatStore.getState().getConversationCoverage(cid)).toEqual({ bottomId: 'p5-first', topId: 'p1-last', countBottomId: null })
     })
 
     it('coverage bottom advance with persistable messages defers until the durable write commits', async () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -31,6 +31,7 @@ import {
   walkExtentBottomId,
   isCaughtUpForCounting,
   resolveCoverageBottom,
+  recoverCoverageForCounting,
   type CoverageRecord,
   type MergeArchiveExtras,
 } from './shared/mamCoverage'
@@ -2938,11 +2939,13 @@ export const chatStore = createStore<ChatState>()(
         const entityEpochAtStart = currentChatEntityEpoch(conversationId)
         const storageScopeAtStart = getStorageScopeJid()
         const unreadInputVersionAtStart = chatUnreadInputVersion.get(conversationId) ?? 0
+        const record = get().conversationCoverage.get(conversationId)
         const recountContextDeferral = (): RecountDeferralReason | undefined => {
           if (chatCacheEpoch !== cacheEpochAtStart || currentChatEntityEpoch(conversationId) !== entityEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
             return 'context-changed'
           }
           if (chatRecountVersion.get(conversationId) !== version) return 'recount-superseded'
+          if (get().conversationCoverage.get(conversationId) !== record) return 'input-version-changed'
           if ((chatUnreadInputVersion.get(conversationId) ?? 0) !== unreadInputVersionAtStart) {
             return 'input-version-changed'
           }
@@ -2962,7 +2965,6 @@ export const chatStore = createStore<ChatState>()(
         const mam = mamState.getMAMQueryState(get().mamQueryStates, conversationId)
         if (!isCaughtUpForCounting(mam)) return defer('history-not-caught-up')
 
-        const record = get().conversationCoverage.get(conversationId)
         const bottom = await resolveCoverageBottom(conversationId, record, false)
         const coverageContextDeferral = recountContextDeferral()
         if (coverageContextDeferral) return defer(coverageContextDeferral)
@@ -3133,6 +3135,7 @@ export const chatStore = createStore<ChatState>()(
         set((state) => ({
           mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, conversationId, isLoading, requestId),
         }))
+        if (!isLoading) chatRecountRetry.resume(conversationId)
       },
 
       setMAMError: (conversationId, error, requestId) => {
@@ -3173,6 +3176,7 @@ export const chatStore = createStore<ChatState>()(
         const mergeDiagnostics = newArchiveMergeTally()
         let ownArchiveWrite: Promise<boolean> | undefined
         let coverageBootstrappedFromWalkExtent = false
+        let coverageChanged = false
         set((state) => {
           // Get existing messages for this conversation
           const rawExisting = state.messages.get(conversationId) || []
@@ -3288,12 +3292,8 @@ export const chatStore = createStore<ChatState>()(
             mustGateOnChain
           const gapsAfterMerge = deferGapCommit ? state.conversationGaps : newGaps
 
-          // The walk's own extent, the bootstrap's anchor when a `start`-filtered
-          // catch-up leaves `initialAfter` undefined. Scanned only for the
-          // direction that can use it.
-          const walkOldestId = direction !== 'backward'
-            ? extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
-            : undefined
+          // Counting needs a persisted message anchor; RSM cursors also name signals.
+          const walkOldestId = extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
           // Persisted coverage record; see mamCoverage.ts for the durability
           // invariant this defers on. A merge with nothing persistable
           // (signal-only give-up) applies now.
@@ -3313,6 +3313,7 @@ export const chatStore = createStore<ChatState>()(
             walkOldestId,
           })
           const prevCoverage = state.conversationCoverage.get(conversationId)
+          coverageChanged = newCoverage !== state.conversationCoverage
           const deferCoverageCommit =
             newCoverage !== state.conversationCoverage &&
             mustGateOnChain
@@ -3510,19 +3511,32 @@ export const chatStore = createStore<ChatState>()(
         if (shouldRecountAfterMerge) {
           void get().recomputeUnreadForConversation(conversationId)
         }
-        if (direction === 'forward' && complete) {
+        if (coverageChanged || (direction === 'forward' && complete)) {
           if (!archiveCommitGate && conversationArchiveSaves.has(conversationId)) {
             archiveCommitGate = conversationArchiveSaves.chain(conversationId, Promise.resolve(true))
           }
-          const resume = () => {
+          const resume = async () => {
             if (chatCacheEpoch !== cacheEpochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+            if (direction === 'forward' && complete && !preserveGapMarker && !extras?.walkCarriedModifications) {
+              const record = get().conversationCoverage.get(conversationId)
+              const inputVersion = chatUnreadInputVersion.get(conversationId)
+              const repaired = await recoverCoverageForCounting(conversationId, record,
+                [extras?.initialAfter, extras?.walkOldestId ?? walkExtentBottomId(mamMessages)], false)
+              if (chatCacheEpoch !== cacheEpochAtMerge || currentChatEntityEpoch(conversationId) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge || chatUnreadInputVersion.get(conversationId) !== inputVersion) return
+              if (repaired && get().conversationCoverage.get(conversationId) === record) {
+                noteCoverageTransition(getScopedStorageKey(), conversationId, record ? 'replaced' : 'created')
+                set(state => ({ conversationCoverage: new Map(state.conversationCoverage).set(conversationId, repaired) }))
+                coverageChanged = true
+              }
+            }
             chatRecountRetry.resume(conversationId)
-            if (coverageBootstrappedFromWalkExtent) {
-              void get().recomputeUnreadForConversation(conversationId, { allowActive: true })
+            if (coverageChanged) {
+              chatRecountRetry.schedule(conversationId, true,
+                options => get().recomputeUnreadForConversation(conversationId, options), () => chatRecountReady(conversationId))
             }
           }
-          if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
-          else resume()
+          if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) return resume() })
+          else void resume()
         }
       },
 

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -1811,7 +1811,7 @@ describe('roomStore — `start`-filtered catch-up bootstraps coverage from its w
     catchUp(true)
     await settle()
 
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id', countBottomId: 'edge-archive-id' })
 
     await vi.waitFor(() => {
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
@@ -1875,7 +1875,7 @@ describe('roomStore — `start`-filtered catch-up bootstraps coverage from its w
     )
 
     await settle()
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id', countBottomId: 'edge-archive-id' })
     await vi.waitFor(() => {
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(1)
     }, { timeout: 2000 })
@@ -1915,7 +1915,7 @@ describe('roomStore — `start`-filtered catch-up bootstraps coverage from its w
     catchUp(true)
     await settle()
 
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'edge-archive-id', countBottomId: 'edge-archive-id' })
     await vi.waitFor(() => {
       expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
     }, { timeout: 2000 })

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -63,6 +63,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
 
 // Import the mocked module for assertions
 import * as messageCache from '../utils/messageCache'
+import { exactPosition } from './shared/readState'
 
 /**
  * The durable half of a retraction resolves the identity ladder before it writes,
@@ -2860,18 +2861,21 @@ describe('roomStore', () => {
         stanzaId: 'newer',
       }
       // Forward catch-up resumed from 'local-edge' and reached live.
-      roomStore.getState().mergeRoomMAMMessages(
-        jid, [fetched], { first: 'newer' }, true, 'forward', false, false,
-        { initialAfter: 'local-edge' }
-      )
+      const lookup = vi.spyOn(messageCache, 'resolveArchivePosition').mockResolvedValue(exactPosition(held, 'room'))
+      try {
+        roomStore.getState().mergeRoomMAMMessages(
+          jid, [fetched], { first: 'newer' }, true, 'forward', false, false,
+          { initialAfter: 'local-edge' }
+        )
 
-      await vi.waitFor(() => {
-        expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'local-edge' })
-      })
-      // ...and it reached localStorage, so it survives the next fresh session.
-      const persisted = Object.entries(localStorageMock._store)
-        .find(([k]) => k.startsWith('fluux-room-coverage'))
-      expect(persisted?.[1]).toContain('local-edge')
+        await vi.waitFor(() => {
+          expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'local-edge', countBottomId: 'local-edge' })
+        })
+        // ...and it reached localStorage, so it survives the next fresh session.
+        const persisted = Object.entries(localStorageMock._store)
+          .find(([k]) => k.startsWith('fluux-room-coverage'))
+        expect(persisted?.[1]).toContain('local-edge')
+      } finally { lookup.mockRestore() }
     })
 
     it('does NOT mark the visible timeline complete when a Phase B deep probe reaches the archive start below the resident window', () => {
@@ -3258,20 +3262,23 @@ describe('roomStore', () => {
         type: 'groupchat', id: 'm1', roomJid: jid, from: `${jid}/a`, nick: 'a', stanzaId: 'sid-1',
         body: 'm1', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
       }
-      roomStore.getState().mergeRoomMAMMessages(jid, [m], { first: 'sid-1', last: 'sid-1' }, false, 'backward', false, true,
-        { initialBefore: '', fetchLatestTopId: 'sid-1' })
-      await vi.waitFor(() => {
-        expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1' })
-      })
-      roomStore.getState().resetRoomMAMStates()
-      expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1' })
+      const lookup = vi.spyOn(messageCache, 'resolveArchivePosition').mockResolvedValue(exactPosition(m, 'room'))
+      try {
+        roomStore.getState().mergeRoomMAMMessages(jid, [m], { first: 'sid-1', last: 'sid-1' }, false, 'backward', false, true,
+          { initialBefore: '', fetchLatestTopId: 'sid-1' })
+        await vi.waitFor(() => {
+          expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1', countBottomId: 'sid-1' })
+        })
+        roomStore.getState().resetRoomMAMStates()
+        expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'sid-1', topId: 'sid-1', countBottomId: 'sid-1' })
+      } finally { lookup.mockRestore() }
     })
 
     it('signal-only give-up (zero messages) records coverage immediately (nothing to persist)', () => {
       roomStore.getState().addRoom(createRoom(jid))
       roomStore.getState().mergeRoomMAMMessages(jid, [], { first: 'p5-first', last: 'p5-last' }, false, 'backward', false, true,
         { initialBefore: '', fetchLatestTopId: 'p1-last' })
-      expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'p5-first', topId: 'p1-last' })
+      expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'p5-first', topId: 'p1-last', countBottomId: null })
     })
 
     it('coverage bottom advance with persistable messages defers until the durable write commits', async () => {

--- a/packages/fluux-sdk/src/stores/roomStore.throttledPersist.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.throttledPersist.test.ts
@@ -138,7 +138,7 @@ describe('roomStore throttled persistence', () => {
   // the `topId` refresh test in the structural-durability suite below, which
   // drives the one coverage transition that is still throttled.
   it('persists both coverage removals across two rooms', () => {
-    // CoverageRecord is { bottomId, topId? }.
+    // Legacy coverage records omit the counting anchor.
     roomStore.setState({
       roomCoverage: new Map([
         [ROOM, { bottomId: 'cov-1' }],
@@ -534,20 +534,20 @@ describe('roomStore gap/coverage structural durability', () => {
     }), [createMessage('held', ROOM, 'a', 'held', false, new Date('2026-07-20T00:00:00Z'))])
 
     createCoverage(ROOM, 'deep-old', 'top-1')
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-1', countBottomId: null })
 
     refreshCoverageTop(ROOM, 'deep-old', 'top-2') // throttled → window OPEN
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-2' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-2', countBottomId: null })
 
     // Contiguity with the record actively DISPROVEN → the record is replaced
     // wholesale with this walk's extent, which may be far shallower.
     roomStore.getState().mergeRoomMAMMessages(
       ROOM, [], { first: 'new-shallow' }, true, 'backward', false, true, { sawCoverageTop: false }
     )
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'new-shallow' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
 
     // Memory holds new-shallow; storage must not still hold deep-old.
-    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'new-shallow' })
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
   })
 
   // The other half of the bound: the fix must not defeat the throttle for the
@@ -563,10 +563,10 @@ describe('roomStore gap/coverage structural durability', () => {
     refreshCoverageTop(ROOM, 'cov-bottom', 'top-2') // leading edge → window OPEN
     refreshCoverageTop(ROOM, 'cov-bottom', 'top-3') // coalesced, NOT force-flushed
     expect(writeCount()).toBe(1)
-    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'cov-bottom', topId: 'top-2' })
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'cov-bottom', topId: 'top-2', countBottomId: null })
 
     flush()
-    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'cov-bottom', topId: 'top-3' })
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'cov-bottom', topId: 'top-3', countBottomId: null })
   })
 
   /**
@@ -596,7 +596,7 @@ describe('roomStore gap/coverage structural durability', () => {
     expect(coverageOnDisk().has(ROOM3)).toBe(false)
 
     flush()
-    expect(coverageOnDisk().get(ROOM3)).toEqual({ bottomId: 'cov-3', topId: 'top-1' })
+    expect(coverageOnDisk().get(ROOM3)).toEqual({ bottomId: 'cov-3', topId: 'top-1', countBottomId: null })
   })
 
   it('coalesces a Phase B bottomId deepening', () => {
@@ -611,11 +611,11 @@ describe('roomStore gap/coverage structural durability', () => {
 
     deepenCoverage(ROOM, 'deep-0', 'deep-1')
     deepenCoverage(ROOM, 'deep-1', 'deep-2')
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1', countBottomId: null })
 
     expect(writeCount()).toBe(2) // 4 under #1133
     flush()
-    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1', countBottomId: null })
   })
 
   /**
@@ -642,13 +642,13 @@ describe('roomStore gap/coverage structural durability', () => {
       { first: 'new-shallow' }, true, 'backward', false, true, { sawCoverageTop: false },
     )
     // Deliberately still the old record: the transition has NOT applied yet.
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-1', countBottomId: null })
 
     // Drain the save chain's microtasks WITHOUT advancing the throttle timer.
     for (let i = 0; i < 10; i++) await Promise.resolve()
-    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'new-shallow' })
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
 
-    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'new-shallow' })
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'new-shallow', countBottomId: null })
   })
 
   it('persists a coverage REMOVAL that was coalesced into an open window', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -46,6 +46,7 @@ import {
   walkExtentBottomId,
   isCaughtUpForCounting,
   resolveCoverageBottom,
+  recoverCoverageForCounting,
   serializeCoverage,
   deserializeCoverage,
   type CoverageRecord,
@@ -2817,11 +2818,13 @@ export const roomStore = createStore<RoomState>()(
     const entityEpochAtStart = currentRoomEntityEpoch(roomJid)
     const storageScopeAtStart = getStorageScopeJid()
     const unreadInputVersionAtStart = roomUnreadInputVersion.get(roomJid) ?? 0
+    const record = get().roomCoverage.get(roomJid)
     const recountContextDeferral = (): RecountDeferralReason | undefined => {
       if (roomCacheEpoch !== cacheEpochAtStart || currentRoomEntityEpoch(roomJid) !== entityEpochAtStart || getStorageScopeJid() !== storageScopeAtStart) {
         return 'context-changed'
       }
       if (roomRecountVersion.get(roomJid) !== version) return 'recount-superseded'
+      if (get().roomCoverage.get(roomJid) !== record) return 'input-version-changed'
       if ((roomUnreadInputVersion.get(roomJid) ?? 0) !== unreadInputVersionAtStart) {
         return 'input-version-changed'
       }
@@ -2841,7 +2844,6 @@ export const roomStore = createStore<RoomState>()(
     const mam = mamState.getMAMQueryState(get().mamQueryStates, roomJid)
     if (!isCaughtUpForCounting(mam)) return defer('history-not-caught-up')
 
-    const record = get().roomCoverage.get(roomJid)
     const bottom = await resolveCoverageBottom(roomJid, record, true)
     const coverageContextDeferral = recountContextDeferral()
     if (coverageContextDeferral) return defer(coverageContextDeferral)
@@ -4244,6 +4246,7 @@ export const roomStore = createStore<RoomState>()(
     set((state) => ({
       mamQueryStates: mamState.setMAMLoading(state.mamQueryStates, roomJid, isLoading, requestId),
     }))
+    if (!isLoading) roomRecountRetry.resume(roomJid)
   },
 
   setRoomMAMError: (roomJid, error, requestId) => {
@@ -4287,6 +4290,7 @@ export const roomStore = createStore<RoomState>()(
     const mergeDiagnostics = newArchiveMergeTally()
     let ownArchiveWrite: Promise<boolean> | undefined
     let coverageBootstrappedFromWalkExtent = false
+    let coverageChanged = false
     set((state) => {
       const room = state.rooms.get(roomJid)
       if (!room) return state
@@ -4408,12 +4412,8 @@ export const roomStore = createStore<RoomState>()(
       const gapsAfterMerge = deferGapCommit ? state.roomGaps : newGaps
       if (gapsAfterMerge !== state.roomGaps) saveGapsToStorage(gapsAfterMerge)
 
-      // The walk's own extent, the bootstrap's anchor when a `start`-filtered
-      // catch-up leaves `initialAfter` undefined. Scanned only for the
-      // direction that can use it.
-      const walkOldestId = direction !== 'backward'
-        ? extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
-        : undefined
+      // Counting needs a persisted message anchor; RSM cursors also name signals.
+      const walkOldestId = extras?.walkOldestId ?? walkExtentBottomId(mamMessages)
       // Persisted coverage record; see mamCoverage.ts for the durability
       // invariant this defers on. A merge with nothing persistable
       // (signal-only give-up) applies now.
@@ -4433,6 +4433,7 @@ export const roomStore = createStore<RoomState>()(
         walkOldestId,
       })
       const prevCoverage = state.roomCoverage.get(roomJid)
+      coverageChanged = newCoverage !== state.roomCoverage
       const deferCoverageCommit =
         newCoverage !== state.roomCoverage &&
         mustGateOnChain
@@ -4631,19 +4632,35 @@ export const roomStore = createStore<RoomState>()(
     if (shouldRecountAfterMerge) {
       void get().recomputeUnreadForRoom(roomJid)
     }
-    if (direction === 'forward' && complete) {
+    if (coverageChanged || (direction === 'forward' && complete)) {
       if (!archiveCommitGate && roomArchiveSaves.has(roomJid)) {
         archiveCommitGate = roomArchiveSaves.chain(roomJid, Promise.resolve(true))
       }
-      const resume = () => {
+      const resume = async () => {
         if (roomCacheEpoch !== cacheEpochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge) return
+        if (direction === 'forward' && complete && !preserveGapMarker && !extras?.walkCarriedModifications) {
+          const record = get().roomCoverage.get(roomJid)
+          const inputVersion = roomUnreadInputVersion.get(roomJid)
+          const repaired = await recoverCoverageForCounting(roomJid, record,
+            [extras?.initialAfter, extras?.walkOldestId ?? walkExtentBottomId(mamMessages)], true)
+          if (roomCacheEpoch !== cacheEpochAtMerge || currentRoomEntityEpoch(roomJid) !== entityEpochAtMerge || getStorageScopeJid() !== storageScopeAtMerge || roomUnreadInputVersion.get(roomJid) !== inputVersion) return
+          if (repaired && get().roomCoverage.get(roomJid) === record) {
+            set(state => {
+              const next = new Map(state.roomCoverage).set(roomJid, repaired)
+              saveCoverageToStorage(next, undefined, { roomJid, kind: record ? 'replaced' : 'created' })
+              return { roomCoverage: next }
+            })
+            coverageChanged = true
+          }
+        }
         roomRecountRetry.resume(roomJid)
-        if (coverageBootstrappedFromWalkExtent) {
-          void get().recomputeUnreadForRoom(roomJid, { allowActive: true })
+        if (coverageChanged) {
+          roomRecountRetry.schedule(roomJid, true,
+            options => get().recomputeUnreadForRoom(roomJid, options), () => roomRecountReady(roomJid))
         }
       }
-      if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) resume() })
-      else resume()
+      if (archiveCommitGate) void archiveCommitGate.then((committed) => { if (committed) return resume() })
+      else void resume()
     }
   },
 

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -30,20 +30,20 @@ const base = (over: Partial<ArchiveMergeCoverageInput> = {}): ArchiveMergeCovera
 describe('syncCoverageAfterArchiveMerge', () => {
   it('fetch-latest establishes the record from the walk extent', () => {
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'deep', fetchLatestTopId: 'top' }))
-    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'deep', topId: 'top' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'deep', topId: 'top', countBottomId: null })
   })
 
   it('signal-only give-up (zero messages, page.first set) still establishes the record', () => {
     // The walked window IS proven contiguous coverage even with
     // zero displayable messages — this is the durable resume for the cap.
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'page5-first', fetchLatestTopId: 'page1-last' }))
-    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'page5-first', topId: 'page1-last' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'page5-first', topId: 'page1-last', countBottomId: null })
   })
 
   it('disjoint fetch-latest REPLACES a stale record', () => {
     const coverage = new Map([['a@b', { bottomId: 'old-deep', topId: 'old-top' }]])
     const out = syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'new-deep', fetchLatestTopId: 'new-top' }))
-    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'new-deep', topId: 'new-top' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'new-deep', topId: 'new-top', countBottomId: null })
   })
 
   it('a walk that SAW the existing topId keeps the deeper bottom, refreshes topId', () => {
@@ -66,7 +66,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const out = syncCoverageAfterArchiveMerge(
       base({ coverage, rsmFirst: 'id-301', fetchLatestTopId: 'id-400', sawCoverageTop: false })
     )
-    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'id-301', topId: 'id-400' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'id-301', topId: 'id-400', countBottomId: null })
   })
 
   it('a walk that carried modifications never certifies coverage (their cache writes are fire-and-forget)', () => {
@@ -91,7 +91,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const extended = syncCoverageAfterArchiveMerge(
       base({ coverage, isFetchLatest: false, initialBefore: 'deep', rsmFirst: 'deeper' })
     )
-    expect(extended.coverage.get('a@b')).toEqual({ bottomId: 'deeper', topId: 'top' })
+    expect(extended.coverage.get('a@b')).toEqual({ bottomId: 'deeper', topId: 'top', countBottomId: 'deep' })
     const stray = syncCoverageAfterArchiveMerge(
       base({ coverage, isFetchLatest: false, initialBefore: 'elsewhere', rsmFirst: 'x' })
     )
@@ -118,7 +118,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
 
     it('a completed forward catch-up seeds the record from its resume cursor', () => {
       const out = syncCoverageAfterArchiveMerge(fwd({ complete: true, initialAfter: 'local-edge' }))
-      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge' })
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge', countBottomId: 'local-edge' })
     })
 
     it('an INCOMPLETE forward catch-up seeds nothing (it never reached live)', () => {
@@ -139,7 +139,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
       // No resume cursor (the local edge was an own send with no archive id),
       // so the anchor is the oldest entry the completed walk carried itself.
       const out = syncCoverageAfterArchiveMerge(fwd({ complete: true, walkOldestId: 'walk-oldest' }))
-      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'walk-oldest' })
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'walk-oldest', countBottomId: 'walk-oldest' })
       expect(out.transition).toBe('created')
     })
 
@@ -156,7 +156,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
       const out = syncCoverageAfterArchiveMerge(
         fwd({ complete: true, initialAfter: 'local-edge', walkOldestId: 'walk-oldest' })
       )
-      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge' })
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge', countBottomId: 'local-edge' })
     })
 
     it('a completed forward catch-up with neither cursor nor extent seeds nothing', () => {
@@ -229,7 +229,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
   })
 
   it('returns the same reference when the computed record is unchanged', () => {
-    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
+    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top', countBottomId: null }]])
     expect(syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'deep', fetchLatestTopId: 'top' })).coverage).toBe(coverage)
   })
 })
@@ -283,7 +283,7 @@ describe('syncCoverageAfterArchiveMerge — reported transition', () => {
   })
 
   it('reports `none` for every branch that leaves the map alone', () => {
-    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
+    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top', countBottomId: null }]])
     const none = (over: Partial<ArchiveMergeCoverageInput>) =>
       syncCoverageAfterArchiveMerge(base({ coverage, ...over })).transition
     expect(none({ preserveGapMarker: true, rsmFirst: 'x' })).toBe('none')

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -29,6 +29,7 @@ export type { CoverageRecord, MergeArchiveExtras } from '../../core/types'
  * | `created`      | disk holds NO record; next session re-seeds from the local downloaded edge, which is shallower. Asserts nothing. | throttle |
  * | `deepened`     | disk holds the SHALLOWER previous bottom; Phase B re-walks covered ground. | throttle |
  * | `topRefreshed` | disk holds a stale re-entry marker; one extra walked page.  | throttle   |
+ * | `countAnchored` | disk lacks the new materialized counting anchor; counting defers. | throttle |
  * | `replaced`     | **disk keeps the record whose contiguity this walk just DISPROVED, and Phase B seeds its backward walk from it — skipping the disconnected interval.** | **force-flush** |
  *
  * The asymmetry is the whole point: every safe transition errs SHALLOW (costing
@@ -43,7 +44,7 @@ export type { CoverageRecord, MergeArchiveExtras } from '../../core/types'
  * which cost one whole-blob serialization per conversation on a first session
  * (~400 on the reference profile) and one per Phase B page.
  */
-export type CoverageTransition = 'none' | 'created' | 'deepened' | 'topRefreshed' | 'replaced'
+export type CoverageTransition = 'none' | 'created' | 'deepened' | 'topRefreshed' | 'countAnchored' | 'replaced'
 
 /** {@link syncCoverageAfterArchiveMerge}'s result: the map, and what happened. */
 export interface CoverageSyncResult {
@@ -82,7 +83,7 @@ export interface ArchiveMergeCoverageInput {
   /** The `after` cursor a forward catch-up resumed from (the local downloaded
    *  edge). Undefined for `start`-filtered or cursorless catch-ups. */
   initialAfter?: string
-  /** Oldest archive id the forward walk itself carried — its own extent, from
+  /** Oldest persistable message the walk itself carried — its own extent, from
    *  {@link walkExtentBottomId}. The bootstrap's fallback anchor when the
    *  catch-up resumed by timestamp and so has no `initialAfter`. */
   walkOldestId?: string
@@ -173,7 +174,7 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
     if (!complete || !bootstrapBottom) return unchanged
     if (coverage.get(id)) return unchanged
     const next = new Map(coverage)
-    next.set(id, { bottomId: bootstrapBottom })
+    next.set(id, { bottomId: bootstrapBottom, countBottomId: bootstrapBottom })
     return { coverage: next, transition: 'created' }
   }
 
@@ -182,6 +183,12 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
   if (isFetchLatest) {
     if (!rsmFirst) return unchanged
     if (sawCoverageTop && existing) {
+      if (existing.countBottomId === null && walkOldestId) {
+        const next = new Map(coverage)
+        next.set(id, { ...existing, countBottomId: walkOldestId,
+          ...(fetchLatestTopId ? { topId: fetchLatestTopId } : {}) })
+        return { coverage: next, transition: 'countAnchored' }
+      }
       if (fetchLatestTopId && fetchLatestTopId !== existing.topId) {
         const next = new Map(coverage)
         next.set(id, { ...existing, topId: fetchLatestTopId })
@@ -189,9 +196,10 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
       }
       return unchanged
     }
-    if (existing && existing.bottomId === rsmFirst && existing.topId === fetchLatestTopId) return unchanged
+    const countBottomId = walkOldestId ?? null
+    if (existing && existing.bottomId === rsmFirst && existing.topId === fetchLatestTopId && existing.countBottomId === countBottomId) return unchanged
     const next = new Map(coverage)
-    next.set(id, { bottomId: rsmFirst, ...(fetchLatestTopId ? { topId: fetchLatestTopId } : {}) })
+    next.set(id, { bottomId: rsmFirst, countBottomId, ...(fetchLatestTopId ? { topId: fetchLatestTopId } : {}) })
     // With a record present and contiguity with it NOT proven, this overwrites
     // an assertion rather than making a first one — the one unsafe transition.
     return { coverage: next, transition: existing ? 'replaced' : 'created' }
@@ -199,7 +207,8 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
 
   if (existing && rsmFirst && initialBefore === existing.bottomId && rsmFirst !== existing.bottomId) {
     const next = new Map(coverage)
-    next.set(id, { ...existing, bottomId: rsmFirst })
+    next.set(id, { ...existing, bottomId: rsmFirst,
+      countBottomId: walkOldestId ?? (existing.countBottomId === undefined ? existing.bottomId : existing.countBottomId) })
     // The query resumed id-EXACTLY from the recorded bottom, so the new bottom
     // extends the same contiguous run: losing it leaves the shallower one,
     // which is still true.
@@ -240,10 +249,10 @@ export function isCaughtUpForCounting(mam: {
 }
 
 /**
- * The result of resolving a {@link CoverageRecord}'s `bottomId` to a position
- * in archive order: the position when it is cached, `'missing'` when there is
- * no record at all, or `'unresolvable'` when the record names an archive id
- * that is no longer in the cache (evicted, or the record is stale).
+ * The result of resolving a {@link CoverageRecord}'s counting anchor to a
+ * position in archive order: the position when cached, `'missing'` when no
+ * anchor has been established, or `'unresolvable'` when the anchor has no
+ * cache row (evicted, stale, or a legacy cursor naming a bodyless signal).
  *
  * `'missing'` is NOT `null`-as-fine: a missing record means the entity has
  * not yet been proven contiguous with the live edge, so the caller must defer
@@ -256,8 +265,8 @@ export function isCaughtUpForCounting(mam: {
 export type CoverageBottom = ExactPosition | 'missing' | 'unresolvable'
 
 /**
- * Resolve a coverage record's `bottomId` to its archive position, scoped to
- * `entityId` (conversation id or room JID). See {@link CoverageBottom} for
+ * Resolve `countBottomId`, falling back to `bottomId` for legacy records, to
+ * its archive position scoped to `entityId` (conversation id or room JID). See {@link CoverageBottom} for
  * the three outcomes and {@link resolveArchivePosition} (`messageCache.ts`)
  * for how the lookup itself is scoped between chat and room.
  */
@@ -267,6 +276,26 @@ export async function resolveCoverageBottom(
   isRoom: boolean
 ): Promise<CoverageBottom> {
   if (!record) return 'missing'
-  const position = await resolveArchivePosition(entityId, record.bottomId, isRoom)
+  if (record.countBottomId === null) return 'missing'
+  const position = await resolveArchivePosition(entityId, record.countBottomId ?? record.bottomId, isRoom)
   return position ?? 'unresolvable'
+}
+
+/** Rebase an unusable counting record on a completed, durably saved forward
+ *  walk. Candidates must come from that walk's resume cursor or materialized
+ *  extent; unrelated cache rows cannot establish continuity. */
+export async function recoverCoverageForCounting(
+  entityId: string,
+  record: CoverageRecord | undefined,
+  candidates: Array<string | undefined>,
+  isRoom: boolean,
+): Promise<CoverageRecord | undefined> {
+  const bottom = await resolveCoverageBottom(entityId, record, isRoom)
+  if (typeof bottom !== 'string') return undefined
+  for (const id of new Set(candidates)) {
+    if (id && await resolveArchivePosition(entityId, id, isRoom)) {
+      return { bottomId: id, countBottomId: id }
+    }
+  }
+  return undefined
 }

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -2544,9 +2544,8 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
 }
 
 /**
- * Resolve an archive id — a MAM `page.first`/`page.last` value, which is what a
- * {@link CoverageRecord}'s `bottomId` names — to its position in archive
- * order. `parseArchiveMessage`/`parseRoomArchiveMessage` (`MAM.ts`) store this
+ * Resolve a materialized archive id — including a {@link CoverageRecord}'s
+ * `countBottomId` — to its position in archive order. `parseArchiveMessage`/`parseRoomArchiveMessage` (`MAM.ts`) store this
  * id as the row's `stanzaId` (`stanzaId = parsed.stanzaId || archiveId`), so
  * the lookup goes through the stanza-id path, never the client-generated
  * `id`. Rooms reuse their own per-archive id sequence, so a bare `stanzaId`


### PR DESCRIPTION
Archived receipts and other bodyless signals are valid MAM pagination cursors but have no cached message. Using them as counting anchors invalidates coverage and leaves unread badges stale after the conversation has been read.

Keep raw pagination cursors and a separate persisted message anchor for counting. Recover missing or unusable legacy coverage from a completed, durable catch-up, then resume recounting without advancing the read pointer. Preserve signal-only pagination, cache-write guards and protection against stale asynchronous resolutions in both chats and rooms.

The WebKit Home navigation check remains intermittently affected by a 26 px backtrack, reproduced identically on the unchanged base commit; that separate issue is outside this fix.
