### PR TITLE
fix(ui): align message toolbar with the hovered row

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-message-row-id="msg-1"
               >
                 <div
-                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
+                  class="relative group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
                   data-message-body="Hello there!"
                   data-message-from="Alice Smith"
                   data-message-id="msg-1"
@@ -133,107 +133,107 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     </div>
                   </div>
                   <div
-                    class="relative flex-1 min-w-0"
+                    class="absolute -top-12 end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
+                    data-message-toolbar="true"
                   >
                     <div
-                      class="absolute -top-16 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
-                      data-message-toolbar="true"
+                      class="flex items-center p-0.5 fluux-popover rounded-md "
                     >
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        👍
+                      </button>
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        ❤️
+                      </button>
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        😂
+                      </button>
                       <div
-                        class="flex items-center p-0.5 fluux-popover rounded-md "
+                        class="w-px h-5 bg-fluux-hover"
+                      />
+                      <div
+                        class="relative"
                       >
                         <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          aria-label="chat.moreReactions"
+                          class="p-1.5 transition-colors hover:bg-fluux-hover"
                           type="button"
                         >
-                          👍
-                        </button>
-                        <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
-                          type="button"
-                        >
-                          ❤️
-                        </button>
-                        <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
-                          type="button"
-                        >
-                          😂
-                        </button>
-                        <div
-                          class="w-px h-5 bg-fluux-hover"
-                        />
-                        <div
-                          class="relative"
-                        >
-                          <button
-                            aria-label="chat.moreReactions"
-                            class="p-1.5 transition-colors hover:bg-fluux-hover"
-                            type="button"
+                          <span
+                            data-testid="icon-emoji"
                           >
-                            <span
-                              data-testid="icon-emoji"
-                            >
-                              Emoji
-                            </span>
-                          </button>
-                        </div>
+                            Emoji
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex"
+                      >
+                        <button
+                          aria-label="chat.reply"
+                          class="p-1.5 transition-colors hover:bg-fluux-hover"
+                          type="button"
+                        >
+                          <span
+                            data-testid="icon-reply"
+                          >
+                            Reply
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex"
+                      >
+                        <button
+                          aria-label="chat.forwardMessage"
+                          class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
+                          disabled=""
+                          type="button"
+                        >
+                          <span
+                            data-testid="icon-forward"
+                          >
+                            Forward
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex relative"
+                      >
                         <div
                           class="inline-flex"
                         >
                           <button
-                            aria-label="chat.reply"
-                            class="p-1.5 transition-colors hover:bg-fluux-hover"
-                            type="button"
-                          >
-                            <span
-                              data-testid="icon-reply"
-                            >
-                              Reply
-                            </span>
-                          </button>
-                        </div>
-                        <div
-                          class="inline-flex"
-                        >
-                          <button
-                            aria-label="chat.forwardMessage"
-                            class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
+                            aria-label="chat.moreOptions"
+                            class="p-1.5 transition-colors hover:bg-fluux-hover opacity-50 cursor-not-allowed"
                             disabled=""
                             type="button"
                           >
                             <span
-                              data-testid="icon-forward"
+                              data-testid="icon-more"
                             >
-                              Forward
+                              More
                             </span>
                           </button>
                         </div>
-                        <div
-                          class="inline-flex relative"
-                        >
-                          <div
-                            class="inline-flex"
-                          >
-                            <button
-                              aria-label="chat.moreOptions"
-                              class="p-1.5 transition-colors hover:bg-fluux-hover opacity-50 cursor-not-allowed"
-                              disabled=""
-                              type="button"
-                            >
-                              <span
-                                data-testid="icon-more"
-                              >
-                                More
-                              </span>
-                            </button>
-                          </div>
-                        </div>
                       </div>
                     </div>
+                  </div>
+                  <div
+                    class="relative flex-1 min-w-0"
+                  >
                     <div
                       class="relative w-full min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  "
                       data-msg-chrome="header"
@@ -285,7 +285,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-message-row-id="msg-2"
               >
                 <div
-                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
+                  class="relative group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
                   data-message-body="Hi! How are you?"
                   data-message-from="Me"
                   data-message-id="msg-2"
@@ -307,106 +307,106 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     </div>
                   </div>
                   <div
-                    class="relative flex-1 min-w-0"
+                    class="absolute -top-12 end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
+                    data-message-toolbar="true"
                   >
                     <div
-                      class="absolute -top-16 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
-                      data-message-toolbar="true"
+                      class="flex items-center p-0.5 fluux-popover rounded-md "
                     >
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        👍
+                      </button>
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        ❤️
+                      </button>
+                      <button
+                        aria-label="chat.reactWith"
+                        class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                        type="button"
+                      >
+                        😂
+                      </button>
                       <div
-                        class="flex items-center p-0.5 fluux-popover rounded-md "
+                        class="w-px h-5 bg-fluux-hover"
+                      />
+                      <div
+                        class="relative"
                       >
                         <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          aria-label="chat.moreReactions"
+                          class="p-1.5 transition-colors hover:bg-fluux-hover"
                           type="button"
                         >
-                          👍
-                        </button>
-                        <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
-                          type="button"
-                        >
-                          ❤️
-                        </button>
-                        <button
-                          aria-label="chat.reactWith"
-                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
-                          type="button"
-                        >
-                          😂
-                        </button>
-                        <div
-                          class="w-px h-5 bg-fluux-hover"
-                        />
-                        <div
-                          class="relative"
-                        >
-                          <button
-                            aria-label="chat.moreReactions"
-                            class="p-1.5 transition-colors hover:bg-fluux-hover"
-                            type="button"
+                          <span
+                            data-testid="icon-emoji"
                           >
-                            <span
-                              data-testid="icon-emoji"
-                            >
-                              Emoji
-                            </span>
-                          </button>
-                        </div>
+                            Emoji
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex"
+                      >
+                        <button
+                          aria-label="chat.editMessage"
+                          class="p-1.5 transition-colors hover:bg-fluux-hover"
+                          type="button"
+                        >
+                          <span
+                            data-testid="icon-edit"
+                          >
+                            Edit
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex"
+                      >
+                        <button
+                          aria-label="chat.forwardMessage"
+                          class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
+                          disabled=""
+                          type="button"
+                        >
+                          <span
+                            data-testid="icon-forward"
+                          >
+                            Forward
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="inline-flex relative"
+                      >
                         <div
                           class="inline-flex"
                         >
                           <button
-                            aria-label="chat.editMessage"
-                            class="p-1.5 transition-colors hover:bg-fluux-hover"
+                            aria-label="chat.moreOptions"
+                            class="p-1.5 transition-colors hover:bg-fluux-hover "
                             type="button"
                           >
                             <span
-                              data-testid="icon-edit"
+                              data-testid="icon-more"
                             >
-                              Edit
+                              More
                             </span>
                           </button>
-                        </div>
-                        <div
-                          class="inline-flex"
-                        >
-                          <button
-                            aria-label="chat.forwardMessage"
-                            class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
-                            disabled=""
-                            type="button"
-                          >
-                            <span
-                              data-testid="icon-forward"
-                            >
-                              Forward
-                            </span>
-                          </button>
-                        </div>
-                        <div
-                          class="inline-flex relative"
-                        >
-                          <div
-                            class="inline-flex"
-                          >
-                            <button
-                              aria-label="chat.moreOptions"
-                              class="p-1.5 transition-colors hover:bg-fluux-hover "
-                              type="button"
-                            >
-                              <span
-                                data-testid="icon-more"
-                              >
-                                More
-                              </span>
-                            </button>
-                          </div>
                         </div>
                       </div>
                     </div>
+                  </div>
+                  <div
+                    class="relative flex-1 min-w-0"
+                  >
                     <div
                       class="relative w-fit max-w-full min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-tint message-own-tint-start message-own-tint-end"
                       data-msg-chrome="header"

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -961,12 +961,8 @@ describe('Own-message tint', () => {
 })
 
 describe('Hover toolbar anchoring', () => {
-  // Regression: the own-message tint hugs its content (`w-fit`), so anchoring the
-  // hover toolbar inside that box made the toolbar drift left/right with the
-  // bubble width — a short own message pulled its menu far from the row edge.
-  // The toolbar now lives in a full-width positioning column that also wraps the
-  // hugging tint box, so it pins to the row's right edge for every message
-  // regardless of how narrow the tint is. These guard that structure.
+  // The content-hugging own tint cannot own the toolbar's horizontal anchor;
+  // row padding cannot own its vertical anchor. Both edges belong to the row.
   it('renders the toolbar OUTSIDE the hugging own-tint box (not a descendant of it)', () => {
     const props = createDefaultProps({ message: createTestMessage({ isOutgoing: true }) })
     const { container } = render(<MessageBubble {...props} />)
@@ -977,30 +973,25 @@ describe('Hover toolbar anchoring', () => {
     expect(toolbar!.closest('.message-own-tint')).toBeNull()
   })
 
-  it('anchors the toolbar in a full-width (flex-1) column that also holds the tint box', () => {
+  it('anchors the toolbar to the full message row outside the content column', () => {
     const props = createDefaultProps({ message: createTestMessage({ isOutgoing: true }) })
     const { container } = render(<MessageBubble {...props} />)
 
-    const column = container.querySelector('[data-message-toolbar]')!.parentElement!
-    // The positioning column spans the full available width and is the offset
-    // parent for the absolutely-positioned toolbar.
-    expect(column.className).toContain('flex-1')
-    expect(column.className).toContain('relative')
-    // The content-hugging tint box is a sibling of the toolbar inside that column.
-    const tint = column.querySelector('.message-own-tint')
+    const row = container.querySelector('[data-message-toolbar]')!.parentElement!
+    expect(row).toBe(container.firstChild)
+    expect(row).toHaveClass('relative')
+    const tint = row.querySelector('.message-own-tint')
     expect(tint).not.toBeNull()
     expect(tint!.className).toContain('w-fit')
   })
 
-  it('keeps incoming content full-width (w-full) with the toolbar as a sibling', () => {
+  it('keeps incoming content full-width (w-full)', () => {
     const props = createDefaultProps({ message: createTestMessage({ isOutgoing: false }) })
     const { container } = render(<MessageBubble {...props} />)
 
-    const column = container.querySelector('[data-message-toolbar]')!.parentElement!
-    expect(column.className).toContain('flex-1')
     // Incoming rows have no tint; their content fills the column.
     expect(container.querySelector('.message-own-tint')).toBeNull()
-    const content = column.querySelector('[data-msg-chrome]')!
+    const content = container.querySelector('[data-msg-chrome]')!
     expect(content.className).toContain('w-full')
   })
 })

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -481,7 +481,7 @@ export const MessageBubble = memo(function MessageBubble({
   // Own-message tint hugs its content instead of spanning the row: `w-fit` sizes
   // the filled surface to the widest line (body or the name+time header) and
   // `max-w-full` still wraps long messages at the available width. The tint box
-  // sits inside a full-width positioning column (see below), so incoming rows and
+  // sits inside a full-width content column, so incoming rows and
   // whisper cards fill that column with `w-full`; their layout is unchanged.
   const contentWidthClass = ownTint ? 'w-fit max-w-full' : 'w-full'
   // A run of consecutive own messages shares its widest line's width so the tint
@@ -538,7 +538,7 @@ export const MessageBubble = memo(function MessageBubble({
       data-message-from={senderName}
       data-message-time={formatTime(message.timestamp)}
       data-message-body={deriveCopyBody(message, t)}
-      className={`${outerRowClass}${ownRowClass}`}
+      className={`relative ${outerRowClass}${ownRowClass}`}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
@@ -577,42 +577,37 @@ export const MessageBubble = memo(function MessageBubble({
         )}
       </div>
 
+      {/* Floating hover toolbar - hidden when user is composing or message is retracted */}
+      {!message.isRetracted && (
+        <MessageToolbar
+          onReaction={handleReaction}
+          onReply={onReply}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          myReactions={reactionsEnabled ? myReactions : []}
+          canReply={canReply}
+          canEdit={canEdit}
+          canDelete={canDelete}
+          isHidden={hideToolbar || false}
+          isSelected={isSelected || false}
+          hasKeyboardSelection={hasKeyboardSelection || false}
+          showToolbarForSelection={showToolbarForSelection || false}
+          showReactionPicker={showReactionPicker}
+          setShowReactionPicker={setShowReactionPicker}
+          showMoreMenu={showMoreMenu}
+          setShowMoreMenu={setShowMoreMenu}
+          isHovered={isHovered}
+          onToolbarMouseEnter={onMouseEnter}
+        />
+      )}
+
       {/* Content. The own-message tint is suppressed inside a whisper thread
           (`!inThread`): it sets its own `background` (overriding the bounded
           card's purple fill) and widens the row via margin-inline, which would
           mismatch the fill and knock the side borders 8px out of alignment with
           the incoming rows — shattering the single "private with X" card. The
           name header already carries the own-vs-counterpart distinction. */}
-      {/* Full-width positioning column. The hover toolbar is anchored here (not
-          inside the tint box) so it pins to the row's right edge and keeps a
-          stable position regardless of how narrow the own-message tint hugs its
-          content. Incoming rows already spanned the full width, so their toolbar
-          position is unchanged. */}
       <div className="relative flex-1 min-w-0">
-        {/* Floating hover toolbar - hidden when user is composing or message is retracted */}
-        {!message.isRetracted && (
-          <MessageToolbar
-            onReaction={handleReaction}
-            onReply={onReply}
-            onEdit={onEdit}
-            onDelete={onDelete}
-            myReactions={reactionsEnabled ? myReactions : []}
-            canReply={canReply}
-            canEdit={canEdit}
-            canDelete={canDelete}
-            isHidden={hideToolbar || false}
-            isSelected={isSelected || false}
-            hasKeyboardSelection={hasKeyboardSelection || false}
-            showToolbarForSelection={showToolbarForSelection || false}
-            showAvatar={showAvatar}
-            showReactionPicker={showReactionPicker}
-            setShowReactionPicker={setShowReactionPicker}
-            showMoreMenu={showMoreMenu}
-            setShowMoreMenu={setShowMoreMenu}
-            isHovered={isHovered}
-            onToolbarMouseEnter={onMouseEnter}
-          />
-        )}
       <div
         ref={ownGroupRef}
         className={`relative ${contentWidthClass} min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${ownTintClass}`}

--- a/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
@@ -59,7 +59,6 @@ describe('MessageToolbar', () => {
     isSelected: false,
     hasKeyboardSelection: false,
     showToolbarForSelection: false,
-    showAvatar: false,
     showReactionPicker: false,
     setShowReactionPicker: vi.fn(),
     showMoreMenu: false,
@@ -376,26 +375,4 @@ describe('MessageToolbar', () => {
     })
   })
 
-  describe('Positioning', () => {
-    it('should position differently when showAvatar is true', () => {
-      const { container } = render(
-        <MessageToolbar {...defaultProps} showAvatar={true} />
-      )
-
-      // Group-start rows are taller (name+time header), so the bar is lifted
-      // further (-top-16) to straddle the row's top edge and clear the hover tint.
-      const toolbar = container.firstChild as HTMLElement
-      expect(toolbar).toHaveClass('-top-16')
-    })
-
-    it('should position normally when showAvatar is false', () => {
-      const { container } = render(
-        <MessageToolbar {...defaultProps} showAvatar={false} />
-      )
-
-      // Outer hover zone has extended positioning to provide larger hit area
-      const toolbar = container.firstChild as HTMLElement
-      expect(toolbar).toHaveClass('-top-12')
-    })
-  })
 })

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -38,8 +38,6 @@ export interface MessageToolbarProps {
   hasKeyboardSelection: boolean
   /** Whether toolbar should be shown for keyboard selection */
   showToolbarForSelection: boolean
-  /** Whether the message shows an avatar (affects positioning) */
-  showAvatar: boolean
   /** Whether reaction picker is open (controlled externally for click-outside) */
   showReactionPicker: boolean
   /** Setter for reaction picker state */
@@ -72,7 +70,6 @@ export const MessageToolbar = memo(function MessageToolbar({
   isSelected,
   hasKeyboardSelection,
   showToolbarForSelection,
-  showAvatar,
   showReactionPicker,
   setShowReactionPicker,
   showMoreMenu,
@@ -142,17 +139,12 @@ export const MessageToolbar = memo(function MessageToolbar({
         : 'group-hover:pointer-events-auto'
 
   return (
-    // Outer wrapper provides an extended hover zone (padding) around the visible toolbar
-    // select-none prevents toolbar from being included in text selection.
-    // The top offset lifts the bar to straddle the row's top edge so its rounded
-    // border sits over the calm chat surface rather than inside the message-hover
-    // tint (which otherwise bleeds around the bar's corners, most visibly in light
-    // theme where the popover surface and the tint differ). A group-start row is
-    // taller (name+time header), so it needs the larger -top-16 to land the bar at
-    // the same visual height a continuation row reaches with -top-12.
+    // Anchor to the full message row so density, dividers, and whisper spacing
+    // cannot open a pointer gap. The visible bar overlaps the row's top edge;
+    // the surrounding padding stays inert so underlying text remains selectable.
     <div
       data-message-toolbar
-      className={`absolute ${showAvatar ? '-top-16' : '-top-12'} -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out ${visibilityClass}`}
+      className={`absolute -top-12 end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out ${visibilityClass}`}
     >
       {/* Visible toolbar. The p-0.5 inset keeps each control's square hover/active
           fill (hover:bg-fluux-hover, reacted bg-fluux-brand/20) clear of the

--- a/scripts/popover-geometry.ts
+++ b/scripts/popover-geometry.ts
@@ -17,6 +17,7 @@
  */
 
 import { test, expect, type Page, type Locator } from '@playwright/test'
+import type { roomStore } from '@fluux/sdk/stores'
 import { bootDemo } from './e2e/demoBoot'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -211,4 +212,68 @@ test.describe('contact suggestion popover geometry', () => {
     expect(await heightOf(), 'the dialog height must not depend on the list having been open')
       .toBeCloseTo(closed, 0)
   })
+})
+
+// The visible bar must touch the hovered row even when group spacing collapses.
+// A timer-only test cannot detect the pointer dead zone between the two boxes.
+test.describe('message toolbar alignment', () => {
+  for (const density of ['comfortable', 'compact'] as const) {
+    for (const afterDivider of [false, true]) {
+      test(`${density}, ${afterDivider ? 'after unread divider' : 'regular group'}: remains reachable at a slow pointer speed`, async ({ page }) => {
+        await bootDemo(page, `${DEMO_URL}&density=${density}`)
+        await page.evaluate(() => {
+          const demo = window as Window & { __demoClient?: { stopAnimation(): void } }
+          demo.__demoClient?.stopAnimation()
+        })
+        await page.locator('[data-nav="rooms"]').click()
+        await page.getByText('Team Chat', { exact: true }).first().click()
+        await page.locator('.composer-mirror + textarea').waitFor()
+
+        const messageId = 'demo-room-whisper-pub'
+        if (afterDivider) {
+          await page.evaluate((id) => {
+            const store = (window as unknown as { __roomStore: typeof roomStore }).__roomStore
+            const state = store.getState()
+            store.setState({
+              firstNewMessageMarkers: new Map(state.firstNewMessageMarkers).set(state.activeRoomJid!, { id }),
+            })
+          }, messageId)
+        }
+        const row = page.locator(`[data-message-body][data-message-id="${messageId}"]`)
+        await row.scrollIntoViewIfNeeded()
+        if (afterDivider) {
+          await expect.poll(() => row.evaluate(el =>
+            el.previousElementSibling?.hasAttribute('data-new-message-marker'),
+          )).toBe(true)
+        }
+        await row.hover()
+        const toolbar = row.locator('[data-message-toolbar]')
+        await expect(toolbar).toHaveCSS('opacity', '1')
+        const geometry = await row.evaluate(el => {
+          const rowBox = el.getBoundingClientRect()
+          const bar = el.querySelector('[data-message-toolbar] > div')!.getBoundingClientRect()
+          return { overlap: bar.bottom - rowBox.top, endInset: rowBox.right - bar.right }
+        })
+        expect(geometry.overlap, 'visible bar must touch the row with no pointer dead zone').toBeGreaterThanOrEqual(0)
+        expect(geometry.overlap, 'bar must stay at the top edge, clear of the message content').toBeLessThanOrEqual(6)
+        expect(geometry.endInset, 'bar keeps its inset from the full-width row edge').toBeCloseTo(24, 0)
+
+        const rowBox = (await row.boundingBox())!
+        const replyBox = (await toolbar.getByRole('button', { name: 'Reply', exact: true }).boundingBox())!
+        const x = replyBox.x + replyBox.width / 2
+        const targetY = replyBox.y + replyBox.height / 2
+        const startY = rowBox.y + 10
+        await page.mouse.move(x, startY)
+        // Pause at each step longer than the hover-leave delay (100ms). The
+        // alignment must make the crossing safe without depending on speed.
+        for (let step = 1; step <= 8; step++) {
+          await page.mouse.move(x, startY + (targetY - startY) * step / 8)
+          await page.waitForTimeout(150)
+          await expect(toolbar).toHaveCSS('opacity', '1')
+        }
+        await page.mouse.click(x, targetY)
+        await expect(page.getByText('Replying to', { exact: false })).toBeVisible()
+      })
+    }
+  }
 })


### PR DESCRIPTION
Anchor the message action toolbar to the full message row so it stays aligned in comfortable and compact spacing, including immediately after the new-message divider and inside private-message threads. This removes the gap that made the buttons disappear during slow pointer movement while preserving hover timing and text selection.
