### PR TITLE
build: use ring in development and AWS-LC in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
-    # Backstop against a hung build/test (default GitHub timeout is 6h). A cached run is ~5min.
-    timeout-minutes: 20
+    # Exercise both TLS providers, including AWS-LC's native build on a cold cache.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -308,13 +308,42 @@ jobs:
         with:
           workspaces: apps/fluux/src-tauri
 
+      - name: Setup Node.js for Tauri config checks
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install CLI dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Production and Dev packaging select the intended TLS provider
+        run: npm run check:tls-build
+
+      - name: Development builds exclude AWS-LC
+        working-directory: apps/fluux/src-tauri
+        run: |
+          cargo tree --locked --target all --edges normal,build,dev --prefix none > "$RUNNER_TEMP/tls-dev-tree.txt"
+          if grep -E '^aws-lc-(rs|sys) ' "$RUNNER_TEMP/tls-dev-tree.txt"; then
+            echo "::error::AWS-LC must only be enabled by production-tls"
+            exit 1
+          fi
+
       - name: Run tests
         working-directory: apps/fluux/src-tauri
         run: cargo test --locked
 
+      - name: Run tests with production TLS
+        working-directory: apps/fluux/src-tauri
+        run: cargo test --locked --features production-tls
+
       - name: Clippy
         working-directory: apps/fluux/src-tauri
         run: cargo clippy --locked -- -D warnings
+
+      - name: Clippy with production TLS
+        working-directory: apps/fluux/src-tauri
+        run: cargo clippy --locked --features production-tls -- -D warnings
 
       - name: Check generated files are up to date
         run: git diff --exit-code apps/fluux/src-tauri/gen/
@@ -353,6 +382,14 @@ jobs:
         working-directory: apps/fluux/src-tauri
         run: cargo check --locked
 
+      - name: Check Windows backend with production TLS
+        working-directory: apps/fluux/src-tauri
+        run: cargo check --locked --features production-tls
+
       - name: Clippy
         working-directory: apps/fluux/src-tauri
         run: cargo clippy --locked -- -D warnings
+
+      - name: Clippy with production TLS
+        working-directory: apps/fluux/src-tauri
+        run: cargo clippy --locked --features production-tls -- -D warnings

--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -4943,7 +4943,6 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -5228,7 +5227,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -7,6 +7,11 @@ license = "AGPL-3.0-or-later"
 repository = ""
 edition = "2021"
 
+[features]
+default = []
+# Enabled by the production Tauri config; local Dev builds keep ring only.
+production-tls = ["rustls/aws_lc_rs", "rustls/prefer-post-quantum"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -38,8 +43,8 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.30"
 futures-util = "0.3"
 quick-xml = "0.42"
-tokio-rustls = "0.26"
-rustls = { version = "0.23", features = ["ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rustls-native-certs = "0.8"
 hickory-resolver = "0.26"
 # IDNA (RFC 5890) A-label conversion for internationalized domains. DNS and
@@ -56,7 +61,6 @@ dirs = "7"
 # E2EE / OpenPGP (XEP-0373 "OX")
 # Sequoia-PGP provides cert generation, encryption, decryption, and
 # fingerprinting. `crypto-rust` keeps us on a pure-Rust backend
-# (consistent with the rest of the project — ring for rustls, etc.)
 # rather than requiring system libnettle or OpenSSL.
 sequoia-openpgp = { version = "2.0", default-features = false, features = [
     "crypto-rust",
@@ -103,7 +107,8 @@ tauri-plugin-updater = "2"
 # app bundle natively, so the plugin is effectively a no-op there.
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
-reqwest = { version = "0.13", features = ["blocking"] }
+# Preserve reqwest's non-TLS defaults, but use the provider installed at startup.
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "http2", "system-proxy", "rustls-no-provider"] }
 scraper = "0.27"
 
 # user-idle for Windows (macOS uses ioreg, Linux uses direct X11 calls)

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -197,6 +197,7 @@ use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_opener::OpenerExt;
 
 mod download;
+mod tls;
 mod upload;
 mod xmpp_proxy;
 mod openpgp;
@@ -1366,6 +1367,8 @@ fn print_startup_diagnostics() {
 }
 
 fn main() {
+    tls::init_crypto_provider();
+
     // Keep the loopback hop to the local XMPP bridge off any system-wide proxy.
     // On Linux this also runs from a pre-main ctor (before WebKitGTK init); on
     // macOS/Windows this is the earliest hook before the webview is created.

--- a/apps/fluux/src-tauri/src/tls.rs
+++ b/apps/fluux/src-tauri/src/tls.rs
@@ -1,0 +1,20 @@
+//! Process-wide TLS provider shared by reqwest, Tauri plugins and the XMPP proxy.
+
+/// Install before any network client is created. Fail immediately if another
+/// initializer has selected a provider, rather than silently changing the
+/// production TLS policy according to which component makes the first request.
+pub fn init_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        #[cfg(feature = "production-tls")]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(not(feature = "production-tls"))]
+        let provider = rustls::crypto::ring::default_provider();
+
+        provider
+            .install_default()
+            .expect("Fluux must install its TLS provider before creating network clients");
+    });
+}

--- a/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
@@ -253,16 +253,6 @@ async fn send_close_with_reason(
     .await;
 }
 
-/// Initialize rustls crypto provider (must be called once at startup)
-fn init_crypto_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-
-    INIT.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
-}
-
 /// TLS certificate verifier that accepts all certificates without validation.
 ///
 /// **DANGEROUS**: Only used when `--dangerous-insecure-tls` CLI flag is set.
@@ -324,10 +314,12 @@ impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
 fn create_tls_connector() -> Result<TlsConnector, String> {
     if is_insecure_tls() {
         warn!("TLS certificate verification DISABLED (--dangerous-insecure-tls)");
-        let provider = rustls::crypto::ring::default_provider();
+        let provider = rustls::crypto::CryptoProvider::get_default()
+            .expect("TLS provider must be initialized before creating a connector")
+            .clone();
         let config = ClientConfig::builder()
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier(Arc::new(provider))))
+            .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier(provider)))
             .with_no_client_auth();
         return Ok(TlsConnector::from(Arc::new(config)));
     }
@@ -1445,7 +1437,7 @@ pub async fn start_proxy(
     app_handle: Option<tauri::AppHandle>,
 ) -> Result<ProxyStartResult, String> {
     // Initialize crypto provider before any TLS operations
-    init_crypto_provider();
+    crate::tls::init_crypto_provider();
 
     let mut proxy_guard = PROXY.write().await;
 
@@ -1558,7 +1550,7 @@ mod tests {
 
     #[test]
     fn test_create_tls_connector() {
-        init_crypto_provider();
+        crate::tls::init_crypto_provider();
         let result = create_tls_connector();
         assert!(
             result.is_ok(),

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
     }
   },
   "build": {
+    "features": ["production-tls"],
     "beforeBuildCommand": "npm run build",
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:5173",

--- a/apps/fluux/src-tauri/tauri.dev.conf.json
+++ b/apps/fluux/src-tauri/tauri.dev.conf.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fluux Messenger Dev",
-  "identifier": "com.processone.fluux.dev"
+  "identifier": "com.processone.fluux.dev",
+  "build": {
+    "features": []
+  }
 }

--- a/apps/fluux/src-tauri/tests/tls_provider.rs
+++ b/apps/fluux/src-tauri/tests/tls_provider.rs
@@ -1,0 +1,37 @@
+// A separate test executable keeps rustls' process-global provider independent
+// of proxy tests and plugins that might initialize it before this assertion.
+#[path = "../src/tls.rs"]
+mod tls;
+
+#[test]
+fn initializes_the_builds_provider_before_any_network_client() {
+    use rustls::crypto::CryptoProvider;
+
+    assert!(CryptoProvider::get_default().is_none());
+    tls::init_crypto_provider();
+    tls::init_crypto_provider();
+
+    let provider = CryptoProvider::get_default().expect("startup must install a TLS provider");
+    let expected_group = if cfg!(feature = "production-tls") {
+        rustls::NamedGroup::X25519MLKEM768
+    } else {
+        rustls::NamedGroup::X25519
+    };
+    assert_eq!(
+        provider.kx_groups[0].name(),
+        expected_group,
+        "the selected provider must match the build, including post-quantum preference in production"
+    );
+
+    // reqwest's no-provider mode panics here if the application only enabled
+    // Cargo features without installing the provider before its first client.
+    reqwest::blocking::Client::builder()
+        .build()
+        .expect("native uploads, downloads and link previews must work before XMPP connects");
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        reqwest::Client::builder()
+            .build()
+            .expect("async HTTP clients must use the same startup provider");
+    });
+}

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -54,6 +54,40 @@ The override lives in `apps/fluux/src-tauri/tauri.dev.conf.json` and is merged i
 
 macOS binds notification authorization (`UNUserNotificationCenter`) to the app's **code signature *and* bundle id**, not the bundle id alone. A locally-built app that shares the production identifier inherits (but cannot match) the grant given to the signed production build, so notifications silently read as *"permission not granted"* even though **System Settings → Notifications** still lists the app as allowed. (The dock badge keeps working, because it needs no authorization.) A distinct `.dev` identity gets its own authorization and never disturbs the production grant.
 
+### TLS providers in development and production
+
+Local Dev builds and plain `cargo test` use rustls with **ring**, so they do not
+compile AWS-LC. Production packaging enables the Cargo feature `production-tls`
+through the base `tauri.conf.json`; it selects **AWS-LC** with rustls' hybrid
+post-quantum key exchange preference. The server must support that exchange for
+it to be negotiated. This concerns native TLS, not OpenPGP end-to-end encryption
+or the browser's TLS implementation.
+
+The Dev config replaces `build.features` with an empty list. This also applies to
+optimized local Dev bundles: Cargo's `release` profile alone does **not** select
+production TLS. The provider is installed at process startup, before any HTTP
+client, Tauri plugin or XMPP connection. Certificate and hostname validation use
+the same paths in both modes; neither mode enables `--dangerous-insecure-tls`.
+
+| Command | Native TLS provider |
+| --- | --- |
+| `npm run tauri:dev`, `npm run tauri:build`, `npm run tauri:install` (repository root) | ring |
+| `npm run tauri build` (from `apps/fluux`, base config) | AWS-LC |
+| `cargo test --locked` (from `apps/fluux/src-tauri`) | ring |
+| `cargo test --locked --features production-tls` (same directory) | AWS-LC |
+
+To exercise production TLS with a debug build, run `npm run tauri -- build --debug`
+from `apps/fluux`. When building directly with Cargo for distribution, pass
+`--features production-tls` explicitly. AWS-LC remains in `Cargo.lock` because
+production needs it; `cargo tree --locked --edges normal,build,dev` shows whether
+the current build actually includes it. Some plugins still compile ring in
+production, but the process-wide provider is AWS-LC.
+
+CI tests both native configurations and checks that the development dependency
+graph excludes AWS-LC. `npm run check:tls-build` exercises the installed Tauri CLI's
+config merging and Cargo arguments with a runner that stops before compilation
+or signing. Run it after `npm ci`; it also requires Cargo on `PATH`.
+
 ### Test notifications with `tauri:install`, not `tauri:dev`
 
 `tauri dev` runs the **unbundled** debug binary (it never produces a `.app`), which macOS will not reliably authorize for notifications, so it is not the tool for testing native notifications, and there is nothing to code-sign there. Build and install a real bundle instead:
@@ -316,8 +350,9 @@ The resulting package will be created in the parent directory: `../fluux-messeng
 If you've already built the binary with Tauri, you can skip the build step:
 
 ```bash
-# First build with Tauri
-npm run tauri:build
+# First build with the production Tauri config (from the repository root)
+npm run build:sdk
+npm run tauri -w @xmpp/fluux -- build
 
 # Then package (auto-detects existing binary)
 dpkg-buildpackage -d -uc -us -b

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -239,6 +239,12 @@ git push origin --delete release/0.9.0
    - Download URLs and signatures for each platform
 5. `latest.json` is uploaded to the GitHub Release
 
+Release builds use the base Tauri config, whose `build.features` enables
+`production-tls` (AWS-LC with hybrid post-quantum key exchange support). Do not pass
+`tauri.dev.conf.json` when producing release binaries: that override selects ring
+for faster local builds. A direct Cargo build for distribution must explicitly
+include `--features production-tls`; `--release` alone only selects optimization.
+
 ## Auto-Updater Flow
 
 When users have the app installed:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "anomaly:review": "node scripts/anomaly-review.mjs",
     "check:anomaly-review": "node --test scripts/anomaly-review.test.mjs",
     "check:examples": "node --test scripts/check-jsdoc-examples.test.mjs && node scripts/check-jsdoc-examples.mjs",
+    "check:tls-build": "node --test scripts/tls-build-config.test.mjs",
     "check:anomaly:prod": "npm run build:app && node scripts/check-anomaly-elimination.mjs",
     "check:anomaly:dev": "FLUUX_ANOMALY=1 npm run build:app && FLUUX_ANOMALY=1 node scripts/check-anomaly-elimination.mjs",
     "build:e2e": "npm run build:sdk && node scripts/build-e2e.mjs",

--- a/scripts/tls-build-config.test.mjs
+++ b/scripts/tls-build-config.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const require = createRequire(import.meta.url)
+const cli = require.resolve('@tauri-apps/cli/tauri.js')
+const appVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version
+const tauriVersion = readFileSync(join(root, 'apps/fluux/src-tauri/Cargo.lock'), 'utf8')
+  .match(/name = "tauri"\r?\nversion = "([^"]+)"/)[1]
+
+// Exercise Tauri's actual config merging and Cargo invocation. The runner
+// records its arguments and deliberately stops before compilation or signing.
+function buildArgs({ dev = false, debug = false } = {}) {
+  const fixture = mkdtempSync(join(tmpdir(), 'fluux-tls-build-'))
+  try {
+    const native = join(fixture, 'src-tauri')
+    mkdirSync(join(native, 'src'), { recursive: true })
+    mkdirSync(join(fixture, 'dist'))
+    writeFileSync(join(fixture, 'dist/index.html'), '<!doctype html><title>Build probe</title>')
+    writeFileSync(join(fixture, 'package.json'), JSON.stringify({ name: 'tls-build-probe', version: appVersion }))
+    writeFileSync(join(native, 'src/main.rs'), 'fn main() {}\n')
+    writeFileSync(join(native, 'Cargo.toml'), `[package]\nname="tls-build-probe"\nversion="${appVersion}"\nedition="2021"\n[features]\nproduction-tls=[]\n[dependencies]\ntauri={path="tauri"}\n`)
+    // Cargo metadata only needs a local stub; this probe must also work on a
+    // fresh runner with no registry cache and must never download or build Rust.
+    mkdirSync(join(native, 'tauri/src'), { recursive: true })
+    writeFileSync(join(native, 'tauri/src/lib.rs'), '')
+    writeFileSync(join(native, 'tauri/Cargo.toml'), `[package]\nname="tauri"\nversion="${tauriVersion}"\nedition="2021"\n[features]\ncustom-protocol=[]\n`)
+    for (const name of ['tauri.conf.json', 'tauri.dev.conf.json', 'tauri.linux.conf.json', 'tauri.macos.conf.json', 'tauri.windows.conf.json']) {
+      const source = join(root, 'apps/fluux/src-tauri', name)
+      if (existsSync(source)) cpSync(source, join(native, name))
+    }
+    const recorded = join(fixture, 'args.json')
+    const recorder = join(fixture, 'record.cjs')
+    writeFileSync(recorder, '#!/usr/bin/env node\nrequire("node:fs").writeFileSync(process.env.FLUUX_TLS_BUILD_ARGS, JSON.stringify(process.argv.slice(2))); process.exit(17);\n', { mode: 0o755 })
+    const runner = process.platform === 'win32' ? join(fixture, 'record.cmd') : recorder
+    if (process.platform === 'win32') writeFileSync(runner, `@"${process.execPath}" "${recorder}" %*\r\n`)
+    const args = [cli, 'build', '--ci', '--no-bundle', '--runner', runner]
+    if (debug) args.push('--debug')
+    if (dev) args.push('--config', join(native, 'tauri.dev.conf.json'))
+    args.push('--config', JSON.stringify({ build: { beforeBuildCommand: '', frontendDist: '../dist' } }))
+    const result = spawnSync(process.execPath, args, {
+      cwd: fixture,
+      env: {
+        ...process.env,
+        CARGO_HOME: join(fixture, 'cargo-home'),
+        CARGO_NET_OFFLINE: 'true',
+        FLUUX_TLS_BUILD_ARGS: recorded,
+      },
+      encoding: 'utf8',
+      timeout: 60_000,
+    })
+    assert.ok(existsSync(recorded), `Tauri must reach the build runner:\n${result.error ?? ''}\n${result.stdout}\n${result.stderr}`)
+    assert.notEqual(result.status, 0, 'the probe must stop before creating an artifact')
+    return JSON.parse(readFileSync(recorded, 'utf8'))
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+}
+
+function hasProductionTls(args) {
+  const index = args.indexOf('--features')
+  return index >= 0 && args[index + 1].split(/[ ,]+/).includes('production-tls')
+}
+
+test('production packaging selects production TLS', () => {
+  assert.ok(hasProductionTls(buildArgs()), 'production builds must enable production-tls')
+})
+
+test('optimized Dev bundles exclude production TLS', () => {
+  const args = buildArgs({ dev: true })
+  assert.ok(args.includes('--release'), 'Dev bundles still use the optimized Cargo profile')
+  assert.ok(!hasProductionTls(args), 'the Dev override must remove production-tls')
+})
+
+test('production TLS can be tested without an optimized build', () => {
+  const args = buildArgs({ debug: true })
+  assert.ok(!args.includes('--release'))
+  assert.ok(hasProductionTls(args), 'TLS selection must be independent of the Cargo profile')
+})


### PR DESCRIPTION
Local development and test builds compile AWS-LC even when Fluux uses ring. Use ring for Dev builds and select AWS-LC, with hybrid post-quantum key exchange support, for production packaging through an explicit `production-tls` feature. The choice follows the Tauri configuration, including optimized local Dev bundles.

Install the selected provider at process startup so native HTTP clients and the XMPP proxy share the same TLS policy. Add CI checks for both configurations and document the Cargo and Tauri build commands.
