### PR TITLE
fix: harden remaining read-pointer writers

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -437,8 +437,8 @@ lifetime rather than server-side archival.
 Where the user has read to, as one object written atomically: an **order** (the only comparable
 data) and an **identity** (what the position is called, locally and on the wire). It replaces the
 `lastSeenMessageId` + `lastReadAt` pair, which were two fields describing one fact and drifted apart
-(#1081). Paths using `advance` move it only forward; `markReadToNewest` instead replaces it directly
-with the resident tail, which can move it backward when the window has slid into older history.
+(#1081). Advancement and identity-proven floor resolution are defined by `advance` and
+`hasFloorResolutionEvidence` in the implementation below.
 
 **Standard notion:** a read cursor, or last-read watermark. Bundling order and name into one
 non-splittable value is the unusual part.

--- a/docs/superpowers/plans/2026-07-06-muc-catchup-read-state.md
+++ b/docs/superpowers/plans/2026-07-06-muc-catchup-read-state.md
@@ -700,56 +700,9 @@ Expected: FAIL — action does not exist.
 
 - [ ] **Step 3: Implement**
 
-`roomStore.ts` — interface (near `markAsRead`):
-
-```typescript
-  /** Esc / mark-all-read: advance the read pointer to the newest known
-   *  message, zero the counts, drop the divider. The MDS publisher picks up
-   *  the pointer advance via the roomMeta watch. */
-  markReadToNewest: (roomJid: string) => void
-  /** Bulk vacation-recovery: markReadToNewest for every joined room with unread. */
-  markAllRoomsRead: () => void
-```
-
-Implementation (near `markAsRead`'s implementation):
-
-```typescript
-  markReadToNewest: (roomJid) => {
-    set((state) => {
-      const existing = state.rooms.get(roomJid)
-      if (!existing) return state
-      const meta = state.roomMeta.get(roomJid)
-      const runtime = state.roomRuntime.get(roomJid)
-      const resident = runtime?.messages?.length ? runtime.messages : existing.messages
-      const newest = resident[resident.length - 1] ?? existing.lastMessage
-      if (!newest) return state
-
-      const read = {
-        lastSeenMessageId: newest.id,
-        unreadCount: 0,
-        mentionsCount: 0,
-        lastReadAt: newest.timestamp,
-      }
-      const newMeta = new Map(state.roomMeta)
-      if (meta) newMeta.set(roomJid, { ...meta, ...read })
-      const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, ...read })
-      const newMarkers = new Map(state.firstNewMessageMarkers)
-      newMarkers.delete(roomJid)
-      return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
-    })
-  },
-
-  markAllRoomsRead: () => {
-    for (const room of get().joinedRooms()) {
-      const meta = get().roomMeta.get(room.jid)
-      const unread = (meta?.unreadCount ?? room.unreadCount ?? 0) + (meta?.mentionsCount ?? room.mentionsCount ?? 0)
-      if (unread > 0) get().markReadToNewest(room.jid)
-    }
-  },
-```
-
-(Verify the joined-rooms selector name with `grep -n "joinedRooms" packages/fluux-sdk/src/stores/roomStore.ts` — use the existing one.) `chatStore.markReadToNewest`: same shape over `conversations`/`conversationMeta`/`messages` map/`firstNewMessageMarkers`.
+The current `markReadToNewest` contracts and implementations are owned by
+`packages/fluux-sdk/src/stores/chatStore.ts` / `roomStore.ts`; the latter also owns
+`markAllRoomsRead`.
 
 Hooks — `useRoomActions.ts` (follow the file's `useCallback` pattern):
 

--- a/docs/superpowers/plans/2026-07-28-read-state-c-writer-restriction.md
+++ b/docs/superpowers/plans/2026-07-28-read-state-c-writer-restriction.md
@@ -7,9 +7,9 @@ writer classes (outgoing-message inference, activation snap, MAM outgoing-bounda
 without ever widening pointer movement except where a persisted `archiveOrderKey` proves the
 position.
 
-**Architecture:** All decision logic stays in the pure `stores/shared` modules
-(`readPointer.ts`, `readState.ts`, `notificationState.ts`, `readMarkerSync.ts`); the stores
-only fan the results into their maps. The `(timestamp, archiveOrderKey)` total order that PR B
+**Architecture:** The pure `stores/shared` modules own the comparison and transition contracts
+(`readPointer.ts`, `readState.ts`, `notificationState.ts`, `readMarkerSync.ts`); see the
+`chatStore.ts` / `roomStore.ts` action comments for store integration. The `(timestamp, archiveOrderKey)` total order that PR B
 introduced for *counting* becomes the single order used by the pointer side too, so divider,
 count and pointer can no longer disagree about what "after" means.
 
@@ -51,7 +51,7 @@ than guessing.
 | `packages/fluux-sdk/src/stores/shared/readState.ts` | `compareOrder`, `computeFloor`, `makeArchiveOrderKey`, renderability re-export | read-only in this PR |
 | `packages/fluux-sdk/src/stores/shared/notificationState.ts` | Pure notification transitions | 2, 4, 5, 6, 8 |
 | `packages/fluux-sdk/src/stores/shared/readMarkerSync.ts` | XEP-0490 resolution | 3, 5 |
-| `packages/fluux-sdk/src/stores/chatStore.ts` / `roomStore.ts` | Map fan-out only | 2, 5, 6, 8 |
+| `packages/fluux-sdk/src/stores/chatStore.ts` / `roomStore.ts` | Store action integration (see action comments) | 2, 5, 6, 8 |
 | `packages/fluux-sdk/src/utils/mamCatchUpUtils.ts` | MAM sizing constants | 6 |
 | `packages/fluux-sdk/src/core/mdsSideEffects.ts` | XEP-0490 publisher (comment only) | 7 |
 | `apps/fluux/src/utils/newMessagesMarker.ts` | Dead code | 8 (delete) |
@@ -1624,9 +1624,8 @@ git commit -m "docs(read-state): re-justify the surviving read-position guards"
 **Interfaces:**
 - Produces: `onMarkAsRead(state, messages: PointerSource[], kind, options:
   { windowAtLiveEdge: boolean; viewportAtLiveEdge: boolean })`.
-  The `advanceSeenTo?: PointerSource` parameter is gone. `markReadToNewest` is NOT affected — it
-  builds its pointer directly and keeps its own
-  `messages ?? meta.lastMessage ?? existing.lastMessage` fallback chain.
+  The `advanceSeenTo?: PointerSource` parameter is gone. The `markReadToNewest` contract
+  is owned by its action comments in `chatStore.ts` / `roomStore.ts`.
 
 - [ ] **Step 1: Confirm the dead code is still dead**
 
@@ -1703,58 +1702,9 @@ acceptable failure here; note it as compiler-enforced in your report).
 
 - [ ] **Step 4: Implement**
 
-```ts
-/**
- * Compute new notification state when an entity is explicitly marked as read.
- *
- * Clears unreadCount and mentionsCount. Preserves firstNewMessageId — the marker
- * has a separate lifecycle (set on activate, cleared on deactivate or explicit
- * clear).
- *
- * The pointer advances to the newest loaded message ONLY when the loaded window
- * and the current-generation viewport are both at the live edge. Otherwise the
- * counts clear but the position stays where the user actually read, so the
- * XEP-0490 publisher never speaks past what they saw.
- *
- * Picking the message from the two independent live-edge facts is this
- * function's job (read-state PR C, D8).
- */
-export function onMarkAsRead(
-  state: EntityNotificationState,
-  messages: Array<PointerSource>,
-  kind: 'chat' | 'room',
-  options: { windowAtLiveEdge: boolean; viewportAtLiveEdge: boolean }
-): EntityNotificationState {
-  const newest =
-    options.windowAtLiveEdge && options.viewportAtLiveEdge
-      ? messages[messages.length - 1]
-      : undefined
-  const seenUnchanged = newest === undefined || newest.id === state.readPointer?.messageId
-  if (state.unreadCount === 0 && state.mentionsCount === 0 && seenUnchanged) {
-    return state
-  }
-  return {
-    ...state,
-    unreadCount: 0,
-    mentionsCount: 0,
-    readPointer: newest ? makeReadPointer(newest, kind) : state.readPointer,
-  }
-}
-```
-
-In `chatStore.markAsRead`, delete the `lastMessage` and `advanceSeenTo` locals and call:
-
-```ts
-          const windowAtLiveEdge = state.windowAtLiveEdge.get(conversationId) !== false
-          const viewportAtLiveEdge =
-            currentViewportEvidence(chatViewportEvidenceKey(conversationId)) === 'at-edge'
-          const updated = notifState.onMarkAsRead(notifInput, messages, 'chat', {
-            windowAtLiveEdge,
-            viewportAtLiveEdge,
-          })
-```
-
-Apply the room twin. Leave both `markReadToNewest` implementations untouched.
+See `onMarkAsRead` and its doc comment in
+`packages/fluux-sdk/src/stores/shared/notificationState.ts` for the current pure transition,
+and the `markAsRead` implementations in `chatStore.ts` / `roomStore.ts` for store integration.
 
 - [ ] **Step 5: Delete the dead module**
 

--- a/docs/superpowers/specs/2026-07-06-muc-catchup-read-state-design.md
+++ b/docs/superpowers/specs/2026-07-06-muc-catchup-read-state-design.md
@@ -166,15 +166,16 @@ respecting `event.defaultPrevented`; no global shortcut framework):
    handlers win).
 2. Composer transient state (reply chip, edit mode, mention popup) →
    cancels it.
-3. Otherwise → **mark read**: pointer to newest, divider + pill clear,
-   re-anchor to bottom, MDS publishes. No-op if already read at bottom.
+3. Otherwise → **mark read** via `markReadToNewest`, clear divider + pill,
+   re-anchor to bottom. No-op if already read at bottom.
+   Its pointer and MDS contract is owned by the action
+   comments in `packages/fluux-sdk/src/stores/chatStore.ts` / `roomStore.ts`.
 
 Identical in 1:1 chats and rooms.
 
 **Mark-all-read:** an action in the rooms sidebar header overflow menu.
-Advances every joined room's pointer to its newest cached message,
-clears counts; publishes ride the existing MDS debounce. No keyboard
-shortcut in v1.
+Uses `roomStore.markAllRoomsRead`; see its action comment and the
+`markReadToNewest` contract above. No keyboard shortcut in v1.
 
 ## Section 4 — MDS sync (XEP-0490), both directions
 

--- a/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
+++ b/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
@@ -462,13 +462,10 @@ legacy-blob fixture that could express a backdated floor, so this is a note rath
   which has to keep passing untouched.
 - **`apps/fluux/src/utils/newMessagesMarker.ts` + its test deleted.** Still referenced only by
   its own test file.
-- **`onMarkAsRead`'s `advanceSeenTo` parameter dropped.** Both stores duplicate
-  `atLiveEdge ? lastMessage : undefined`; the decision moves into the pure function as
-  `onMarkAsRead(state, messages, kind, { windowAtLiveEdge, viewportAtLiveEdge })`. It picks
-  the newest only when the loaded slice reaches the archive tail **and** the current activation
-  generation reports that the viewport is at the live edge. Either fact missing still clears
-  the counts but preserves the pointer. For the current `markReadToNewest` contract, see
-  its action comments in `chatStore.ts` / `roomStore.ts`.
+- **`onMarkAsRead`'s `advanceSeenTo` parameter dropped.** The current live-edge and
+  reference-preservation contract is owned by its doc comment in
+  `packages/fluux-sdk/src/stores/shared/notificationState.ts`.
+  For the `markReadToNewest` contract, see its action comments in `chatStore.ts` / `roomStore.ts`.
 - **`resolveSeenStanzaId` cache-resolution is NOT in PR C** — moved to
   [Out of scope](#out-of-scope). It does not restrict a pointer writer, so it does not belong
   in this PR's thesis, and it is the only item that changes the publisher's control flow.

--- a/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
+++ b/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
@@ -467,9 +467,8 @@ legacy-blob fixture that could express a backdated floor, so this is a note rath
   `onMarkAsRead(state, messages, kind, { windowAtLiveEdge, viewportAtLiveEdge })`. It picks
   the newest only when the loaded slice reaches the archive tail **and** the current activation
   generation reports that the viewport is at the live edge. Either fact missing still clears
-  the counts but preserves the pointer. Only `markAsRead` is affected — `markReadToNewest`
-  builds its pointer directly and keeps its own
-  `messages ?? meta.lastMessage ?? existing.lastMessage` fallback chain.
+  the counts but preserves the pointer. For the current `markReadToNewest` contract, see
+  its action comments in `chatStore.ts` / `roomStore.ts`.
 - **`resolveSeenStanzaId` cache-resolution is NOT in PR C** — moved to
   [Out of scope](#out-of-scope). It does not restrict a pointer writer, so it does not belong
   in this PR's thesis, and it is the only item that changes the publisher's control flow.

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -401,9 +401,8 @@ export function setupMdsSideEffects(
           ? { stanzaId: fromSlice.stanzaId, readPointer: makeReadPointer(fromSlice, 'room') }
           : undefined
       }
-      // Non-active rooms keep no resident array (memory windowing); mark-all-read
-      // points at the newest known message, whose stanza-id survives on the
-      // lastMessage preview.
+      // Inactive rooms may have no resident array after eviction. Their lastMessage
+      // preview can still resolve a pointer naming that same row.
       const last = conversationLastMessage(jid) as RoomMessage | undefined
       return last && last.from === from && isMessageRow(last, row) &&
         hasRoomPublicationIdentity(row, last) && last.stanzaId

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2975,9 +2975,6 @@ export const chatStore = createStore<ChatState>()(
           return undefined
         }
 
-        // Snapshot the pointer identity the archive-derived count below is
-        // computed against. Re-check it at the final commit because an
-        // allowActive recount can race advanceReadPointer.
         const pointerAtCompute = metaNow.readPointer
         const unreadInputVersionAtCompute = chatUnreadInputVersion.get(conversationId) ?? 0
 
@@ -3043,19 +3040,12 @@ export const chatStore = createStore<ChatState>()(
           const meta = state.conversationMeta.get(conversationId)
           if (!meta) { defer('no-meta'); return state }
 
-          // `res.unread` was derived against `pointerAtCompute`
-          // (metaNow.readPointer, captured before the coverage-bottom and
-          // countUnreadInArchive awaits). chatRecountVersion only orders this
-          // recompute against ANOTHER recompute for the same entity — it does
-          // NOT order it against a direct writer like onMessageReceived's own
-          // live-edge convergence, which advances the pointer and commits a
-          // fresh, correct unreadCount without bumping the version. An
-          // allowActive recompute (this trigger's whole point is to run while
-          // still active) can therefore be in flight exactly when that direct
-          // write lands. Re-reading the pointer here and bailing if it moved
-          // means a result computed against a now-stale pointer never clobbers
-          // the newer, correct value. An input change queues the bounded
-          // trailing retry; a direct pointer advance launches its own recount.
+          // `res.unread` belongs to the pointer captured before the archive awaits.
+          // chatRecountVersion orders competing recounts, but direct writers can
+          // change the boundary without bumping it. Compare the whole reference:
+          // floor-to-exact resolution changes the count even when message identity
+          // stays the same. See the in-flight activation recount cases in
+          // readPointerWriters.test.ts.
           if (meta.readPointer !== pointerAtCompute) {
             defer('pointer-changed')
             return state

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2921,7 +2921,7 @@ export const chatStore = createStore<ChatState>()(
         // Every guard here still sits ABOVE the first await
         // (`resolveCoverageBottom` below), so nothing can move underneath them
         // while they run. State that moves AFTER them is caught on the far side
-        // by `recountContextDeferral()` and by the `pointerIdAtCompute`
+        // by `recountContextDeferral()` and by the `pointerAtCompute`
         // re-check at the final commit. That is where a post-await guard
         // belongs — so if an await is ever inserted above this block, the fix
         // is a re-check after THAT await, not a second copy on this side.
@@ -2978,7 +2978,7 @@ export const chatStore = createStore<ChatState>()(
         // Snapshot the pointer identity the archive-derived count below is
         // computed against. Re-check it at the final commit because an
         // allowActive recount can race advanceReadPointer.
-        const pointerIdAtCompute = metaNow.readPointer?.identity.messageId
+        const pointerAtCompute = metaNow.readPointer
         const unreadInputVersionAtCompute = chatUnreadInputVersion.get(conversationId) ?? 0
 
         const floor = computeFloor(metaNow.readPointer, metaNow.historyFloor)
@@ -3043,7 +3043,7 @@ export const chatStore = createStore<ChatState>()(
           const meta = state.conversationMeta.get(conversationId)
           if (!meta) { defer('no-meta'); return state }
 
-          // `res.unread` was derived against `pointerIdAtCompute`
+          // `res.unread` was derived against `pointerAtCompute`
           // (metaNow.readPointer, captured before the coverage-bottom and
           // countUnreadInArchive awaits). chatRecountVersion only orders this
           // recompute against ANOTHER recompute for the same entity — it does
@@ -3056,7 +3056,7 @@ export const chatStore = createStore<ChatState>()(
           // means a result computed against a now-stale pointer never clobbers
           // the newer, correct value. An input change queues the bounded
           // trailing retry; a direct pointer advance launches its own recount.
-          if (meta.readPointer?.identity.messageId !== pointerIdAtCompute) {
+          if (meta.readPointer !== pointerAtCompute) {
             defer('pointer-changed')
             return state
           }

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2024,10 +2024,23 @@ export const chatStore = createStore<ChatState>()(
           const windowAtLiveEdge = state.windowAtLiveEdge.get(conversationId) !== false
           const viewportAtLiveEdge =
             currentViewportEvidence(chatViewportEvidenceKey(conversationId)) === 'at-edge'
-          const updated = notifState.onMarkAsRead(notifInput, messages, 'chat', {
+          let updated = notifState.onMarkAsRead(notifInput, messages, 'chat', {
             windowAtLiveEdge,
             viewportAtLiveEdge,
           })
+
+          // Store recounts need an exact boundary for a proven, already-read row.
+          const newest = messages[messages.length - 1]
+          if (windowAtLiveEdge && viewportAtLiveEdge && newest && updated.readPointer
+            && hasFloorResolutionEvidence(updated.readPointer, messages, messages.length - 1, 'chat')) {
+            updated = {
+              ...updated,
+              readPointer: {
+                order: makeReadPointer(newest, 'chat').order,
+                identity: updated.readPointer.identity,
+              },
+            }
+          }
 
           // Pure function returns the same reference when nothing changed.
           if (updated === notifInput) return {}

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -87,6 +87,7 @@ import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplaye
 import {
   advance,
   deserializeReadPointer,
+  hasFloorResolutionEvidence,
   makeReadPointer,
   type ReadPointer,
 } from './shared/readPointer'
@@ -419,9 +420,10 @@ interface ChatState {
   deleteConversation: (id: string) => void
   addMessage: (msg: Message, options?: { isLiveArrival?: boolean }) => void
   markAsRead: (conversationId: string) => void
-  /** Esc / mark-all-read: advance the read pointer to the newest known
-   *  message, zero the unread count, drop the divider. The MDS publisher
-   *  picks up the pointer advance via the conversationMeta watch. */
+  /** Esc / mark-all-read: use the resident tail (lastMessage if empty) as a
+   *  candidate under `advance` / `hasFloorResolutionEvidence` in `shared/readPointer.ts`.
+   *  Zero the unread count and drop the divider. The MDS publisher observes
+   *  pointer changes through conversationMeta. */
   markReadToNewest: (conversationId: string) => void
   clearFirstNewMessageId: (conversationId: string) => void
   /** Recompute the session-only "New messages" divider from the current read pointer
@@ -1672,7 +1674,8 @@ export const chatStore = createStore<ChatState>()(
           const meta: ConversationMetadata = {
             unreadCount: conv.unreadCount,
             lastMessage: conv.lastMessage,
-            readPointer: conv.readPointer,
+            // Re-adding an entity cannot replace the store's live read position.
+            readPointer: existingMeta?.readPointer ?? conv.readPointer,
             // When this conversation entered our world. Written once, at
             // creation, and never again — a floor that moved on every re-add
             // would keep burying history the user has not seen. The persisted
@@ -2057,25 +2060,32 @@ export const chatStore = createStore<ChatState>()(
           if (!existing) return state
 
           const meta = state.conversationMeta.get(conversationId)
-          const messages = state.messages.get(conversationId)
-          const newest = messages?.[messages.length - 1] ?? meta?.lastMessage ?? existing.lastMessage
+          const messages = state.messages.get(conversationId) ?? []
+          const newest = messages[messages.length - 1] ?? meta?.lastMessage ?? existing.lastMessage
           if (!newest) return state
 
-          // Skip update if already fully read: pointer at the computed newest id,
+          const currentReadPointer = meta?.readPointer ?? existing.readPointer
+          const candidate = makeReadPointer(newest, 'chat')
+          const readPointer = currentReadPointer && (
+            currentReadPointer.identity.state === 'addressable'
+              ? hasFloorResolutionEvidence(currentReadPointer, [newest], 0, 'chat')
+              : hasFloorResolutionEvidence(currentReadPointer, messages, messages.length - 1, 'chat')
+          )
+            ? { order: candidate.order, identity: currentReadPointer.identity }
+            : advance(currentReadPointer, candidate)
+
+          // Skip update if already fully read: no pointer advancement,
           // no unread count, and no "new messages" divider to clear.
-          const currentSeenMessageId = (meta?.readPointer ?? existing.readPointer)?.identity.messageId
           const currentUnreadCount = meta?.unreadCount ?? existing.unreadCount ?? 0
           if (
-            currentSeenMessageId === newest.id &&
+            readPointer === currentReadPointer &&
             currentUnreadCount === 0 &&
             !state.firstNewMessageMarkers.has(conversationId)
           ) {
             return state
           }
 
-          const readPointer = makeReadPointer(newest, 'chat')
-
-          // Mark-all-read jumps the pointer straight to the newest message —
+          // Mark-all-read retains or advances the pointer —
           // prune the overlay now rather than leaving every noted entry to a
           // later recompute trigger.
           pruneTransient(chatTransientScopeKey(conversationId), readPointer.order)

--- a/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
+++ b/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { chatStore } from './chatStore'
+import { roomStore } from './roomStore'
+import { createMessage as createRoomMessage, createRoom } from './roomStore.testHelpers'
+import { makeReadPointer, type PointerSource, type ReadPointer } from './shared/readPointer'
+import { onMarkAsRead } from './shared/notificationState'
+import { localStorageMock } from '../core/sideEffects.testHelpers'
+import type { Conversation, Message } from '../core/types/chat'
+import * as messageCache from '../utils/messageCache'
+import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { resetDiagnosticsForTesting, subscribeDiagnostics, type UnreadRecountDiagnostic } from '../diagnostics/channel'
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+const CHAT = 'alice@example.com'
+const ROOM = 'room@conference.example.com'
+const tail = { id: 'm3', from: `${ROOM}/alice`, timestamp: new Date(3_000), stanzaId: 's3' }
+
+function heldPointer(kind: 'chat' | 'room', role: 'exact' | 'floor', timestamp = 9_000): ReadPointer {
+  const pointer = makeReadPointer({ ...tail, id: 'm9', stanzaId: 's9', timestamp: new Date(timestamp) }, kind)
+  return role === 'floor' ? { ...pointer, order: { role, timestamp } } : pointer
+}
+
+function conversation(readPointer?: ReadPointer): Conversation {
+  return { id: CHAT, name: 'Alice', type: 'chat', unreadCount: 3, readPointer }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  localStorageMock.clear()
+  chatStore.getState().reset()
+  roomStore.getState().reset()
+})
+
+afterEach(() => {
+  chatStore.getState().reset()
+  roomStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe.each(['chat', 'room'] as const)('%s mark-read writers', (kind) => {
+  describe.each(['exact', 'floor'] as const)('held %s pointer', (role) => {
+    it('onMarkAsRead is a no-op when the pointer is ahead and counts are already clear', () => {
+      const state = { unreadCount: 0, mentionsCount: 0, readPointer: heldPointer(kind, role) }
+
+      expect(onMarkAsRead(state, [tail], kind, {
+        windowAtLiveEdge: true, viewportAtLiveEdge: true,
+      })).toBe(state)
+    })
+
+    it.each([9_000, 3_000])('onMarkAsRead retains a pointer at %i when the resident tail cannot advance it', (timestamp) => {
+      const readPointer = heldPointer(kind, role, timestamp)
+      const firstNewMessageRow = { id: 'm2' }
+      const result = onMarkAsRead(
+        { unreadCount: 3, mentionsCount: 2, readPointer, firstNewMessageRow },
+        [tail],
+        kind,
+        { windowAtLiveEdge: true, viewportAtLiveEdge: true }
+      )
+
+      expect(result.readPointer).toBe(readPointer)
+      expect(result.unreadCount).toBe(0)
+      expect(result.mentionsCount).toBe(0)
+      expect(result.firstNewMessageRow).toBe(firstNewMessageRow)
+    })
+
+    it.each([9_000, 3_000])('markReadToNewest retains a pointer at %i and clears counts and divider', (timestamp) => {
+      const readPointer = heldPointer(kind, role, timestamp)
+      if (kind === 'chat') {
+        const message: Message = { ...tail, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false }
+        chatStore.getState().addConversation(conversation(readPointer))
+        chatStore.setState({
+          messages: new Map([[CHAT, [message]]]),
+          firstNewMessageMarkers: new Map([[CHAT, { id: 'm2' }]]),
+        })
+
+        chatStore.getState().markReadToNewest(CHAT)
+
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+        expect(chatStore.getState().conversations.get(CHAT)?.readPointer).toBe(readPointer)
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+        expect(chatStore.getState().firstNewMessageMarkers.has(CHAT)).toBe(false)
+        const cleared = chatStore.getState()
+        chatStore.getState().markReadToNewest(CHAT)
+        expect(chatStore.getState()).toBe(cleared)
+      } else {
+        roomStore.getState().addRoom(createRoom(ROOM, { readPointer, unreadCount: 3, mentionsCount: 2 }))
+        roomStore.setState({
+          messages: new Map([[ROOM, [{ ...createRoomMessage(tail.id, ROOM, 'alice', 'hello', false, tail.timestamp), stanzaId: tail.stanzaId }]]]),
+          firstNewMessageMarkers: new Map([[ROOM, { id: 'm2' }]]),
+        })
+
+        roomStore.getState().markReadToNewest(ROOM)
+
+        expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(readPointer)
+        expect(roomStore.getState().rooms.get(ROOM)?.readPointer).toBe(readPointer)
+        expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+        expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(0)
+        expect(roomStore.getState().firstNewMessageMarkers.has(ROOM)).toBe(false)
+        const cleared = roomStore.getState()
+        roomStore.getState().markReadToNewest(ROOM)
+        expect(roomStore.getState()).toBe(cleared)
+      }
+    })
+  })
+
+  it('onMarkAsRead still advances to a later resident tail', () => {
+    const readPointer = heldPointer(kind, 'exact', 1_000)
+    const result = onMarkAsRead(
+      { unreadCount: 3, mentionsCount: 2, readPointer },
+      [tail], kind, { windowAtLiveEdge: true, viewportAtLiveEdge: true }
+    )
+    expect(result.readPointer).toEqual(makeReadPointer(tail, kind))
+  })
+
+  it.each([
+    { windowAtLiveEdge: false, viewportAtLiveEdge: true },
+    { windowAtLiveEdge: true, viewportAtLiveEdge: false },
+  ])('onMarkAsRead requires both live-edge facts to resolve a floor: %j', (options) => {
+    const readPointer: ReadPointer = {
+      order: { role: 'floor', timestamp: 3_000 },
+      identity: makeReadPointer(tail, kind).identity,
+    }
+
+    const result = onMarkAsRead({ unreadCount: 1, mentionsCount: 1, readPointer }, [tail], kind, options)
+
+    expect(result.readPointer).toBe(readPointer)
+    expect(result.unreadCount).toBe(0)
+    expect(result.mentionsCount).toBe(0)
+  })
+
+  describe('markReadToNewest lastMessage fallback', () => {
+    const archiveIdentity = makeReadPointer(tail, kind).identity
+
+    it.each([
+      ['local identity with an archive preview', { state: 'local', messageId: tail.id }, tail, 3_000],
+      ['local identity with a local preview', { state: 'local', messageId: tail.id }, { ...tail, stanzaId: undefined }, 3_000],
+      ['different message at the same timestamp', archiveIdentity, { ...tail, id: 'm4' }, 3_000],
+      ['different archive ID', archiveIdentity, { ...tail, stanzaId: 'another-archive-id' }, 3_000],
+      ['missing archive ID', archiveIdentity, { ...tail, stanzaId: undefined }, 3_000],
+      ['preview behind the floor', archiveIdentity, tail, 4_000],
+      ['conflicting occupant', { ...archiveIdentity, occupantId: 'original' }, { ...tail, occupantId: 'replacement' }, 3_000],
+    ] as const)('retains the floor for %s without resident evidence', (_name, identity, preview, timestamp) => {
+      const readPointer: ReadPointer = { order: { role: 'floor', timestamp }, identity }
+
+      if (kind === 'chat') {
+        const message: Message = {
+          ...preview, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false,
+        }
+        chatStore.getState().addConversation({ ...conversation(readPointer), lastMessage: message })
+        expect(chatStore.getState().messages.get(CHAT) ?? []).toHaveLength(0)
+
+        chatStore.getState().markReadToNewest(CHAT)
+
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+        expect(chatStore.getState().conversations.get(CHAT)?.readPointer).toBe(readPointer)
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+      } else {
+        const message = {
+          ...createRoomMessage(preview.id, ROOM, 'alice', 'hello', false, preview.timestamp), ...preview,
+        }
+        roomStore.getState().addRoom(createRoom(ROOM, {
+          joined: true, readPointer, lastMessage: message, unreadCount: 1, mentionsCount: 1,
+        }))
+        expect(roomStore.getState().messages.get(ROOM) ?? []).toHaveLength(0)
+
+        roomStore.getState().markAllRoomsRead()
+
+        expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(readPointer)
+        expect(roomStore.getState().rooms.get(ROOM)?.readPointer).toBe(readPointer)
+        expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+        expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(0)
+      }
+    })
+  })
+
+  describe.each(['onMarkAsRead', 'markReadToNewest'] as const)('%s floor resolution', (writer) => {
+    function markRead(readPointer: ReadPointer | undefined, messages: PointerSource[], unreadCount = 1) {
+      if (writer === 'onMarkAsRead') {
+        const firstNewMessageRow = { id: 'm2' }
+        const result = onMarkAsRead(
+          { unreadCount, mentionsCount: 0, readPointer, firstNewMessageRow },
+          messages, kind, { windowAtLiveEdge: true, viewportAtLiveEdge: true }
+        )
+        expect(result.unreadCount).toBe(0)
+        expect(result.mentionsCount).toBe(0)
+        expect(result.firstNewMessageRow).toBe(firstNewMessageRow)
+        return result.readPointer
+      }
+      if (kind === 'chat') {
+        chatStore.getState().addConversation({ ...conversation(readPointer), unreadCount })
+        chatStore.setState({ messages: new Map([[CHAT, messages.map((message) => ({
+          ...message, type: 'chat' as const, conversationId: CHAT,
+          from: message.from ?? CHAT, body: 'hello', isOutgoing: false,
+        }))]]) })
+
+        chatStore.getState().markReadToNewest(CHAT)
+
+        const meta = chatStore.getState().conversationMeta.get(CHAT)!
+        expect(meta.unreadCount).toBe(0)
+        expect(chatStore.getState().conversations.get(CHAT)?.readPointer).toBe(meta.readPointer)
+        expect(chatStore.getState().firstNewMessageMarkers.has(CHAT)).toBe(false)
+        return meta.readPointer
+      }
+      roomStore.getState().addRoom(createRoom(ROOM, { readPointer, unreadCount, mentionsCount: 0 }))
+      roomStore.setState({ messages: new Map([[ROOM, messages.map((message) => ({
+        ...createRoomMessage(message.id, ROOM, 'alice', 'hello', false, message.timestamp),
+        ...message,
+      }))]]) })
+
+      roomStore.getState().markReadToNewest(ROOM)
+
+      const meta = roomStore.getState().roomMeta.get(ROOM)!
+      expect(meta.unreadCount).toBe(0)
+      expect(meta.mentionsCount).toBe(0)
+      expect(roomStore.getState().rooms.get(ROOM)?.readPointer).toBe(meta.readPointer)
+      expect(roomStore.getState().firstNewMessageMarkers.has(ROOM)).toBe(false)
+      return meta.readPointer
+    }
+
+    it.each([0, 1])('resolves the same archive message with an unread count of %i', (unreadCount) => {
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp: 3_000 },
+        identity: makeReadPointer(tail, kind).identity,
+      }
+
+      const result = markRead(readPointer, [tail], unreadCount)
+
+      expect(result?.order).toEqual(makeReadPointer(tail, kind).order)
+      expect(result?.identity).toBe(readPointer.identity)
+    })
+
+    it.each([
+      ['different message at the same timestamp', { ...tail, id: 'm4' }],
+      ['different archive ID', { ...tail, stanzaId: 'another-archive-id' }],
+      ['missing archive ID', { ...tail, stanzaId: undefined }],
+      ['same message behind the floor', { ...tail, timestamp: new Date(2_000) }],
+    ] as const)('retains the floor for %s', (_name, message) => {
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp: 3_000 },
+        identity: makeReadPointer(tail, kind).identity,
+      }
+
+      expect(markRead(readPointer, [message])).toBe(readPointer)
+    })
+
+    it('retains the floor for a conflicting occupant sharing the message and archive IDs', () => {
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp: 3_000 },
+        identity: makeReadPointer({ ...tail, occupantId: 'original' }, kind).identity,
+      }
+
+      expect(markRead(readPointer, [{ ...tail, occupantId: 'replacement' }])).toBe(readPointer)
+    })
+
+    it.each([2_000, 3_000])('preserves local identity when resolving a unique chat tail from %i', (timestamp) => {
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp },
+        identity: { state: 'local', messageId: tail.id },
+      }
+      const message = { ...tail, stanzaId: kind === 'chat' ? tail.stanzaId : undefined }
+
+      const result = markRead(readPointer, [message])
+
+      if (kind === 'chat') {
+        expect(result?.order).toEqual(makeReadPointer(message, kind).order)
+        expect(result?.identity).toBe(readPointer.identity)
+      } else if (timestamp === 3_000) {
+        expect(result).toBe(readPointer)
+      } else {
+        expect(result).toEqual(makeReadPointer(message, kind))
+      }
+    })
+
+    it('retains a local floor when the tail ID is duplicated in the resident window', () => {
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp: 3_000 },
+        identity: { state: 'local', messageId: tail.id },
+      }
+
+      expect(markRead(readPointer, [
+        { ...tail, timestamp: new Date(2_000), stanzaId: undefined }, tail,
+      ])).toBe(readPointer)
+    })
+
+    it.each(['exact', 'floor'] as const)('advances a held %s pointer to a later different message', (role) => {
+      expect(markRead(heldPointer(kind, role, 1_000), [tail])).toEqual(makeReadPointer(tail, kind))
+    })
+
+    it('initializes the pointer when none is held', () => {
+      expect(markRead(undefined, [tail])).toEqual(makeReadPointer(tail, kind))
+    })
+  })
+})
+
+describe('mark-all-read followed by a coverage-complete recount', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    _resetStorageScopeForTesting()
+    globalThis.indexedDB = new IDBFactory()
+    messageCache._resetDBForTesting()
+    resetDiagnosticsForTesting()
+  })
+
+  afterEach(() => {
+    messageCache._resetDBForTesting()
+    resetDiagnosticsForTesting()
+  })
+
+  it.each([
+    ['chat', 'resident'], ['room', 'resident'], ['chat', 'evicted'], ['room', 'evicted'],
+  ] as const)('keeps the inactive %s read after resolving its newest-message floor with its window %s', async (kind, window) => {
+    const readPointer: ReadPointer = {
+      order: { role: 'floor', timestamp: 3_000 },
+      identity: makeReadPointer(tail, kind).identity,
+    }
+    const mam = {
+      isLoading: false, error: null, hasQueried: true,
+      isHistoryComplete: true, isCaughtUpToLive: true,
+    }
+    const verdicts: UnreadRecountDiagnostic['verdict'][] = []
+    const firstRecount = new Promise<void>((resolve) => {
+      subscribeDiagnostics((event) => {
+        if (event.kind === 'unread-recount') {
+          verdicts.push(event.verdict)
+          resolve()
+        }
+      })
+    })
+
+    if (kind === 'chat') {
+      const message: Message = {
+        ...tail, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false,
+      }
+      chatStore.getState().addConversation({ ...conversation(readPointer), lastMessage: message, unreadCount: 1 })
+      expect(await messageCache.saveMessages([
+        { ...message, id: 'm1', stanzaId: 's1', timestamp: new Date(1_000) }, message,
+      ])).toBe(true)
+      chatStore.setState({
+        activeConversationId: window === 'evicted' ? CHAT : null,
+        messages: new Map([[CHAT, [message]]]),
+        mamQueryStates: new Map([[CHAT, mam]]),
+        conversationCoverage: new Map([[CHAT, { bottomId: 's1' }]]),
+      })
+      if (window === 'evicted') {
+        expect(chatStore.getState().messages.get(CHAT)).toEqual([message])
+        chatStore.getState().setActiveConversation(null)
+        expect(chatStore.getState().activeConversationId).toBeNull()
+        expect(chatStore.getState().messages.get(CHAT) ?? []).toHaveLength(0)
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.lastMessage).toBe(message)
+        expect(chatStore.getState().conversations.get(CHAT)?.lastMessage).toBe(message)
+        await firstRecount
+      } else {
+        await chatStore.getState().recomputeUnreadForConversation(CHAT)
+      }
+      expect(verdicts).toEqual([{ status: 'counted', count: 1, previousCount: 1 }])
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+
+      chatStore.getState().markReadToNewest(CHAT)
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+      await chatStore.getState().recomputeUnreadForConversation(CHAT)
+
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer?.order.role).toBe('exact')
+    } else {
+      const message = {
+        ...createRoomMessage(tail.id, ROOM, 'alice', 'hello', false, tail.timestamp),
+        stanzaId: tail.stanzaId, isMention: true,
+      }
+      roomStore.getState().addRoom(createRoom(ROOM, {
+        joined: true, readPointer, lastMessage: message, unreadCount: 1, mentionsCount: 1,
+      }), [message])
+      expect(await messageCache.saveRoomMessages([
+        { ...message, id: 'm1', stanzaId: 's1', timestamp: new Date(1_000) }, message,
+      ])).toBe(true)
+      roomStore.setState({
+        activeRoomJid: window === 'evicted' ? ROOM : null,
+        mamQueryStates: new Map([[ROOM, mam]]),
+        roomCoverage: new Map([[ROOM, { bottomId: 's1' }]]),
+      })
+      if (window === 'evicted') {
+        expect(roomStore.getState().messages.get(ROOM)).toEqual([message])
+        roomStore.getState().setActiveRoom(null)
+        expect(roomStore.getState().activeRoomJid).toBeNull()
+        expect(roomStore.getState().messages.get(ROOM) ?? []).toHaveLength(0)
+        expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage).toBe(message)
+        expect(roomStore.getState().rooms.get(ROOM)?.lastMessage).toBe(message)
+        await firstRecount
+      } else {
+        await roomStore.getState().recomputeUnreadForRoom(ROOM)
+      }
+      expect(verdicts).toEqual([{ status: 'counted', count: 1, previousCount: 1 }])
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(readPointer)
+
+      roomStore.getState().markAllRoomsRead()
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(0)
+      await roomStore.getState().recomputeUnreadForRoom(ROOM)
+
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(0)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.order.role).toBe('exact')
+    }
+    expect(verdicts).toEqual([
+      { status: 'counted', count: 1, previousCount: 1 },
+      { status: 'counted', count: 0, previousCount: 0 },
+    ])
+  })
+})
+
+describe('addConversation preserves the held read pointer on re-add', () => {
+  it.each(['older', 'newer', 'missing'] as const)('retains the held pointer with a %s supplied pointer', (candidate) => {
+    const readPointer = heldPointer('chat', 'exact')
+    chatStore.getState().addConversation(conversation(readPointer))
+    const supplied = candidate === 'missing'
+      ? undefined
+      : makeReadPointer({ ...tail, timestamp: new Date(candidate === 'older' ? 3_000 : 12_000) }, 'chat')
+
+    chatStore.getState().addConversation({ ...conversation(supplied), name: 'Alice renamed' })
+
+    expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+    expect(chatStore.getState().conversations.get(CHAT)?.readPointer).toBe(readPointer)
+    expect(chatStore.getState().conversations.get(CHAT)?.name).toBe('Alice renamed')
+  })
+
+  it('accepts the supplied pointer when the existing conversation has none', () => {
+    chatStore.getState().addConversation(conversation())
+    const readPointer = heldPointer('chat', 'exact')
+
+    chatStore.getState().addConversation(conversation(readPointer))
+
+    expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+  })
+})

--- a/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
+++ b/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
@@ -11,6 +11,12 @@ import type { Conversation, Message } from '../core/types/chat'
 import * as messageCache from '../utils/messageCache'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 import { resetDiagnosticsForTesting, subscribeDiagnostics, type UnreadRecountDiagnostic } from '../diagnostics/channel'
+import {
+  beginViewportGeneration,
+  reportViewport,
+  currentViewportGeneration,
+  _clearAllViewportEvidenceForTesting,
+} from './shared/viewportEvidence'
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
@@ -32,15 +38,58 @@ beforeEach(() => {
   localStorageMock.clear()
   chatStore.getState().reset()
   roomStore.getState().reset()
+  _clearAllViewportEvidenceForTesting()
 })
 
 afterEach(() => {
   chatStore.getState().reset()
   roomStore.getState().reset()
+  _clearAllViewportEvidenceForTesting()
   vi.useRealTimers()
 })
 
 describe.each(['chat', 'room'] as const)('%s mark-read writers', (kind) => {
+  it.each([
+    ['window away', false, 'at-edge', 's3'],
+    ['viewport away', true, 'away', 's3'],
+    ['viewport unknown', true, undefined, 's3'],
+    ['different archive ID', true, 'at-edge', 'another-archive-id'],
+  ] as const)('store markAsRead retains the held pointer with %s', (_name, windowAtLiveEdge, viewport, archiveId) => {
+    const readPointer: ReadPointer = {
+      order: { role: 'floor', timestamp: 3_000 },
+      identity: { ...makeReadPointer(tail, kind).identity, state: 'addressable', archiveId },
+    }
+    const key = { kind, entityId: kind === 'chat' ? CHAT : ROOM, accountScope: '' }
+    beginViewportGeneration(key)
+    if (viewport) reportViewport(key, currentViewportGeneration(key), viewport)
+
+    if (kind === 'chat') {
+      const message: Message = {
+        ...tail, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false,
+      }
+      chatStore.getState().addConversation(conversation(readPointer))
+      chatStore.setState({
+        messages: new Map([[CHAT, [message]]]),
+        windowAtLiveEdge: new Map([[CHAT, windowAtLiveEdge]]),
+      })
+      chatStore.getState().markAsRead(CHAT)
+
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+    } else {
+      const message = {
+        ...createRoomMessage(tail.id, ROOM, 'alice', 'hello', false, tail.timestamp), stanzaId: tail.stanzaId,
+      }
+      roomStore.getState().addRoom(createRoom(ROOM, { readPointer, unreadCount: 3, mentionsCount: 2 }), [message])
+      roomStore.setState({ windowAtLiveEdge: new Map([[ROOM, windowAtLiveEdge]]) })
+      roomStore.getState().markAsRead(ROOM)
+
+      expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer).toBe(readPointer)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.mentionsCount).toBe(0)
+    }
+  })
+
   describe.each(['exact', 'floor'] as const)('held %s pointer', (role) => {
     it('onMarkAsRead is a no-op when the pointer is ahead and counts are already clear', () => {
       const state = { unreadCount: 0, mentionsCount: 0, readPointer: heldPointer(kind, role) }
@@ -220,17 +269,19 @@ describe.each(['chat', 'room'] as const)('%s mark-read writers', (kind) => {
       return meta.readPointer
     }
 
-    it.each([0, 1])('resolves the same archive message with an unread count of %i', (unreadCount) => {
-      const readPointer: ReadPointer = {
-        order: { role: 'floor', timestamp: 3_000 },
-        identity: makeReadPointer(tail, kind).identity,
-      }
+    if (writer === 'markReadToNewest') {
+      it.each([0, 1])('resolves the same archive message with an unread count of %i', (unreadCount) => {
+        const readPointer: ReadPointer = {
+          order: { role: 'floor', timestamp: 3_000 },
+          identity: makeReadPointer(tail, kind).identity,
+        }
 
-      const result = markRead(readPointer, [tail], unreadCount)
+        const result = markRead(readPointer, [tail], unreadCount)
 
-      expect(result?.order).toEqual(makeReadPointer(tail, kind).order)
-      expect(result?.identity).toBe(readPointer.identity)
-    })
+        expect(result?.order).toEqual(makeReadPointer(tail, kind).order)
+        expect(result?.identity).toBe(readPointer.identity)
+      })
+    }
 
     it.each([
       ['different message at the same timestamp', { ...tail, id: 'm4' }],
@@ -255,7 +306,7 @@ describe.each(['chat', 'room'] as const)('%s mark-read writers', (kind) => {
       expect(markRead(readPointer, [{ ...tail, occupantId: 'replacement' }])).toBe(readPointer)
     })
 
-    it.each([2_000, 3_000])('preserves local identity when resolving a unique chat tail from %i', (timestamp) => {
+    it.each([2_000, 3_000])('preserves local identity when marking a unique chat tail read from %i', (timestamp) => {
       const readPointer: ReadPointer = {
         order: { role: 'floor', timestamp },
         identity: { state: 'local', messageId: tail.id },
@@ -265,7 +316,11 @@ describe.each(['chat', 'room'] as const)('%s mark-read writers', (kind) => {
       const result = markRead(readPointer, [message])
 
       if (kind === 'chat') {
-        expect(result?.order).toEqual(makeReadPointer(message, kind).order)
+        if (writer === 'onMarkAsRead' && timestamp === 3_000) {
+          expect(result).toBe(readPointer)
+        } else {
+          expect(result?.order).toEqual(makeReadPointer(message, kind).order)
+        }
         expect(result?.identity).toBe(readPointer.identity)
       } else if (timestamp === 3_000) {
         expect(result).toBe(readPointer)
@@ -307,6 +362,73 @@ describe('mark-all-read followed by a coverage-complete recount', () => {
   afterEach(() => {
     messageCache._resetDBForTesting()
     resetDiagnosticsForTesting()
+  })
+
+  it.each([
+    ['chat', 0], ['chat', 1], ['room', 0], ['room', 1],
+  ] as const)('store markAsRead keeps the %s read through a complete recount from %i unread', async (kind, unreadCount) => {
+    const readPointer: ReadPointer = {
+      order: { role: 'floor', timestamp: 3_000 },
+      identity: makeReadPointer(tail, kind).identity,
+    }
+    const mam = {
+      isLoading: false, error: null, hasQueried: true,
+      isHistoryComplete: true, isCaughtUpToLive: true,
+    }
+    const verdicts: UnreadRecountDiagnostic['verdict'][] = []
+    subscribeDiagnostics((event) => {
+      if (event.kind === 'unread-recount') verdicts.push(event.verdict)
+    })
+    const key = { kind, entityId: kind === 'chat' ? CHAT : ROOM, accountScope: '' }
+    beginViewportGeneration(key)
+    reportViewport(key, currentViewportGeneration(key), 'at-edge')
+
+    if (kind === 'chat') {
+      const message: Message = {
+        ...tail, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false,
+      }
+      chatStore.getState().addConversation({
+        ...conversation(readPointer), unreadCount, lastMessage: message,
+      })
+      expect(await messageCache.saveMessages([
+        { ...message, id: 'm1', stanzaId: 's1', timestamp: new Date(1_000) }, message,
+      ])).toBe(true)
+      chatStore.setState({
+        messages: new Map([[CHAT, [message]]]),
+        mamQueryStates: new Map([[CHAT, mam]]),
+        conversationCoverage: new Map([[CHAT, { bottomId: 's1' }]]),
+      })
+
+      chatStore.getState().markAsRead(CHAT)
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+
+      await chatStore.getState().recomputeUnreadForConversation(CHAT)
+
+      expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+    } else {
+      const message = {
+        ...createRoomMessage(tail.id, ROOM, 'alice', 'hello', false, tail.timestamp),
+        stanzaId: tail.stanzaId,
+      }
+      roomStore.getState().addRoom(createRoom(ROOM, {
+        joined: true, readPointer, lastMessage: message, unreadCount, mentionsCount: 0,
+      }), [message])
+      expect(await messageCache.saveRoomMessages([
+        { ...message, id: 'm1', stanzaId: 's1', timestamp: new Date(1_000) }, message,
+      ])).toBe(true)
+      roomStore.setState({
+        mamQueryStates: new Map([[ROOM, mam]]),
+        roomCoverage: new Map([[ROOM, { bottomId: 's1' }]]),
+      })
+
+      roomStore.getState().markAsRead(ROOM)
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+
+      await roomStore.getState().recomputeUnreadForRoom(ROOM)
+
+      expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+    }
+    expect(verdicts).toEqual([{ status: 'counted', count: 0, previousCount: 0 }])
   })
 
   it.each([

--- a/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
+++ b/packages/fluux-sdk/src/stores/readPointerWriters.test.ts
@@ -364,6 +364,80 @@ describe('mark-all-read followed by a coverage-complete recount', () => {
     resetDiagnosticsForTesting()
   })
 
+  it.each(['markAsRead', 'markReadToNewest'] as const)(
+    'rejects an in-flight activation recount after %s resolves the same-message floor',
+    async (writer) => {
+      const message: Message = {
+        ...tail, type: 'chat', conversationId: CHAT, from: CHAT, body: 'hello', isOutgoing: false,
+      }
+      const readPointer: ReadPointer = {
+        order: { role: 'floor', timestamp: 3_000 },
+        identity: makeReadPointer(message, 'chat').identity,
+      }
+      chatStore.getState().addConversation({
+        ...conversation(readPointer), unreadCount: 1, lastMessage: message,
+      })
+      expect(await messageCache.saveMessages([
+        { ...message, id: 'm1', stanzaId: 's1', timestamp: new Date(1_000) }, message,
+      ])).toBe(true)
+      chatStore.setState({
+        messages: new Map([[CHAT, [message]]]),
+        mamQueryStates: new Map([[CHAT, {
+          isLoading: false, error: null, hasQueried: true,
+          isHistoryComplete: true, isCaughtUpToLive: true,
+        }]]),
+        conversationCoverage: new Map([[CHAT, { bottomId: 's1' }]]),
+        windowAtLiveEdge: new Map([[CHAT, true]]),
+      })
+
+      const countUnreadInArchive = messageCache.countUnreadInArchive
+      let staleCount: Awaited<ReturnType<typeof countUnreadInArchive>> | undefined
+      let releaseCount!: () => void
+      const countGate = new Promise<void>((resolve) => { releaseCount = resolve })
+      const countSpy = vi.spyOn(messageCache, 'countUnreadInArchive').mockImplementationOnce(async (...args) => {
+        const result = await countUnreadInArchive(...args)
+        staleCount = result
+        await countGate
+        return result
+      })
+      const verdicts: UnreadRecountDiagnostic['verdict'][] = []
+      const recountFinished = new Promise<void>((resolve) => {
+        subscribeDiagnostics((event) => {
+          if (event.kind === 'unread-recount') {
+            verdicts.push(event.verdict)
+            resolve()
+          }
+        })
+      })
+
+      try {
+        chatStore.getState().setActiveConversation(CHAT)
+        await vi.waitFor(() => expect(staleCount).toEqual({ unread: 1 }))
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toBe(readPointer)
+        const key = { kind: 'chat' as const, entityId: CHAT, accountScope: '' }
+        reportViewport(key, currentViewportGeneration(key), 'at-edge')
+
+        chatStore.getState()[writer](CHAT)
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.readPointer).toEqual({
+          order: makeReadPointer(message, 'chat').order,
+          identity: readPointer.identity,
+        })
+        expect(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+
+        releaseCount()
+        await recountFinished
+
+        expect.soft(chatStore.getState().conversationMeta.get(CHAT)?.unreadCount).toBe(0)
+        expect.soft(chatStore.getState().conversations.get(CHAT)?.unreadCount).toBe(0)
+        expect.soft(verdicts).toEqual([{ status: 'deferred', reason: 'pointer-changed' }])
+      } finally {
+        releaseCount()
+        await recountFinished
+        countSpy.mockRestore()
+      }
+    },
+  )
+
   it.each([
     ['chat', 0], ['chat', 1], ['room', 0], ['room', 1],
   ] as const)('store markAsRead keeps the %s read through a complete recount from %i unread', async (kind, unreadCount) => {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2086,9 +2086,9 @@ describe('roomStore', () => {
     it('advances the pointer to the newest message, zeroes counts, clears the divider', () => {
       const roomJid = 'test@conference.example.com'
       const messages = [
-        createMessage('m1', roomJid, 'alice', 'first'),
-        createMessage('m2', roomJid, 'alice', 'second'),
-        createMessage('m3', roomJid, 'alice', 'third'),
+        createMessage('m1', roomJid, 'alice', 'first', false, new Date(1_000)),
+        createMessage('m2', roomJid, 'alice', 'second', false, new Date(2_000)),
+        createMessage('m3', roomJid, 'alice', 'third', false, new Date(3_000)),
       ]
       roomStore.getState().addRoom(createRoom(roomJid, {
         joined: true,
@@ -2115,9 +2115,9 @@ describe('roomStore', () => {
     it('is a no-op (same Map references) when the room is already read to newest', () => {
       const roomJid = 'test@conference.example.com'
       const messages = [
-        createMessage('m1', roomJid, 'alice', 'first'),
-        createMessage('m2', roomJid, 'alice', 'second'),
-        createMessage('m3', roomJid, 'alice', 'third'),
+        createMessage('m1', roomJid, 'alice', 'first', false, new Date(1_000)),
+        createMessage('m2', roomJid, 'alice', 'second', false, new Date(2_000)),
+        createMessage('m3', roomJid, 'alice', 'third', false, new Date(3_000)),
       ]
       roomStore.getState().addRoom(createRoom(roomJid, {
         joined: true,

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -3012,10 +3012,23 @@ export const roomStore = createStore<RoomState>()(
       const windowAtLiveEdge = state.windowAtLiveEdge.get(roomJid) !== false
       const viewportAtLiveEdge =
         currentViewportEvidence(roomViewportEvidenceKey(roomJid)) === 'at-edge'
-      const updated = notifState.onMarkAsRead(notifInput, messages, 'room', {
+      let updated = notifState.onMarkAsRead(notifInput, messages, 'room', {
         windowAtLiveEdge,
         viewportAtLiveEdge,
       })
+
+      // Store recounts need an exact boundary for a proven, already-read row.
+      const newest = messages[messages.length - 1]
+      if (windowAtLiveEdge && viewportAtLiveEdge && newest && updated.readPointer
+        && hasFloorResolutionEvidence(updated.readPointer, messages, messages.length - 1, 'room')) {
+        updated = {
+          ...updated,
+          readPointer: {
+            order: makeReadPointer(newest, 'room').order,
+            identity: updated.readPointer.identity,
+          },
+        }
+      }
 
       // Skip update if no change
       if (updated === notifInput) return {}

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -21,7 +21,6 @@ import {
   findMessageRowIndex,
   identityKeys,
   mergeableOccupantCandidates,
-  isMessageRow,
   resolveMessageReference,
   messageReferences,
   correctionReferences,
@@ -98,9 +97,9 @@ import { addPendingRetraction, applyPendingRetractions, removePendingRetraction,
 import { retractRoomMessageInStorage, retractUnresidentRoomTarget } from './shared/retractionStorage'
 import { createRemoteDividerAdvanceTracker } from './shared/dividerAdvance'
 import { locallyPublishedDisplayed } from '../core/localMdsPublishes'
-import { isAhead, pointerRowRef, rowRefOfPointer } from './shared/readPointer'
+import { isAhead, rowRefOfPointer } from './shared/readPointer'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
-import { advance, makeReadPointer } from './shared/readPointer'
+import { advance, hasFloorResolutionEvidence, makeReadPointer } from './shared/readPointer'
 import { loadRoomReadState, saveRoomReadState, clearRoomReadState, _clearAllRoomReadStateForTesting, type RoomReadState } from './shared/readStateStorage'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
@@ -1085,9 +1084,10 @@ export interface RoomState {
    */
   getRoomLastTimestamp: (roomJid: string) => number | undefined
   markAsRead: (roomJid: string) => void
-  /** Esc / mark-all-read: advance the read pointer to the newest known
-   *  message, zero the counts, drop the divider. The MDS publisher picks up
-   *  the pointer advance via the roomMeta watch. */
+  /** Esc / mark-all-read: use the resident tail (lastMessage if empty) as a
+   *  candidate under `advance` / `hasFloorResolutionEvidence` in `shared/readPointer.ts`.
+   *  Zero the counts and drop the divider. The MDS publisher observes
+   *  pointer changes through roomMeta. */
   markReadToNewest: (roomJid: string) => void
   /** Bulk vacation-recovery: markReadToNewest for every joined room with unread. */
   markAllRoomsRead: () => void
@@ -3058,15 +3058,22 @@ export const roomStore = createStore<RoomState>()(
       const newest = resident[resident.length - 1] ?? existing.lastMessage
       if (!newest) return state
 
-      // Skip update if already fully read: pointer at the computed newest id,
+      // Skip update if already fully read: no pointer advancement,
       // no unread/mentions, and no "new messages" divider to clear.
       const meta = state.roomMeta.get(roomJid)
       const currentReadPointer = meta?.readPointer ?? existing.readPointer
+      const candidate = makeReadPointer(newest, 'room')
+      const readPointer = currentReadPointer && (
+        currentReadPointer.identity.state === 'addressable'
+          ? hasFloorResolutionEvidence(currentReadPointer, [newest], 0, 'room')
+          : hasFloorResolutionEvidence(currentReadPointer, resident, resident.length - 1, 'room')
+      )
+        ? { order: candidate.order, identity: currentReadPointer.identity }
+        : advance(currentReadPointer, candidate)
       const currentUnreadCount = meta?.unreadCount ?? existing.unreadCount
       const currentMentionsCount = meta?.mentionsCount ?? existing.mentionsCount
       if (
-        currentReadPointer !== undefined &&
-        isMessageRow(newest, pointerRowRef(currentReadPointer)) &&
+        readPointer === currentReadPointer &&
         currentUnreadCount === 0 &&
         currentMentionsCount === 0 &&
         !state.firstNewMessageMarkers.has(roomJid)
@@ -3075,12 +3082,12 @@ export const roomStore = createStore<RoomState>()(
       }
 
       const read = {
-        readPointer: makeReadPointer(newest, 'room'),
+        readPointer,
         unreadCount: 0,
         mentionsCount: 0,
       }
 
-      // Mark-all-read jumps the pointer straight to the newest message —
+      // Mark-all-read retains or advances the pointer —
       // prune the overlay now rather than leaving every noted entry to a
       // later recompute trigger.
       pruneTransient(roomTransientScopeKey(roomJid), read.readPointer.order)

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -403,7 +403,9 @@ export function onMarkAsRead(
   let readPointer = state.readPointer
   if (newest) {
     const candidate = makeReadPointer(newest, kind)
-    readPointer = state.readPointer && hasFloorResolutionEvidence(state.readPointer, messages, messages.length - 1, kind)
+    readPointer = state.readPointer
+      && mayAdvanceTo(candidate.order, state.readPointer.order)
+      && hasFloorResolutionEvidence(state.readPointer, messages, messages.length - 1, kind)
       ? { order: candidate.order, identity: state.readPointer.identity }
       : advance(state.readPointer, candidate)
   }

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -381,11 +381,12 @@ export function onDeactivate(
  * has a separate lifecycle (set on activate, cleared on deactivate or explicit
  * clear).
  *
- * The pointer advances to the newest loaded message ONLY when the loaded window
+ * The newest loaded message is a pointer candidate ONLY when the loaded window
  * and the current-generation viewport are both at the live edge. Otherwise the
  * counts clear but the position stays where the user actually read, so the
  * XEP-0490 publisher never speaks past what they saw.
  *
+ * Candidate handling follows {@link advance} and {@link hasFloorResolutionEvidence}.
  * Picking the message from the two independent live-edge facts is this
  * function's job.
  */
@@ -399,9 +400,14 @@ export function onMarkAsRead(
     options.windowAtLiveEdge && options.viewportAtLiveEdge
       ? messages[messages.length - 1]
       : undefined
-  const seenUnchanged =
-    newest === undefined ||
-    (state.readPointer !== undefined && isMessageRow(newest, pointerRowRef(state.readPointer)))
+  let readPointer = state.readPointer
+  if (newest) {
+    const candidate = makeReadPointer(newest, kind)
+    readPointer = state.readPointer && hasFloorResolutionEvidence(state.readPointer, messages, messages.length - 1, kind)
+      ? { order: candidate.order, identity: state.readPointer.identity }
+      : advance(state.readPointer, candidate)
+  }
+  const seenUnchanged = readPointer === state.readPointer
   if (state.unreadCount === 0 && state.mentionsCount === 0 && seenUnchanged) {
     return state
   }
@@ -409,7 +415,7 @@ export function onMarkAsRead(
     ...state,
     unreadCount: 0,
     mentionsCount: 0,
-    readPointer: newest ? makeReadPointer(newest, kind) : state.readPointer,
+    readPointer,
   }
 }
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -387,8 +387,9 @@ export function onDeactivate(
  * XEP-0490 publisher never speaks past what they saw.
  *
  * Candidate handling follows {@link advance} and {@link hasFloorResolutionEvidence}.
- * Picking the message from the two independent live-edge facts is this
- * function's job.
+ * Floor resolution here also requires {@link mayAdvanceTo}. Without advancement,
+ * the pointer keeps its reference, and zero counts preserve the state reference.
+ * Same-position floor resolution belongs to the stores' `markAsRead` callers.
  */
 export function onMarkAsRead(
   state: EntityNotificationState,


### PR DESCRIPTION
Hardens the remaining read-pointer write hazards in `onMarkAsRead`, chat/room `markReadToNewest`, and `addConversation` re-adds. This is latent-defect hardening with no established incident from the original unguarded writers. `acceptStranger` has called `addConversation` without an existence check since March, so not every caller is protected.

Equal-position floor resolution now belongs to the two `markAsRead` store callers, rather than the pure `onMarkAsRead` transition. The pure function must return the same reference when nothing advances; the stores persist the pointer and therefore ensure that marking read survives a complete archive recount. Chat recounts also reject an in-flight result when the captured pointer reference changes, matching the existing room guard. The other writers retain their resolution rules, including the archive-identified `lastMessage` fallback after eviction.

Five expectations now test recount and local-reference behavior instead of pointer shape; each was independently proved capable of failing under mutation.

This does not redesign read-pointer ownership or revisit the published guard in https://github.com/processone/fluux-messenger/pull/1382. The blocked `pendingRemoteDisplayedStanzaId` condition remains separately reported, without a local workaround.

One complete local test run showed a timeout in the unchanged
recountDeferralTally.test.ts. It did not reproduce when the complete file
ran in isolation on either base or head. The cause remains unestablished;
neither host load nor a pre-existing failure has been demonstrated.

The first validation run reached its 30-minute test-agent limit before
live browser validation completed. Review and focused checks passed;
no unexpected read-pointer assertion failure was reported.

The initial branch was reconstructed from the preserved patch for run 01M2661KR80MHBT4V8DDW46DVK after that run's history could not be recovered. Its original commits were 4b0b1c7d4600d6e1a313685245fa0f911fcb86b9, 36e9b11953c6b9805399be467686b8eb3bb52adb, 1fdb3fe48854271679ca2608c28f84b83dfc6f63, and b27d5eef352c962b42fbc812c340e76f4e284180.

The current validated head `822af5be4378316cbac4b0aa8a789f66d076b135` was recovered through the supported custody-return operation from run `01M27ZJ5J2MKNVV9B22Y6RKA1J`, on its upstream base `c372c80c5657cd022c57aececdf05b60992affc2`. Both the commit and its tree `e7c6006647b07b9f1cee62736531728b8d82d443` match the recorded validated result exactly; the recovery reused the original validated commits.

The existing branch was rewritten after the maintainer explicitly authorized that update. The push used a lease pinned to its previous head `f8d5863077557319aa257757b0df531091bf7062`.
