### PR TITLE
test(e2e): drop the dead WebKit prepend-drift tolerance

### DIFF
--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -57,12 +57,6 @@ const FRAME_SAMPLE_MS = 500   // window for scrollTop stability sampling after p
 // without the loop being able to catch it. 20px covers this measurement noise while
 // still catching real regressions (e.g. oscillations produce 100px+ swings).
 const PREPEND_DRIFT_PX = 20  // acceptable anchor-position drift after prepend (px)
-// WebKit resolves row heights on a slower, coarser measurement cadence than Chromium, so its
-// settled residual after a prepend restore runs higher (~28-40px observed on CI) even once
-// scrollTop and the virtualizer offset have both stopped moving. Give WebKit a wider bound —
-// still an order of magnitude below a real mis-anchor (a dropped batch is ~2880px) and below the
-// LARGE_JUMP_PX oscillation gate, so genuine regressions are still caught on both engines.
-const PREPEND_DRIFT_WEBKIT_PX = 48
 const LARGE_JUMP_PX = 150     // frame-to-frame jump threshold signalling instability
 const AT_BOTTOM_OK_PX = 150   // distance-from-bottom still considered "stuck to bottom"
 const FAB_THRESHOLD_PX = 300
@@ -667,14 +661,11 @@ test.describe('Virtualization scroll invariants', () => {
 
     // Assertion B: the anchor row's on-screen position holds within tolerance.
     // Wait for the restore to fully settle, then read the anchor's DOM offset (see
-    // waitForAnchorSettled for why we measure the DOM, not the virtualizer offset map). WebKit
-    // resolves row heights on a coarser cadence, so its settled residual runs higher than
-    // Chromium's — the tolerance is engine-specific (see PREPEND_DRIFT_WEBKIT_PX).
-    const driftLimit = test.info().project.name === 'webkit' ? PREPEND_DRIFT_WEBKIT_PX : PREPEND_DRIFT_PX
+    // waitForAnchorSettled for why we measure the DOM, not the virtualizer offset map).
     const anchorOffsetAfter = await waitForAnchorSettled(page, anchorId)
     expect(anchorOffsetAfter, `anchor "${anchorId}" not found in DOM after prepend — windowed out (drift)`).not.toBeNull()
     const drift = Math.abs(anchorOffsetAfter! - anchorOffsetBefore)
-    expect(drift, `anchor drifted by ${drift}px (limit: ${driftLimit}px, before=${anchorOffsetBefore}, after=${anchorOffsetAfter})`).toBeLessThanOrEqual(driftLimit)
+    expect(drift, `anchor drifted by ${drift}px (limit: ${PREPEND_DRIFT_PX}px, before=${anchorOffsetBefore}, after=${anchorOffsetAfter})`).toBeLessThanOrEqual(PREPEND_DRIFT_PX)
   })
 
   // ── 2: No runaway pagination ───────────────────────────────────────────────


### PR DESCRIPTION
invariant-1 chose its prepend-drift limit with `test.info().project.name === 'webkit'`, but `playwright.e2e.config.ts` names projects `${suite}-${engine}` (`scroll-webkit`, `composer-webkit`, …). The comparison never matched, so `PREPEND_DRIFT_WEBKIT_PX` (48px) was never applied: WebKit has always been held to the 20px `PREPEND_DRIFT_PX`, and passes there.

This removes the constant, its comment claiming a 28–40px WebKit residual, and the branch, and applies `PREPEND_DRIFT_PX` on every engine. Keeping the dead tolerance meant the bound would silently widen to 48px if anyone ever corrected the name check.

Twenty repeats of `scroll-webkit` under CPU load measured 0px anchor drift after a ~3800px prepend.