### PR TITLE
perf(search): index room retraction identities

### DIFF
--- a/packages/fluux-sdk/src/utils/messageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/messageIdentity.ts
@@ -50,9 +50,11 @@
  *
  * ## Persisted shapes
  *
- * `identityKeys` for room scope and {@link searchDocumentKey} are written to
- * IndexedDB. Their exact strings — separators included — are a stored shape:
- * changing one orphans every existing row or document. Locked by tests. A room
+ * Room-scoped {@link identityKeys} are persisted in both message-cache rows and
+ * search documents; changing their spelling requires migrating both databases.
+ * {@link searchDocumentKey} is also persisted. Their exact strings — separators
+ * included — are a stored shape: changing one without a migration orphans existing
+ * rows or documents. Locked by tests. A room
  * fallback {@link canonicalKey} additionally carries the occupant-id when one is
  * known, allowing future nick-reassignment collisions to coexist. Existing rows
  * keep their legacy keys; no migration can recover content already overwritten,
@@ -177,8 +179,7 @@ function fallbackKey(scope: IdentityScope, m: Pick<IdentityFields, 'from' | 'id'
 /**
  * Every identity key the message carries, most-specific first. For matching.
  *
- * Room keys are a PERSISTED shape (`StoredRoomMessage.identityKeys`); do not
- * change their spelling without a migration.
+ * For durable-key compatibility, see the module's Persisted shapes contract.
  *
  * THE SPELLING IS ALSO LOAD-BEARING IN MEMORY, which is not visible from here.
  * The transient unread overlay indexes its entries by these aliases and resolves

--- a/packages/fluux-sdk/src/utils/searchIndex.identityLookups.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.identityLookups.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory, IDBIndex, IDBObjectStore } from 'fake-indexeddb'
+import { openDB } from 'idb'
+import type { RoomMessage } from '../core/types'
+import { identityKeys, roomScope } from './messageIdentity'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
+import { _resetDBForTesting as resetMessageCache } from './messageCache'
+import {
+  _resetDBForTesting, closeSearchIndex, indexMessages, initSearchIndex, removeMessage, search,
+} from './searchIndex'
+
+const SCOPE = 'identity-probe@example.test'
+const ROOM = 'cleanup@conference.example.test'
+const DB_NAME = `fluux-search-index:${SCOPE}`
+
+function message(id: string, overrides: Partial<RoomMessage> = {}): RoomMessage {
+  return {
+    type: 'groupchat', id, stanzaId: `archive-${id}`, roomJid: ROOM,
+    from: `${ROOM}/alice`, nick: 'alice', occupantId: 'alice-one',
+    body: 'cleanup fixture', timestamp: new Date(1_700_000_000_000), isOutgoing: false,
+    ...overrides,
+  }
+}
+
+function document(row: RoomMessage) {
+  return {
+    indexId: `room:${row.stanzaId ?? `${row.roomJid}:${row.from}:${row.id}`}`,
+    messageId: row.id, conversationId: row.roomJid, from: row.from, nick: row.nick,
+    timestamp: row.timestamp.getTime(), isRoom: true, body: row.body, tokens: ['cleanup'],
+    ...(row.stanzaId && { stanzaId: row.stanzaId }),
+    ...(row.originId && { originId: row.originId }),
+    ...(row.occupantId && { occupantId: row.occupantId }),
+  }
+}
+
+/** An actual old database: no derived keys or identity index exist yet. */
+async function seedLegacy(rows: RoomMessage[], version = 2) {
+  const db = await openDB(DB_NAME, version, {
+    upgrade(db) {
+      db.createObjectStore('search-tokens', { keyPath: 'token' })
+      const docs = db.createObjectStore('search-docs', { keyPath: 'indexId' })
+      docs.createIndex('timestamp', 'timestamp')
+      docs.createIndex('conversationId', 'conversationId')
+      db.createObjectStore('search-meta', { keyPath: 'key' })
+    },
+  })
+  const tx = db.transaction(['search-docs', 'search-tokens', 'search-meta'], 'readwrite')
+  for (const row of rows) await tx.objectStore('search-docs').put(document(row))
+  await tx.objectStore('search-tokens').put({ token: 'cleanup', postings: rows.map(row => document(row).indexId) })
+  await tx.objectStore('search-meta').put({ key: 'fixture-marker', value: 'preserved' })
+  await tx.done
+  db.close()
+}
+
+function observeDocumentReads() {
+  const fetched: string[] = []
+  const getAll = IDBIndex.prototype.getAll
+  vi.spyOn(IDBIndex.prototype, 'getAll').mockImplementation(function (this: IDBIndex, ...args) {
+    const request = getAll.apply(this, args)
+    if (this.objectStore.name === 'search-docs') {
+      request.addEventListener('success', () => {
+        fetched.push(...request.result.map((doc: { indexId: string }) => doc.indexId))
+      })
+    }
+    return request
+  })
+  const gets = vi.spyOn(IDBObjectStore.prototype, 'get')
+  return { fetched, gets }
+}
+
+describe('indexed room retraction identities', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    globalThis.indexedDB = new IDBFactory()
+    _resetDBForTesting()
+    resetMessageCache()
+    setStorageScopeJid(SCOPE)
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await closeSearchIndex()
+  })
+
+  it('reads only matching copies from a freshly written room index', async () => {
+    const target = message('target', { originId: 'shared-origin' })
+    const copy = message('copy', { originId: target.originId })
+    const unrelated = Array.from({ length: 40 }, (_, i) => message(`unrelated-${i}`))
+    await indexMessages([target, copy, ...unrelated])
+    const { fetched, gets } = observeDocumentReads()
+
+    await removeMessage(target, SCOPE, {
+      identityKeys: identityKeys(roomScope(ROOM), target), ids: [target.id, copy.id],
+    })
+
+    expect(new Set(fetched)).toEqual(new Set([document(copy).indexId]))
+    expect(gets.mock.calls.map(([key]) => key)).not.toContain(document(unrelated[0]).indexId)
+    expect((await search('cleanup')).map(row => row.messageId).sort()).toEqual(unrelated.map(row => row.id).sort())
+  })
+
+  it.each([1, 2])('migrates a v%i index without losing legacy aliases or unrelated records', async (version) => {
+    const target = message('survivor', { originId: 'shared-origin' })
+    const originCopy = message('absorbed', { originId: target.originId })
+    const fallbackCopy = message('old-client-id', { stanzaId: undefined })
+    const ambiguous = message('ambiguous', { stanzaId: undefined, occupantId: undefined })
+    const otherOccupant = message('other-occupant', { originId: target.originId, occupantId: 'alice-two' })
+    const otherRoom = message('other-room', { roomJid: 'other@conference.example.test', originId: target.originId })
+    const unrelated = Array.from({ length: 270 }, (_, i) => message(`unrelated-${i}`))
+    const rows = [originCopy, fallbackCopy, ambiguous, otherOccupant, otherRoom, ...unrelated]
+    await seedLegacy(rows, version)
+    const migrationReads = vi.spyOn(IDBObjectStore.prototype, 'getAll')
+    await initSearchIndex(SCOPE)
+    expect(migrationReads.mock.calls.length).toBeGreaterThan(1)
+    expect(migrationReads.mock.calls.every(([, count]) => typeof count === 'number' && count <= 256)).toBe(true)
+    migrationReads.mockRestore()
+    const db = await openDB(DB_NAME)
+    try {
+      expect(db.version).toBe(3)
+      expect(await db.count('search-docs')).toBe(rows.length)
+      expect(await db.getAll('search-docs')).toEqual(expect.arrayContaining(
+        rows.map(row => expect.objectContaining(document(row))),
+      ))
+      expect(await db.get('search-meta', 'fixture-marker')).toEqual({ key: 'fixture-marker', value: 'preserved' })
+      // Restart before removal: durable aliases, not an in-memory ownership map, must suffice.
+      await closeSearchIndex()
+      _resetDBForTesting()
+      await initSearchIndex(SCOPE)
+      const { fetched } = observeDocumentReads()
+      const keys = [target, originCopy, fallbackCopy, ambiguous].flatMap(row => identityKeys(roomScope(ROOM), row))
+      await removeMessage(target, SCOPE, { identityKeys: keys, ids: rows.map(row => row.id) })
+
+      expect(new Set(fetched)).toEqual(new Set([originCopy, fallbackCopy, ambiguous, otherOccupant].map(row => document(row).indexId)))
+      const expected = [ambiguous, otherOccupant, otherRoom, ...unrelated].map(row => row.id).sort()
+      expect((await db.getAll('search-docs')).map(row => row.messageId).sort()).toEqual(expected)
+      expect((await db.get('search-tokens', 'cleanup')).postings.sort()).toEqual(
+        [ambiguous, otherOccupant, otherRoom, ...unrelated].map(row => document(row).indexId).sort(),
+      )
+    } finally { db.close() }
+  })
+
+  it('aborts the upgrade atomically if an identity backfill write fails', async () => {
+    const rows = [message('first'), message('second')]
+    await seedLegacy(rows)
+    const put = IDBObjectStore.prototype.put
+    let writes = 0
+    const fault = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+      if (this.name === 'search-docs' && ++writes === 2) throw new Error('injected migration failure')
+      return put.apply(this, args)
+    })
+    await expect(initSearchIndex(SCOPE)).rejects.toMatchObject({ name: 'AbortError' })
+    fault.mockRestore()
+    await closeSearchIndex()
+    const old = await openDB(DB_NAME, 2)
+    try {
+      expect(await old.getAll('search-docs')).toEqual(rows.map(document))
+      expect(old.transaction('search-docs').store.indexNames.contains('identityKeys')).toBe(false)
+    } finally { old.close() }
+    await initSearchIndex(SCOPE)
+    const upgraded = await openDB(DB_NAME)
+    try {
+      expect(upgraded.version).toBe(3)
+      expect(await upgraded.count('search-docs')).toBe(2)
+    } finally { upgraded.close() }
+  })
+})

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -533,7 +533,7 @@ describe('searchIndex', () => {
       expect(await search('strong ownership')).toHaveLength(1)
     })
 
-    it('bounds room identity-closure candidates to the room index', async () => {
+    it('bounds room identity-closure candidates to matching aliases', async () => {
       const roomJid = 'team@conference.example.com'
       const target = createRoomMessage(roomJid, {
         id: 'target-id',
@@ -543,6 +543,11 @@ describe('searchIndex', () => {
       })
       await indexMessages([
         target,
+        createRoomMessage(roomJid, {
+          id: 'same-room-other-id',
+          stanzaId: 'SAME-ROOM-OTHER-ARCHIVE',
+          body: 'unrelated same-room document',
+        }),
         createRoomMessage('other@conference.example.com', {
           id: 'other-id',
           stanzaId: 'OTHER-ARCHIVE',
@@ -560,9 +565,9 @@ describe('searchIndex', () => {
       })
 
       expect(storeGetAll).not.toHaveBeenCalled()
-      expect(indexGetAll).toHaveBeenCalledWith(roomJid)
+      expect(indexGetAll).not.toHaveBeenCalledWith(roomJid)
       expect(await search('bounded target')).toEqual([])
-      expect(await search('unrelated')).toHaveLength(2)
+      expect(await search('unrelated')).toHaveLength(3)
     })
 
     it('should keep a chat document owned by another conversation', async () => {

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -1,12 +1,7 @@
 /**
  * Full-text search index using a custom inverted index stored in IndexedDB.
  *
- * Zero runtime memory overhead — the index lives entirely in IndexedDB.
- * Queries do O(k) IDB lookups (k = number of query terms) instead of O(n) cursor scans.
- *
- * Two object stores:
- * - `search-tokens`: inverted index (token → posting list of indexIds)
- * - `search-docs`: forward index (indexId → document metadata + tokens for deletion)
+ * Token posting lists and document metadata are loaded on demand from IndexedDB.
  *
  * Uses the same scoped-DB pattern as messageCache.ts.
  *
@@ -37,7 +32,7 @@ import {
 } from './messageIdentity'
 
 const DB_NAME = 'fluux-search-index'
-const DB_VERSION = 2
+const DB_VERSION = 3
 const TOKENS_STORE = 'search-tokens'
 const DOCS_STORE = 'search-docs'
 const META_STORE = 'search-meta'
@@ -86,6 +81,8 @@ interface DocEntry {
   stanzaId?: string
   originId?: string
   occupantId?: string
+  /** Derived room-scoped lookup keys; older room documents receive them on upgrade. */
+  identityKeys?: string[]
 }
 
 interface MetaEntry {
@@ -104,6 +101,7 @@ interface SearchIndexSchema extends DBSchema {
     indexes: {
       timestamp: number
       conversationId: string
+      identityKeys: string
     }
   }
   [META_STORE]: {
@@ -144,6 +142,25 @@ export interface SearchIndexResult {
 let dbPromise: Promise<IDBPDatabase<SearchIndexSchema>> | null = null
 let dbNameForPromise: string | null = null
 
+const IDENTITY_MIGRATION_BATCH_SIZE = 256
+
+/** Backfill without materializing an entire account's search documents at once. */
+async function backfillRoomIdentityKeys(store: {
+  getAll(query: IDBKeyRange | undefined, count: number): Promise<DocEntry[]>
+  put(doc: DocEntry): Promise<unknown>
+}): Promise<void> {
+  let rows = await store.getAll(undefined, IDENTITY_MIGRATION_BATCH_SIZE)
+  while (rows.length > 0) {
+    await Promise.all(rows.filter(doc => doc.isRoom).map(async doc =>
+      store.put({ ...doc, identityKeys: roomDocumentIdentityKeys(doc) }),
+    ))
+    rows = await store.getAll(
+      IDBKeyRange.lowerBound(rows[rows.length - 1].indexId, true),
+      IDENTITY_MIGRATION_BATCH_SIZE,
+    )
+  }
+}
+
 function isIndexedDBAvailable(): boolean {
   try {
     return typeof indexedDB !== 'undefined' && indexedDB !== null
@@ -179,7 +196,8 @@ function getDB(
 
   dbNameForPromise = targetDbName
   dbPromise = openDB<SearchIndexSchema>(targetDbName, DB_VERSION, {
-    upgrade(db) {
+    upgrade(db, oldVersion, _newVersion, tx) {
+      void tx.done.catch(() => {})
       if (!db.objectStoreNames.contains(TOKENS_STORE)) {
         db.createObjectStore(TOKENS_STORE, { keyPath: 'token' })
       }
@@ -190,6 +208,15 @@ function getDB(
       }
       if (!db.objectStoreNames.contains(META_STORE)) {
         db.createObjectStore(META_STORE, { keyPath: 'key' })
+      }
+      const docsStore = tx.objectStore(DOCS_STORE)
+      docsStore.createIndex('identityKeys', 'identityKeys', { multiEntry: true })
+      if (oldVersion > 0) {
+        // The version-change transaction makes the backfill atomic with the
+        // index. A failed write must not leave old documents undiscoverable.
+        void backfillRoomIdentityKeys(docsStore).catch(() => {
+          try { tx.abort() } catch { /* The failed request may already have aborted it. */ }
+        })
       }
     },
   })
@@ -413,6 +440,16 @@ function fallbackDocNamesMessage(
   return owner ? roomOwnerNamesMessage(owner, message) : false
 }
 
+function roomDocumentIdentityKeys(doc: DocEntry): string[] {
+  return identityKeys(roomScope(doc.conversationId), {
+    from: doc.from,
+    id: doc.messageId,
+    stanzaId: doc.stanzaId,
+    originId: doc.originId,
+    occupantId: doc.occupantId,
+  })
+}
+
 function docBelongsToRoomIdentityClosure(
   doc: DocEntry,
   message: RoomMessage,
@@ -422,13 +459,7 @@ function docBelongsToRoomIdentityClosure(
   scopeJid: string | null
 ): boolean {
   if (!docBelongsToRoom(doc, message)) return false
-  const docKeys = identityKeys(roomScope(doc.conversationId), {
-    from: doc.from,
-    id: doc.messageId,
-    stanzaId: doc.stanzaId,
-    originId: doc.originId,
-    occupantId: doc.occupantId,
-  })
+  const docKeys = roomDocumentIdentityKeys(doc)
   if (docKeys.slice(0, -1).some((key) => closureKeys.has(key))) return true
   if (!closureKeys.has(docKeys[docKeys.length - 1]) || !closureIds.has(doc.messageId)) {
     return false
@@ -489,14 +520,20 @@ function createDocEntry(
   if (message.type === 'groupchat') {
     doc.nick = message.nick
     if (message.occupantId) doc.occupantId = message.occupantId
+    doc.identityKeys = roomDocumentIdentityKeys(doc)
   }
   return doc
 }
 
 function sameIndexDocument(a: DocEntry, b: DocEntry): boolean {
-  return (Object.keys({ ...a, ...b }) as Array<keyof DocEntry>).every(key => key === 'tokens'
-    ? a.tokens.length === b.tokens.length && a.tokens.every((token, i) => token === b.tokens[i])
-    : a[key] === b[key])
+  return (Object.keys({ ...a, ...b }) as Array<keyof DocEntry>).every(key => {
+    if (key === 'tokens' || key === 'identityKeys') {
+      const left = a[key] ?? []
+      const right = b[key] ?? []
+      return left.length === right.length && left.every((value, i) => value === right[i])
+    }
+    return a[key] === b[key]
+  })
 }
 
 /** The retraction scope a message belongs to. */
@@ -703,7 +740,8 @@ async function writeIndexBatch(
 
 /**
  * Remove a message from the search index.
- * Reads the document's token list and removes it from all posting lists.
+ * Room identity-key hits select candidates; ownership checks still decide
+ * which documents and token postings may be removed.
  */
 export async function removeMessage(
   message: Message | RoomMessage,
@@ -789,8 +827,15 @@ async function removeMessageEntries(
     await drop(getIndexId(source), message.type === 'chat' ? 'chat-closure' : 'room-source')
   }
   if (message.type === 'groupchat' && roomIdentityClosure) {
-    const docs = await docsStore.index('conversationId').getAll(message.roomJid)
-    for (const doc of docs) await drop(doc.indexId, 'room-closure')
+    const seen = new Set<string>()
+    for (const key of closureKeys) {
+      const docs = await docsStore.index('identityKeys').getAll(key)
+      for (const doc of docs) {
+        if (seen.has(doc.indexId)) continue
+        seen.add(doc.indexId)
+        await drop(doc.indexId, 'room-closure')
+      }
+    }
   }
 
   return removedIds

--- a/scripts/e2e/pinWindow.ts
+++ b/scripts/e2e/pinWindow.ts
@@ -37,7 +37,7 @@
 import type { Page } from '@playwright/test'
 
 /** Pin stimuli the invariants drive. Mirrors `LiveEdgeBrowserPorts.trigger`. */
-export type PinTrigger = 'switch' | 'new-message'
+export type PinTrigger = 'switch' | 'new-message' | 'container-shrink'
 
 /**
  * How a pin run ended. `superseded` is deliberately absent: it means a NEWER pin took ownership,

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2582,7 +2582,9 @@ test.describe('Typing indicator never covers message text', () => {
     expect(anchored.distFromBottom, 'precondition: must start at the bottom').toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
 
     // ── Composer GROWS ──────────────────────────────────────────────────────
-    await setDraft(twoLines)
+    // The next resize must exercise a fresh reconciliation; a still-active growth pin can
+    // absorb it without starting either of the shrink-direction triggers asserted below.
+    await withPinWindow(page, { trigger: 'container-shrink' }, () => setDraft(twoLines))
 
     // Anchoring is read FIRST: probeOverlap parks the viewport itself, so any bottom claim made
     // after it would be a claim about the probe.


### PR DESCRIPTION
During bulk moderation cleanup, each room retraction scanned all search documents in the room, amplifying IndexedDB work as history grew. Use indexed identity lookups to select matching stored copies, then apply the existing room and occupant ownership checks.

Persist room identity keys in the search index and atomically backfill existing databases in bounded batches, preserving stored documents and token postings.

Make the composer-resize browser check wait for the preceding correction to finish, so it exercises a fresh reconciliation reliably on slower runners.
