### PR TITLE
test: bound Vitest worker concurrency

### DIFF
--- a/apps/fluux/vitest.config.ts
+++ b/apps/fluux/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
+import { availableParallelism } from 'node:os'
 import { resolveAnomalyGate } from './src/anomaly/gate'
 
 export default defineConfig({
@@ -27,6 +28,8 @@ export default defineConfig({
     // need jsdom-specific behavior opt back in per-file with `// @vitest-environment jsdom`.
     environment: 'happy-dom',
     silent: true,
+    // Leave CPU and memory headroom for crypto tests and concurrent development builds.
+    maxWorkers: Math.min(2, Math.max(1, availableParallelism() - 1)),
     setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'scripts/**/*.test.ts'],
     exclude: ['src/**/*.manual.test.ts'],

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -39,6 +39,26 @@ Open http://localhost:5173 and connect with your XMPP credentials.
 | `npm run tauri:install` | Build + install the desktop app into `/Applications` (macOS) |
 | `npm run screenshots`   | Generate demo screenshots (see below)                        |
 
+### Test concurrency
+
+`npm test` runs the SDK and application suites in sequence. By default, each suite
+uses at most two workers and keeps one available CPU out of the worker budget
+when possible, with a minimum of one worker. This leaves CPU and memory headroom
+for cryptographic tests and other development tasks.
+
+`npm run test:parallel` shares that worker budget between the two suites: on a
+machine with at least three available CPUs it runs one worker per suite. With a
+budget of one worker, it runs the suites in sequence. This budget applies to one
+command; separate terminals or agents each start their own processes.
+
+Override the worker count for an individual suite when comparing performance or
+working on a busy machine:
+
+```bash
+npm run test:run -w @xmpp/fluux -- --maxWorkers=1
+npm run test:run -w @fluux/sdk -- --maxWorkers=1
+```
+
 ## macOS Notifications in Local Development
 
 Local desktop builds run under a **separate dev identity** so they never collide with an installed production Fluux:

--- a/packages/fluux-sdk/vitest.config.ts
+++ b/packages/fluux-sdk/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config'
+import { availableParallelism } from 'node:os'
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
     silent: true,
+    // Leave CPU and memory headroom for crypto tests and concurrent development builds.
+    maxWorkers: Math.min(2, Math.max(1, availableParallelism() - 1)),
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'examples/**/*.test.ts'],
     setupFiles: ['./src/test-setup.ts'],
     coverage: {

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 //
-// Run both workspace test suites concurrently instead of in series.
+// Run both workspace test suites concurrently when the CPU budget permits.
 //
 // `npm test` runs the workspaces sequentially (SDK then app) — safe everywhere, and the
 // default CI gate. On a multi-core dev machine the two suites can overlap: this runs them
@@ -10,15 +10,23 @@
 // stay readable. Exit code is non-zero if either workspace fails.
 //
 import { spawn } from 'node:child_process'
+import { availableParallelism } from 'node:os'
 
 const targets = [
   { tag: 'sdk', args: ['run', 'test:run', '-w', '@fluux/sdk'] },
   { tag: 'app', args: ['run', 'test:run', '-w', '@xmpp/fluux'] },
 ]
 
+// Both Vitest processes share the budget; their per-workspace defaults would add up.
+const workerBudget = Math.min(2, Math.max(1, availableParallelism() - 1))
+const concurrentSuites = Math.min(targets.length, workerBudget)
+const workersPerSuite = Math.floor(workerBudget / concurrentSuites)
+
 function run({ tag, args }) {
   return new Promise((resolve) => {
-    const child = spawn('npm', args, { shell: process.platform === 'win32' })
+    const child = spawn('npm', [...args, '--', `--maxWorkers=${workersPerSuite}`], {
+      shell: process.platform === 'win32',
+    })
     const forward = (stream, out) => {
       let buf = ''
       stream.on('data', (chunk) => {
@@ -42,7 +50,13 @@ function run({ tag, args }) {
 }
 
 const start = Date.now()
-const results = await Promise.all(targets.map(run))
+process.stdout.write(`Vitest: ${concurrentSuites} suite(s), ${workersPerSuite} worker(s) per suite\n`)
+const results = []
+if (concurrentSuites === 1) {
+  for (const target of targets) results.push(await run(target))
+} else {
+  results.push(...await Promise.all(targets.map(run)))
+}
 const seconds = ((Date.now() - start) / 1000).toFixed(1)
 
 const bar = '='.repeat(48)


### PR DESCRIPTION
Cap Vitest at two workers per workspace, adjusted for available CPUs, to leave CPU and memory headroom for cryptographic tests and concurrent development builds.

Share the same budget between the SDK and application suites in `test:parallel`, falling back to sequential execution when only one worker is available. Document the defaults and per-suite CLI overrides without changing test assertions or timeouts.
