### PR TITLE
docs: define common specifications for XMPP libraries

### DIFF
--- a/docs/xmpp-specifications/README.md
+++ b/docs/xmpp-specifications/README.md
@@ -1,0 +1,140 @@
+# Common specifications for the Fluux XMPP libraries
+
+Status: initial design draft. Direction recorded on 2026-09-11; detailed contracts
+are proposed and have no implementation or conformance evidence yet.
+
+## Direction
+
+Build new XMPP libraries from common, language-independent specifications. The
+initial implementations are TypeScript for web, Swift for iOS, and Kotlin for
+Android. Native Windows is the final target to add, after those three targets.
+Their protocol behavior is designed together; their language APIs and platform
+integration can differ.
+
+The specifications are the source of intended behavior. Existing Fluux code and
+other XMPP implementations provide examples, interoperability cases, and lessons
+about failures. They do not define correctness merely by exhibiting a behavior.
+
+The protocol implementations will be new. Platform TLS, credential storage, XML
+parsing, cryptographic primitives, and other suitable foundational components can
+be reused behind specified interfaces. A shared native runtime is not a prerequisite.
+
+These documents describe a new library family. They do not change the current
+SDK, select migration dates, or claim compatibility with its public API or storage.
+
+## Target sequencing
+
+Develop the common specifications and conformance approach for the initial web,
+iOS, and Android implementations. Their relative implementation order remains
+open. Add native Windows last, using the same contracts and scenario corpus.
+
+Keep the shared design independent of those first three runtimes so Windows can
+implement it without redefining protocol behavior. C#/.NET is the proposed Windows
+implementation language; its platform adapters and public API will be specified
+when that target is developed. Windows-specific implementation work is deferred.
+
+## Contents
+
+- [Connection lifecycle](connection-lifecycle.md): first bounded contract,
+  covering ownership, cancellation, and late asynchronous completions.
+- [Conformance](conformance.md): portable scenarios, observation boundaries, and
+  the evidence required to claim implementation of a contract.
+
+## Architectural boundaries
+
+The design has three layers with separately identifiable requirements:
+
+1. **Protocol core.** Addresses, stream parsing and framing, negotiation,
+   authentication, stanza exchange, request correlation, and connection lifecycle.
+2. **Protocol extensions.** Individually specified XEP modules, with explicit
+   dependencies, advertised capabilities, failure behavior, and interactions.
+3. **Headless messaging model.** Message reconciliation, history coverage, read
+   state, and notification eligibility. These are Fluux policies built on protocol
+   facts; they are not all guarantees supplied by XMPP itself.
+
+The UI consumes commands, state, and events from the headless model. It does not
+own protocol sequencing. A bot can use the protocol layers without adopting
+Fluux's conversation model.
+
+Each mutable domain has one declared owner. Modules request work or emit facts
+across boundaries; they do not silently mutate another module's state. The design
+specifies ordering, cancellation, and observable results without requiring the
+same classes, threads, actors, stores, or async API in every language.
+
+## Common behavior and platform variation
+
+The common contract defines meanings, constraints, and failure outcomes. Platform
+adapters provide transport, clocks, scheduling, randomness, storage, credentials,
+and lifecycle observations. Each adapter needs its own contract and integration
+checks; a test adapter passing does not establish production adapter correctness.
+
+Browser WebSocket transport and native TCP transport have different framing and
+capabilities. Their profiles must be explicit. Suspension and process termination
+are inputs the library must recover from under a defined policy, not promises of
+unrestricted background execution.
+
+Language APIs may use promises and subscriptions, Swift concurrency, or Kotlin
+coroutines. Their observable ordering and completion guarantees must agree.
+Internal performance strategies may differ within the specified bounds.
+
+## Specification rules
+
+Every contract identifies:
+
+- Its stable identifier, revision, status, scope, and dependencies.
+- Referenced RFC sections and exact XEP revisions or immutable source snapshots.
+- Inputs, outputs, state ownership, preconditions, and invariants.
+- Success, cancellation, timeout, malformed input, and unsupported-capability cases.
+- Ordering, resource limits, persistence, and restart semantics where relevant.
+- Portable scenarios, implementation evidence, and unresolved decisions.
+
+Distinguish **standard requirements**, **Fluux policy**, and **platform constraints**.
+A Fluux policy may choose among allowed behaviors but cannot silently override a
+standard. Conflicts or ambiguities become explicit decisions with rationale.
+
+Use `draft` for work in progress, `accepted` for a reviewed contract revision, and
+`superseded` for a revision replaced by another. Editing an accepted requirement
+creates a new revision and invalidates the affected evidence. An implementation
+report names the exact specification and scenario revisions it tested.
+
+## Specification catalogue
+
+The following is a work catalogue, not a promise of first-release feature parity:
+
+| Area | Required design work | Status |
+| --- | --- | --- |
+| Lifecycle ownership | Attempts, cancellation, late results, session identity | First draft in this directory |
+| Address model | RFC 7622 parsing, normalization, comparison, invalid input | Unspecified |
+| XML and framing | Namespaces, incremental input, limits, TCP/WebSocket profiles | Unspecified |
+| Transport and negotiation | Discovery, TLS, authentication, binding, downgrade rules | Unspecified |
+| Stanza exchange | IQ correlation, deadlines, sender validation, backpressure | Unspecified |
+| Stream management | Acknowledgements, counters, replay, resumption failure | Unspecified |
+| Extension modules | Feature profiles, dependency and interaction rules | Unspecified |
+| Messaging model | Identity, MAM/carbon reconciliation, read state, notification policy | Unspecified |
+| Persistence and encryption | Transactions, crash recovery, trust and key lifecycle | Unspecified |
+| Delivery to existing users | Public API, data and account migration requirements | Unspecified |
+
+The existing [supported XEP inventory](../../SUPPORTED_XEPS.md) is an input for
+requirements discovery. Its implementation labels do not apply to the new libraries.
+
+## First implementation milestone
+
+Refine the lifecycle contract and portable scenarios, then build a headless runner
+for one new implementation. Implement the same bounded contract in a second
+language to expose accidental assumptions in the specification and test adapter.
+Review real failures and strengthen the contract before expanding feature scope.
+
+Choose the first implementation language separately. A successful lifecycle test
+does not establish a working XMPP client: wire negotiation, transport integration,
+stream management, and interoperability each require their own specifications and
+proof. No library currently claims conformance to this draft.
+
+## Protocol references
+
+These are discovery references, not a frozen conformance baseline. Record exact
+sections and revisions when drafting each wire-level contract.
+
+- [RFC 6120: XMPP Core](https://www.rfc-editor.org/rfc/rfc6120.html)
+- [RFC 7395: XMPP over WebSocket](https://www.rfc-editor.org/rfc/rfc7395.html)
+- [RFC 7622: XMPP Address Format](https://www.rfc-editor.org/rfc/rfc7622.html)
+- [XEP-0198: Stream Management](https://xmpp.org/extensions/xep-0198.html)

--- a/docs/xmpp-specifications/conformance.md
+++ b/docs/xmpp-specifications/conformance.md
@@ -1,0 +1,138 @@
+# Conformance across implementations
+
+Status: proposed harness design. No runner or executable conformance suite is
+provided by this documentation change.
+
+## Authority and evidence
+
+A readable contract explains the rule. Shared scenarios make selected consequences
+testable. A language-specific adapter runs those scenarios against the actual
+implementation and exposes observations at the specified boundary.
+
+An adapter must not reproduce the lifecycle state machine, deduplication logic, or
+other behavior being tested. It translates inputs and observations. Otherwise,
+agreement would demonstrate that adapters match while leaving the libraries untested.
+
+The existing TypeScript SDK is a source of candidate cases, not a correctness
+oracle. Differential testing between implementations can discover discrepancies;
+agreement alone does not prove that either implementation follows XMPP or Fluux policy.
+
+## Proposed portable boundary
+
+Use versioned JSON scenarios and a headless runner for each implementation. The
+runner accepts a scenario and returns normalized observations plus a result. CLI
+launch details can differ by toolchain; the scenario semantics must agree.
+
+A scenario declares its contract revision, capabilities, initial environment,
+ordered input steps, expected observations, forbidden effects, and final state.
+Time and identifiers are explicit test inputs. Future wire scenarios also carry
+XML fragments and fragmentation schedules, including invalid input.
+
+The fake environment controls monotonic time, timer delivery, random values,
+network outcomes, storage outcomes, and lifecycle signals. Inputs are delivered
+through real implementation boundaries. A checkpoint drains immediately runnable
+work without advancing time or supplying missing external input. If the runner
+cannot reach a checkpoint within its work limit, it reports failure or a harness
+error instead of guessing that nothing will happen.
+
+## Example: a superseded attempt cannot become online
+
+This illustrative JSON describes `CONN-001` from
+[FX-CONNECTION](connection-lifecycle.md). It is a format proposal, not an existing
+runner command or a claim that the scenario has passed.
+
+```json
+{
+  "format": "fluux-scenario/0.1-draft",
+  "id": "CONN-001",
+  "contract": "FX-CONNECTION/0.1-draft",
+  "requirements": ["FX-CONNECTION-001", "FX-CONNECTION-002", "FX-CONNECTION-003"],
+  "environment": {"monotonicMs": 0, "connectDeadlineMs": 5000},
+  "steps": [
+    {"command": "connect", "attempt": "A"},
+    {"command": "connect", "attempt": "B"},
+    {"inject": "sessionReady", "attempt": "A", "session": "old", "transport": "late-A"},
+    {
+      "checkpoint": "late-result",
+      "expectState": {"phase": "connecting", "attempt": "B"},
+      "expectConnectOutcomes": [{"attempt": "A", "outcome": "superseded"}],
+      "expectEffects": [{"kind": "closeTransport", "attempt": "A", "transport": "late-A"}],
+      "forbidEvents": [{"kind": "sessionReady", "attempt": "A"}]
+    },
+    {"inject": "sessionReady", "attempt": "B", "session": "new", "transport": "current-B"},
+    {
+      "checkpoint": "current-result",
+      "expectState": {"phase": "online", "attempt": "B", "session": "new"},
+      "expectConnectOutcomes": [
+        {"attempt": "A", "outcome": "superseded"},
+        {"attempt": "B", "outcome": "ready", "session": "new"}
+      ],
+      "expectEvents": [{"kind": "sessionReady", "attempt": "B"}],
+      "forbidEvents": [{"kind": "sessionReady", "attempt": "A"}]
+    }
+  ]
+}
+```
+
+For this proposed format, each checkpoint examines the cumulative trace since the
+start of the scenario. `expectState` matches the complete public lifecycle snapshot;
+`expectConnectOutcomes` matches the complete ordered list of settled connect results.
+`expectEffects` and `expectEvents` require at least one matching observation;
+`forbidEvents` prohibits any matching event. A pattern matches all fields it names.
+Exact event counts and ordering constraints need explicit additional predicates
+when translating the other scenarios into this format.
+
+The fake environment creates `late-A` only when injecting A's completion. Closing
+an earlier resource during cancellation therefore cannot satisfy this assertion.
+
+When executed, this example would check that closure was requested for A. It
+would not prove production resource disposal, enforcement of a cleanup deadline,
+or interoperability.
+
+## Comparing observations
+
+Normalize opaque identifiers by consistent renaming, preserving equality, scope,
+and relationships. Do not delete identity fields or normalize away ordering,
+duplicate events, error classes, or forbidden side effects. Compare XML by the
+specified namespace-aware semantics; retain byte-level comparisons when a framing
+or cryptographic requirement depends on exact bytes.
+
+Requirements define which events must be ordered, which may commute, and which
+effects are forbidden. Do not demand identical diagnostic logs or internal task
+scheduling. Test platform-specific capabilities under named profiles, rather than
+quietly skipping required behavior on one implementation.
+
+## Layers of verification
+
+1. **Portable contract scenarios:** deterministic success, failure, cancellation,
+   duplicate, and reordered-input cases against the real library.
+2. **Boundary checks:** adversarial XML, parser fragmentation, resource bounds,
+   transport and storage adapter behavior, and language concurrency checks.
+3. **Interoperability:** real wire exchanges with ejabberd and at least one other
+   independently implemented server for each claimed protocol profile.
+4. **Device integration:** actual platform storage, credentials, networking,
+   suspension, process termination, and recovery.
+
+Passing a layer establishes only its tested scope. Simulator success does not
+establish background delivery or battery behavior on physical devices.
+
+For each new invariant, introduce a targeted violating mutation and show that its
+scenario fails for the intended reason. Restore the correct behavior and rerun.
+An independent expected result and a positive control prevent a test from passing
+because the implementation does nothing or the adapter silently filters failures.
+
+## Revision and result records
+
+Each result identifies the contract revision and content digest, scenario revision
+and digest, implementation commit and source-tree digest, adapter revision,
+dependency/toolchain versions, environment, capabilities, and invocation. A dirty
+worktree needs a recorded content snapshot; a commit identifier alone is insufficient.
+
+Report each case as passed, failed, unsupported, not run, or harness error. An
+implementation can claim a capability only when all its required cases pass under
+the specified profile. Track missing cases separately from successful tests.
+
+Changing a requirement or scenario invalidates the affected evidence. Editing
+expected results to match one implementation is a contract change requiring review,
+not a routine test repair. No current implementation has a result record for this
+draft set.

--- a/docs/xmpp-specifications/connection-lifecycle.md
+++ b/docs/xmpp-specifications/connection-lifecycle.md
@@ -1,0 +1,146 @@
+# Connection lifecycle
+
+- Contract: `FX-CONNECTION`
+- Revision: `0.1-draft`
+- Status: proposed Fluux policy; no implementation has been tested against it.
+
+## Scope
+
+Define which connection attempt may affect a client instance, and how cancellation
+interacts with late asynchronous results. This is a lifecycle contract above the
+transport and negotiation interfaces. It does not specify their wire behavior,
+authentication mechanisms, reconnection delays, or XEP-0198 replay rules.
+
+The protocol boundary follows the responsibilities described by
+[RFC 6120](https://www.rfc-editor.org/rfc/rfc6120.html). The ownership and cancellation
+rules below are proposed Fluux policy, not additional requirements attributed to
+that RFC.
+
+## Terms and observation boundary
+
+- **Client instance:** owner of one account's connection lifecycle. Its account
+  identity cannot be changed; another account uses another instance.
+- **Attempt:** one request to establish a usable session. Its opaque identifier
+  is unique within the instance and accompanies all asynchronous work it starts.
+- **Session:** a negotiated logical XMPP session. It has a separate identity from
+  the attempt and transport. A future resumption contract may preserve session
+  identity across replacement transports and attempts.
+- **Current attempt:** the only attempt authorized to publish lifecycle changes.
+- **Retired attempt:** a failed, cancelled, replaced, or disconnected attempt.
+  Work it previously started may still finish, but no longer has authority.
+- **Admission:** the point where the lifecycle owner accepts and orders an input.
+  Concurrent callers observe the order established here, not wall-clock order.
+
+The owner processes admitted inputs in one logical sequence. Implementations can
+use different concurrency mechanisms. Required events, outcomes, and transport
+effects must reflect that sequence. Attempt identifiers are distinct from message,
+stream, and account identifiers.
+
+## Abstract inputs and observations
+
+Names below describe the test boundary, not mandated public method signatures.
+
+| Input | Meaning |
+| --- | --- |
+| `connect(attempt)` | Start a new attempt; its account and configuration are already validated |
+| `disconnect` | Withdraw permission to remain connected or automatically reconnect |
+| `sessionReady(attempt, session, transport)` | Negotiation reports a usable session and transfers its identified transport resource to the owner |
+| `attemptFailed(attempt, reason)` | Establishment failed, including an enforced deadline |
+| `transportLost(attempt, reason)` | An established transport has become unusable |
+
+`sessionReady` is a trusted test seam for a separately verified negotiation
+component. A raw socket opening, a peer-supplied string, or an authentication
+response alone cannot be substituted for it by a production adapter.
+
+Observations comprise an `idle`, `connecting`, or `online` lifecycle snapshot;
+ordered lifecycle events; operation outcomes; and requested transport effects.
+An implementation may expose additional diagnostic phases internally.
+
+## Proposed requirements
+
+### FX-CONNECTION-001: one current attempt
+
+Admitting `connect(B)` replaces any current attempt A. Retire A before starting B;
+request cancellation of A's pending work and closure of its transport. A pending
+connect A receives the outcome `superseded`. A previously successful connect A
+keeps its completed result, while its online lifecycle ends with reason `replaced`.
+The snapshot becomes `connecting(B)`.
+
+### FX-CONNECTION-002: retirement revokes authority
+
+After retirement, a result associated with A cannot change the current snapshot,
+publish a session, schedule a reconnect, deliver application data, or write account
+state. A transport resource returned late is closed. Retiring A cannot cancel or
+close B's work or transport. Best-effort cancellation alone is insufficient:
+results must be checked even if their producer ignores cancellation.
+
+### FX-CONNECTION-003: bounded, single connect outcome
+
+Each admitted connect settles once with `ready(session)`, `failed(reason)`,
+`cancelled`, or `superseded`. The establishment deadline is a finite configuration
+input, enforced by the owner using the injected clock. Its expiration is admitted
+as an attempt failure; late completion is subject to requirement 002.
+
+Processing `sessionReady` for the current connecting attempt establishes `online`,
+settles the connect as ready, and publishes one session-ready event. A repeated
+completion for the same attempt and session is ignored. Contradictory completions
+are adapter violations; their additional resources are disposed without changing
+the established session. Losing a session after success produces a lifecycle event
+and does not retroactively reject or complete the connect operation again.
+
+A duplicate completion naming the already-owned transport does not close that
+transport. A distinct resource returned by a duplicate or retired completion is
+disposed; attempt identity and resource identity must both be preserved.
+
+### FX-CONNECTION-004: disconnect is a local barrier
+
+Admitting `disconnect` retires the current attempt and cancels pending automatic
+retry work. A pending connect settles as cancelled. Request transport closure,
+publish a lifecycle change if needed, and expose `idle` with no current attempt.
+Disconnect completes after this local invalidation and issuance of cleanup effects;
+it does not claim that a peer observed a graceful stream close.
+
+Late cleanup work remains owned by its retired attempt. It cannot publish new
+application events or revive the connection. Repeated disconnect while idle is
+idempotent. A later explicit connect can start a new attempt.
+
+### FX-CONNECTION-005: failure and recovery are explicit
+
+Failure of the current connecting attempt retires it and settles its connect as
+failed. Loss of the current online transport retires its attempt and publishes one
+session-ended event with the reason. Both leave the owner idle. The environment
+can request a new connect; this draft adds no automatic retry policy.
+
+A future retry module must use the same admission boundary, respect the disconnect
+barrier, and attach authority to scheduled work so stale retries cannot restart an
+instance. Retry, background suspension, and restart policies need separate contracts.
+
+## Required scenarios
+
+| Scenario | Inputs and required outcome | Requirements |
+| --- | --- | --- |
+| CONN-001 | A starts, B replaces A, A reports ready: B stays connecting; A's resource closes; A cannot publish ready | 001, 002, 003 |
+| CONN-002 | A starts, disconnect completes, A reports ready: instance stays idle; no ready event or new attempt | 002, 003, 004 |
+| CONN-003 | A becomes online, its transport is lost: one session-ended event; connect result remains successful | 003, 005 |
+| CONN-004 | A starts, its deadline expires, A reports ready: failed outcome occurs once; late transport closes | 002, 003, 005 |
+| CONN-005 | A becomes online; duplicate ready for A and the same session: no second connect outcome or ready event | 003 |
+| CONN-006 | Disconnect twice from idle: no attempt, duplicate lifecycle change, or reconnect | 004 |
+| CONN-007 | Two client instances use the same local attempt label; retire one: the other is unaffected | 001, 002 |
+| CONN-008 | A is replaced by B; A reports failure after B becomes online: B remains online | 001, 002, 005 |
+
+Scenarios must include the successful completion of B where applicable to ensure
+an implementation cannot pass by suppressing all results. A deliberately removed
+authority check must make the late-result scenario fail. See
+[conformance](conformance.md) for the required adapter and evidence boundaries.
+
+## Decisions still needed
+
+- Confirm replacement semantics for concurrent connects versus rejecting a second
+  connect as busy. Replacement is the proposal used by this draft's scenarios.
+- Define the transport adapter's resource ownership and bounded cleanup contract,
+  including handling a hung close operation.
+- Specify production timeout defaults, error taxonomy, retry eligibility, and
+  lifecycle handling during process suspension and restart.
+- Specify session resumption and how it composes with this attempt lifecycle.
+- Choose public APIs independently for TypeScript, Swift, and Kotlin, followed by
+  the Windows implementation when that final target is developed.


### PR DESCRIPTION
Introduce a language-independent specification foundation for new Fluux XMPP libraries, with TypeScript, Swift and Kotlin as initial targets and native Windows added last.

Define architectural boundaries, an initial connection lifecycle contract, and a proposed conformance format. Keep unresolved design choices explicit and distinguish draft specifications from implementation evidence.
