### PR TITLE
perf(cache): index room history deduplication

### DIFF
--- a/packages/fluux-sdk/src/utils/messageCache.roomOpening.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.roomOpening.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { openDB } from 'idb'
+import type { RoomMessage } from '../core/types'
+import * as identity from './messageIdentity'
+import * as cache from './messageCache'
+import { _resetStorageScopeForTesting } from './storageScope'
+
+const ROOM = 'large-room@conference.example.test'
+
+function message(index: number): RoomMessage {
+  return {
+    type: 'groupchat', roomJid: ROOM, from: `${ROOM}/sender`, nick: 'sender',
+    id: `client-${index}`, stanzaId: `archive-${index}`, occupantId: 'occupant',
+    timestamp: new Date(1700000000000 + index), isOutgoing: false,
+    body: '', isRetracted: true, retractedAt: new Date(1700001000000),
+  }
+}
+
+beforeEach(() => {
+  _resetStorageScopeForTesting()
+  cache._resetDBForTesting()
+  globalThis.indexedDB = new IDBFactory()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cache._resetDBForTesting()
+})
+
+it('restores a long room tail without deriving identities for every pair of rows', async () => {
+  const rows = Array.from({ length: 256 }, (_, index) => message(index))
+  await cache.saveRoomMessages(rows)
+  const keys = vi.spyOn(identity, 'identityKeys')
+  const restored = await cache.getRoomMessagesAround(ROOM, { id: rows[0].id }, { before: 0 })
+  expect(restored.map(row => row.id)).toEqual(rows.map(row => row.id))
+  expect(keys.mock.calls.length).toBeLessThanOrEqual(rows.length * 4)
+})
+
+async function restoreCopies(copies: Partial<RoomMessage>[]) {
+  await cache.getRoomMessages(ROOM)
+  const db = await openDB('fluux-message-cache')
+  const tx = db.transaction('room-messages-canonical', 'readwrite')
+  const rows = copies.map((copy, index) => ({ ...message(index), ...copy }))
+  // Seed separate stored copies so the write-side merge cannot hide read-side deduplication.
+  for (const [index, row] of rows.entries()) {
+    await tx.store.put({
+      ...row, cacheKey: `copy-${index}`, ids: [row.id],
+      identityKeys: identity.identityKeys(identity.roomScope(ROOM), row),
+      timestamp: row.timestamp.getTime(), retractedAt: row.retractedAt?.getTime(),
+    })
+  }
+  await tx.done
+  db.close()
+  return cache.getRoomMessagesAround(ROOM, { id: rows[0].id }, { before: 0 })
+}
+
+it('keeps the first copy when a later copy shares several identities', async () => {
+  const restored = await restoreCopies([
+    { id: 'original', stanzaId: 'shared-stanza', originId: 'shared-origin' },
+    { id: 'rewritten', stanzaId: 'shared-stanza', originId: 'shared-origin' },
+    { id: 'unrelated' },
+  ])
+  expect(restored.map(row => row.id)).toEqual(['original', 'unrelated'])
+})
+
+it('retains distinct occupants and an ambiguous legacy copy sharing an identity', async () => {
+  const restored = await restoreCopies([
+    { id: 'a', originId: 'shared-origin', occupantId: 'a' },
+    { id: 'b', originId: 'shared-origin', occupantId: 'b' },
+    { id: 'unknown', originId: 'shared-origin', occupantId: undefined },
+    { id: 'copy-of-a', originId: 'shared-origin', occupantId: 'a' },
+  ])
+  expect(restored.map(row => row.id)).toEqual(['a', 'b', 'unknown'])
+})
+
+it('does not use a discarded copy to bridge two otherwise distinct messages', async () => {
+  const restored = await restoreCopies([
+    { id: 'first', stanzaId: 'shared-stanza' },
+    { id: 'discarded', stanzaId: 'shared-stanza', originId: 'extra-origin' },
+    { id: 'independent', originId: 'extra-origin' },
+  ])
+  expect(restored.map(row => row.id)).toEqual(['first', 'independent'])
+})

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -2443,14 +2443,24 @@ export async function getRoomMessagesAround(
   })
 
   const merged: RoomMessage[] = []
+  const scope = roomScope(roomJid)
+  const byIdentity = new Map<string, RoomMessage[]>()
   for (const m of [...olderAndAnchor, ...newer]) {
-    const keys = new Set(identityKeys(roomScope(roomJid), m))
-    const candidates = merged.filter((resident) =>
-      identityKeys(roomScope(roomJid), resident).some((key) => keys.has(key))
-    )
-    const matches = mergeableOccupantCandidates(m, candidates)
-    if (matches.some((resident) => sameLogicalMessage(roomScope(roomJid), resident, m))) continue
+    const keys = identityKeys(scope, m)
+    const candidates = new Set<RoomMessage>()
+    for (const key of keys) {
+      for (const resident of byIdentity.get(key) ?? []) candidates.add(resident)
+    }
+    // Shared keys select candidates; occupant evidence still decides which copies can merge.
+    const matches = mergeableOccupantCandidates(m, [...candidates])
+    if (matches.some((resident) => sameLogicalMessage(scope, resident, m))) continue
     merged.push(m)
+    // Only retained rows contribute aliases: a discarded copy must not bridge identities.
+    for (const key of keys) {
+      const bucket = byIdentity.get(key)
+      if (bucket) bucket.push(m)
+      else byIdentity.set(key, [m])
+    }
   }
   return merged
 }


### PR DESCRIPTION
Restoring an older room position can freeze the UI by deriving message identities repeatedly across the entire cached history. Index retained rows by identity before applying the existing occupant and logical-message checks, preserving chronological order, the full newer tail, and first-copy selection.

For 4,000 synthetic cached messages in WebKit, the restoration step fell from 2.09 seconds to 162 ms. The local scroll run passed 115/116 cases; the Home-navigation test counted a layout adjustment before the keypress and passed three unchanged reruns. Live desktop validation remains pending.
